### PR TITLE
arm64 docker image build in release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      
       - name: Set up QEMU for multiple platforms
         uses: docker/setup-qemu-action@master
         with:
           platforms: arm64,amd64
-
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -53,7 +51,6 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -67,20 +64,17 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-            
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          
       - name: Login to GHCR
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
@@ -92,12 +86,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
-
       - name: Prepare cache for next build
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
 
   docker-debug-release:
     runs-on: ubuntu-latest
@@ -110,7 +102,6 @@ jobs:
         uses: docker/setup-qemu-action@master
         with:
           platforms: arm64,amd64
-
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -118,7 +109,6 @@ jobs:
           key: ${{ runner.os }}-buildx-debug-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-debug-
-
       - name: Docker meta
         id: meta-debug
         uses: docker/metadata-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,20 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      
+      - name: Set up QEMU for multiple platforms
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: arm64,amd64
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -53,17 +67,20 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
+            
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+          
       - name: Login to GHCR
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
@@ -72,3 +89,11 @@ jobs:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Prepare cache for next build
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
Seeing that arm64 builds of CLI are already implemented ( #168 ), this adds arm64 arch digests to the Release image.
Also, I'm adding cache for the build layer to speed up the deployment. 

Loving your work!
Will upload a Helm chart as soon as I understand DERP systems.