### PR TITLE
Make IP Prefix configurable and available ip deterministic

### DIFF
--- a/app.go
+++ b/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"golang.org/x/crypto/acme/autocert"
 	"gorm.io/gorm"
+	"inet.af/netaddr"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/wgkey"
 )
@@ -24,6 +25,7 @@ type Config struct {
 	PrivateKeyPath                 string
 	DerpMap                        *tailcfg.DERPMap
 	EphemeralNodeInactivityTimeout time.Duration
+	IPPrefix                       netaddr.IPPrefix
 
 	DBtype string
 	DBpath string

--- a/app_test.go
+++ b/app_test.go
@@ -38,7 +38,7 @@ func (s *Suite) ResetDB(c *check.C) {
 		c.Fatal(err)
 	}
 	cfg := Config{
-		IPPrefix: netaddr.MustParseIPPrefix("127.0.0.1/32"),
+		IPPrefix: netaddr.MustParseIPPrefix("10.27.0.0/23"),
 	}
 
 	h = Headscale{

--- a/app_test.go
+++ b/app_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"gopkg.in/check.v1"
+	"inet.af/netaddr"
 )
 
 func Test(t *testing.T) {
@@ -36,7 +37,9 @@ func (s *Suite) ResetDB(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	cfg := Config{}
+	cfg := Config{
+		IPPrefix: netaddr.MustParseIPPrefix("127.0.0.1/32"),
+	}
 
 	h = Headscale{
 		cfg:      cfg,

--- a/cli_test.go
+++ b/cli_test.go
@@ -15,6 +15,7 @@ func (s *Suite) TestRegisterMachine(c *check.C) {
 		DiscoKey:    "faa",
 		Name:        "testmachine",
 		NamespaceID: n.ID,
+		IPAddress:   "10.0.0.1",
 	}
 	h.db.Save(&m)
 

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juanfont/headscale"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
+	"inet.af/netaddr"
 	"tailscale.com/tailcfg"
 )
 
@@ -35,6 +36,8 @@ func LoadConfig(path string) error {
 
 	viper.SetDefault("tls_letsencrypt_cache_dir", "/var/www/.cache")
 	viper.SetDefault("tls_letsencrypt_challenge_type", "HTTP-01")
+
+	viper.SetDefault("ip_prefix", "100.64.0.0/10")
 
 	err := viper.ReadInConfig()
 	if err != nil {
@@ -97,6 +100,7 @@ func getHeadscaleApp() (*headscale.Headscale, error) {
 		Addr:           viper.GetString("listen_addr"),
 		PrivateKeyPath: absPath(viper.GetString("private_key_path")),
 		DerpMap:        derpMap,
+		IPPrefix:       netaddr.MustParseIPPrefix(viper.GetString("ip_prefix")),
 
 		EphemeralNodeInactivityTimeout: viper.GetDuration("ephemeral_node_inactivity_timeout"),
 

--- a/utils.go
+++ b/utils.go
@@ -7,18 +7,11 @@ package headscale
 
 import (
 	"crypto/rand"
-	"encoding/binary"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"net"
-	"time"
-
-	mathrand "math/rand"
 
 	"golang.org/x/crypto/nacl/box"
-	"gorm.io/gorm"
 	"inet.af/netaddr"
 	"tailscale.com/types/wgkey"
 )
@@ -78,47 +71,73 @@ func encodeMsg(b []byte, pubKey *wgkey.Key, privKey *wgkey.Private) ([]byte, err
 	return msg, nil
 }
 
-func (h *Headscale) getAvailableIP() (*net.IP, error) {
-	i := 0
-	for {
-		ip, err := getRandomIP(h.cfg.IPPrefix)
-		if err != nil {
-			return nil, err
-		}
-		m := Machine{}
-		if result := h.db.First(&m, "ip_address = ?", ip.String()); errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return ip, nil
-		}
-		i++
-		if i == 100 { // really random number
-			break
-		}
+func (h *Headscale) getAvailableIP() (*netaddr.IP, error) {
+	ipPrefix := h.cfg.IPPrefix
+
+	usedIps, err := h.getUsedIPs()
+	if err != nil {
+		return nil, err
 	}
-	return nil, errors.New(fmt.Sprintf("Could not find an available IP address in %s", h.cfg.IPPrefix.String()))
+
+	// for _, ip := range usedIps {
+	// 	nextIP := ip.Next()
+
+	// 	if !containsIPs(usedIps, nextIP) && ipPrefix.Contains(nextIP) {
+	// 		return &nextIP, nil
+	// 	}
+	// }
+
+	// // If there are no IPs in use, we are starting fresh and
+	// // can issue IPs from the beginning of the prefix.
+	// ip := ipPrefix.IP()
+	// return &ip, nil
+
+	// return nil, fmt.Errorf("failed to find any available IP in %s", ipPrefix)
+
+	// Get the first IP in our prefix
+	ip := ipPrefix.IP()
+
+	for {
+		if !ipPrefix.Contains(ip) {
+			return nil, fmt.Errorf("could not find any suitable IP in %s", ipPrefix)
+		}
+
+		if ip.IsZero() &&
+			ip.IsLoopback() {
+			continue
+		}
+
+		if !containsIPs(usedIps, ip) {
+			return &ip, nil
+		}
+
+		ip = ip.Next()
+	}
 }
 
-func getRandomIP(ipPrefix netaddr.IPPrefix) (*net.IP, error) {
-	mathrand.Seed(time.Now().Unix())
-	ipo, ipnet, err := net.ParseCIDR(ipPrefix.String())
-	if err == nil {
-		ip := ipo.To4()
-		// fmt.Println("In Randomize IPAddr: IP ", ip, " IPNET: ", ipnet)
-		// fmt.Println("Final address is ", ip)
-		// fmt.Println("Broadcast address is ", ipb)
-		// fmt.Println("Network address is ", ipn)
-		r := mathrand.Uint32()
-		ipRaw := make([]byte, 4)
-		binary.LittleEndian.PutUint32(ipRaw, r)
-		// ipRaw[3] = 254
-		// fmt.Println("ipRaw is ", ipRaw)
-		for i, v := range ipRaw {
-			// fmt.Println("IP Before: ", ip[i], " v is ", v, " Mask is: ", ipnet.Mask[i])
-			ip[i] = ip[i] + (v &^ ipnet.Mask[i])
-			// fmt.Println("IP After: ", ip[i])
+func (h *Headscale) getUsedIPs() ([]netaddr.IP, error) {
+	var addresses []string
+	h.db.Model(&Machine{}).Pluck("ip_address", &addresses)
+
+	ips := make([]netaddr.IP, len(addresses))
+	for index, addr := range addresses {
+		ip, err := netaddr.ParseIP(addr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse ip from database, %w", err)
 		}
-		// fmt.Println("FINAL IP: ", ip.String())
-		return &ip, nil
+
+		ips[index] = ip
 	}
 
-	return nil, err
+	return ips, nil
+}
+
+func containsIPs(ips []netaddr.IP, ip netaddr.IP) bool {
+	for _, v := range ips {
+		if v == ip {
+			return true
+		}
+	}
+
+	return false
 }

--- a/utils.go
+++ b/utils.go
@@ -19,6 +19,7 @@ import (
 
 	"golang.org/x/crypto/nacl/box"
 	"gorm.io/gorm"
+	"inet.af/netaddr"
 	"tailscale.com/types/wgkey"
 )
 
@@ -80,7 +81,7 @@ func encodeMsg(b []byte, pubKey *wgkey.Key, privKey *wgkey.Private) ([]byte, err
 func (h *Headscale) getAvailableIP() (*net.IP, error) {
 	i := 0
 	for {
-		ip, err := getRandomIP()
+		ip, err := getRandomIP(h.cfg.IPPrefix)
 		if err != nil {
 			return nil, err
 		}
@@ -93,12 +94,12 @@ func (h *Headscale) getAvailableIP() (*net.IP, error) {
 			break
 		}
 	}
-	return nil, errors.New("Could not find an available IP address in 100.64.0.0/10")
+	return nil, errors.New(fmt.Sprintf("Could not find an available IP address in %s", h.cfg.IPPrefix.String()))
 }
 
-func getRandomIP() (*net.IP, error) {
+func getRandomIP(ipPrefix netaddr.IPPrefix) (*net.IP, error) {
 	mathrand.Seed(time.Now().Unix())
-	ipo, ipnet, err := net.ParseCIDR("100.64.0.0/10")
+	ipo, ipnet, err := net.ParseCIDR(ipPrefix.String())
 	if err == nil {
 		ip := ipo.To4()
 		// fmt.Println("In Randomize IPAddr: IP ", ip, " IPNET: ", ipnet)

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,105 @@
+package headscale
+
+import (
+	"gopkg.in/check.v1"
+	"inet.af/netaddr"
+)
+
+func (s *Suite) TestGetAvailableIp(c *check.C) {
+	ip, err := h.getAvailableIP()
+
+	c.Assert(err, check.IsNil)
+
+	expected := netaddr.MustParseIP("10.27.0.0")
+
+	c.Assert(ip.String(), check.Equals, expected.String())
+}
+
+func (s *Suite) TestGetUsedIps(c *check.C) {
+	ip, err := h.getAvailableIP()
+	c.Assert(err, check.IsNil)
+
+	n, err := h.CreateNamespace("test_ip")
+	c.Assert(err, check.IsNil)
+
+	pak, err := h.CreatePreAuthKey(n.Name, false, false, nil)
+	c.Assert(err, check.IsNil)
+
+	_, err = h.GetMachine("test", "testmachine")
+	c.Assert(err, check.NotNil)
+
+	m := Machine{
+		ID:             0,
+		MachineKey:     "foo",
+		NodeKey:        "bar",
+		DiscoKey:       "faa",
+		Name:           "testmachine",
+		NamespaceID:    n.ID,
+		Registered:     true,
+		RegisterMethod: "authKey",
+		AuthKeyID:      uint(pak.ID),
+		IPAddress:      ip.String(),
+	}
+	h.db.Save(&m)
+
+	ips, err := h.getUsedIPs()
+
+	c.Assert(err, check.IsNil)
+
+	expected := netaddr.MustParseIP("10.27.0.0")
+
+	c.Assert(ips[0], check.Equals, expected)
+}
+
+func (s *Suite) TestGetMultiIp(c *check.C) {
+	n, err := h.CreateNamespace("test-ip-multi")
+	c.Assert(err, check.IsNil)
+
+	for i := 1; i <= 350; i++ {
+		ip, err := h.getAvailableIP()
+		c.Assert(err, check.IsNil)
+
+		pak, err := h.CreatePreAuthKey(n.Name, false, false, nil)
+		c.Assert(err, check.IsNil)
+
+		_, err = h.GetMachine("test", "testmachine")
+		c.Assert(err, check.NotNil)
+
+		m := Machine{
+			ID:             0,
+			MachineKey:     "foo",
+			NodeKey:        "bar",
+			DiscoKey:       "faa",
+			Name:           "testmachine",
+			NamespaceID:    n.ID,
+			Registered:     true,
+			RegisterMethod: "authKey",
+			AuthKeyID:      uint(pak.ID),
+			IPAddress:      ip.String(),
+		}
+		h.db.Save(&m)
+	}
+
+	ips, err := h.getUsedIPs()
+
+	c.Assert(err, check.IsNil)
+
+	c.Assert(len(ips), check.Equals, 350)
+
+	c.Assert(ips[0], check.Equals, netaddr.MustParseIP("10.27.0.0"))
+	c.Assert(ips[9], check.Equals, netaddr.MustParseIP("10.27.0.9"))
+	c.Assert(ips[300], check.Equals, netaddr.MustParseIP("10.27.1.44"))
+
+	expectedNextIP := netaddr.MustParseIP("10.27.1.94")
+	nextIP, err := h.getAvailableIP()
+	c.Assert(err, check.IsNil)
+
+	c.Assert(nextIP.String(), check.Equals, expectedNextIP.String())
+
+	// If we call get Available again, we should receive
+	// the same IP, as it has not been reserved.
+	nextIP2, err := h.getAvailableIP()
+	c.Assert(err, check.IsNil)
+
+	c.Assert(nextIP2.String(), check.Equals, expectedNextIP.String())
+}


### PR DESCRIPTION
Hi

This PR contains two commits were the first (making ip prefix configurable) one can be cherry picked if the second (rework get available ip) is not desirable.

Please see the individual commit messages for details.

The code has some tests, but real world testing help would be appreciated.

If it is not desirable to change the IP allocation, then I can rework it into an alternative to the original, so users can opt in/out.