### PR TITLE
Enable prerelease support on goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,10 @@
-# This is an example .goreleaser.yml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
 before:
   hooks:
     - go mod tidy
+
+release:
+  prerelease: auto
+
 builds:
   - id: darwin-amd64
     main: ./cmd/headscale/headscale.go


### PR DESCRIPTION
So we can have stuff like x.y.z-beta1 tagged as a pre-released in GitHub by goreleaser.