### PR TITLE
Add CLI command to mark preauthkeys as expired

### DIFF
--- a/preauth_keys.go
+++ b/preauth_keys.go
@@ -67,6 +67,13 @@ func (h *Headscale) GetPreAuthKeys(namespaceName string) (*[]PreAuthKey, error) 
 	return &keys, nil
 }
 
+func (h *Headscale) MarkExpirePreAuthKey(k *PreAuthKey) error {
+	if err := h.db.Model(&k).Update("Expiration", time.Now()).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
 // checkKeyValidity does the heavy lifting for validation of the PreAuthKey coming from a node
 // If returns no error and a PreAuthKey, it can be used
 func (h *Headscale) checkKeyValidity(k string) (*PreAuthKey, error) {

--- a/preauth_keys.go
+++ b/preauth_keys.go
@@ -67,6 +67,7 @@ func (h *Headscale) GetPreAuthKeys(namespaceName string) (*[]PreAuthKey, error) 
 	return &keys, nil
 }
 
+// GetPreAuthKey returns a PreAuthKey for a given key
 func (h *Headscale) GetPreAuthKey(namespace string, key string) (*PreAuthKey, error) {
 	pak, err := h.checkKeyValidity(key)
 	if err != nil {
@@ -80,6 +81,7 @@ func (h *Headscale) GetPreAuthKey(namespace string, key string) (*PreAuthKey, er
 	return pak, nil
 }
 
+// MarkExpirePreauthKey marks a PreAuthKey as expired
 func (h *Headscale) MarkExpirePreAuthKey(k *PreAuthKey) error {
 	if err := h.db.Model(&k).Update("Expiration", time.Now()).Error; err != nil {
 		return err

--- a/preauth_keys.go
+++ b/preauth_keys.go
@@ -81,7 +81,7 @@ func (h *Headscale) GetPreAuthKey(namespace string, key string) (*PreAuthKey, er
 	return pak, nil
 }
 
-// MarkExpirePreauthKey marks a PreAuthKey as expired
+// MarkExpirePreAuthKey marks a PreAuthKey as expired
 func (h *Headscale) MarkExpirePreAuthKey(k *PreAuthKey) error {
 	if err := h.db.Model(&k).Update("Expiration", time.Now()).Error; err != nil {
 		return err

--- a/preauth_keys.go
+++ b/preauth_keys.go
@@ -67,6 +67,19 @@ func (h *Headscale) GetPreAuthKeys(namespaceName string) (*[]PreAuthKey, error) 
 	return &keys, nil
 }
 
+func (h *Headscale) GetPreAuthKey(namespace string, key string) (*PreAuthKey, error) {
+	pak, err := h.checkKeyValidity(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if pak.Namespace.Name != namespace {
+		return nil, errors.New("Namespace mismatch")
+	}
+
+	return pak, nil
+}
+
 func (h *Headscale) MarkExpirePreAuthKey(k *PreAuthKey) error {
 	if err := h.db.Model(&k).Update("Expiration", time.Now()).Error; err != nil {
 		return err

--- a/preauth_keys_test.go
+++ b/preauth_keys_test.go
@@ -163,3 +163,20 @@ func (*Suite) TestEphemeralKey(c *check.C) {
 	_, err = h.GetMachine("test7", "testest")
 	c.Assert(err, check.NotNil)
 }
+
+func (*Suite) TestExpirePreauthKey(c *check.C) {
+	n, err := h.CreateNamespace("test3")
+	c.Assert(err, check.IsNil)
+
+	pak, err := h.CreatePreAuthKey(n.Name, true, false, nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(pak.Expiration, check.IsNil)
+
+	err = h.MarkExpirePreAuthKey(pak)
+	c.Assert(err, check.IsNil)
+	c.Assert(pak.Expiration, check.NotNil)
+
+	p, err := h.checkKeyValidity(pak.Key)
+	c.Assert(err, check.Equals, errorAuthKeyExpired)
+	c.Assert(p, check.IsNil)
+}


### PR DESCRIPTION
As pointed out in #78, we can't delete a preauthkey. This PR implements a similar functionality, by marking a preauthkey as expired.