### PR TITLE
Also notify peers when deleting ephemerals

### DIFF
--- a/app.go
+++ b/app.go
@@ -107,9 +107,9 @@ func (h *Headscale) redirect(w http.ResponseWriter, req *http.Request) {
 	http.Redirect(w, req, target, http.StatusFound)
 }
 
-// ExpireEphemeralNodes deletes ephemeral machine records that have not been
+// expireEphemeralNodes deletes ephemeral machine records that have not been
 // seen for longer than h.cfg.EphemeralNodeInactivityTimeout
-func (h *Headscale) ExpireEphemeralNodes(milliSeconds int64) {
+func (h *Headscale) expireEphemeralNodes(milliSeconds int64) {
 	ticker := time.NewTicker(time.Duration(milliSeconds) * time.Millisecond)
 	for range ticker.C {
 		h.expireEphemeralNodesWorker()
@@ -165,7 +165,7 @@ func (h *Headscale) Serve() error {
 	var err error
 
 	go h.watchForKVUpdates(5000)
-	go h.ExpireEphemeralNodes(5000)
+	go h.expireEphemeralNodes(5000)
 
 	if h.cfg.TLSLetsEncryptHostname != "" {
 		if !strings.HasPrefix(h.cfg.ServerURL, "https://") {

--- a/app.go
+++ b/app.go
@@ -165,6 +165,7 @@ func (h *Headscale) Serve() error {
 	var err error
 
 	go h.watchForKVUpdates(5000)
+	go h.ExpireEphemeralNodes(5000)
 
 	if h.cfg.TLSLetsEncryptHostname != "" {
 		if !strings.HasPrefix(h.cfg.ServerURL, "https://") {

--- a/app.go
+++ b/app.go
@@ -135,7 +135,10 @@ func (h *Headscale) expireEphemeralNodesWorker() {
 				if err != nil {
 					log.Error().Err(err).Str("machine", m.Name).Msg("🤮 Cannot delete ephemeral machine from the database")
 				}
-				h.notifyChangesToPeers(&m)
+				err = h.notifyChangesToPeers(&m)
+				if err != nil {
+					continue
+				}
 			}
 		}
 	}

--- a/app.go
+++ b/app.go
@@ -135,6 +135,7 @@ func (h *Headscale) expireEphemeralNodesWorker() {
 				if err != nil {
 					log.Error().Err(err).Str("machine", m.Name).Msg("🤮 Cannot delete ephemeral machine from the database")
 				}
+				h.notifyChangesToPeers(&m)
 			}
 		}
 	}

--- a/cmd/headscale/cli/server.go
+++ b/cmd/headscale/cli/server.go
@@ -21,7 +21,7 @@ var serveCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error initializing: %s", err)
 		}
-		go h.ExpireEphemeralNodes(5000)
+
 		err = h.Serve()
 		if err != nil {
 			log.Fatalf("Error initializing: %s", err)

--- a/machine.go
+++ b/machine.go
@@ -238,3 +238,26 @@ func (m *Machine) GetHostInfo() (*tailcfg.Hostinfo, error) {
 	}
 	return &hostinfo, nil
 }
+
+func (h *Headscale) notifyChangesToPeers(m *Machine) error {
+	peers, _ := h.getPeers(*m)
+	for _, p := range *peers {
+		pUp, ok := h.clientsPolling.Load(uint64(p.ID))
+		if ok {
+			log.Info().
+				Str("func", "notifyChangesToPeers").
+				Str("machine", m.Name).
+				Str("peer", m.Name).
+				Str("address", p.Addresses[0].String()).
+				Msgf("Notifying peer %s (%s)", p.Name, p.Addresses[0])
+			pUp.(chan []byte) <- []byte{}
+		} else {
+			log.Info().
+				Str("func", "notifyChangesToPeers").
+				Str("machine", m.Name).
+				Str("peer", m.Name).
+				Msgf("Peer %s does not appear to be polling", p.Name)
+		}
+	}
+	return nil
+}

--- a/namespaces.go
+++ b/namespaces.go
@@ -169,25 +169,7 @@ func (h *Headscale) checkForNamespacesPendingUpdates() {
 			continue
 		}
 		for _, m := range *machines {
-			peers, _ := h.getPeers(m)
-			for _, p := range *peers {
-				pUp, ok := h.clientsPolling.Load(uint64(p.ID))
-				if ok {
-					log.Info().
-						Str("func", "checkForNamespacesPendingUpdates").
-						Str("machine", m.Name).
-						Str("peer", m.Name).
-						Str("address", p.Addresses[0].String()).
-						Msgf("Notifying peer %s (%s)", p.Name, p.Addresses[0])
-					pUp.(chan []byte) <- []byte{}
-				} else {
-					log.Info().
-						Str("func", "checkForNamespacesPendingUpdates").
-						Str("machine", m.Name).
-						Str("peer", m.Name).
-						Msgf("Peer %s does not appear to be polling", p.Name)
-				}
-			}
+			h.notifyChangesToPeers(&m)
 		}
 	}
 	newV, err := h.getValue("namespaces_pending_updates")

--- a/namespaces.go
+++ b/namespaces.go
@@ -169,7 +169,10 @@ func (h *Headscale) checkForNamespacesPendingUpdates() {
 			continue
 		}
 		for _, m := range *machines {
-			h.notifyChangesToPeers(&m)
+			err = h.notifyChangesToPeers(&m)
+			if err != nil {
+				continue
+			}
 		}
 	}
 	newV, err := h.getValue("namespaces_pending_updates")


### PR DESCRIPTION
As reported by @viq on Twitter, ephemeral nodes are being deleted, but the changes are not notified to their former peers. 

This PR addresses that.