### PR TITLE
Enable marking releases as prerelease

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,10 @@
 before:
   hooks:
     - go mod tidy
+
+release:
+  prerelease: auto
+
 builds:
   - id: darwin-amd64
     main: ./cmd/headscale/headscale.go


### PR DESCRIPTION
This small PR adds allows to get a release tagged as prerelease if we include in the tag stuff like -rc1