### PR TITLE
docs: add notes on how to build own DERP server

### DIFF
--- a/derp.yaml
+++ b/derp.yaml
@@ -1,7 +1,7 @@
 # This file contains some of the official Tailscale DERP servers, 
 # shamelessly taken from https://github.com/tailscale/tailscale/blob/main/net/dnsfallback/dns-fallback-servers.json
 #
-# If you plan to somehow use headscale, please deploy your own DERP infra
+# If you plan to somehow use headscale, please deploy your own DERP infra: https://tailscale.com/kb/1118/custom-derp-servers/
 regions: 
   1:
     regionid: 1


### PR DESCRIPTION
The official doc is hidden under a bunch of issues. Add a doc link here and hope it could be helpful.