### PR TITLE
Golang ci lint config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,10 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.head_ref }}
-          persist-credentials: false
 
       - name: Prettify code
         uses: creyD/prettier_action@v4.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -19,6 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+          persist-credentials: false
 
       - name: Prettify code
         uses: creyD/prettier_action@v4.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,14 +13,6 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      # Install and run golangci-lint as a separate step, it's much faster this
-      # way because this action has caching. It'll get run again in `make lint`
-      # below, but it's still much faster in the end than installing
-      # golangci-lint manually in the `Run lint` step.
-      - uses: golangci/golangci-lint-action@v2
-        with:
-          args: --timeout 5m
-
       # Setup Go
       - name: Setup Go
         uses: actions/setup-go@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,6 @@ jobs:
         uses: creyD/prettier_action@v4.0
         with:
           prettier_options: >-
-            --check '**/*.{ts,js,md,yaml,yml,sass,css,scss,html}'
+            --check **/*.{ts,js,md,yaml,yml,sass,css,scss,html}
           only_changed: false
           dry: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,6 @@ on: [push, pull_request]
 
 jobs:
   golangci-lint:
-    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,31 +1,29 @@
+---
 name: CI
 
 on: [push, pull_request]
 
 jobs:
-  # The "build" workflow
-  lint:
-    # The type of runner that the job will run on
+  golangci-lint:
+    name: lint
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+          args: --timeout 30m
+
+  prettier-lint:
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v2
 
-      # Setup Go
-      - name: Setup Go
-        uses: actions/setup-go@v2
+      - name: Prettify code
+        uses: creyD/prettier_action@v4.0
         with:
-          go-version: "1.16.3" # The Go version to download (if necessary) and use.
-
-      # Install all the dependencies
-      - name: Install dependencies
-        run: |
-          go version
-          go install golang.org/x/lint/golint@latest
-          sudo apt update
-          sudo apt install -y make
-
-      - name: Run lint
-        run: make lint
+          prettier_options: >-
+            --check '**/*.{ts,js,md,yaml,yml,sass,css,scss,html}'
+          only_changed: false
+          dry: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,17 @@
+---
+linters:
+  enable-all: true
+  disable:
+    - exhaustivestruct
+    - revive
+    - lll
+    - interfacer
+    - scopelint
+    - maligned
+    - golint
+    - gofmt
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - funlen
+    - exhaustivestruct

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,7 @@ coverprofile_html:
 	go tool cover -html=coverage.out
 
 lint:
-	golint
-	golangci-lint run --timeout 5m
+	golangci-lint run --timeout 10m
 
 compress: build
 	upx --brute headscale


### PR DESCRIPTION
This PR adds golangci-lint config with a lot more linters. 

It will definitively fail, a lot, so might have to disable it for a while until we have it in order.