### PR TITLE
Add a Makefile with a few targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+# Calculate version
+version = $(shell ./scripts/version-at-commit.sh)
+
+build:
+	go build -ldflags "-s -w -X main.version=$(version)" cmd/headscale/headscale.go
+
+dev: lint test build
+
+test:
+	go test -coverprofile=coverage.out
+
+coverprofile_func:
+	go tool cover -func=coverage.out
+
+coverprofile_html:
+	go tool cover -html=coverage.out
+
+lint:
+	golint
+	golangci-lint run
+
+compress: build
+	upx --brute cmd/headscale/headscale
+

--- a/README.md
+++ b/README.md
@@ -42,17 +42,17 @@ Suggestions/PRs welcomed!
 
 1. Compile the headscale binary
   ```shell
-  go build cmd/headscale/headscale.go 
+  make
   ```
   
-2. Get youself a PostgreSQL DB running (yes, [I know](https://tailscale.com/blog/an-unlikely-database-migration/))
+2. Get yourself a PostgreSQL DB running (yes, [I know](https://tailscale.com/blog/an-unlikely-database-migration/))
 
   ```shell 
   docker run --name headscale -e POSTGRES_DB=headscale -e \
     POSTGRES_USER=foo -e POSTGRES_PASSWORD=bar -p 5432:5432 -d postgres
   ```
 
-3. Sort some stuff up (headscale Wireguard keys & the config.json file)
+3. Set some stuff up (headscale Wireguard keys & the config.json file)
   ```shell
   wg genkey > private.key
   wg pubkey < private.key > public.key  # not needed 

--- a/cmd/headscale/headscale.go
+++ b/cmd/headscale/headscale.go
@@ -17,7 +17,7 @@ import (
 	"tailscale.com/tailcfg"
 )
 
-const version = "0.1"
+var version = "dev"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/scripts/version-at-commit.sh
+++ b/scripts/version-at-commit.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e -o pipefail
+commit="$1"
+versionglob="v[0-9].[0-9]*.[0-9]*"
+devsuffix=".dev"
+if [ -z "$commit" ]; then
+  commit=`git log -n1 --first-parent "--format=format:%h"`
+fi
+
+# automatically assign version
+#
+# handles the following cases:
+#
+# 0. no tags on the repository. Print "dev".
+#
+# 1. no local modifications and commit is directly tagged. Print tag.
+#
+# 2. no local modifications and commit is not tagged. Take greatest version tag in repo X.Y.Z and assign X.Y.(Z+1). Print that + $devsuffix + $timestamp.
+#
+# 3. local modifications. Print "dev".
+
+tags=$(git tag)
+if [[ -z "$tags" ]]; then
+  echo "dev"
+elif `git diff --quiet 2>/dev/null`; then
+  tagged=$(git tag --points-at "$commit")
+  if [[ -n "$tagged" ]] ; then
+    echo $tagged
+  else
+    nearest_tag=$(git describe --tags --abbrev=0 --match "$versionglob" "$commit")
+    v=$(echo $nearest_tag | perl -pe 's/(\d+)$/$1+1/e')
+    isodate=$(TZ=UTC git log -n1 --format=%cd --date=iso "$commit")
+    ts=$(TZ=UTC date --date="$isodate" "+%Y%m%d%H%M%S")
+    echo "${v}${devsuffix}${ts}"
+  fi
+else
+  echo "dev"
+fi


### PR DESCRIPTION
 The default is 'build'. The build target calls the new version-at-commit.sh script which will automatically populate the version variable inside the Headscale binary.

Once we start tagging releases on the git tree, that will come in handy.

The Makefile also has a 'test' target (does nothing yet, no tests yet) and a 'dev' target, which runs linters, tests, and finally builds.