### PR TITLE
Running.md: fix missing backslash (\)

### DIFF
--- a/docs/Running.md
+++ b/docs/Running.md
@@ -26,7 +26,7 @@
 
    ```shell
    docker run --name headscale \
-     -e POSTGRES_DB=headscale
+     -e POSTGRES_DB=headscale \
      -e POSTGRES_USER=foo \
      -e POSTGRES_PASSWORD=bar \
      -p 5432:5432 \


### PR DESCRIPTION
* This would cause otherwise the command to abort after the first statement of the docker command ;)