### PR TITLE
Improving namespace/user support 

### DIFF
--- a/app.go
+++ b/app.go
@@ -175,7 +175,7 @@ func (h *Headscale) Serve() error {
 			}()
 			err = s.ListenAndServeTLS("", "")
 		} else {
-			return errors.New("Unknown value for TLSLetsEncryptChallengeType")
+			return errors.New("unknown value for TLSLetsEncryptChallengeType")
 		}
 	} else if h.cfg.TLSCertPath == "" {
 		if !strings.HasPrefix(h.cfg.ServerURL, "http://") {

--- a/machine.go
+++ b/machine.go
@@ -154,7 +154,6 @@ func (m Machine) toNode() (*tailcfg.Node, error) {
 }
 
 func (h *Headscale) getPeers(m Machine) (*[]*tailcfg.Node, error) {
-
 	machines := []Machine{}
 	if err := h.db.Where("namespace_id = ? AND machine_key <> ? AND registered",
 		m.NamespaceID, m.MachineKey).Find(&machines).Error; err != nil {

--- a/namespaces.go
+++ b/namespaces.go
@@ -106,10 +106,10 @@ func (h *Headscale) SetMachineNamespace(m *Machine, namespaceName string) error 
 func (n *Namespace) toUser() *tailcfg.User {
 	u := tailcfg.User{
 		ID:            tailcfg.UserID(n.ID),
-		LoginName:     "",
+		LoginName:     n.Name,
 		DisplayName:   n.Name,
 		ProfilePicURL: "",
-		Domain:        "",
+		Domain:        "headscale.net",
 		Logins:        []tailcfg.LoginID{},
 		Created:       time.Time{},
 	}


### PR DESCRIPTION
This PR shows sends to the clients the namespace name in the same struct as Tailscale.com sends the user info, so when doing `tailscale status` the namespace is shown.