### PR TITLE
Show if an authkey has been used already in the CLI

### DIFF
--- a/cmd/headscale/cli/preauthkeys.go
+++ b/cmd/headscale/cli/preauthkeys.go
@@ -57,7 +57,7 @@ var listPreAuthKeys = &cobra.Command{
 			return
 		}
 
-		d := pterm.TableData{{"ID", "Key", "Reusable", "Ephemeral", "Expiration", "Created"}}
+		d := pterm.TableData{{"ID", "Key", "Reusable", "Ephemeral", "AlreadyUsed", "Expiration", "Created"}}
 		for _, k := range *keys {
 			expiration := "-"
 			if k.Expiration != nil {
@@ -76,6 +76,7 @@ var listPreAuthKeys = &cobra.Command{
 				k.Key,
 				reusable,
 				strconv.FormatBool(k.Ephemeral),
+				fmt.Sprintf("%v", k.AlreadyUsed),
 				expiration,
 				k.CreatedAt.Format("2006-01-02 15:04:05"),
 			})


### PR DESCRIPTION
This PR implements #154 by adding a new `AlreadyUsed` field in `PreAuthKey` - but does not store it in the DB. Instead, it is filled when fetching the auth keys from the DB.
