### PR TITLE
Add the ability to specify the directory URL used for ACME.

### DIFF
--- a/app.go
+++ b/app.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 	"gorm.io/gorm"
 	"inet.af/netaddr"
@@ -43,6 +44,9 @@ type Config struct {
 
 	TLSCertPath string
 	TLSKeyPath  string
+
+	ACMEURL   string
+	ACMEEmail string
 
 	DNSConfig *tailcfg.DNSConfig
 }
@@ -195,6 +199,10 @@ func (h *Headscale) Serve() error {
 			Prompt:     autocert.AcceptTOS,
 			HostPolicy: autocert.HostWhitelist(h.cfg.TLSLetsEncryptHostname),
 			Cache:      autocert.DirCache(h.cfg.TLSLetsEncryptCacheDir),
+			Client: &acme.Client{
+				DirectoryURL: h.cfg.ACMEURL,
+			},
+			Email: h.cfg.ACMEEmail,
 		}
 
 		s.TLSConfig = m.TLSConfig()

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -169,6 +169,9 @@ func getHeadscaleApp() (*headscale.Headscale, error) {
 		TLSCertPath: absPath(viper.GetString("tls_cert_path")),
 		TLSKeyPath:  absPath(viper.GetString("tls_key_path")),
 
+		ACMEEmail: absPath(viper.GetString("acme_email")),
+		ACMEURL:   absPath(viper.GetString("acme_url")),
+
 		DNSConfig: GetDNSConfig(),
 	}
 

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -169,8 +169,8 @@ func getHeadscaleApp() (*headscale.Headscale, error) {
 		TLSCertPath: absPath(viper.GetString("tls_cert_path")),
 		TLSKeyPath:  absPath(viper.GetString("tls_key_path")),
 
-		ACMEEmail: absPath(viper.GetString("acme_email")),
-		ACMEURL:   absPath(viper.GetString("acme_url")),
+		ACMEEmail: viper.GetString("acme_email"),
+		ACMEURL:   viper.GetString("acme_url"),
 
 		DNSConfig: GetDNSConfig(),
 	}

--- a/config.json.postgres.example
+++ b/config.json.postgres.example
@@ -10,6 +10,8 @@
     "db_name": "headscale",
     "db_user": "foo",
     "db_pass": "bar",
+    "acme_url": "https://acme-v02.api.letsencrypt.org/directory",
+    "acme_email": "",
     "tls_letsencrypt_hostname": "",
     "tls_letsencrypt_listen": ":http",
     "tls_letsencrypt_cache_dir": ".cache",

--- a/config.json.sqlite.example
+++ b/config.json.sqlite.example
@@ -6,6 +6,8 @@
     "ephemeral_node_inactivity_timeout": "30m",
     "db_type": "sqlite3",
     "db_path": "db.sqlite",
+    "acme_url": "https://acme-v02.api.letsencrypt.org/directory",
+    "acme_email": "",
     "tls_letsencrypt_hostname": "",
     "tls_letsencrypt_listen": ":http",
     "tls_letsencrypt_cache_dir": ".cache",


### PR DESCRIPTION
I tested with BuyPass using the following conf values:

```
    "acme_email": "aaron@REDACTED",
    "acme_url": "https://api.buypass.com/acme/directory",
 ```