### PR TITLE
Migrate ip_address field to ip_addresses

### DIFF
--- a/db.go
+++ b/db.go
@@ -30,18 +30,24 @@ func (h *Headscale) initDB() error {
 	if h.dbType == Postgres {
 		db.Exec("create extension if not exists \"uuid-ossp\";")
 	}
+
+	_ = db.Migrator().RenameColumn(&Machine{}, "ip_address", "ip_addresses")
+
 	err = db.AutoMigrate(&Machine{})
 	if err != nil {
 		return err
 	}
+
 	err = db.AutoMigrate(&KV{})
 	if err != nil {
 		return err
 	}
+
 	err = db.AutoMigrate(&Namespace{})
 	if err != nil {
 		return err
 	}
+
 	err = db.AutoMigrate(&PreAuthKey{})
 	if err != nil {
 		return err

--- a/db.go
+++ b/db.go
@@ -28,7 +28,7 @@ func (h *Headscale) initDB() error {
 	h.db = db
 
 	if h.dbType == Postgres {
-		db.Exec("create extension if not exists \"uuid-ossp\";")
+		db.Exec(`create extension if not exists "uuid-ossp";`)
 	}
 
 	_ = db.Migrator().RenameColumn(&Machine{}, "ip_address", "ip_addresses")


### PR DESCRIPTION
The automatic migration did not pick up this change and it breaks
current setups as it only adds a new field which is empty.

This means that clients who dont request a new IP will not have any IP
at all.

