### PR TITLE
Use explicit version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . /go/src/headscale
 RUN go install -a -ldflags="-extldflags=-static" -tags netgo,sqlite_omit_load_extension ./cmd/headscale
 RUN test -e /go/bin/headscale
 
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 COPY --from=build /go/bin/headscale /usr/local/bin/headscale
 ENV TZ UTC


### PR DESCRIPTION
Use explicit version in Dockerfile (addresses #95)

I have only added it to the running container. For the builder one, or the integration tests I rather keep it in latest, so we detect issues ASAP.