### PR TITLE
Improve reliability of PollMapHandler, more integration tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 // ignoring it let us speed up the integration test
 // development
 integration_test.go
+integration_test/
 
 Dockerfile*
 docker-compose*

--- a/app.go
+++ b/app.go
@@ -135,10 +135,7 @@ func (h *Headscale) expireEphemeralNodesWorker() {
 				if err != nil {
 					log.Error().Err(err).Str("machine", m.Name).Msg("🤮 Cannot delete ephemeral machine from the database")
 				}
-				err = h.notifyChangesToPeers(&m)
-				if err != nil {
-					continue
-				}
+				h.notifyChangesToPeers(&m)
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/rs/zerolog v1.23.0 // indirect
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.8.1
+	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/tailscale/hujson v0.0.0-20200924210142-dde312d0d6a2
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e

--- a/go.sum
+++ b/go.sum
@@ -817,6 +817,7 @@ github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5J
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
 github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/integration_test.go
+++ b/integration_test.go
@@ -286,30 +286,30 @@ func (s *IntegrationTestSuite) TestStatus() {
 	}
 }
 
-// func (s *IntegrationTestSuite) TestPingAllPeers() {
-// 	ips, err := getIPs()
-// 	assert.Nil(s.T(), err)
-//
-// 	for hostname, tailscale := range tailscales {
-// 		for peername, ip := range ips {
-// 			s.T().Run(fmt.Sprintf("%s-%s", hostname, peername), func(t *testing.T) {
-// 				// We currently cant ping ourselves, so skip that.
-// 				if peername != hostname {
-// 					command := []string{"tailscale", "ping", "--timeout=1s", "--c=1", ip.String()}
-//
-// 					fmt.Printf("Pinging from %s (%s) to %s (%s)\n", hostname, ips[hostname], peername, ip)
-// 					result, err := executeCommand(
-// 						&tailscale,
-// 						command,
-// 					)
-// 					assert.Nil(t, err)
-// 					fmt.Printf("Result for %s: %s\n", hostname, result)
-// 					assert.Contains(t, result, "pong")
-// 				}
-// 			})
-// 		}
-// 	}
-// }
+func (s *IntegrationTestSuite) TestPingAllPeers() {
+	ips, err := getIPs()
+	assert.Nil(s.T(), err)
+
+	for hostname, tailscale := range tailscales {
+		for peername, ip := range ips {
+			s.T().Run(fmt.Sprintf("%s-%s", hostname, peername), func(t *testing.T) {
+				// We currently cant ping ourselves, so skip that.
+				if peername != hostname {
+					command := []string{"tailscale", "ping", "--timeout=1s", "--c=1", ip.String()}
+
+					fmt.Printf("Pinging from %s (%s) to %s (%s)\n", hostname, ips[hostname], peername, ip)
+					result, err := executeCommand(
+						&tailscale,
+						command,
+					)
+					assert.Nil(t, err)
+					fmt.Printf("Result for %s: %s\n", hostname, result)
+					assert.Contains(t, result, "pong")
+				}
+			})
+		}
+	}
+}
 
 func getIPs() (map[string]netaddr.IP, error) {
 	ips := make(map[string]netaddr.IP)

--- a/integration_test.go
+++ b/integration_test.go
@@ -9,17 +9,24 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"testing"
+	"time"
 
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
-	"inet.af/netaddr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 
-	"gopkg.in/check.v1"
+	"inet.af/netaddr"
 )
 
-var _ = check.Suite(&IntegrationSuite{})
+type IntegrationTestSuite struct {
+	suite.Suite
+}
 
-type IntegrationSuite struct{}
+func TestIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(IntegrationTestSuite))
+}
 
 var integrationTmpDir string
 var ih Headscale
@@ -27,7 +34,7 @@ var ih Headscale
 var pool dockertest.Pool
 var network dockertest.Network
 var headscale dockertest.Resource
