### PR TITLE
List nodes in namespace + register under node command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Suggestions/PRs welcomed!
 
 8. In the server, register your machine to a namespace with the CLI
   ```shell
-  ./headscale -n myfirstnamespace register YOURMACHINEKEY
+  ./headscale -n myfirstnamespace node register YOURMACHINEKEY
   ```
 
 ## Configuration reference

--- a/api.go
+++ b/api.go
@@ -43,7 +43,7 @@ func (h *Headscale) RegisterWebAPI(c *gin.Context) {
 
 	<p>
 		<code>
-			<b>headscale register %s</b>
+			<b>headscale -n NAMESPACE node register %s</b>
 		</code>
 	</p>
 

--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -35,6 +35,32 @@ var RegisterCmd = &cobra.Command{
 	},
 }
 
+var ListNodesCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List the nodes in a given namespace",
+	Run: func(cmd *cobra.Command, args []string) {
+		n, err := cmd.Flags().GetString("namespace")
+		if err != nil {
+			log.Fatalf("Error getting namespace: %s", err)
+		}
+
+		h, err := getHeadscaleApp()
+		if err != nil {
+			log.Fatalf("Error initializing: %s", err)
+		}
+		machines, err := h.ListMachinesInNamespace(n)
+		if err != nil {
+			log.Fatalf("Error getting nodes: %s", err)
+		}
+
+		fmt.Printf("name\tlast seen")
+		for _, m := range *machines {
+			fmt.Printf("%s\t%s\n", m.Name, m.LastSeen.Format("2006-01-02 15:04:05"))
+		}
+
+	},
+}
+
 var NodeCmd = &cobra.Command{
 	Use:   "node",
 	Short: "Manage the nodes of Headscale",

--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -53,7 +53,7 @@ var ListNodesCmd = &cobra.Command{
 			log.Fatalf("Error getting nodes: %s", err)
 		}
 
-		fmt.Printf("name\tlast seen")
+		fmt.Printf("name\t\tlast seen\n")
 		for _, m := range *machines {
 			fmt.Printf("%s\t%s\n", m.Name, m.LastSeen.Format("2006-01-02 15:04:05"))
 		}

--- a/cmd/headscale/headscale.go
+++ b/cmd/headscale/headscale.go
@@ -86,7 +86,6 @@ func main() {
 	headscaleCmd.AddCommand(cli.NamespaceCmd)
 	headscaleCmd.AddCommand(cli.NodeCmd)
 	headscaleCmd.AddCommand(cli.PreauthkeysCmd)
-	headscaleCmd.AddCommand(cli.RegisterCmd)
 	headscaleCmd.AddCommand(cli.RoutesCmd)
 	headscaleCmd.AddCommand(cli.ServeCmd)
 	headscaleCmd.AddCommand(versionCmd)
@@ -103,12 +102,6 @@ func main() {
 		log.Fatalf(err.Error())
 	}
 
-	cli.RegisterCmd.PersistentFlags().StringP("namespace", "n", "", "Namespace")
-	err = cli.RegisterCmd.MarkPersistentFlagRequired("namespace")
-	if err != nil {
-		log.Fatalf(err.Error())
-	}
-
 	cli.RoutesCmd.PersistentFlags().StringP("namespace", "n", "", "Namespace")
 	err = cli.RoutesCmd.MarkPersistentFlagRequired("namespace")
 	if err != nil {
@@ -117,6 +110,9 @@ func main() {
 
 	cli.NamespaceCmd.AddCommand(cli.CreateNamespaceCmd)
 	cli.NamespaceCmd.AddCommand(cli.ListNamespacesCmd)
+
+	cli.NodeCmd.AddCommand(cli.ListNodesCmd)
+	cli.NodeCmd.AddCommand(cli.RegisterCmd)
 
 	cli.RoutesCmd.AddCommand(cli.ListRoutesCmd)
 	cli.RoutesCmd.AddCommand(cli.EnableRouteCmd)


### PR DESCRIPTION
Implements #14 (need to add more info + json output, but basics are there). Also `register` cmd is now under `node` (I reckon makes more sense)