### PR TITLE
Use 8080 as default port in the example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Please bear in mind that all the commands from headscale support adding `-o json
 Headscale's configuration file is named `config.json` or `config.yaml`. Headscale will look for it in `/etc/headscale`, `~/.headscale` and finally the directory from where the Headscale binary is executed.
 
 ```
-    "server_url": "http://192.168.1.12:8000",
-    "listen_addr": "0.0.0.0:8000",
+    "server_url": "http://192.168.1.12:8080",
+    "listen_addr": "0.0.0.0:8080",
 ```
 
 `server_url` is the external URL via which Headscale is reachable. `listen_addr` is the IP address and port the Headscale program should listen on.

--- a/cmd/headscale/headscale_test.go
+++ b/cmd/headscale/headscale_test.go
@@ -51,8 +51,8 @@ func (*Suite) TestPostgresConfigLoading(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Test that config file was interpreted correctly
-	c.Assert(viper.GetString("server_url"), check.Equals, "http://127.0.0.1:8000")
-	c.Assert(viper.GetString("listen_addr"), check.Equals, "0.0.0.0:8000")
+	c.Assert(viper.GetString("server_url"), check.Equals, "http://127.0.0.1:8080")
+	c.Assert(viper.GetString("listen_addr"), check.Equals, "0.0.0.0:8080")
 	c.Assert(viper.GetString("derp_map_path"), check.Equals, "derp.yaml")
 	c.Assert(viper.GetString("db_type"), check.Equals, "postgres")
 	c.Assert(viper.GetString("db_port"), check.Equals, "5432")
@@ -84,8 +84,8 @@ func (*Suite) TestSqliteConfigLoading(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// Test that config file was interpreted correctly
-	c.Assert(viper.GetString("server_url"), check.Equals, "http://127.0.0.1:8000")
-	c.Assert(viper.GetString("listen_addr"), check.Equals, "0.0.0.0:8000")
+	c.Assert(viper.GetString("server_url"), check.Equals, "http://127.0.0.1:8080")
+	c.Assert(viper.GetString("listen_addr"), check.Equals, "0.0.0.0:8080")
 	c.Assert(viper.GetString("derp_map_path"), check.Equals, "derp.yaml")
 	c.Assert(viper.GetString("db_type"), check.Equals, "sqlite3")
 	c.Assert(viper.GetString("db_path"), check.Equals, "db.sqlite")
@@ -125,7 +125,7 @@ func (*Suite) TestTLSConfigValidation(c *check.C) {
 	fmt.Println(tmp)
 
 	// Check configuration validation errors (2)
-	configYaml = []byte("---\nserver_url: \"http://127.0.0.1:8000\"\ntls_letsencrypt_hostname: \"example.com\"\ntls_letsencrypt_challenge_type: \"TLS-ALPN-01\"")
+	configYaml = []byte("---\nserver_url: \"http://127.0.0.1:8080\"\ntls_letsencrypt_hostname: \"example.com\"\ntls_letsencrypt_challenge_type: \"TLS-ALPN-01\"")
 	writeConfig(c, tmpDir, configYaml)
 	err = cli.LoadConfig(tmpDir)
 	c.Assert(err, check.IsNil)

--- a/config.json.postgres.example
+++ b/config.json.postgres.example
@@ -1,6 +1,6 @@
 {
-    "server_url": "http://127.0.0.1:8000",
-    "listen_addr": "0.0.0.0:8000",
+    "server_url": "http://127.0.0.1:8080",
+    "listen_addr": "0.0.0.0:8080",
     "private_key_path": "private.key",
     "derp_map_path": "derp.yaml",
     "ephemeral_node_inactivity_timeout": "30m",

--- a/config.json.sqlite.example
+++ b/config.json.sqlite.example
@@ -1,6 +1,6 @@
 {
-    "server_url": "http://127.0.0.1:8000",
-    "listen_addr": "0.0.0.0:8000",
+    "server_url": "http://127.0.0.1:8080",
+    "listen_addr": "0.0.0.0:8080",
     "private_key_path": "private.key",
     "derp_map_path": "derp.yaml",
     "ephemeral_node_inactivity_timeout": "30m",


### PR DESCRIPTION
We had :8000 in the examples, while the Dockerfile and Kubernetes YAMLs use :8080. 

This PR changes everything to :8080, as it is the port that had actually running software pointing at it.

This fixes #68.