### PR TITLE
Fix namespace instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Suggestions/PRs welcomed!
 
     the db.sqlite mount is only needed if you use sqlite
     ```shell
+    touch db.sqlite
     docker run -v $(pwd)/private.key:/private.key -v $(pwd)/config.json:/config.json -v $(pwd)/derp.yaml:/derp.yaml -v $(pwd)/db.sqlite:/db.sqlite -p 127.0.0.1:8000:8000 headscale/headscale:x.x.x headscale namespaces create myfirstnamespace
     ```
     or if your server is already running in docker:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Suggestions/PRs welcomed!
 
     the db.sqlite mount is only needed if you use sqlite
     ```shell
-    docker run -v $(pwd)/private.key:/private.key -v $(pwd)/config.json:/config.json -v $(pwd)/derp.yaml:/derp.yaml -v $(pwd)/db.sqlite:/db.sqlite -p 127.0.0.1:8000:8000 headscale/headscale:x.x.x headscale create myfirstnamespace
+    docker run -v $(pwd)/private.key:/private.key -v $(pwd)/config.json:/config.json -v $(pwd)/derp.yaml:/derp.yaml -v $(pwd)/db.sqlite:/db.sqlite -p 127.0.0.1:8000:8000 headscale/headscale:x.x.x headscale namespaces create myfirstnamespace
     ```
     or if your server is already running in docker:
     ```shell


### PR DESCRIPTION
The instructions in README.md were missing the `namespaces` part of the command.