### PR TITLE
minor readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ An open source implementation of the Tailscale coordination server.
 
 4. Run it
   ```
-  ./headcale
+  ./headscale
   ```
   
 5. Add your first machine


### PR DESCRIPTION
`s/headcale/headscale`

btw. I _like_ the name `headcale` better.