### PR TITLE
Remove trace lines about NO_COLOR.

### DIFF
--- a/cmd/headscale/headscale.go
+++ b/cmd/headscale/headscale.go
@@ -22,14 +22,12 @@ func main() {
 		colors = true
 	default:
 		// no color, return text as is.
-		log.Trace().Msg("Colors are not supported, disabling")
 		colors = false
 	}
 
 	// Adhere to no-color.org manifesto of allowing users to
 	// turn off color in cli/services
 	if _, noColorIsSet := os.LookupEnv("NO_COLOR"); noColorIsSet {
-		log.Trace().Msg("NO_COLOR is set, disabling colors")
 		colors = false
 	}
 


### PR DESCRIPTION
Currently there is a warning for every command run when NO_COLOR is set. For example:

```
$ headscale nodes 
{"level":"trace","time":"2021-09-12T07:31:48-06:00","message":"NO_COLOR is set, disabling colors"}
Manage the nodes of Headscale

Usage:
  headscale nodes [command]

Available Commands:
  delete      Delete a node
  list        List the nodes in a given namespace
  register    Registers a machine to your network
  share       Shares a node from the current namespace to the specified one

Flags:
  -h, --help               help for nodes
  -n, --namespace string   Namespace

Global Flags:
  -o, --output string   Output format. Empty for human-readable, 'json' or 'json-line'

Use "headscale nodes [command] --help" for more information about a command.
$
```

This disables that.