### PR TITLE
Namespace is now a flag for all the commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Suggestions/PRs welcomed!
 
 8. In the server, register your machine to a namespace with the CLI
   ```shell
-  ./headscale -n myfirstnamespace register YOURMACHINEKEY 
+  ./headscale -n myfirstnamespace register YOURMACHINEKEY
   ```
 
 ## Configuration reference

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Suggestions/PRs welcomed!
 
 8. In the server, register your machine to a namespace with the CLI
   ```shell
-  ./headscale register YOURMACHINEKEY myfirstnamespace
+  ./headscale -n myfirstnamespace register YOURMACHINEKEY 
   ```
 
 ## Configuration reference

--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -8,20 +8,25 @@ import (
 )
 
 var RegisterCmd = &cobra.Command{
-	Use:   "register machineID namespace",
+	Use:   "register machineID",
 	Short: "Registers a machine to your network",
 	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 2 {
+		if len(args) < 1 {
 			return fmt.Errorf("Missing parameters")
 		}
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		n, err := cmd.Flags().GetString("namespace")
+		if err != nil {
+			log.Fatalf("Error getting namespace: %s", err)
+		}
+
 		h, err := getHeadscaleApp()
 		if err != nil {
 			log.Fatalf("Error initializing: %s", err)
 		}
-		err = h.RegisterMachine(args[0], args[1])
+		err = h.RegisterMachine(args[0], n)
 		if err != nil {
 			fmt.Printf("Error: %s", err)
 			return

--- a/cmd/headscale/cli/preauthkeys.go
+++ b/cmd/headscale/cli/preauthkeys.go
@@ -15,31 +15,34 @@ var PreauthkeysCmd = &cobra.Command{
 }
 
 var ListPreAuthKeys = &cobra.Command{
-	Use:   "list NAMESPACE",
+	Use:   "list",
 	Short: "List the preauthkeys for this namespace",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return fmt.Errorf("Missing parameters")
-		}
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
+		n, err := cmd.Flags().GetString("namespace")
+		if err != nil {
+			log.Fatalf("Error getting namespace: %s", err)
+		}
+
 		h, err := getHeadscaleApp()
 		if err != nil {
 			log.Fatalf("Error initializing: %s", err)
 		}
-		keys, err := h.GetPreAuthKeys(args[0])
+		keys, err := h.GetPreAuthKeys(n)
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
 		for _, k := range *keys {
+			expiration := "-"
+			if k.Expiration != nil {
+				expiration = k.Expiration.Format("2006-01-02 15:04:05")
+			}
 			fmt.Printf(
 				"key: %s, namespace: %s, reusable: %v, expiration: %s, created_at: %s\n",
 				k.Key,
 				k.Namespace.Name,
 				k.Reusable,
-				k.Expiration.Format("2006-01-02 15:04:05"),
+				expiration,
 				k.CreatedAt.Format("2006-01-02 15:04:05"),
 			)
 		}
@@ -47,15 +50,14 @@ var ListPreAuthKeys = &cobra.Command{
 }
 
 var CreatePreAuthKeyCmd = &cobra.Command{
-	Use:   "create NAMESPACE",
+	Use:   "create",
 	Short: "Creates a new preauthkey in the specified namespace",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return fmt.Errorf("Missing parameters")
-		}
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
+		n, err := cmd.Flags().GetString("namespace")
+		if err != nil {
+			log.Fatalf("Error getting namespace: %s", err)
+		}
+
 		h, err := getHeadscaleApp()
 		if err != nil {
 			log.Fatalf("Error initializing: %s", err)
@@ -73,7 +75,7 @@ var CreatePreAuthKeyCmd = &cobra.Command{
 			expiration = &exp
 		}
 
-		_, err = h.CreatePreAuthKey(args[0], reusable, expiration)
+		_, err = h.CreatePreAuthKey(n, reusable, expiration)
 		if err != nil {
 			fmt.Println(err)
 			return

--- a/cmd/headscale/cli/routes.go
+++ b/cmd/headscale/cli/routes.go
@@ -7,21 +7,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var RoutesCmd = &cobra.Command{
+	Use:   "routes",
+	Short: "Manage the routes of Headscale",
+}
+
 var ListRoutesCmd = &cobra.Command{
-	Use:   "list-routes NAMESPACE NODE",
+	Use:   "list NODE",
 	Short: "List the routes exposed by this node",
 	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 2 {
+		if len(args) < 1 {
 			return fmt.Errorf("Missing parameters")
 		}
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		n, err := cmd.Flags().GetString("namespace")
+		if err != nil {
+			log.Fatalf("Error getting namespace: %s", err)
+		}
+
 		h, err := getHeadscaleApp()
 		if err != nil {
 			log.Fatalf("Error initializing: %s", err)
 		}
-		routes, err := h.GetNodeRoutes(args[0], args[1])
+		routes, err := h.GetNodeRoutes(n, args[0])
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -31,20 +41,25 @@ var ListRoutesCmd = &cobra.Command{
 }
 
 var EnableRouteCmd = &cobra.Command{
-	Use:   "enable-route",
+	Use:   "enable node-name route",
 	Short: "Allows exposing a route declared by this node to the rest of the nodes",
 	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 3 {
+		if len(args) < 2 {
 			return fmt.Errorf("Missing parameters")
 		}
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		n, err := cmd.Flags().GetString("namespace")
+		if err != nil {
+			log.Fatalf("Error getting namespace: %s", err)
+		}
+
 		h, err := getHeadscaleApp()
 		if err != nil {
 			log.Fatalf("Error initializing: %s", err)
 		}
-		err = h.EnableNodeRoute(args[0], args[1], args[2])
+		err = h.EnableNodeRoute(n, args[0], args[1])
 		if err != nil {
 			fmt.Println(err)
 			return

--- a/cmd/headscale/headscale.go
+++ b/cmd/headscale/headscale.go
@@ -83,21 +83,35 @@ func main() {
 		log.Fatalf(err.Error())
 	}
 
-	headscaleCmd.AddCommand(versionCmd)
-	headscaleCmd.AddCommand(cli.ServeCmd)
-	headscaleCmd.AddCommand(cli.RegisterCmd)
-	headscaleCmd.AddCommand(cli.PreauthkeysCmd)
 	headscaleCmd.AddCommand(cli.NamespaceCmd)
 	headscaleCmd.AddCommand(cli.NodeCmd)
+	headscaleCmd.AddCommand(cli.PreauthkeysCmd)
+	headscaleCmd.AddCommand(cli.RegisterCmd)
+	headscaleCmd.AddCommand(cli.RoutesCmd)
+	headscaleCmd.AddCommand(cli.ServeCmd)
+	headscaleCmd.AddCommand(versionCmd)
+
+	cli.NodeCmd.PersistentFlags().StringP("namespace", "n", "", "Namespace")
+	cli.NodeCmd.MarkPersistentFlagRequired("namespace")
+
+	cli.PreauthkeysCmd.PersistentFlags().StringP("namespace", "n", "", "Namespace")
+	cli.PreauthkeysCmd.MarkPersistentFlagRequired("namespace")
+
+	cli.RegisterCmd.PersistentFlags().StringP("namespace", "n", "", "Namespace")
+	cli.RegisterCmd.MarkPersistentFlagRequired("namespace")
+
+	cli.RoutesCmd.PersistentFlags().StringP("namespace", "n", "", "Namespace")
+	cli.RoutesCmd.MarkPersistentFlagRequired("namespace")
 
 	cli.NamespaceCmd.AddCommand(cli.CreateNamespaceCmd)
 	cli.NamespaceCmd.AddCommand(cli.ListNamespacesCmd)
 
-	cli.NodeCmd.AddCommand(cli.ListRoutesCmd)
-	cli.NodeCmd.AddCommand(cli.EnableRouteCmd)
+	cli.RoutesCmd.AddCommand(cli.ListRoutesCmd)
+	cli.RoutesCmd.AddCommand(cli.EnableRouteCmd)
 
 	cli.PreauthkeysCmd.AddCommand(cli.ListPreAuthKeys)
 	cli.PreauthkeysCmd.AddCommand(cli.CreatePreAuthKeyCmd)
+
 	cli.CreatePreAuthKeyCmd.PersistentFlags().Bool("reusable", false, "Make the preauthkey reusable")
 	cli.CreatePreAuthKeyCmd.Flags().StringP("expiration", "e", "", "Human-readable expiration of the key (30m, 24h, 365d...)")
 

--- a/cmd/headscale/headscale.go
+++ b/cmd/headscale/headscale.go
@@ -92,16 +92,28 @@ func main() {
 	headscaleCmd.AddCommand(versionCmd)
 
 	cli.NodeCmd.PersistentFlags().StringP("namespace", "n", "", "Namespace")
-	cli.NodeCmd.MarkPersistentFlagRequired("namespace")
+	err = cli.NodeCmd.MarkPersistentFlagRequired("namespace")
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
 
 	cli.PreauthkeysCmd.PersistentFlags().StringP("namespace", "n", "", "Namespace")
-	cli.PreauthkeysCmd.MarkPersistentFlagRequired("namespace")
+	err = cli.PreauthkeysCmd.MarkPersistentFlagRequired("namespace")
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
 
 	cli.RegisterCmd.PersistentFlags().StringP("namespace", "n", "", "Namespace")
-	cli.RegisterCmd.MarkPersistentFlagRequired("namespace")
+	err = cli.RegisterCmd.MarkPersistentFlagRequired("namespace")
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
 
 	cli.RoutesCmd.PersistentFlags().StringP("namespace", "n", "", "Namespace")
-	cli.RoutesCmd.MarkPersistentFlagRequired("namespace")
+	err = cli.RoutesCmd.MarkPersistentFlagRequired("namespace")
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
 
 	cli.NamespaceCmd.AddCommand(cli.CreateNamespaceCmd)
 	cli.NamespaceCmd.AddCommand(cli.ListNamespacesCmd)


### PR DESCRIPTION
This PR changes how namespaces are specified in the commands of Headscale. Basically mimicking how `kubectl` behaves. 