### PR TITLE
Note when running as another user in systemd

### DIFF
--- a/docs/running-headscale-linux.md
+++ b/docs/running-headscale-linux.md
@@ -138,6 +138,16 @@ RuntimeDirectory=headscale
 WantedBy=multi-user.target
 ```
 
+Note that when running as the headscale user ensure that, either you add your current user to the headscale group:
+```shell
+usermod -a -G headscale current_user
+```
+or run all headscale commands as the headscale user:
+
+```shell
+su - headscale
+```
+
 2. In `/etc/headscale/config.yaml`, override the default `headscale` unix socket with a SystemD friendly path:
 
 ```yaml

--- a/docs/running-headscale-linux.md
+++ b/docs/running-headscale-linux.md
@@ -139,9 +139,11 @@ WantedBy=multi-user.target
 ```
 
 Note that when running as the headscale user ensure that, either you add your current user to the headscale group:
+
 ```shell
 usermod -a -G headscale current_user
 ```
+
 or run all headscale commands as the headscale user:
 
 ```shell


### PR DESCRIPTION
Headscale commands fail when running them as the current user instead of the user defined in the systemd file. This note provides 2 methods of how to correctly run the headscale commands.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#user-content-contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [] added unit tests
- [] added integration tests
- [x] updated documentation if needed
- [] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
