### PR TITLE
Update DERP server definitions

### DIFF
--- a/derp.yaml
+++ b/derp.yaml
@@ -1,5 +1,5 @@
 # This file contains some of the official Tailscale DERP servers, 
-# shamelessly taken from https://github.com/tailscale/tailscale/blob/main/derp/derpmap/derpmap.go
+# shamelessly taken from https://github.com/tailscale/tailscale/blob/main/net/dnsfallback/dns-fallback-servers.json
 #
 # If you plan to somehow use headscale, please deploy your own DERP infra
 regions: 
@@ -16,6 +16,14 @@ regions:
       stunport: 0
       stunonly: false
       derptestport: 0
+    - name: 1b
+      regionid: 1
+      hostname: derp1b.tailscale.com
+      ipv4: 45.55.35.93
+      ipv6: "2604:a880:800:a1::f:2001"
+      stunport: 0
+      stunonly: false
+      derptestport: 0
   2:
     regionid: 2
     regioncode: sfo
@@ -26,6 +34,14 @@ regions:
       hostname: derp2.tailscale.com
       ipv4: 167.172.206.31
       ipv6: "2604:a880:2:d1::c5:7001"
+      stunport: 0
+      stunonly: false
+      derptestport: 0
+    - name: 2b
+      regionid: 2
+      hostname: derp2b.tailscale.com
+      ipv4: 64.227.106.23
+      ipv6: "2604:a880:4:1d0::29:9000"
       stunport: 0
       stunonly: false
       derptestport: 0
@@ -52,6 +68,79 @@ regions:
       hostname: derp4.tailscale.com
       ipv4: 167.172.182.26
       ipv6: "2a03:b0c0:3:e0::36e:900"
+      stunport: 0
+      stunonly: false
+      derptestport: 0
+    - name: 4b
+      regionid: 4
+      hostname: derp4b.tailscale.com
+      ipv4: 157.230.25.0
+      ipv6: "2a03:b0c0:3:e0::58f:3001"
+      stunport: 0
+      stunonly: false
+      derptestport: 0
+  5:
+    regionid: 5
+    regioncode: syd
+    regionname: Sydney
+    nodes:
+    - name: 5a
+      regionid: 5
+      hostname: derp5.tailscale.com
+      ipv4: 103.43.75.49
+      ipv6: "2001:19f0:5801:10b7:5400:2ff:feaa:284c"
+      stunport: 0
+      stunonly: false
+      derptestport: 0
+  6:
+    regionid: 6
+    regioncode: blr
+    regionname: Bangalore
+    nodes:
+    - name: 6a
+      regionid: 6
+      hostname: derp6.tailscale.com
+      ipv4: 68.183.90.120
+      ipv6: "2400:6180:100:d0::982:d001"
+      stunport: 0
+      stunonly: false
+      derptestport: 0
+  7:
+    regionid: 7
+    regioncode: tok
+    regionname: Tokyo
+    nodes:
+    - name: 7a
+      regionid: 7
+      hostname: derp7.tailscale.com
+      ipv4: 167.179.89.145
+      ipv6: "2401:c080:1000:467f:5400:2ff:feee:22aa"
+      stunport: 0
+      stunonly: false
+      derptestport: 0
+  8:
+    regionid: 8
+    regioncode: lhr
+    regionname: London
+    nodes:
+    - name: 8a
+      regionid: 8
+      hostname: derp8.tailscale.com
+      ipv4: 167.71.139.179
+      ipv6: "2a03:b0c0:1:e0::3cc:e001"
+      stunport: 0
+      stunonly: false
+      derptestport: 0
+  9:
+    regionid: 9
+    regioncode: sao
+    regionname: São Paulo
+    nodes:
+    - name: 9a
+      regionid: 9
+      hostname: derp9.tailscale.com
+      ipv4: 207.148.3.137
+      ipv6: "2001:19f0:6401:1d9c:5400:2ff:feef:bb82"
       stunport: 0
       stunonly: false
       derptestport: 0


### PR DESCRIPTION
The repo link referenced in derp.yaml is invalid and is missing the new DERP addresses.
This PR updates the file to use the newest tailscale DERP servers and updates the link in the comment.

Out of curiousity is `stunonly` always `false`, and `derptestport` always `0`?
`stunport`, `stunonly`, and `derptestport` have no references in the code so not sure if these fields are still needed.