### PR TITLE
Strip binary, update to go-1.17.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17.3"
+          go-version: "1.17"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17.3"
+          go-version: "1.17"
 
       - name: Run Integration tests
         run: go test -tags integration -timeout 30m

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17.3" # The Go version to download (if necessary) and use.
+          go-version: "1.17" # The Go version to download (if necessary) and use.
 
       # Install all the dependencies
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder image
-FROM golang:1.17.1-bullseye AS build
+FROM golang:1.17.6-bullseye AS build
 ENV GOPATH /go
 WORKDIR /go/src/headscale
 
@@ -9,6 +9,7 @@ RUN go mod download
 COPY . .
 
 RUN go install -a -ldflags="-extldflags=-static" -tags netgo,sqlite_omit_load_extension ./cmd/headscale
+RUN strip /go/bin/headscale
 RUN test -e /go/bin/headscale
 
 # Production image

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # Builder image
-FROM golang:1.17.1-alpine AS build
+FROM golang:1.17.6-alpine AS build
 ENV GOPATH /go
 WORKDIR /go/src/headscale
 
@@ -10,6 +10,7 @@ RUN go mod download
 COPY . .
 
 RUN go install -a -ldflags="-extldflags=-static" -tags netgo,sqlite_omit_load_extension ./cmd/headscale
+RUN strip /go/bin/headscale
 RUN test -e /go/bin/headscale
 
 # Production image


### PR DESCRIPTION
With this PR the binary is compiled with go 1.17.6 to close some of the open CVE´s in go 1.17.1. 
Furthermore the resulting binary is stripped which reduces the size of the binary by ~10MB.

```
before:
-rwxr-xr-x    1 root     root      32766008 Jan 13 16:07 /bin/headscale

after:
-rwxr-xr-x    1 root     root      22325232 Jan 14 08:14 /bin/headscale
```


- [x] read the [CONTRIBUTING guidelines](README.md#user-content-contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
