### PR TITLE
Fix setting of version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 version = $(shell ./scripts/version-at-commit.sh)
 
 build:
-	go build -ldflags "-s -w -X main.version=$(version)" cmd/headscale/headscale.go
+	go build -ldflags "-s -w -X github.com/juanfont/headscale/cmd/headscale/cli.version=$(version)" cmd/headscale/headscale.go
 
 dev: lint test build
 

--- a/scripts/version-at-commit.sh
+++ b/scripts/version-at-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -o pipefail
 commit="$1"


### PR DESCRIPTION
Make version-at-commit.sh work on systems that don't have bash in `/bin/bash` while here.