### PR TITLE
Template Fixes

### DIFF
--- a/apple_mobileconfig.go
+++ b/apple_mobileconfig.go
@@ -2,8 +2,8 @@ package headscale
 
 import (
 	"bytes"
+	"html/template"
 	"net/http"
-	"text/template"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gofrs/uuid"

--- a/swagger.go
+++ b/swagger.go
@@ -3,8 +3,8 @@ package headscale
 import (
 	"bytes"
 	_ "embed"
+	"html/template"
 	"net/http"
-	"text/template"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"


### PR DESCRIPTION
## Description
This pull request fixes a number of template errors resulting in XSS vulnerabilities.

## Security Advisory
I recommend creating a [GitHub security advisory](https://docs.github.com/en/code-security/security-advisories/creating-a-security-advisory) with the following:
* Affected product
    * Ecosystem: `Go`
    * Package name: `github.com/juanfont/headscale`
    * Affected versions: unknown
    * Patches versions: TBD
* Severity: `Assess severity using CVSS`
* Vector string: `CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:U/C:L/I:L/A:N`
* CWE: [74](https://cwe.mitre.org/data/definitions/74.html)
* CVE identifier: `Request CVE ID later`
* Title: `Unsanitized HTML Template Evaluation`
* Description:

### Impact
If the Tailscale client were to be compromised, it could instruct users to go to
a malicious URL where said client has **total** control over content on the Headscale
webpage due to incorrect template evaluation. For example, if you visit
`/register?key=<script>alert('XSS')</script>` on a Headscale control server, you'll
see an alert box.

### Patches
TBD

### Workarounds
Analyze all Headscale URLs for suspicious content (Especially percent-encoded query parameters)

### References
* [html/template](https://pkg.go.dev/html/template)

---

@juanfont