-var tailscaleCount int = 10
+var tailscaleCount int = 5
 var tailscales map[string]dockertest.Resource
 
 func executeCommand(resource *dockertest.Resource, cmd []string) (string, error) {
@@ -63,7 +70,7 @@ func dockerRestartPolicy(config *docker.HostConfig) {
 	}
 }
 
-func (s *IntegrationSuite) SetUpSuite(c *check.C) {
+func (s *IntegrationTestSuite) SetupSuite() {
 	var err error
 	h = Headscale{
 		dbType:   "sqlite3",
@@ -104,8 +111,7 @@ func (s *IntegrationSuite) SetUpSuite(c *check.C) {
 			fmt.Sprintf("%s/derp.yaml:/etc/headscale/derp.yaml", currentPath),
 		},
 		Networks: []*dockertest.Network{&network},
-		// Cmd: []string{"sleep", "3600"},
-		Cmd: []string{"headscale", "serve"},
+		Cmd:      []string{"headscale", "serve"},
 		PortBindings: map[docker.Port][]docker.PortBinding{
 			"8080/tcp": []docker.PortBinding{{HostPort: "8080"}},
 		},
@@ -127,10 +133,8 @@ func (s *IntegrationSuite) SetUpSuite(c *check.C) {
 		tailscaleOptions := &dockertest.RunOptions{
 			Name:     hostname,
 			Networks: []*dockertest.Network{&network},
-			// Make the container run until killed
-			// Cmd: []string{"sleep", "3600"},
-			Cmd: []string{"tailscaled", "--tun=userspace-networking", "--socks5-server=localhost:1055"},
-			Env: []string{},
+			Cmd:      []string{"tailscaled", "--tun=userspace-networking", "--socks5-server=localhost:1055"},
+			Env:      []string{},
 		}
 
 		if pts, err := pool.BuildAndRunWithBuildOptions(tailscaleBuildOptions, tailscaleOptions, dockerRestartPolicy); err == nil {
@@ -141,6 +145,7 @@ func (s *IntegrationSuite) SetUpSuite(c *check.C) {
 		fmt.Printf("Created %s container\n", hostname)
 	}
 
+	// TODO: Replace this logic with something that can be detected on Github Actions
 	fmt.Println("Waiting for headscale to be ready")
 	hostEndpoint := fmt.Sprintf("localhost:%s", headscale.GetPort("8080/tcp"))
 
@@ -164,14 +169,14 @@ func (s *IntegrationSuite) SetUpSuite(c *check.C) {
 		&headscale,
 		[]string{"headscale", "namespaces", "create", "test"},
 	)
-	c.Assert(err, check.IsNil)
+	assert.Nil(s.T(), err)
 
 	fmt.Println("Creating pre auth key")
 	authKey, err := executeCommand(
 		&headscale,
 		[]string{"headscale", "-n", "test", "preauthkeys", "create", "--reusable", "--expiration", "24h"},
 	)
-	c.Assert(err, check.IsNil)
+	assert.Nil(s.T(), err)
 
 	headscaleEndpoint := fmt.Sprintf("http://headscale:%s", headscale.GetPort("8080/tcp"))
 
@@ -186,12 +191,16 @@ func (s *IntegrationSuite) SetUpSuite(c *check.C) {
 			command,
 		)
 		fmt.Println("tailscale result: ", result)
-		c.Assert(err, check.IsNil)
+		assert.Nil(s.T(), err)
 		fmt.Printf("%s joined\n", hostname)
 	}
+
+	// The nodes need a bit of time to get their updated maps from headscale
+	// TODO: See if we can have a more deterministic wait here.
+	time.Sleep(20 * time.Second)
 }
 
-func (s *IntegrationSuite) TearDownSuite(c *check.C) {
+func (s *IntegrationTestSuite) TearDownSuite() {
 	if err := pool.Purge(&headscale); err != nil {
 		log.Printf("Could not purge resource: %s\n", err)
 	}
@@ -207,21 +216,102 @@ func (s *IntegrationSuite) TearDownSuite(c *check.C) {
 	}
 }
 
-func (s *IntegrationSuite) TestListNodes(c *check.C) {
+func (s *IntegrationTestSuite) TestListNodes() {
 	fmt.Println("Listing nodes")
 	result, err := executeCommand(
 		&headscale,
 		[]string{"headscale", "-n", "test", "nodes", "list"},
 	)
-	c.Assert(err, check.IsNil)
+	assert.Nil(s.T(), err)
+
+	fmt.Printf("List nodes: \n%s\n", result)
+
+	// Chck that the correct count of host is present in node list
+	lines := strings.Split(result, "\n")
+	assert.Equal(s.T(), len(tailscales), len(lines)-2)
 
 	for hostname, _ := range tailscales {
-		c.Assert(strings.Contains(result, hostname), check.Equals, true)
+		assert.Contains(s.T(), result, hostname)
 	}
 }
 
-func (s *IntegrationSuite) TestGetIpAddresses(c *check.C) {
+func (s *IntegrationTestSuite) TestGetIpAddresses() {
 	ipPrefix := netaddr.MustParseIPPrefix("100.64.0.0/10")
+	ips, err := getIPs()
+	assert.Nil(s.T(), err)
+
+	for hostname, _ := range tailscales {
+		s.T().Run(hostname, func(t *testing.T) {
+			ip := ips[hostname]
+
+			fmt.Printf("IP for %s: %s\n", hostname, ip)
+
+			// c.Assert(ip.Valid(), check.IsTrue)
+			assert.True(t, ip.Is4())
+			assert.True(t, ipPrefix.Contains(ip))
+
+			ips[hostname] = ip
+		})
+	}
+}
+
+func (s *IntegrationTestSuite) TestStatus() {
+	ips, err := getIPs()
+	assert.Nil(s.T(), err)
+
+	for hostname, tailscale := range tailscales {
+		s.T().Run(hostname, func(t *testing.T) {
+			command := []string{"tailscale", "status"}
+
+			fmt.Printf("Getting status for %s\n", hostname)
+			result, err := executeCommand(
+				&tailscale,
+				command,
+			)
+			assert.Nil(t, err)
+			// fmt.Printf("Status for %s: %s", hostname, result)
+
+			// Check if we have as many nodes in status
+			// as we have IPs/tailscales
+			lines := strings.Split(result, "\n")
+			assert.Equal(t, len(ips), len(lines)-1)
+			assert.Equal(t, len(tailscales), len(lines)-1)
+
+			// Check that all hosts is present in all hosts status
+			for ipHostname, ip := range ips {
+				assert.Contains(t, result, ip.String())
+				assert.Contains(t, result, ipHostname)
+			}
+		})
+	}
+}
+
+// func (s *IntegrationTestSuite) TestPingAllPeers() {
+// 	ips, err := getIPs()
+// 	assert.Nil(s.T(), err)
+//
+// 	for hostname, tailscale := range tailscales {
+// 		for peername, ip := range ips {
+// 			s.T().Run(fmt.Sprintf("%s-%s", hostname, peername), func(t *testing.T) {
+// 				// We currently cant ping ourselves, so skip that.
+// 				if peername != hostname {
+// 					command := []string{"tailscale", "ping", "--timeout=1s", "--c=1", ip.String()}
+//
+// 					fmt.Printf("Pinging from %s (%s) to %s (%s)\n", hostname, ips[hostname], peername, ip)
+// 					result, err := executeCommand(
+// 						&tailscale,
+// 						command,
+// 					)
+// 					assert.Nil(t, err)
+// 					fmt.Printf("Result for %s: %s\n", hostname, result)
+// 					assert.Contains(t, result, "pong")
+// 				}
+// 			})
+// 		}
+// 	}
+// }
+
+func getIPs() (map[string]netaddr.IP, error) {
 	ips := make(map[string]netaddr.IP)
 	for hostname, tailscale := range tailscales {
 		command := []string{"tailscale", "ip"}
@@ -230,17 +320,16 @@ func (s *IntegrationSuite) TestGetIpAddresses(c *check.C) {
 			&tailscale,
 			command,
 		)
-		c.Assert(err, check.IsNil)
+		if err != nil {
+			return nil, err
+		}
 
 		ip, err := netaddr.ParseIP(strings.TrimSuffix(result, "\n"))
-		c.Assert(err, check.IsNil)
-
-		fmt.Printf("IP for %s: %s", hostname, result)
-
-		// c.Assert(ip.Valid(), check.IsTrue)
-		c.Assert(ip.Is4(), check.Equals, true)
-		c.Assert(ipPrefix.Contains(ip), check.Equals, true)
+		if err != nil {
+			return nil, err
+		}
 
 		ips[hostname] = ip
 	}
+	return ips, nil
 }

--- a/namespaces.go
+++ b/namespaces.go
@@ -169,10 +169,7 @@ func (h *Headscale) checkForNamespacesPendingUpdates() {
 			continue
 		}
 		for _, m := range *machines {
-			err = h.notifyChangesToPeers(&m)
-			if err != nil {
-				continue
-			}
+			h.notifyChangesToPeers(&m)
 		}
 	}
 	newV, err := h.getValue("namespaces_pending_updates")

--- a/poll.go
+++ b/poll.go
@@ -1,0 +1,98 @@
+package headscale
+
+import (
+	"io"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/wgkey"
+)
+
+func (h *Headscale) PollNetMapStream(
+	c *gin.Context,
+	m Machine,
+	req tailcfg.MapRequest,
+	mKey wgkey.Key,
+	pollData chan []byte,
+	update chan []byte,
+	cancelKeepAlive chan []byte,
+) {
+
+	go h.keepAlive(cancelKeepAlive, pollData, mKey, req, m)
+
+	c.Stream(func(w io.Writer) bool {
+		log.Trace().
+			Str("handler", "PollNetMapStream").
+			Str("machine", m.Name).
+			Msg("Waiting for data to stream...")
+		select {
+
+		case data := <-pollData:
+			log.Trace().
+				Str("handler", "PollNetMapStream").
+				Str("machine", m.Name).
+				Int("bytes", len(data)).
+				Msg("Sending data received via pollData channel")
+			_, err := w.Write(data)
+			if err != nil {
+				log.Error().
+					Str("handler", "PollNetMapStream").
+					Str("machine", m.Name).
+					Err(err).
+					Msg("Cannot write data")
+			}
+			log.Trace().
+				Str("handler", "PollNetMapStream").
+				Str("machine", m.Name).
+				Int("bytes", len(data)).
+				Msg("Data from pollData channel written successfully")
+			now := time.Now().UTC()
+			m.LastSeen = &now
+			h.db.Save(&m)
+			log.Trace().
+				Str("handler", "PollNetMapStream").
+				Str("machine", m.Name).
+				Int("bytes", len(data)).
+				Msg("Machine updated successfully after sending pollData")
+			return true
+
+		case <-update:
+			log.Debug().
+				Str("handler", "PollNetMapStream").
+				Str("machine", m.Name).
+				Msg("Received a request for update")
+			data, err := h.getMapResponse(mKey, req, m)
+			if err != nil {
+				log.Error().
+					Str("handler", "PollNetMapStream").
+					Str("machine", m.Name).
+					Err(err).
+					Msg("Could not get the map update")
+			}
+			_, err = w.Write(*data)
+			if err != nil {
+				log.Error().
+					Str("handler", "PollNetMapStream").
+					Str("machine", m.Name).
+					Err(err).
+					Msg("Could not write the map response")
+			}
+			return true
+
+		case <-c.Request.Context().Done():
+			log.Info().
+				Str("handler", "PollNetMapStream").
+				Str("machine", m.Name).
+				Msg("The client has closed the connection")
+			now := time.Now().UTC()
+			m.LastSeen = &now
+			h.db.Save(&m)
+			cancelKeepAlive <- []byte{}
+			h.clientsPolling.Delete(m.ID)
+			close(update)
+			return false
+		}
+	})
+}

--- a/routes.go
+++ b/routes.go
@@ -49,12 +49,7 @@ func (h *Headscale) EnableNodeRoute(namespace string, nodeName string, routeStr 
 			// The peers map is stored in memory in the server process.
 			// Definitely not accessible from the CLI tool.
 			// We need RPC to the server - or some kind of 'needsUpdate' field in the DB
-			peers, _ := h.getPeers(*m)
-			for _, p := range *peers {
-				if pUp, ok := h.clientsPolling.Load(uint64(p.ID)); ok {
-					pUp.(chan []byte) <- []byte{}
-				}
-			}
+			h.notifyChangesToPeers(m)
 			return &rIP, nil
 		}
 	}

--- a/utils.go
+++ b/utils.go
@@ -10,9 +10,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"golang.org/x/crypto/nacl/box"
 	"inet.af/netaddr"
+	"tailscale.com/tailcfg"
 	"tailscale.com/types/wgkey"
 )
 
@@ -58,6 +60,7 @@ func encode(v interface{}, pubKey *wgkey.Key, privKey *wgkey.Private) ([]byte, e
 	if err != nil {
 		return nil, err
 	}
+
 	return encodeMsg(b, pubKey, privKey)
 }
 
@@ -138,4 +141,18 @@ func containsIPs(ips []netaddr.IP, ip netaddr.IP) bool {
 	}
 
 	return false
+}
+
+func tailNodesToString(nodes []*tailcfg.Node) string {
+	temp := make([]string, len(nodes))
+
+	for index, node := range nodes {
+		temp[index] = node.Name
+	}
+
+	return fmt.Sprintf("[ %s ](%d)", strings.Join(temp, ", "), len(temp))
+}
+
+func tailMapResponseToString(resp tailcfg.MapResponse) string {
+	return fmt.Sprintf("{ Node: %s, Peers: %s }", resp.Node.Name, tailNodesToString(resp.Peers))
 }


### PR DESCRIPTION
This PR adds several more integration tests with `Tailscale`, and tries to resolve some of the issues that arise from this in `PollNetMapHandler`:

- Integration test ensuring all Nodes are present in each note `tailscale status` output
- Integration test pinging all nodes from all nodes (cross-ping)

These test will mostly pass, however, there is still some timing and/or race conditions preventing them from being completely reliable. This will be work for the future now that we have a reference to compare against.

The integration tests has switched from gocheck to [testify](https://pkg.go.dev/github.com/stretchr/testify/suite?utm_source=godoc#pkg-overview), as they provide a much richer test setup (and most importantly allow for sub-tests in for loops)

### Current state
When setting up five tailscale nodes via the integration tests and running 20 tests we get the following result:

```
------------------------------------------
Full successful runs: 18
Failed runs: 2
------------------------------------------
```
Which means that most of the runs, all nodes got the appropriate updates and was able to see all nodes in the mesh.

When trying to run test for cross-ping, the tests were slightly more unreliable:

```
------------------------------------------
Full successful runs: 13
Failed runs: 7
------------------------------------------
```
Which seem to be a product that there is not two failure modes: 
- Not having the correct maps, preventing us from pinging a host we dont know about
- `tailscale ping` fails for other reasons. e.g. connection not set up.

These results are after some work on breaking up `PollMapHandler` and ensuring that most nodes can enter the "stream" mode correctly (see comment in PR).

**Apologise** for the massive commit, there was a bit of trying and failing + a merge.