### PR TITLE
Change all commands to plural words

### DIFF
--- a/cmd/headscale/cli/namespaces.go
+++ b/cmd/headscale/cli/namespaces.go
@@ -9,7 +9,7 @@ import (
 )
 
 var NamespaceCmd = &cobra.Command{
-	Use:   "namespace",
+	Use:   "namespaces",
 	Short: "Manage the namespaces of Headscale",
 }
 

--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -9,6 +9,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var NodeCmd = &cobra.Command{
+	Use:   "nodes",
+	Short: "Manage the nodes of Headscale",
+}
+
 var RegisterCmd = &cobra.Command{
 	Use:   "register machineID",
 	Short: "Registers a machine to your network",
@@ -80,9 +85,4 @@ var ListNodesCmd = &cobra.Command{
 		}
 
 	},
-}
-
-var NodeCmd = &cobra.Command{
-	Use:   "node",
-	Short: "Manage the nodes of Headscale",
 }

--- a/cmd/headscale/cli/preauthkeys.go
+++ b/cmd/headscale/cli/preauthkeys.go
@@ -11,7 +11,7 @@ import (
 )
 
 var PreauthkeysCmd = &cobra.Command{
-	Use:   "preauthkey",
+	Use:   "preauthkeys",
 	Short: "Handle the preauthkeys in Headscale",
 }
 


### PR DESCRIPTION
Before this PR some commands in Headscale were plural (e.g. `routes`) while others were singular (e.g. `namespace`).

This single commit changes all the available commands into plural words.