### PR TITLE
Rename namespaces

### DIFF
--- a/cmd/headscale/cli/namespaces.go
+++ b/cmd/headscale/cli/namespaces.go
@@ -15,6 +15,7 @@ func init() {
 	namespaceCmd.AddCommand(createNamespaceCmd)
 	namespaceCmd.AddCommand(listNamespacesCmd)
 	namespaceCmd.AddCommand(destroyNamespaceCmd)
+	namespaceCmd.AddCommand(renameNamespaceCmd)
 }
 
 var namespaceCmd = &cobra.Command{
@@ -105,5 +106,33 @@ var listNamespacesCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
+	},
+}
+
+var renameNamespaceCmd = &cobra.Command{
+	Use:   "rename OLD_NAME NEW_NAME",
+	Short: "Renames a namespace",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 2 {
+			return fmt.Errorf("Missing parameters")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		o, _ := cmd.Flags().GetString("output")
+		h, err := getHeadscaleApp()
+		if err != nil {
+			log.Fatalf("Error initializing: %s", err)
+		}
+		err = h.RenameNamespace(args[0], args[1])
+		if strings.HasPrefix(o, "json") {
+			JsonOutput(map[string]string{"Result": "Namespace renamed"}, err, o)
+			return
+		}
+		if err != nil {
+			fmt.Printf("Error renaming namespace: %s\n", err)
+			return
+		}
+		fmt.Printf("Namespace renamed\n")
 	},
 }

--- a/namespaces_test.go
+++ b/namespaces_test.go
@@ -46,3 +46,32 @@ func (s *Suite) TestDestroyNamespaceErrors(c *check.C) {
 	err = h.DestroyNamespace("test")
 	c.Assert(err, check.Equals, errorNamespaceNotEmpty)
 }
+
+func (s *Suite) TestRenameNamespace(c *check.C) {
+	n, err := h.CreateNamespace("test")
+	c.Assert(err, check.IsNil)
+	c.Assert(n.Name, check.Equals, "test")
+
+	ns, err := h.ListNamespaces()
+	c.Assert(err, check.IsNil)
+	c.Assert(len(*ns), check.Equals, 1)
+
+	err = h.RenameNamespace("test", "test_renamed")
+	c.Assert(err, check.IsNil)
+
+	_, err = h.GetNamespace("test")
+	c.Assert(err, check.Equals, errorNamespaceNotFound)
+
+	_, err = h.GetNamespace("test_renamed")
+	c.Assert(err, check.IsNil)
+
+	err = h.RenameNamespace("test_does_not_exit", "test")
+	c.Assert(err, check.Equals, errorNamespaceNotFound)
+
+	n2, err := h.CreateNamespace("test2")
+	c.Assert(err, check.IsNil)
+	c.Assert(n2.Name, check.Equals, "test2")
+
+	err = h.RenameNamespace("test2", "test_renamed")
+	c.Assert(err, check.Equals, errorNamespaceExists)
+}


### PR DESCRIPTION
Add cli support for renaming namespaces.

Also fix a bug where database errors when destroying a namespace were silently ignored.