### PR TITLE
Fix deadlock issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ Headscale's configuration file is named `config.json` or `config.yaml`. Headscal
 `server_url` is the external URL via which Headscale is reachable. `listen_addr` is the IP address and port the Headscale program should listen on. `ip_prefix` is the IP prefix (range) in which IP addresses for nodes will be allocated (default 100.64.0.0/10, e.g., 192.168.4.0/24, 10.0.0.0/8)
 
 ```
+    "log_level": "debug"
+```
+`log_level` can be used to set the Log level for Headscale, it defaults to `debug`, and the available levels are: `trace`, `debug`, `info`, `warn` and `error`.
+
+```
     "private_key_path": "private.key",
 ```
 

--- a/acls.go
+++ b/acls.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/tailscale/hujson"
 	"inet.af/netaddr"
@@ -66,7 +67,8 @@ func (h *Headscale) generateACLRules() (*[]tailcfg.FilterRule, error) {
 		for j, u := range a.Users {
 			srcs, err := h.generateACLPolicySrcIP(u)
 			if err != nil {
-				log.Printf("Error parsing ACL %d, User %d", i, j)
+				log.Error().
+					Msgf("Error parsing ACL %d, User %d", i, j)
 				return nil, err
 			}
 			srcIPs = append(srcIPs, *srcs...)
@@ -77,7 +79,8 @@ func (h *Headscale) generateACLRules() (*[]tailcfg.FilterRule, error) {
 		for j, d := range a.Ports {
 			dests, err := h.generateACLPolicyDestPorts(d)
 			if err != nil {
-				log.Printf("Error parsing ACL %d, Port %d", i, j)
+				log.Error().
+					Msgf("Error parsing ACL %d, Port %d", i, j)
 				return nil, err
 			}
 			destPorts = append(destPorts, *dests...)

--- a/api.go
+++ b/api.go
@@ -65,7 +65,7 @@ func (h *Headscale) RegistrationHandler(c *gin.Context) {
 	mKey, err := wgkey.ParseHex(mKeyStr)
 	if err != nil {
 		log.Error().
-			Str("Handler", "Registration").
+			Str("handler", "Registration").
 			Err(err).
 			Msg("Cannot parse machine key")
 		c.String(http.StatusInternalServerError, "Sad!")
@@ -75,7 +75,7 @@ func (h *Headscale) RegistrationHandler(c *gin.Context) {
 	err = decode(body, &req, &mKey, h.privateKey)
 	if err != nil {
 		log.Error().
-			Str("Handler", "Registration").
+			Str("handler", "Registration").
 			Err(err).
 			Msg("Cannot decode message")
 		c.String(http.StatusInternalServerError, "Very sad!")
@@ -84,7 +84,7 @@ func (h *Headscale) RegistrationHandler(c *gin.Context) {
 
 	var m Machine
 	if result := h.db.Preload("Namespace").First(&m, "machine_key = ?", mKey.HexString()); errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		log.Info().Str("Name", req.Hostinfo.Hostname).Msg("New machine")
+		log.Info().Str("machine", req.Hostinfo.Hostname).Msg("New machine")
 		m = Machine{
 			Expiry:     &req.Expiry,
 			MachineKey: mKey.HexString(),
@@ -93,7 +93,7 @@ func (h *Headscale) RegistrationHandler(c *gin.Context) {
 		}
 		if err := h.db.Create(&m).Error; err != nil {
 			log.Error().
-				Str("Handler", "Registration").
+				Str("handler", "Registration").
 				Err(err).
 				Msg("Could not create row")
 			return
@@ -111,8 +111,8 @@ func (h *Headscale) RegistrationHandler(c *gin.Context) {
 	if m.NodeKey == wgkey.Key(req.NodeKey).HexString() {
 		if m.Registered {
 			log.Debug().
-				Str("Handler", "Registration").
-				Str("Machine", m.Name).
+				Str("handler", "Registration").
+				Str("machine", m.Name).
 				Msg("Client is registered and we have the current NodeKey. All clear to /mSending keepaliveap")
 
 			resp.AuthURL = ""
@@ -121,7 +121,7 @@ func (h *Headscale) RegistrationHandler(c *gin.Context) {
 			respBody, err := encode(resp, &mKey, h.privateKey)
 			if err != nil {
 				log.Error().
-					Str("Handler", "Registration").
+					Str("handler", "Registration").
 					Err(err).
 					Msg("Cannot encode message")
 				c.String(http.StatusInternalServerError, "")
@@ -132,15 +132,15 @@ func (h *Headscale) RegistrationHandler(c *gin.Context) {
 		}
 
 		log.Debug().
-			Str("Handler", "Registration").
-			Str("Machine", m.Name).
+			Str("handler", "Registration").
+			Str("machine", m.Name).
 			Msg("Not registered and not NodeKey rotation. Sending a authurl to register")
 		resp.AuthURL = fmt.Sprintf("%s/register?key=%s",
 			h.cfg.ServerURL, mKey.HexString())
 		respBody, err := encode(resp, &mKey, h.privateKey)
 		if err != nil {
 			log.Error().
-				Str("Handler", "Registration").
+				Str("handler", "Registration").
 				Err(err).
 				Msg("Cannot encode message")
 			c.String(http.StatusInternalServerError, "")
@@ -153,8 +153,8 @@ func (h *Headscale) RegistrationHandler(c *gin.Context) {
 	// The NodeKey we have matches OldNodeKey, which means this is a refresh after an key expiration
 	if m.NodeKey == wgkey.Key(req.OldNodeKey).HexString() {
 		log.Debug().
-			Str("Handler", "Registration").
-			Str("Machine", m.Name).
+			Str("handler", "Registration").
+			Str("machine", m.Name).
 			Msg("We have the OldNodeKey in the database. This is a key refresh")
 		m.NodeKey = wgkey.Key(req.NodeKey).HexString()
 		h.db.Save(&m)
@@ -164,7 +164,7 @@ func (h *Headscale) RegistrationHandler(c *gin.Context) {
 		respBody, err := encode(resp, &mKey, h.privateKey)
 		if err != nil {
 			log.Error().
-				Str("Handler", "Registration").
+				Str("handler", "Registration").
 				Err(err).
 				Msg("Cannot encode message")
 			c.String(http.StatusInternalServerError, "Extremely sad!")
@@ -178,8 +178,8 @@ func (h *Headscale) RegistrationHandler(c *gin.Context) {
 	// when headscale is stopped in the middle of the auth process.
 	if m.Registered {
 		log.Debug().
-			Str("Handler", "Registration").
-			Str("Machine", m.Name).
+			Str("handler", "Registration").
+			Str("machine", m.Name).
 			Msg("The node is sending us a new NodeKey, but machine is registered. All clear for /map")
 		resp.AuthURL = ""
 		resp.MachineAuthorized = true
@@ -187,7 +187,7 @@ func (h *Headscale) RegistrationHandler(c *gin.Context) {
 		respBody, err := encode(resp, &mKey, h.privateKey)
 		if err != nil {
 			log.Error().
-				Str("Handler", "Registration").
+				Str("handler", "Registration").
 				Err(err).
 				Msg("Cannot encode message")
 			c.String(http.StatusInternalServerError, "")
@@ -198,15 +198,15 @@ func (h *Headscale) RegistrationHandler(c *gin.Context) {
 	}
 
 	log.Debug().
-		Str("Handler", "Registration").
-		Str("Machine", m.Name).
+		Str("handler", "Registration").
+		Str("machine", m.Name).
 		Msg("The node is sending us a new NodeKey, sending auth url")
 	resp.AuthURL = fmt.Sprintf("%s/register?key=%s",
 		h.cfg.ServerURL, mKey.HexString())
 	respBody, err := encode(resp, &mKey, h.privateKey)
 	if err != nil {
 		log.Error().
-			Str("Handler", "Registration").
+			Str("handler", "Registration").
 			Err(err).
 			Msg("Cannot encode message")
 		c.String(http.StatusInternalServerError, "")
@@ -230,7 +230,7 @@ func (h *Headscale) PollNetMapHandler(c *gin.Context) {
 	mKey, err := wgkey.ParseHex(mKeyStr)
 	if err != nil {
 		log.Error().
-			Str("Handler", "PollNetMap").
+			Str("handler", "PollNetMap").
 			Err(err).
 			Msg("Cannot parse client key")
 		c.String(http.StatusBadRequest, "")
@@ -240,7 +240,7 @@ func (h *Headscale) PollNetMapHandler(c *gin.Context) {
 	err = decode(body, &req, &mKey, h.privateKey)
 	if err != nil {
 		log.Error().
-			Str("Handler", "PollNetMap").
+			Str("handler", "PollNetMap").
 			Err(err).
 			Msg("Cannot decode message")
 		c.String(http.StatusBadRequest, "")
@@ -250,7 +250,7 @@ func (h *Headscale) PollNetMapHandler(c *gin.Context) {
 	var m Machine
 	if result := h.db.Preload("Namespace").First(&m, "machine_key = ?", mKey.HexString()); errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		log.Warn().
-			Str("Handler", "PollNetMap").
+			Str("handler", "PollNetMap").
 			Msgf("Ignoring request, cannot find machine with key %s", mKey.HexString())
 		c.String(http.StatusUnauthorized, "")
 		return
@@ -298,49 +298,49 @@ func (h *Headscale) PollNetMapHandler(c *gin.Context) {
 
 	// Details on the protocol can be found in https://github.com/tailscale/tailscale/blob/main/tailcfg/tailcfg.go#L696
 	log.Debug().
-		Str("Handler", "PollNetMap").
-		Str("Machine", m.Name).
-		Bool("ReadOnly", req.ReadOnly).
-		Bool("OmitPeers", req.OmitPeers).
-		Bool("Stream", req.Stream)
+		Str("handler", "PollNetMap").
+		Str("machine", m.Name).
+		Bool("readOnly", req.ReadOnly).
+		Bool("omitPeers", req.OmitPeers).
+		Bool("stream", req.Stream)
 
 	if req.ReadOnly {
 		log.Info().
-			Str("Handler", "PollNetMap").
-			Str("Machine", m.Name).
+			Str("handler", "PollNetMap").
+			Str("machine", m.Name).
 			Msg("Client is starting up. Asking for DERP map")
 		c.Data(200, "application/json; charset=utf-8", *data)
 		return
 	}
 	if req.OmitPeers && !req.Stream {
 		log.Info().
-			Str("Handler", "PollNetMap").
-			Str("Machine", m.Name).
+			Str("handler", "PollNetMap").
+			Str("machine", m.Name).
 			Msg("Client sent endpoint update and is ok with a response without peer list")
 		c.Data(200, "application/json; charset=utf-8", *data)
 		return
 	} else if req.OmitPeers && req.Stream {
 		log.Warn().
-			Str("Handler", "PollNetMap").
-			Str("Machine", m.Name).
+			Str("handler", "PollNetMap").
+			Str("machine", m.Name).
 			Msg("Ignoring request, don't know how to handle it")
 		c.String(http.StatusBadRequest, "")
 		return
 	}
 
 	log.Info().
-		Str("Handler", "PollNetMap").
-		Str("Machine", m.Name).
+		Str("handler", "PollNetMap").
+		Str("machine", m.Name).
 		Msg("Client is ready to access the tailnet")
 	log.Info().
-		Str("Handler", "PollNetMap").
-		Str("Machine", m.Name).
+		Str("handler", "PollNetMap").
+		Str("machine", m.Name).
 		Msg("Sending initial map")
 	pollData <- *data
 
 	log.Info().
-		Str("Handler", "PollNetMap").
-		Str("Machine", m.Name).
+		Str("handler", "PollNetMap").
+		Str("machine", m.Name).
 		Msg("Notifying peers")
 	peers, _ := h.getPeers(m)
 	h.pollMu.Lock()
@@ -348,17 +348,17 @@ func (h *Headscale) PollNetMapHandler(c *gin.Context) {
 		pUp, ok := h.clientsPolling[uint64(p.ID)]
 		if ok {
 			log.Info().
-				Str("Handler", "PollNetMap").
-				Str("Machine", m.Name).
-				Str("Peer", m.Name).
-				Str("Address", p.Addresses[0].String()).
+				Str("handler", "PollNetMap").
+				Str("machine", m.Name).
+				Str("peer", m.Name).
+				Str("address", p.Addresses[0].String()).
 				Msgf("Notifying peer %s (%s)", p.Name, p.Addresses[0])
 			pUp <- []byte{}
 		} else {
 			log.Info().
-				Str("Handler", "PollNetMap").
-				Str("Machine", m.Name).
-				Str("Peer", m.Name).
+				Str("handler", "PollNetMap").
+				Str("machine", m.Name).
+				Str("peer", m.Name).
 				Msgf("Peer %s does not appear to be polling", p.Name)
 		}
 	}
@@ -370,15 +370,15 @@ func (h *Headscale) PollNetMapHandler(c *gin.Context) {
 		select {
 		case data := <-pollData:
 			log.Trace().
-				Str("Handler", "PollNetMap").
-				Str("Machine", m.Name).
-				Int("Bytes", len(data)).
+				Str("handler", "PollNetMap").
+				Str("machine", m.Name).
+				Int("bytes", len(data)).
 				Msg("Sending data")
 			_, err := w.Write(data)
 			if err != nil {
 				log.Error().
-					Str("Handler", "PollNetMap").
-					Str("Machine", m.Name).
+					Str("handler", "PollNetMap").
+					Str("machine", m.Name).
 					Err(err).
 					Msg("Cannot write data")
 			}
@@ -389,22 +389,22 @@ func (h *Headscale) PollNetMapHandler(c *gin.Context) {
 
 		case <-update:
 			log.Debug().
-				Str("Handler", "PollNetMap").
-				Str("Machine", m.Name).
+				Str("handler", "PollNetMap").
+				Str("machine", m.Name).
 				Msg("Received a request for update")
 			data, err := h.getMapResponse(mKey, req, m)
 			if err != nil {
 				log.Error().
-					Str("Handler", "PollNetMap").
-					Str("Machine", m.Name).
+					Str("handler", "PollNetMap").
+					Str("machine", m.Name).
 					Err(err).
 					Msg("Could not get the map update")
 			}
 			_, err = w.Write(*data)
 			if err != nil {
 				log.Error().
-					Str("Handler", "PollNetMap").
-					Str("Machine", m.Name).
+					Str("handler", "PollNetMap").
+					Str("machine", m.Name).
 					Err(err).
 					Msg("Could not write the map response")
 			}
@@ -412,8 +412,8 @@ func (h *Headscale) PollNetMapHandler(c *gin.Context) {
 
 		case <-c.Request.Context().Done():
 			log.Info().
-				Str("Handler", "PollNetMap").
-				Str("Machine", m.Name).
+				Str("handler", "PollNetMap").
+				Str("machine", m.Name).
 				Msg("The client has closed the connection")
 			now := time.Now().UTC()
 			m.LastSeen = &now
@@ -440,14 +440,14 @@ func (h *Headscale) keepAlive(cancel chan []byte, pollData chan []byte, mKey wgk
 			data, err := h.getMapKeepAliveResponse(mKey, req, m)
 			if err != nil {
 				log.Error().
-					Str("Func", "keepAlive").
+					Str("func", "keepAlive").
 					Err(err).
 					Msg("Error generating the keep alive msg")
 				return
 			}
 			log.Debug().
-				Str("Func", "keepAlive").
-				Str("Machine", m.Name).
+				Str("func", "keepAlive").
+				Str("machine", m.Name).
 				Msg("Sending keepalive")
 			pollData <- *data
 			h.pollMu.Unlock()
@@ -460,7 +460,7 @@ func (h *Headscale) getMapResponse(mKey wgkey.Key, req tailcfg.MapRequest, m Mac
 	node, err := m.toNode()
 	if err != nil {
 		log.Error().
-			Str("Func", "getMapResponse").
+			Str("func", "getMapResponse").
 			Err(err).
 			Msg("Cannot convert to node")
 		return nil, err
@@ -468,7 +468,7 @@ func (h *Headscale) getMapResponse(mKey wgkey.Key, req tailcfg.MapRequest, m Mac
 	peers, err := h.getPeers(m)
 	if err != nil {
 		log.Error().
-			Str("Func", "getMapResponse").
+			Str("func", "getMapResponse").
 			Err(err).
 			Msg("Cannot fetch peers")
 		return nil, err
@@ -543,8 +543,8 @@ func (h *Headscale) getMapKeepAliveResponse(mKey wgkey.Key, req tailcfg.MapReque
 
 func (h *Headscale) handleAuthKey(c *gin.Context, db *gorm.DB, idKey wgkey.Key, req tailcfg.RegisterRequest, m Machine) {
 	log.Debug().
-		Str("Func", "handleAuthKey").
-		Str("Machine", req.Hostinfo.Hostname).
+		Str("func", "handleAuthKey").
+		Str("machine", req.Hostinfo.Hostname).
 		Msgf("Processing auth key for %s", req.Hostinfo.Hostname)
 	resp := tailcfg.RegisterResponse{}
 	pak, err := h.checkKeyValidity(req.Auth.AuthKey)
@@ -553,8 +553,8 @@ func (h *Headscale) handleAuthKey(c *gin.Context, db *gorm.DB, idKey wgkey.Key, 
 		respBody, err := encode(resp, &idKey, h.privateKey)
 		if err != nil {
 			log.Error().
-				Str("Func", "handleAuthKey").
-				Str("Machine", m.Name).
+				Str("func", "handleAuthKey").
+				Str("machine", m.Name).
 				Err(err).
 				Msg("Cannot encode message")
 			c.String(http.StatusInternalServerError, "")
@@ -562,28 +562,28 @@ func (h *Headscale) handleAuthKey(c *gin.Context, db *gorm.DB, idKey wgkey.Key, 
 		}
 		c.Data(200, "application/json; charset=utf-8", respBody)
 		log.Error().
-			Str("Func", "handleAuthKey").
-			Str("Machine", m.Name).
+			Str("func", "handleAuthKey").
+			Str("machine", m.Name).
 			Msg("Failed authentication via AuthKey")
 		return
 	}
 
 	log.Debug().
-		Str("Func", "handleAuthKey").
-		Str("Machine", m.Name).
+		Str("func", "handleAuthKey").
+		Str("machine", m.Name).
 		Msg("Authentication key was valid, proceeding to acquire an IP address")
 	ip, err := h.getAvailableIP()
 	if err != nil {
 		log.Error().
-			Str("Func", "handleAuthKey").
-			Str("Machine", m.Name).
+			Str("func", "handleAuthKey").
+			Str("machine", m.Name).
 			Msg("Failed to find an available IP")
 		return
 	}
 	log.Info().
-		Str("Func", "handleAuthKey").
-		Str("Machine", m.Name).
-		Str("IP", ip.String()).
+		Str("func", "handleAuthKey").
+		Str("machine", m.Name).
+		Str("ip", ip.String()).
 		Msgf("Assining %s to %s", ip, m.Name)
 
 	m.AuthKeyID = uint(pak.ID)
@@ -599,8 +599,8 @@ func (h *Headscale) handleAuthKey(c *gin.Context, db *gorm.DB, idKey wgkey.Key, 
 	respBody, err := encode(resp, &idKey, h.privateKey)
 	if err != nil {
 		log.Error().
-			Str("Func", "handleAuthKey").
-			Str("Machine", m.Name).
+			Str("func", "handleAuthKey").
+			Str("machine", m.Name).
 			Err(err).
 			Msg("Cannot encode message")
 		c.String(http.StatusInternalServerError, "Extremely sad!")
@@ -608,8 +608,8 @@ func (h *Headscale) handleAuthKey(c *gin.Context, db *gorm.DB, idKey wgkey.Key, 
 	}
 	c.Data(200, "application/json; charset=utf-8", respBody)
 	log.Info().
-		Str("Func", "handleAuthKey").
-		Str("Machine", m.Name).
-		Str("IP", ip.String()).
+		Str("func", "handleAuthKey").
+		Str("machine", m.Name).
+		Str("ip", ip.String()).
 		Msg("Successfully authenticated via AuthKey")
 }

--- a/api.go
+++ b/api.go
@@ -92,7 +92,10 @@ func (h *Headscale) RegistrationHandler(c *gin.Context) {
 			NodeKey:    wgkey.Key(req.NodeKey).HexString(),
 		}
 		if err := h.db.Create(&m).Error; err != nil {
-			log.Printf("Could not create row: %s", err)
+			log.Error().
+				Str("Handler", "Registration").
+				Err(err).
+				Msg("Could not create row")
 			return
 		}
 	}
@@ -335,7 +338,10 @@ func (h *Headscale) PollNetMapHandler(c *gin.Context) {
 		Msg("Sending initial map")
 	pollData <- *data
 
-	log.Printf("[PollMap] (%s) Notifying peers", m.Name)
+	log.Info().
+		Str("Handler", "PollNetMap").
+		Str("Machine", m.Name).
+		Msg("Notifying peers")
 	peers, _ := h.getPeers(m)
 	h.pollMu.Lock()
 	for _, p := range *peers {

--- a/app.go
+++ b/app.go
@@ -127,15 +127,15 @@ func (h *Headscale) expireEphemeralNodesWorker() {
 	for _, ns := range *namespaces {
 		machines, err := h.ListMachinesInNamespace(ns.Name)
 		if err != nil {
-			log.Error().Err(err).Str("Namespace", ns.Name).Msg("Error listing machines in namespace")
+			log.Error().Err(err).Str("namespace", ns.Name).Msg("Error listing machines in namespace")
 			return
 		}
 		for _, m := range *machines {
 			if m.AuthKey != nil && m.LastSeen != nil && m.AuthKey.Ephemeral && time.Now().After(m.LastSeen.Add(h.cfg.EphemeralNodeInactivityTimeout)) {
-				log.Info().Str("Machine", m.Name).Msg("Ephemeral client removed from database")
+				log.Info().Str("machine", m.Name).Msg("Ephemeral client removed from database")
 				err = h.db.Unscoped().Delete(m).Error
 				if err != nil {
-					log.Error().Err(err).Str("Name", m.Name).Msg("🤮 Cannot delete ephemeral machine from the database")
+					log.Error().Err(err).Str("machine", m.Name).Msg("🤮 Cannot delete ephemeral machine from the database")
 				}
 			}
 		}

--- a/app.go
+++ b/app.go
@@ -59,7 +59,7 @@ type Headscale struct {
 	aclRules  *[]tailcfg.FilterRule
 
 	pollMu         sync.Mutex
-	clientsPolling map[uint64]chan []byte // this is by all means a hackity hack
+	clientsPolling sync.Map
 }
 
 // NewHeadscale returns the Headscale app
@@ -99,7 +99,6 @@ func NewHeadscale(cfg Config) (*Headscale, error) {
 		return nil, err
 	}
 
-	h.clientsPolling = make(map[uint64]chan []byte)
 	return &h, nil
 }
 

--- a/cmd/headscale/cli/root.go
+++ b/cmd/headscale/cli/root.go
@@ -2,8 +2,9 @@ package cli
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 func init() {
@@ -17,7 +18,7 @@ var rootCmd = &cobra.Command{
 headscale is an open source implementation of the Tailscale control server
 
 Juan Font Alonso <juanfontalonso@gmail.com> - 2021
-https://gitlab.com/juanfont/headscale`,
+https://github.com/juanfont/headscale`,
 }
 
 func Execute() {

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -39,6 +39,8 @@ func LoadConfig(path string) error {
 
 	viper.SetDefault("ip_prefix", "100.64.0.0/10")
 
+	viper.SetDefault("log_level", "debug")
+
 	err := viper.ReadInConfig()
 	if err != nil {
 		return fmt.Errorf("Fatal error reading config file: %s \n", err)
@@ -170,24 +172,24 @@ func JsonOutput(result interface{}, errResult error, outputFormat string) {
 		if errResult != nil {
 			j, err = json.MarshalIndent(ErrorOutput{errResult.Error()}, "", "\t")
 			if err != nil {
-				log.Fatalln(err)
+				log.Fatal().Err(err)
 			}
 		} else {
 			j, err = json.MarshalIndent(result, "", "\t")
 			if err != nil {
-				log.Fatalln(err)
+				log.Fatal().Err(err)
 			}
 		}
 	case "json-line":
 		if errResult != nil {
 			j, err = json.Marshal(ErrorOutput{errResult.Error()})
 			if err != nil {
-				log.Fatalln(err)
+				log.Fatal().Err(err)
 			}
 		} else {
 			j, err = json.Marshal(result)
 			if err != nil {
-				log.Fatalln(err)
+				log.Fatal().Err(err)
 			}
 		}
 	}

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/juanfont/headscale"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 	"inet.af/netaddr"
@@ -52,7 +52,8 @@ func LoadConfig(path string) error {
 
 	if (viper.GetString("tls_letsencrypt_hostname") != "") && (viper.GetString("tls_letsencrypt_challenge_type") == "TLS-ALPN-01") && (!strings.HasSuffix(viper.GetString("listen_addr"), ":443")) {
 		// this is only a warning because there could be something sitting in front of headscale that redirects the traffic (e.g. an iptables rule)
-		log.Println("Warning: when using tls_letsencrypt_hostname with TLS-ALPN-01 as challenge type, headscale must be reachable on port 443, i.e. listen_addr should probably end in :443")
+		log.Warn().
+			Msg("Warning: when using tls_letsencrypt_hostname with TLS-ALPN-01 as challenge type, headscale must be reachable on port 443, i.e. listen_addr should probably end in :443")
 	}
 
 	if (viper.GetString("tls_letsencrypt_challenge_type") != "HTTP-01") && (viper.GetString("tls_letsencrypt_challenge_type") != "TLS-ALPN-01") {
@@ -82,9 +83,13 @@ func absPath(path string) string {
 }
 
 func getHeadscaleApp() (*headscale.Headscale, error) {
-	derpMap, err := loadDerpMap(absPath(viper.GetString("derp_map_path")))
+	derpPath := absPath(viper.GetString("derp_map_path"))
+	derpMap, err := loadDerpMap(derpPath)
 	if err != nil {
-		log.Printf("Could not load DERP servers map file: %s", err)
+		log.Error().
+			Str("Path", derpPath).
+			Err(err).
+			Msg("Could not load DERP servers map file")
 	}
 
 	// Minimum inactivity time out is keepalive timeout (60s) plus a few seconds
@@ -129,9 +134,13 @@ func getHeadscaleApp() (*headscale.Headscale, error) {
 	// We are doing this here, as in the future could be cool to have it also hot-reload
 
 	if viper.GetString("acl_policy_path") != "" {
-		err = h.LoadACLPolicy(absPath(viper.GetString("acl_policy_path")))
+		aclPath := absPath(viper.GetString("acl_policy_path"))
+		err = h.LoadACLPolicy(aclPath)
 		if err != nil {
-			log.Printf("Could not load the ACL policy: %s", err)
+			log.Error().
+				Str("Path", aclPath).
+				Err(err).
+				Msg("Could not load the ACL policy")
 		}
 	}
 

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -89,7 +89,7 @@ func getHeadscaleApp() (*headscale.Headscale, error) {
 	derpMap, err := loadDerpMap(derpPath)
 	if err != nil {
 		log.Error().
-			Str("Path", derpPath).
+			Str("path", derpPath).
 			Err(err).
 			Msg("Could not load DERP servers map file")
 	}
@@ -140,7 +140,7 @@ func getHeadscaleApp() (*headscale.Headscale, error) {
 		err = h.LoadACLPolicy(aclPath)
 		if err != nil {
 			log.Error().
-				Str("Path", aclPath).
+				Str("path", aclPath).
 				Err(err).
 				Msg("Could not load the ACL policy")
 		}

--- a/cmd/headscale/headscale.go
+++ b/cmd/headscale/headscale.go
@@ -1,15 +1,41 @@
 package main
 
 import (
-	"log"
+	"os"
+	"time"
 
 	"github.com/juanfont/headscale/cmd/headscale/cli"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 )
 
 func main() {
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	log.Logger = log.Output(zerolog.ConsoleWriter{
+		Out:        os.Stdout,
+		TimeFormat: time.RFC3339,
+	})
+
 	err := cli.LoadConfig("")
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatal().Err(err)
+	}
+
+	logLevel := viper.GetString("log_level")
+	switch logLevel {
+	case "trace":
+		zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	case "debug":
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	case "info":
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	case "warn":
+		zerolog.SetGlobalLevel(zerolog.WarnLevel)
+	case "error":
+		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+	default:
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}
 
 	cli.Execute()

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/klauspost/compress v1.13.1
 	github.com/lib/pq v1.10.2 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7 // indirect
+	github.com/rs/zerolog v1.23.0 // indirect
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.8.1
 	github.com/tailscale/hujson v0.0.0-20200924210142-dde312d0d6a2

--- a/go.sum
+++ b/go.sum
@@ -683,6 +683,8 @@ github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
+github.com/rs/zerolog v1.23.0 h1:UskrK+saS9P9Y789yNNulYKdARjPZuS35B8gJF2x60g=
+github.com/rs/zerolog v1.23.0/go.mod h1:6c7hFfxPOy7TacJc4Fcdi24/J0NKYGzjG8FWRI916Qo=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryancurrah/gomodguard v1.1.0/go.mod h1:4O8tr7hBODaGE6VIhfJDHcwzh5GUccKSJBU0UMXJFVM=
 github.com/ryanrolds/sqlclosecheck v0.3.0/go.mod h1:1gREqxyTGR3lVtpngyFo3hZAgk0KCtEdgEkHwDbigdA=

--- a/machine.go
+++ b/machine.go
@@ -3,10 +3,11 @@ package headscale
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/rs/zerolog/log"
 
 	"gorm.io/datatypes"
 	"inet.af/netaddr"
@@ -157,7 +158,7 @@ func (h *Headscale) getPeers(m Machine) (*[]*tailcfg.Node, error) {
 	machines := []Machine{}
 	if err := h.db.Where("namespace_id = ? AND machine_key <> ? AND registered",
 		m.NamespaceID, m.MachineKey).Find(&machines).Error; err != nil {
-		log.Printf("Error accessing db: %s", err)
+		log.Error().Err(err).Msg("Error accessing db")
 		return nil, err
 	}
 

--- a/namespaces.go
+++ b/namespaces.go
@@ -34,7 +34,7 @@ func (h *Headscale) CreateNamespace(name string) (*Namespace, error) {
 	n.Name = name
 	if err := h.db.Create(&n).Error; err != nil {
 		log.Error().
-			Str("Func", "CreateNamespace").
+			Str("func", "CreateNamespace").
 			Err(err).
 			Msg("Could not create row")
 		return nil, err
@@ -137,7 +137,7 @@ func (h *Headscale) RequestMapUpdates(namespaceID uint) error {
 	data, err := json.Marshal(names)
 	if err != nil {
 		log.Error().
-			Str("Func", "RequestMapUpdates").
+			Str("func", "RequestMapUpdates").
 			Err(err).
 			Msg("Could not marshal namespaces_pending_updates")
 		return err
@@ -161,8 +161,8 @@ func (h *Headscale) checkForNamespacesPendingUpdates() {
 	}
 	for _, name := range names {
 		log.Trace().
-			Str("Func", "RequestMapUpdates").
-			Str("Machine", name).
+			Str("func", "RequestMapUpdates").
+			Str("machine", name).
 			Msg("Sending updates to nodes in namespace")
 		machines, err := h.ListMachinesInNamespace(name)
 		if err != nil {
@@ -175,17 +175,17 @@ func (h *Headscale) checkForNamespacesPendingUpdates() {
 				pUp, ok := h.clientsPolling[uint64(p.ID)]
 				if ok {
 					log.Info().
-						Str("Func", "checkForNamespacesPendingUpdates").
-						Str("Machine", m.Name).
-						Str("Peer", m.Name).
-						Str("Address", p.Addresses[0].String()).
+						Str("func", "checkForNamespacesPendingUpdates").
+						Str("machine", m.Name).
+						Str("peer", m.Name).
+						Str("address", p.Addresses[0].String()).
 						Msgf("Notifying peer %s (%s)", p.Name, p.Addresses[0])
 					pUp <- []byte{}
 				} else {
 					log.Info().
-						Str("Func", "checkForNamespacesPendingUpdates").
-						Str("Machine", m.Name).
-						Str("Peer", m.Name).
+						Str("func", "checkForNamespacesPendingUpdates").
+						Str("machine", m.Name).
+						Str("peer", m.Name).
 						Msgf("Peer %s does not appear to be polling", p.Name)
 				}
 			}
@@ -200,7 +200,7 @@ func (h *Headscale) checkForNamespacesPendingUpdates() {
 		err = h.setValue("namespaces_pending_updates", "")
 		if err != nil {
 			log.Error().
-				Str("Func", "checkForNamespacesPendingUpdates").
+				Str("func", "checkForNamespacesPendingUpdates").
 				Err(err).
 				Msg("Could not save to KV")
 			return

--- a/namespaces.go
+++ b/namespaces.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
 	"tailscale.com/tailcfg"
 )
@@ -33,7 +33,10 @@ func (h *Headscale) CreateNamespace(name string) (*Namespace, error) {
 	}
 	n.Name = name
 	if err := h.db.Create(&n).Error; err != nil {
-		log.Printf("Could not create row: %s", err)
+		log.Error().
+			Str("Func", "CreateNamespace").
+			Err(err).
+			Msg("Could not create row")
 		return nil, err
 	}
 	return &n, nil
@@ -133,7 +136,10 @@ func (h *Headscale) RequestMapUpdates(namespaceID uint) error {
 	names = append(names, namespace.Name)
 	data, err := json.Marshal(names)
 	if err != nil {
-		log.Printf("Could not marshal namespaces_pending_updates: %s", err)
+		log.Error().
+			Str("Func", "RequestMapUpdates").
+			Err(err).
+			Msg("Could not marshal namespaces_pending_updates")
 		return err
 	}
 	return h.setValue("namespaces_pending_updates", string(data))
@@ -154,7 +160,10 @@ func (h *Headscale) checkForNamespacesPendingUpdates() {
 		return
 	}
 	for _, name := range names {
-		log.Printf("Sending updates to nodes in namespace %s", name)
+		log.Trace().
+			Str("Func", "RequestMapUpdates").
+			Str("Machine", name).
+			Msg("Sending updates to nodes in namespace")
 		machines, err := h.ListMachinesInNamespace(name)
 		if err != nil {
 			continue
@@ -165,10 +174,19 @@ func (h *Headscale) checkForNamespacesPendingUpdates() {
 			for _, p := range *peers {
 				pUp, ok := h.clientsPolling[uint64(p.ID)]
 				if ok {
-					log.Printf("[%s] Notifying peer %s (%s)", m.Name, p.Name, p.Addresses[0])
+					log.Info().
+						Str("Func", "checkForNamespacesPendingUpdates").
+						Str("Machine", m.Name).
+						Str("Peer", m.Name).
+						Str("Address", p.Addresses[0].String()).
+						Msgf("Notifying peer %s (%s)", p.Name, p.Addresses[0])
 					pUp <- []byte{}
 				} else {
-					log.Printf("[%s] Peer %s does not appear to be polling", m.Name, p.Name)
+					log.Info().
+						Str("Func", "checkForNamespacesPendingUpdates").
+						Str("Machine", m.Name).
+						Str("Peer", m.Name).
+						Msgf("Peer %s does not appear to be polling", p.Name)
 				}
 			}
 			h.pollMu.Unlock()
@@ -181,7 +199,10 @@ func (h *Headscale) checkForNamespacesPendingUpdates() {
 	if v == newV { // only clear when no changes, so we notified everybody
 		err = h.setValue("namespaces_pending_updates", "")
 		if err != nil {
-			log.Printf("Could not save to KV: %s", err)
+			log.Error().
+				Str("Func", "checkForNamespacesPendingUpdates").
+				Err(err).
+				Msg("Could not save to KV")
 			return
 		}
 	}

--- a/routes.go
+++ b/routes.go
@@ -52,8 +52,8 @@ func (h *Headscale) EnableNodeRoute(namespace string, nodeName string, routeStr 
 			peers, _ := h.getPeers(*m)
 			h.pollMu.Lock()
 			for _, p := range *peers {
-				if pUp, ok := h.clientsPolling[uint64(p.ID)]; ok {
-					pUp <- []byte{}
+				if pUp, ok := h.clientsPolling.Load(uint64(p.ID)); ok {
+					pUp.(chan []byte) <- []byte{}
 				}
 			}
 			h.pollMu.Unlock()


### PR DESCRIPTION
This PR depends on (or contains if you like) #74, please review that first and merge that / or just merge this when both are reviewed.

This PR removes most of the locks in the PollingMap handler as there
was combinations that caused deadlocks. Instead of doing a plain map and
doing the locking ourselves, we use sync.Map which handles it for us.

This should resolve #56 #50 and #73 