### PR TITLE
Split lint and test CI files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,14 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      # Install and run golangci-lint as a separate step, it's much faster this
+      # way because this action has caching. It'll get run again in `make lint`
+      # below, but it's still much faster in the end than installing
+      # golangci-lint manually in the `Run lint` step.
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          args: --timeout 2m
+
       # Setup Go
       - name: Setup Go
         uses: actions/setup-go@v2
@@ -23,11 +31,9 @@ jobs:
       - name: Install dependencies
         run: |
           go version
+          go install golang.org/x/lint/golint@latest
           sudo apt update
           sudo apt install -y make
 
-      - name: Run tests
-        run: make test
-
-      - name: Run build
-        run: make
+      - name: Run lint
+        run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   # The "build" workflow
-  test:
+  lint:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This commit splits the lint and test steps into two different jobs in
github actions.

Consider this a suggestion, the idea is that when we look at PRs we will
see explicitly which one of the two types of checks fails without having
to open Github actions.

<img width="922" alt="image" src="https://user-images.githubusercontent.com/98431/130325456-197d6e6b-3626-4f64-a9b0-aaa34b32b2b6.png">
