### PR TITLE
Regression bug fix when re-authenticating machine with auth-key

### DIFF
--- a/api.go
+++ b/api.go
@@ -600,7 +600,6 @@ func (h *Headscale) handleAuthKey(
 		machine.NodeKey = nodeKey
 		machine.AuthKeyID = uint(pak.ID)
 		h.RefreshMachine(machine, registerRequest.Expiry)
-
 	} else {
 
 		now := time.Now().UTC()
@@ -614,7 +613,7 @@ func (h *Headscale) handleAuthKey(
 			LastSeen:       &now,
 			AuthKeyID:      uint(pak.ID),
 		}
-	
+
 		machine, err = h.RegisterMachine(
 			machineToRegister,
 		)
@@ -629,9 +628,9 @@ func (h *Headscale) handleAuthKey(
 				http.StatusInternalServerError,
 				"could not register machine",
 			)
-	
+
 			return
-		}			
+		}
 	}
 
 	h.UsePreAuthKey(pak)

--- a/api.go
+++ b/api.go
@@ -601,7 +601,6 @@ func (h *Headscale) handleAuthKey(
 		machine.AuthKeyID = uint(pak.ID)
 		h.RefreshMachine(machine, registerRequest.Expiry)
 	} else {
-
 		now := time.Now().UTC()
 		machineToRegister := Machine{
 			Name:           registerRequest.Hostinfo.Hostname,


### PR DESCRIPTION
This pull request fixes a regression bug where re-authenticating an expired machine (as a result of logout) resulted in a duplicate machine record. The fix simply refreshes the expired machine record to make it current.

This request updates https://github.com/juanfont/headscale/pull/490 based on review.

