### PR TITLE
Topic/renovatebot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["config:base"]",
+  "baseBranches": ["main"],
+  "branchPrefix": "renovateaction",
+  "extends": ["config:base", ":rebaseStalePrs"],
+  "enabledManagers": ["dockerfile", "go", "github-actions"]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,38 @@
 {
-  "extends": ["config:base"]",
   "baseBranches": ["main"],
-  "branchPrefix": "renovateaction",
+  "username": "renovate-release",
+  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+  "branchPrefix": "renovateaction/",
+  "onboarding": false,
   "extends": ["config:base", ":rebaseStalePrs"],
-  "enabledManagers": ["dockerfile", "go", "github-actions"]
+  "ignorePresets": [":prHourlyLimit2"],
+  "enabledManagers": ["dockerfile", "gomod", "github-actions","regex" ],
+  "includeForks": true,
+  "repositories": ["juanfont/headscale"],
+  "platform": "github",
+  "packageRules": [
+    {
+        "matchDatasources": ["go"],
+        "groupName": "Go modules",
+        "groupSlug": "gomod",
+        "separateMajorMinor": false
+    },
+    {
+        "matchDatasources": ["docker"],
+        "groupName": "Dockerfiles",
+        "groupSlug": "dockerfiles"
+    } 
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+          ".github/workflows/.*.yml$"
+      ],
+      "matchStrings": [
+        "\\s*go-version:\\s*\"?(?<currentValue>.*?)\"?\\n"
+      ],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "actions/go-version"
+    }
+  ]
 }

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -1,0 +1,26 @@
+---
+name: Renovate
+on:
+  schedule:
+    - cron: '* * 5,20 * *' #Every 5th and 20th of the month
+  workflow_dispatch: 
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get token
+        id: get_token
+        uses: machine-learning-apps/actions-app-token@master
+        with:
+          APP_PEM: ${{ secrets.RENOVATEBOT_SECRET }}
+          APP_ID: ${{ secrets.RENOVATEBOT_APP_ID }}
+
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v31.81.2
+        with:
+          configurationFile: .github/renovate.json
+          token: 'x-access-token:${{ steps.get_token.outputs.app_token }}'
+          onboarding: false

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -19,8 +19,9 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v31.81.2
+        uses: renovatebot/github-action@v31.81.3
         with:
           configurationFile: .github/renovate.json
           token: "x-access-token:${{ steps.get_token.outputs.app_token }}"
-          onboarding: false
+        # env:
+        #  LOG_LEVEL: "debug"

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -2,8 +2,8 @@
 name: Renovate
 on:
   schedule:
-    - cron: '* * 5,20 * *' #Every 5th and 20th of the month
-  workflow_dispatch: 
+    - cron: "* * 5,20 * *" # Every 5th and 20th of the month
+  workflow_dispatch:
 jobs:
   renovate:
     runs-on: ubuntu-latest
@@ -22,5 +22,5 @@ jobs:
         uses: renovatebot/github-action@v31.81.2
         with:
           configurationFile: .github/renovate.json
-          token: 'x-access-token:${{ steps.get_token.outputs.app_token }}'
+          token: "x-access-token:${{ steps.get_token.outputs.app_token }}"
           onboarding: false


### PR DESCRIPTION
<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#user-content-contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [] added unit tests
- [] added integration tests
- [] updated documentation if needed
- [] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

This will implement #323. 
To make the renovatebot work, we would need to create a github app. (I decided to implement it with an app, as the permissions can be set more specifically)

In the developer setting create a new app.
1. Set GitHub App name (eg.renovatebot-headscale, or something like that)
2. Set Homepage URL to https://github.com/juanfont/headscale
3. Set permissions:
- Administration Read-only
- Contents Read & write
- Issues Read & write
- Metadata Read-only
- Pull requests Read & write
- Workflows Read & write
- Everything else leave on No access
4. Install App "Only select repositories" --> juanfont/headscale
5. Generate Private Key (this will let you download a zip with a cert inside)
6. Add to the Secrets Actions of the repository two new secrets
7. *RENOVATEBOT_APP_ID* with the content App ID
8. *RENOVATEBOT_SECRET* with the private key encoded in base64 (cat <APPNAME>.<CURRENT_DATE>.private-key.pem | base64 -w 0 && echo
9. Merge PR

After the setup of renovatebot it run it manually for the first time. This will result in some PRs to update some github actions. After that the renovatebot will look automatically on the 5th and 20th of each month for updates. Otherwise it will spam a lot of PRs for update. This can be reconfigured if needed.
