### PR TITLE
Add a DestroyNamespace command and tests for the Namespace functions.

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,52 @@
+package headscale
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	_ "github.com/jinzhu/gorm/dialects/sqlite" // sql driver
+
+	"gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+var _ = check.Suite(&Suite{})
+
+type Suite struct{}
+
+var tmpDir string
+var h Headscale
+
+func (s *Suite) SetUpTest(c *check.C) {
+	s.ResetDB(c)
+}
+
+func (s *Suite) TearDownTest(c *check.C) {
+	os.RemoveAll(tmpDir)
+}
+
+func (s *Suite) ResetDB(c *check.C) {
+	if len(tmpDir) != 0 {
+		os.RemoveAll(tmpDir)
+	}
+	var err error
+	tmpDir, err = ioutil.TempDir("", "autoygg-client-test")
+	if err != nil {
+		c.Fatal(err)
+	}
+	cfg := Config{}
+
+	h = Headscale{
+		cfg:      cfg,
+		dbType:   "sqlite3",
+		dbString: tmpDir + "/headscale_test.db",
+	}
+	err = h.initDB()
+	if err != nil {
+		c.Fatal(err)
+	}
+}

--- a/cmd/headscale/cli/namespaces.go
+++ b/cmd/headscale/cli/namespaces.go
@@ -41,6 +41,34 @@ var CreateNamespaceCmd = &cobra.Command{
 	},
 }
 
+var DestroyNamespaceCmd = &cobra.Command{
+	Use:   "destroy NAME",
+	Short: "Destroys a namespace",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return fmt.Errorf("Missing parameters")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		o, _ := cmd.Flags().GetString("output")
+		h, err := getHeadscaleApp()
+		if err != nil {
+			log.Fatalf("Error initializing: %s", err)
+		}
+		err = h.DestroyNamespace(args[0])
+		if strings.HasPrefix(o, "json") {
+			JsonOutput(map[string]string{"Result": "Namespace destroyed"}, err, o)
+			return
+		}
+		if err != nil {
+			fmt.Printf("Error destroying namespace: %s\n", err)
+			return
+		}
+		fmt.Printf("Namespace destroyed\n")
+	},
+}
+
 var ListNamespacesCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all the namespaces",

--- a/cmd/headscale/headscale.go
+++ b/cmd/headscale/headscale.go
@@ -115,6 +115,7 @@ func main() {
 
 	cli.NamespaceCmd.AddCommand(cli.CreateNamespaceCmd)
 	cli.NamespaceCmd.AddCommand(cli.ListNamespacesCmd)
+	cli.NamespaceCmd.AddCommand(cli.DestroyNamespaceCmd)
 
 	cli.NodeCmd.AddCommand(cli.ListNodesCmd)
 	cli.NodeCmd.AddCommand(cli.RegisterCmd)

--- a/namespaces_test.go
+++ b/namespaces_test.go
@@ -1,0 +1,57 @@
+package headscale
+
+import (
+	//_ "github.com/jinzhu/gorm/dialects/sqlite" // sql driver
+
+	"gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&Suite{})
+
+func (s *Suite) TestCreateAndDestroyNamespace(c *check.C) {
+	n, err := h.CreateNamespace("test")
+	c.Assert(err, check.IsNil)
+	c.Assert(n.Name, check.Equals, "test")
+
+	ns, err := h.ListNamespaces()
+	c.Assert(err, check.IsNil)
+	c.Assert(len(*ns), check.Equals, 1)
+
+	err = h.DestroyNamespace("test")
+	c.Assert(err, check.IsNil)
+
+	_, err = h.GetNamespace("test")
+	c.Assert(err, check.NotNil)
+}
+
+func (s *Suite) TestDestroyNamespaceErrors(c *check.C) {
+	err := h.DestroyNamespace("test")
+	c.Assert(err, check.Equals, errorNamespaceNotFound)
+
+	n, err := h.CreateNamespace("test")
+	c.Assert(err, check.IsNil)
+
+	pak, err := h.CreatePreAuthKey(n.Name, false, nil)
+	c.Assert(err, check.IsNil)
+
+	db, err := h.db()
+	if err != nil {
+		c.Fatal(err)
+	}
+	defer db.Close()
+	m := Machine{
+		ID:             0,
+		MachineKey:     "foo",
+		NodeKey:        "bar",
+		DiscoKey:       "faa",
+		Name:           "testmachine",
+		NamespaceID:    n.ID,
+		Registered:     true,
+		RegisterMethod: "authKey",
+		AuthKeyID:      uint(pak.ID),
+	}
+	db.Save(&m)
+
+	err = h.DestroyNamespace("test")
+	c.Assert(err, check.Equals, errorNamespaceNotEmpty)
+}

--- a/preauth_keys_test.go
+++ b/preauth_keys_test.go
@@ -1,51 +1,10 @@
 package headscale
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"testing"
 	"time"
-
-	_ "github.com/jinzhu/gorm/dialects/sqlite" // sql driver
 
 	"gopkg.in/check.v1"
 )
-
-func Test(t *testing.T) {
-	check.TestingT(t)
-}
-
-var _ = check.Suite(&Suite{})
-
-type Suite struct{}
-
-var tmpDir string
-var h Headscale
-
-func (s *Suite) SetUpSuite(c *check.C) {
-	var err error
-	tmpDir, err = ioutil.TempDir("", "autoygg-client-test")
-	if err != nil {
-		c.Fatal(err)
-	}
-	fmt.Printf("tmpDir is %s\n", tmpDir)
-	cfg := Config{}
-
-	h = Headscale{
-		cfg:      cfg,
-		dbType:   "sqlite3",
-		dbString: tmpDir + "/headscale_test.db",
-	}
-	err = h.initDB()
-	if err != nil {
-		c.Fatal(err)
-	}
-}
-
-func (s *Suite) TearDownSuite(c *check.C) {
-	os.RemoveAll(tmpDir)
-}
 
 func (*Suite) TestCreatePreAuthKey(c *check.C) {
 	_, err := h.CreatePreAuthKey("bogus", true, nil)


### PR DESCRIPTION
This also reorganizes the test infrastructure a bit, moving the shared functions to app_test.go