### PR TITLE
Set up build avoidance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v14.1
         with:
-          fetch-depth: 2
           files: |
             go.*
             **/*.go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,21 +15,36 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v14.1
+        with:
+          fetch-depth: 2
+          files: |
+            go.*
+            **/*.go
+            integration_test/
+            config-example.yaml
+
       - name: Setup Go
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v2
         with:
           go-version: "1.17"
 
       - name: Install dependencies
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           go version
           sudo apt update
           sudo apt install -y make
 
       - name: Run build
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: make build
 
       - uses: actions/upload-artifact@v2
+        if: steps.changed-files.outputs.any_changed == 'true'
         with:
           name: headscale-linux
           path: headscale

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v14.1
         with:
+          fetch-depth: 2
           files: |
             go.*
             **/*.go
@@ -40,6 +41,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v14.1
         with:
+          fetch-depth: 2
           files: |
             **/*.md
             **/*.yml
@@ -52,6 +54,7 @@ jobs:
             **/*.html
 
       - name: Prettify code
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: creyD/prettier_action@v4.0
         with:
           prettier_options: >-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v14.1
         with:
-          fetch-depth: 2
           files: |
             go.*
             **/*.go
@@ -36,12 +37,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v14.1
         with:
-          fetch-depth: 2
           files: |
             **/*.md
             **/*.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v14.1
+        with:
+          files: |
+            go.*
+            **/*.go
+            integration_test/
+            config-example.yaml
+
       - name: golangci-lint
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: golangci/golangci-lint-action@v2
         with:
           version: latest
@@ -24,6 +35,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v14.1
+        with:
+          files: |
+            **/*.md
+            **/*.yml
+            **/*.yaml
+            **/*.ts
+            **/*.js
+            **/*.sass
+            **/*.css
+            **/*.scss
+            **/*.html
 
       - name: Prettify code
         uses: creyD/prettier_action@v4.0

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -13,6 +13,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v14.1
         with:
+          fetch-depth: 2
           files: |
             go.*
             **/*.go

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -8,12 +8,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v14.1
         with:
-          fetch-depth: 2
           files: |
             go.*
             **/*.go

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -3,21 +3,28 @@ name: CI
 on: [pull_request]
 
 jobs:
-  # The "build" workflow
   integration-test:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      # Setup Go
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v14.1
+        with:
+          files: |
+            go.*
+            **/*.go
+            integration_test/
+            config-example.yaml
+
       - name: Setup Go
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v2
         with:
           go-version: "1.17"
 
       - name: Run Integration tests
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: go test -tags integration -timeout 30m

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v14.1
         with:
+          fetch-depth: 2
           files: |
             go.*
             **/*.go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v14.1
         with:
-          fetch-depth: 2
           files: |
             go.*
             **/*.go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,31 +3,39 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  # The "build" workflow
   test:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      # Setup Go
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v14.1
+        with:
+          files: |
+            go.*
+            **/*.go
+            integration_test/
+            config-example.yaml
+
       - name: Setup Go
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17" # The Go version to download (if necessary) and use.
+          go-version: "1.17"
 
-      # Install all the dependencies
       - name: Install dependencies
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           go version
           sudo apt update
           sudo apt install -y make
 
       - name: Run tests
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: make test
 
       - name: Run build
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: make


### PR DESCRIPTION
This commit configures the CI to run specific parts of the CI when
relevant changes has been made.

This should help us not have to deal with the integration tests when we
do doc/admin changes.
