### PR TITLE
docs: fix typo in ACME challenge type comment

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -123,7 +123,7 @@ tls_client_auth_mode: relaxed
 tls_letsencrypt_cache_dir: /var/lib/headscale/cache
 
 # Type of ACME challenge to use, currently supported types:
-# HTTP-01 or TLS_ALPN-01
+# HTTP-01 or TLS-ALPN-01
 # See [docs/tls.md](docs/tls.md) for more information
 tls_letsencrypt_challenge_type: HTTP-01
 # When HTTP-01 challenge is chosen, letsencrypt must set up a


### PR DESCRIPTION
<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#user-content-contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

Fixed typo in example config comment. Closes #386.

```
TLS_ALPN-01 => TLS-ALPN-01
```
