### PR TITLE
Fix default preauthkey expiration

### DIFF
--- a/cmd/headscale/cli/preauthkeys.go
+++ b/cmd/headscale/cli/preauthkeys.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DefaultPreAuthKeyExpiry = 24 * time.Hour
+	DefaultPreAuthKeyExpiry = 1 * time.Hour
 )
 
 func init() {
@@ -145,14 +145,12 @@ var createPreAuthKeyCmd = &cobra.Command{
 			Ephemeral: ephemeral,
 		}
 
-		if cmd.Flags().Changed("expiration") {
-			duration, _ := cmd.Flags().GetDuration("expiration")
-			expiration := time.Now().UTC().Add(duration)
+		duration, _ := cmd.Flags().GetDuration("expiration")
+		expiration := time.Now().UTC().Add(duration)
 
-			log.Trace().Dur("expiration", duration).Msg("expiration has been set")
+		log.Trace().Dur("expiration", duration).Msg("expiration has been set")
 
-			request.Expiration = timestamppb.New(expiration)
-		}
+		request.Expiration = timestamppb.New(expiration)
 
 		ctx, client, conn, cancel := getHeadscaleCLIClient()
 		defer cancel()

--- a/integration_cli_test.go
+++ b/integration_cli_test.go
@@ -426,7 +426,12 @@ func (s *IntegrationCLITestSuite) TestPreAuthKeyCommandWithoutExpiry() {
 	assert.Nil(s.T(), err)
 
 	assert.Len(s.T(), listedPreAuthKeys, 1)
-	assert.True(s.T(), time.Time{}.Equal(listedPreAuthKeys[0].Expiration.AsTime()))
+
+	assert.True(s.T(), listedPreAuthKeys[0].Expiration.AsTime().After(time.Now()))
+	assert.True(
+		s.T(),
+		listedPreAuthKeys[0].Expiration.AsTime().Before(time.Now().Add(time.Minute*70)),
+	)
 }
 
 func (s *IntegrationCLITestSuite) TestPreAuthKeyCommandReusableEphemeral() {


### PR DESCRIPTION
When creating a preauthkey, the default expiration was passed through as a nil value, instead of the default value (24h). This resulted in the preauthkey being created with expiration key '0001-01-01 00:00:00', which meant the key would not work, because it was already expired.

This commit applies the default expiration time (24h) when a preauthkey is created without a specific expiration. It also updates an integration test to make sure this bug does not reoccur.