### PR TITLE
Added JSON-formatted output to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ An open source implementation of the Tailscale coordination server.
 
 ## Overview
 
-Tailscale is [a modern VPN](https://tailscale.com/) built on top of [Wireguard](https://www.wireguard.com/). It [works like an overlay network](https://tailscale.com/blog/how-tailscale-works/) between the computers of your networks - using all kinds of [NAT traversal sorcery](https://tailscale.com/blog/how-nat-traversal-works/). 
+Tailscale is [a modern VPN](https://tailscale.com/) built on top of [Wireguard](https://www.wireguard.com/). It [works like an overlay network](https://tailscale.com/blog/how-tailscale-works/) between the computers of your networks - using all kinds of [NAT traversal sorcery](https://tailscale.com/blog/how-nat-traversal-works/).
 
-Everything in Tailscale is Open Source, except the GUI clients for proprietary OS (Windows and macOS/iOS), and the 'coordination/control server'. 
+Everything in Tailscale is Open Source, except the GUI clients for proprietary OS (Windows and macOS/iOS), and the 'coordination/control server'.
 
 The control server works as an exchange point of cryptographic public keys for the nodes in the Tailscale network. It also assigns the IP addresses of the clients, creates the boundaries between each user, enables sharing machines between users, and exposes the advertised routes of your nodes.
 
@@ -20,7 +20,7 @@ Headscale implements this coordination server.
 - [x] Node registration through the web flow
 - [x] Network changes are relied to the nodes
 - [x] ~~Multiuser~~ Namespace support
-- [x] Basic routing (advertise & accept) 
+- [x] Basic routing (advertise & accept)
 - [ ] Share nodes between ~~users~~ namespaces
 - [x] Node registration via pre-auth keys
 - [X] JSON-formatted output
@@ -43,10 +43,10 @@ Suggestions/PRs welcomed!
   ```shell
   make
   ```
-  
+
 2. Get yourself a PostgreSQL DB running (yes, [I know](https://tailscale.com/blog/an-unlikely-database-migration/))
 
-  ```shell 
+  ```shell
   docker run --name headscale -e POSTGRES_DB=headscale -e \
     POSTGRES_USER=foo -e POSTGRES_PASSWORD=bar -p 5432:5432 -d postgres
   ```
@@ -54,7 +54,7 @@ Suggestions/PRs welcomed!
 3. Set some stuff up (headscale Wireguard keys & the config.json file)
   ```shell
   wg genkey > private.key
-  wg pubkey < private.key > public.key  # not needed 
+  wg pubkey < private.key > public.key  # not needed
   cp config.json.example config.json
   ```
 
@@ -67,7 +67,7 @@ Suggestions/PRs welcomed!
   ```shell
   ./headscale serve
   ```
-  
+
 6. Add your first machine
   ```shell
   tailscale up -login-server YOUR_HEADSCALE_URL
@@ -148,15 +148,15 @@ To get a certificate automatically via [Let's Encrypt](https://letsencrypt.org/)
 
 ## Disclaimer
 
-1. We have nothing to do with Tailscale, or Tailscale Inc. 
+1. We have nothing to do with Tailscale, or Tailscale Inc.
 2. The purpose of writing this was to learn how Tailscale works.
-3. ~~I don't use Headscale myself.~~ 
+3. ~~I don't use Headscale myself.~~
 
 
 
-## More on Tailscale 
+## More on Tailscale
 
 - https://tailscale.com/blog/how-tailscale-works/
 - https://tailscale.com/blog/tailscale-key-management/
-- https://tailscale.com/blog/an-unlikely-database-migration/ 
+- https://tailscale.com/blog/an-unlikely-database-migration/
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Headscale implements this coordination server.
 - [x] Basic routing (advertise & accept) 
 - [ ] Share nodes between ~~users~~ namespaces
 - [x] Node registration via pre-auth keys
+- [X] JSON-formatted output
 - [ ] ACLs
 - [ ] DNS
 
@@ -79,6 +80,22 @@ Suggestions/PRs welcomed!
   ./headscale -n myfirstnamespace node register YOURMACHINEKEY
   ```
 
+Alternatively, you can use Auth Keys to register your machines:
+
+1. Create an authkey
+    ```shell
+    ./headscale -n myfirstnamespace preauthkey create --reusable --expiration 24h
+    ```
+
+2. Use the authkey from your machine to register it
+   ```shell
+   tailscale up -login-server YOUR_HEADSCALE_URL --authkey YOURAUTHKEY
+   ```
+
+
+Please bear in mind that all the commands from headscale support adding `-o json` or `-o json-line`  to get a nicely JSON-formatted output.
+
+
 ## Configuration reference
 
 Headscale's configuration file is named `config.json` or `config.yaml`. Headscale will look for it in `/etc/headscale`, `~/.headscale` and finally the directory from where the Headscale binary is executed.
@@ -131,7 +148,15 @@ To get a certificate automatically via [Let's Encrypt](https://letsencrypt.org/)
 
 ## Disclaimer
 
-1. I have nothing to do with Tailscale, or Tailscale Inc. 
+1. We have nothing to do with Tailscale, or Tailscale Inc. 
 2. The purpose of writing this was to learn how Tailscale works.
-3. I don't use Headscale myself.
+3. ~~I don't use Headscale myself.~~ 
+
+
+
+## More on Tailscale 
+
+- https://tailscale.com/blog/how-tailscale-works/
+- https://tailscale.com/blog/tailscale-key-management/
+- https://tailscale.com/blog/an-unlikely-database-migration/ 
 

--- a/cmd/headscale/cli/namespaces.go
+++ b/cmd/headscale/cli/namespaces.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -22,16 +23,21 @@ var CreateNamespaceCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		o, _ := cmd.Flags().GetString("output")
 		h, err := getHeadscaleApp()
 		if err != nil {
 			log.Fatalf("Error initializing: %s", err)
 		}
-		_, err = h.CreateNamespace(args[0])
-		if err != nil {
-			fmt.Println(err)
+		namespace, err := h.CreateNamespace(args[0])
+		if strings.HasPrefix(o, "json") {
+			jsonOutput(namespace, err, o)
 			return
 		}
-		fmt.Printf("Ook.\n")
+		if err != nil {
+			fmt.Printf("Error creating namespace: %s\n", err)
+			return
+		}
+		fmt.Printf("Namespace created\n")
 	},
 }
 
@@ -39,17 +45,22 @@ var ListNamespacesCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all the namespaces",
 	Run: func(cmd *cobra.Command, args []string) {
+		o, _ := cmd.Flags().GetString("output")
 		h, err := getHeadscaleApp()
 		if err != nil {
 			log.Fatalf("Error initializing: %s", err)
 		}
-		ns, err := h.ListNamespaces()
+		namespaces, err := h.ListNamespaces()
+		if strings.HasPrefix(o, "json") {
+			jsonOutput(namespaces, err, o)
+			return
+		}
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
 		fmt.Printf("ID\tName\n")
-		for _, n := range *ns {
+		for _, n := range *namespaces {
 			fmt.Printf("%d\t%s\n", n.ID, n.Name)
 		}
 	},

--- a/cmd/headscale/cli/namespaces.go
+++ b/cmd/headscale/cli/namespaces.go
@@ -30,7 +30,7 @@ var CreateNamespaceCmd = &cobra.Command{
 		}
 		namespace, err := h.CreateNamespace(args[0])
 		if strings.HasPrefix(o, "json") {
-			jsonOutput(namespace, err, o)
+			JsonOutput(namespace, err, o)
 			return
 		}
 		if err != nil {
@@ -52,7 +52,7 @@ var ListNamespacesCmd = &cobra.Command{
 		}
 		namespaces, err := h.ListNamespaces()
 		if strings.HasPrefix(o, "json") {
-			jsonOutput(namespaces, err, o)
+			JsonOutput(namespaces, err, o)
 			return
 		}
 		if err != nil {

--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -21,17 +22,22 @@ var RegisterCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error getting namespace: %s", err)
 		}
+		o, _ := cmd.Flags().GetString("output")
 
 		h, err := getHeadscaleApp()
 		if err != nil {
 			log.Fatalf("Error initializing: %s", err)
 		}
-		err = h.RegisterMachine(args[0], n)
-		if err != nil {
-			fmt.Printf("Error: %s", err)
+		m, err := h.RegisterMachine(args[0], n)
+		if strings.HasPrefix(o, "json") {
+			jsonOutput(m, err, o)
 			return
 		}
-		fmt.Println("Ook.")
+		if err != nil {
+			fmt.Printf("Cannot register machine: %s\n", err)
+			return
+		}
+		fmt.Printf("Machine registered\n")
 	},
 }
 

--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -49,12 +49,18 @@ var ListNodesCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error getting namespace: %s", err)
 		}
+		o, _ := cmd.Flags().GetString("output")
 
 		h, err := getHeadscaleApp()
 		if err != nil {
 			log.Fatalf("Error initializing: %s", err)
 		}
 		machines, err := h.ListMachinesInNamespace(n)
+		if strings.HasPrefix(o, "json") {
+			jsonOutput(machines, err, o)
+			return
+		}
+
 		if err != nil {
 			log.Fatalf("Error getting nodes: %s", err)
 		}

--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -30,7 +30,7 @@ var RegisterCmd = &cobra.Command{
 		}
 		m, err := h.RegisterMachine(args[0], n)
 		if strings.HasPrefix(o, "json") {
-			jsonOutput(m, err, o)
+			JsonOutput(m, err, o)
 			return
 		}
 		if err != nil {
@@ -57,7 +57,7 @@ var ListNodesCmd = &cobra.Command{
 		}
 		machines, err := h.ListMachinesInNamespace(n)
 		if strings.HasPrefix(o, "json") {
-			jsonOutput(machines, err, o)
+			JsonOutput(machines, err, o)
 			return
 		}
 

--- a/cmd/headscale/cli/preauthkeys.go
+++ b/cmd/headscale/cli/preauthkeys.go
@@ -31,7 +31,7 @@ var ListPreAuthKeys = &cobra.Command{
 		}
 		keys, err := h.GetPreAuthKeys(n)
 		if strings.HasPrefix(o, "json") {
-			jsonOutput(keys, err, o)
+			JsonOutput(keys, err, o)
 			return
 		}
 
@@ -85,7 +85,7 @@ var CreatePreAuthKeyCmd = &cobra.Command{
 
 		k, err := h.CreatePreAuthKey(n, reusable, expiration)
 		if strings.HasPrefix(o, "json") {
-			jsonOutput(k, err, o)
+			JsonOutput(k, err, o)
 			return
 		}
 		if err != nil {

--- a/cmd/headscale/cli/preauthkeys.go
+++ b/cmd/headscale/cli/preauthkeys.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hako/durafmt"
@@ -22,14 +23,20 @@ var ListPreAuthKeys = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error getting namespace: %s", err)
 		}
+		o, _ := cmd.Flags().GetString("output")
 
 		h, err := getHeadscaleApp()
 		if err != nil {
 			log.Fatalf("Error initializing: %s", err)
 		}
 		keys, err := h.GetPreAuthKeys(n)
+		if strings.HasPrefix(o, "json") {
+			jsonOutput(keys, err, o)
+			return
+		}
+
 		if err != nil {
-			fmt.Println(err)
+			fmt.Printf("Error getting the list of keys: %s\n", err)
 			return
 		}
 		for _, k := range *keys {
@@ -57,6 +64,7 @@ var CreatePreAuthKeyCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error getting namespace: %s", err)
 		}
+		o, _ := cmd.Flags().GetString("output")
 
 		h, err := getHeadscaleApp()
 		if err != nil {
@@ -75,11 +83,15 @@ var CreatePreAuthKeyCmd = &cobra.Command{
 			expiration = &exp
 		}
 
-		_, err = h.CreatePreAuthKey(n, reusable, expiration)
+		k, err := h.CreatePreAuthKey(n, reusable, expiration)
+		if strings.HasPrefix(o, "json") {
+			jsonOutput(k, err, o)
+			return
+		}
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
-		fmt.Printf("Ook.\n")
+		fmt.Printf("Key: %s\n", k.Key)
 	},
 }

--- a/cmd/headscale/cli/routes.go
+++ b/cmd/headscale/cli/routes.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -26,16 +27,24 @@ var ListRoutesCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error getting namespace: %s", err)
 		}
+		o, _ := cmd.Flags().GetString("output")
 
 		h, err := getHeadscaleApp()
 		if err != nil {
 			log.Fatalf("Error initializing: %s", err)
 		}
 		routes, err := h.GetNodeRoutes(n, args[0])
+
+		if strings.HasPrefix(o, "json") {
+			jsonOutput(routes, err, o)
+			return
+
+		}
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
+
 		fmt.Println(routes)
 	},
 }
@@ -54,15 +63,22 @@ var EnableRouteCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error getting namespace: %s", err)
 		}
+		o, _ := cmd.Flags().GetString("output")
 
 		h, err := getHeadscaleApp()
 		if err != nil {
 			log.Fatalf("Error initializing: %s", err)
 		}
-		err = h.EnableNodeRoute(n, args[0], args[1])
+		route, err := h.EnableNodeRoute(n, args[0], args[1])
+		if strings.HasPrefix(o, "json") {
+			jsonOutput(route, err, o)
+			return
+		}
+
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
+		fmt.Printf("Enabled route %s\n", route)
 	},
 }

--- a/cmd/headscale/cli/routes.go
+++ b/cmd/headscale/cli/routes.go
@@ -36,10 +36,10 @@ var ListRoutesCmd = &cobra.Command{
 		routes, err := h.GetNodeRoutes(n, args[0])
 
 		if strings.HasPrefix(o, "json") {
-			jsonOutput(routes, err, o)
+			JsonOutput(routes, err, o)
 			return
-
 		}
+
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -71,7 +71,7 @@ var EnableRouteCmd = &cobra.Command{
 		}
 		route, err := h.EnableNodeRoute(n, args[0], args[1])
 		if strings.HasPrefix(o, "json") {
-			jsonOutput(route, err, o)
+			JsonOutput(route, err, o)
 			return
 		}
 

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -79,7 +79,7 @@ func loadDerpMap(path string) (*tailcfg.DERPMap, error) {
 	return &derpMap, err
 }
 
-func jsonOutput(result interface{}, errResult error, outputFormat string) {
+func JsonOutput(result interface{}, errResult error, outputFormat string) {
 	var j []byte
 	var err error
 	switch outputFormat {

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -12,6 +14,10 @@ import (
 	"gopkg.in/yaml.v2"
 	"tailscale.com/tailcfg"
 )
+
+type ErrorOutput struct {
+	Error string
+}
 
 func absPath(path string) string {
 	// If a relative path is provided, prefix it with the the directory where
@@ -71,4 +77,36 @@ func loadDerpMap(path string) (*tailcfg.DERPMap, error) {
 	}
 	err = yaml.Unmarshal(b, &derpMap)
 	return &derpMap, err
+}
+
+func jsonOutput(result interface{}, errResult error, outputFormat string) {
+	var j []byte
+	var err error
+	switch outputFormat {
+	case "json":
+		if errResult != nil {
+			j, err = json.MarshalIndent(ErrorOutput{errResult.Error()}, "", "\t")
+			if err != nil {
+				log.Fatalln(err)
+			}
+		} else {
+			j, err = json.MarshalIndent(result, "", "\t")
+			if err != nil {
+				log.Fatalln(err)
+			}
+		}
+	case "json-line":
+		if errResult != nil {
+			j, err = json.Marshal(ErrorOutput{errResult.Error()})
+			if err != nil {
+				log.Fatalln(err)
+			}
+		} else {
+			j, err = json.Marshal(result)
+			if err != nil {
+				log.Fatalln(err)
+			}
+		}
+	}
+	fmt.Println(string(j))
 }

--- a/cmd/headscale/headscale.go
+++ b/cmd/headscale/headscale.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -20,27 +19,12 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version.",
 	Long:  "The version of headscale.",
 	Run: func(cmd *cobra.Command, args []string) {
-
 		o, _ := cmd.Flags().GetString("output")
-		switch o {
-		case "":
-			fmt.Println(version)
-		case "json":
-			j, err := json.MarshalIndent(map[string]string{"version": version}, "", "\t")
-			if err != nil {
-				log.Fatalln(err)
-			}
-			fmt.Println(string(j))
-
-		case "json-line":
-			j, err := json.Marshal(map[string]string{"version": version})
-			if err != nil {
-				log.Fatalln(err)
-			}
-			fmt.Println(string(j))
-		default:
-			fmt.Printf("Unknown format %s\n", o)
+		if strings.HasPrefix(o, "json") {
+			cli.JsonOutput(map[string]string{"version": version}, nil, o)
+			return
 		}
+		fmt.Println(version)
 	},
 }
 

--- a/utils.go
+++ b/utils.go
@@ -105,8 +105,8 @@ func getRandomIP() (*net.IP, error) {
 	ipo, ipnet, err := net.ParseCIDR("100.64.0.0/10")
 	if err == nil {
 		ip := ipo.To4()
-		fmt.Println("In Randomize IPAddr: IP ", ip, " IPNET: ", ipnet)
-		fmt.Println("Final address is ", ip)
+		// fmt.Println("In Randomize IPAddr: IP ", ip, " IPNET: ", ipnet)
+		// fmt.Println("Final address is ", ip)
 		// fmt.Println("Broadcast address is ", ipb)
 		// fmt.Println("Network address is ", ipn)
 		r := mathrand.Uint32()
@@ -119,7 +119,7 @@ func getRandomIP() (*net.IP, error) {
 			ip[i] = ip[i] + (v &^ ipnet.Mask[i])
 			// fmt.Println("IP After: ", ip[i])
 		}
-		fmt.Println("FINAL IP: ", ip.String())
+		// fmt.Println("FINAL IP: ", ip.String())
 		return &ip, nil
 	}
 


### PR DESCRIPTION
This series of commits add support for a basic JSON output in all the Headscale commands.

The structure of the JSON is veeeery subject to changes, but this should help with the development of integration tests + automating the deployments of headscale.