### PR TITLE
Add support for Split DNS (Restricted Nameservers)

### DIFF
--- a/app.go
+++ b/app.go
@@ -113,7 +113,8 @@ func NewHeadscale(cfg Config) (*Headscale, error) {
 		if err != nil {
 			return nil, err
 		}
-		if h.cfg.DNSConfig.Routes == nil { // we might have routes already from Split DNS
+		// we might have routes already from Split DNS
+		if h.cfg.DNSConfig.Routes == nil { 
 			h.cfg.DNSConfig.Routes = make(map[string][]dnstype.Resolver)
 		}
 		for _, d := range magicDNSDomains {

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -109,9 +109,9 @@ func GetDNSConfig() (*tailcfg.DNSConfig, string) {
 			if len(dnsConfig.Nameservers) > 0 {
 				dnsConfig.Routes = make(map[string][]dnstype.Resolver)
 				restrictedDNS := viper.GetStringMapStringSlice("dns_config.restricted_nameservers")
-				for domain, resNameservers := range restrictedDNS {
-					resResolvers := make([]dnstype.Resolver, len(resNameservers))
-					for index, nameserverStr := range resNameservers {
+				for domain, restrictedNameservers := range restrictedDNS {
+					restrictedResolvers := make([]dnstype.Resolver, len(restrictedNameservers))
+					for index, nameserverStr := range restrictedNameservers {
 						nameserver, err := netaddr.ParseIP(nameserverStr)
 						if err != nil {
 							log.Error().
@@ -119,11 +119,11 @@ func GetDNSConfig() (*tailcfg.DNSConfig, string) {
 								Err(err).
 								Msgf("Could not parse restricted nameserver IP: %s", nameserverStr)
 						}
-						resResolvers[index] = dnstype.Resolver{
+						restrictedResolvers[index] = dnstype.Resolver{
 							Addr: nameserver.String(),
 						}
 					}
-					dnsConfig.Routes[domain] = resResolvers
+					dnsConfig.Routes[domain] = restrictedResolvers
 				}
 			} else {
 				log.Warn().

--- a/docs/DNS.md
+++ b/docs/DNS.md
@@ -36,4 +36,4 @@ dns_config:
 - `domains`: Search domains to inject.
 - `magic_dns`: Whether to use [MagicDNS](https://tailscale.com/kb/1081/magicdns/). Only works if there is at least a nameserver defined.
 - `base_domain`: Defines the base domain to create the hostnames for MagicDNS. `base_domain` must be a FQDNs, without the trailing dot. The FQDN of the hosts will be `hostname.namespace.base_domain` (e.g., _myhost.mynamespace.example.com_).
-- `restricted_nameservers`: Also known as Split DNS (see https://tailscale.com/kb/1054/dns/), list of search domains and the DNS you want to use for them.
+- `restricted_nameservers`: Split DNS (see https://tailscale.com/kb/1054/dns/), list of search domains and the DNS to query for each one.


### PR DESCRIPTION
This simple PR adds support for Split DNS in the headscale configuration.

All the base infrastructure was there, the only missing bit was actually reading them from the config file.

Implements #179, and works on #181.