### PR TITLE
Remove more deadlocks

### DIFF
--- a/api.go
+++ b/api.go
@@ -455,7 +455,6 @@ func (h *Headscale) keepAlive(cancel chan []byte, pollData chan []byte, mKey wgk
 			return
 
 		default:
-			h.pollMu.Lock()
 			data, err := h.getMapKeepAliveResponse(mKey, req, m)
 			if err != nil {
 				log.Error().
@@ -464,12 +463,13 @@ func (h *Headscale) keepAlive(cancel chan []byte, pollData chan []byte, mKey wgk
 					Msg("Error generating the keep alive msg")
 				return
 			}
+
 			log.Debug().
 				Str("func", "keepAlive").
 				Str("machine", m.Name).
 				Msg("Sending keepalive")
 			pollData <- *data
-			h.pollMu.Unlock()
+
 			time.Sleep(60 * time.Second)
 		}
 	}

--- a/api.go
+++ b/api.go
@@ -298,13 +298,8 @@ func (h *Headscale) PollNetMapHandler(c *gin.Context) {
 		Str("handler", "PollNetMap").
 		Str("id", c.Param("id")).
 		Str("machine", m.Name).
-		Msg("Locking poll mutex")
+		Msg("Storing update channel")
 	h.clientsPolling.Store(m.ID, update)
-	log.Trace().
-		Str("handler", "PollNetMap").
-		Str("id", c.Param("id")).
-		Str("machine", m.Name).
-		Msg("Unlocking poll mutex")
 
 	data, err := h.getMapResponse(mKey, req, m)
 	if err != nil {

--- a/app.go
+++ b/app.go
@@ -58,7 +58,6 @@ type Headscale struct {
 	aclPolicy *ACLPolicy
 	aclRules  *[]tailcfg.FilterRule
 
-	pollMu         sync.Mutex
 	clientsPolling sync.Map
 }
 

--- a/routes.go
+++ b/routes.go
@@ -50,13 +50,11 @@ func (h *Headscale) EnableNodeRoute(namespace string, nodeName string, routeStr 
 			// Definetely not accessible from the CLI tool.
 			// We need RPC to the server - or some kind of 'needsUpdate' field in the DB
 			peers, _ := h.getPeers(*m)
-			h.pollMu.Lock()
 			for _, p := range *peers {
 				if pUp, ok := h.clientsPolling.Load(uint64(p.ID)); ok {
 					pUp.(chan []byte) <- []byte{}
 				}
 			}
-			h.pollMu.Unlock()
 			return &rIP, nil
 		}
 	}


### PR DESCRIPTION
This PR removes more deadlocks, one I forgot and on (from keepAlive) that I could not understand why was there.

Ideally we need some wireup tests to test for locks and check actual tailscale(d) behaviour over time.