### PR TITLE
Add additional locations to look for the config.json file

### DIFF
--- a/cmd/headscale/headscale.go
+++ b/cmd/headscale/headscale.go
@@ -171,6 +171,8 @@ var enableRouteCmd = &cobra.Command{
 
 func main() {
 	viper.SetConfigName("config")
+	viper.AddConfigPath("/etc/headscale/")
+	viper.AddConfigPath("$HOME/.headscale")
 	viper.AddConfigPath(".")
 	viper.AutomaticEnv()
 	err := viper.ReadInConfig()


### PR DESCRIPTION
Make headscale look for its config file in 

  /etc/headscale
  $HOME/.headscale

in addition to the current directory.