### PR TITLE
Make STUN run by default when embedded DERP is enabled

### DIFF
--- a/app.go
+++ b/app.go
@@ -48,6 +48,14 @@ import (
 )
 
 const (
+	errSTUNAddressNotSet                   = Error("STUN address not set")
+	errUnsupportedDatabase                 = Error("unsupported DB")
+	errUnsupportedLetsEncryptChallengeType = Error(
+		"unknown value for Lets Encrypt challenge type",
+	)
+)
+
+const (
 	AuthPrefix         = "Bearer "
 	Postgres           = "postgres"
 	Sqlite             = "sqlite3"
@@ -57,12 +65,6 @@ const (
 
 	registerCacheExpiration = time.Minute * 15
 	registerCacheCleanup    = time.Minute * 20
-
-	errUnsupportedDatabase                 = Error("unsupported DB")
-	errUnsupportedLetsEncryptChallengeType = Error(
-		"unknown value for Lets Encrypt challenge type",
-	)
-	errSTUNAddressNotSet = Error("STUN address not set")
 
 	DisabledClientAuth = "disabled"
 	RelaxedClientAuth  = "relaxed"

--- a/app.go
+++ b/app.go
@@ -501,7 +501,8 @@ func (h *Headscale) Serve() error {
 	h.DERPMap = GetDERPMap(h.cfg.DERP)
 
 	if h.cfg.DERP.ServerEnabled {
-		if h.cfg.DERP.STUNAddr == "" { // When embedded DERP is enabled we always need a STUN server address, embedded or external
+		// When embedded DERP is enabled we always need a STUN server address, embedded or external
+		if h.cfg.DERP.STUNAddr == "" {
 			return errSTUNAddressNotSet
 		}
 

--- a/app.go
+++ b/app.go
@@ -127,7 +127,6 @@ type DERPConfig struct {
 	ServerRegionID   int
 	ServerRegionCode string
 	ServerRegionName string
-	STUNEnabled      bool
 	STUNAddr         string
 	URLs             []url.URL
 	Paths            []string
@@ -503,15 +502,13 @@ func (h *Headscale) Serve() error {
 	h.DERPMap = GetDERPMap(h.cfg.DERP)
 
 	if h.cfg.DERP.ServerEnabled {
-		// When embedded DERP is enabled we always need a STUN server address, embedded or external
+		// When embedded DERP is enabled we always need a STUN server
 		if h.cfg.DERP.STUNAddr == "" {
 			return errSTUNAddressNotSet
 		}
 
 		h.DERPMap.Regions[h.DERPServer.region.RegionID] = &h.DERPServer.region
-		if h.cfg.DERP.STUNEnabled {
-			go h.ServeSTUN()
-		}
+		go h.ServeSTUN()
 	}
 
 	if h.cfg.DERP.AutoUpdate {

--- a/app.go
+++ b/app.go
@@ -62,6 +62,7 @@ const (
 	errUnsupportedLetsEncryptChallengeType = Error(
 		"unknown value for Lets Encrypt challenge type",
 	)
+	errSTUNAddressNotSet = Error("STUN address not set")
 
 	DisabledClientAuth = "disabled"
 	RelaxedClientAuth  = "relaxed"
@@ -502,6 +503,10 @@ func (h *Headscale) Serve() error {
 	h.DERPMap = GetDERPMap(h.cfg.DERP)
 
 	if h.cfg.DERP.ServerEnabled {
+		if h.cfg.DERP.STUNAddr == "" { // When embedded DERP is enabled we always need a STUN server address, embedded or external
+			return errSTUNAddressNotSet
+		}
+
 		h.DERPMap.Regions[h.DERPServer.region.RegionID] = &h.DERPServer.region
 		if h.cfg.DERP.STUNEnabled {
 			go h.ServeSTUN()

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -124,8 +124,11 @@ func GetDERPConfig() headscale.DERPConfig {
 	serverRegionID := viper.GetInt("derp.server.region_id")
 	serverRegionCode := viper.GetString("derp.server.region_code")
 	serverRegionName := viper.GetString("derp.server.region_name")
-	stunEnabled := viper.GetBool("derp.server.stun.enabled")
-	stunAddr := viper.GetString("derp.server.stun.listen_addr")
+	stunAddr := viper.GetString("derp.server.stun_listen_addr")
+
+	if serverEnabled && stunAddr == "" {
+		log.Fatal().Msg("derp.server.stun_listen_addr must be set if derp.server.enabled is true")
+	}
 
 	urlStrs := viper.GetStringSlice("derp.urls")
 
@@ -152,7 +155,6 @@ func GetDERPConfig() headscale.DERPConfig {
 		ServerRegionID:   serverRegionID,
 		ServerRegionCode: serverRegionCode,
 		ServerRegionName: serverRegionName,
-		STUNEnabled:      stunEnabled,
 		STUNAddr:         stunAddr,
 		URLs:             urls,
 		Paths:            paths,

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -55,6 +55,9 @@ func LoadConfig(path string) error {
 
 	viper.SetDefault("dns_config", nil)
 
+	viper.SetDefault("derp.server.enabled", false)
+	viper.SetDefault("derp.server.stun.enabled", true)
+
 	viper.SetDefault("unix_socket", "/var/run/headscale.sock")
 	viper.SetDefault("unix_socket_permission", "0o770")
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -69,14 +69,12 @@ derp:
     region_code: "headscale"
     region_name: "Headscale Embedded DERP"
 
-    # Enabled by default when embedded DERP is enabled. Listens in UDP at the configured address for STUN connections
-    # to help on NAT traversal.
-    # If DERP is enabled, but STUN is disabled you still need to input an external STUN server in the listen_addr field.
+
+    # Listens in UDP at the configured address for STUN connections to help on NAT traversal.
+    # When the embedded DERP server is enabled stun_listen_addr MUST be defined.
     #
     # For more details on how this works, check this great article: https://tailscale.com/blog/how-tailscale-works/
-    stun:
-      enabled: true
-      listen_addr: "0.0.0.0:3478"
+    stun_listen_addr: "0.0.0.0:3478"
 
   # List of externally available DERP maps encoded in JSON
   urls:

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -69,7 +69,6 @@ derp:
     region_code: "headscale"
     region_name: "Headscale Embedded DERP"
 
-
     # Listens in UDP at the configured address for STUN connections to help on NAT traversal.
     # When the embedded DERP server is enabled stun_listen_addr MUST be defined.
     #

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -69,10 +69,13 @@ derp:
     region_code: "headscale"
     region_name: "Headscale Embedded DERP"
 
-    # If enabled, also listens in UDP at the configured address for STUN connections to help on NAT traversal
+    # Enabled by default when embedded DERP is enabled. Listens in UDP at the configured address for STUN connections
+    # to help on NAT traversal.
+    # If DERP is enabled, but STUN is disabled you still need to input an external STUN server in the listen_addr field.
+    #
     # For more details on how this works, check this great article: https://tailscale.com/blog/how-tailscale-works/
     stun:
-      enabled: false
+      enabled: true
       listen_addr: "0.0.0.0:3478"
 
   # List of externally available DERP maps encoded in JSON

--- a/derp_server.go
+++ b/derp_server.go
@@ -77,17 +77,15 @@ func (h *Headscale) generateRegionLocalDERP() (tailcfg.DERPRegion, error) {
 		},
 	}
 
-	if h.cfg.DERP.STUNEnabled {
-		_, portStr, err := net.SplitHostPort(h.cfg.DERP.STUNAddr)
-		if err != nil {
-			return tailcfg.DERPRegion{}, err
-		}
-		port, err := strconv.Atoi(portStr)
-		if err != nil {
-			return tailcfg.DERPRegion{}, err
-		}
-		localDERPregion.Nodes[0].STUNPort = port
+	_, portSTUNStr, err := net.SplitHostPort(h.cfg.DERP.STUNAddr)
+	if err != nil {
+		return tailcfg.DERPRegion{}, err
 	}
+	portSTUN, err := strconv.Atoi(portSTUNStr)
+	if err != nil {
+		return tailcfg.DERPRegion{}, err
+	}
+	localDERPregion.Nodes[0].STUNPort = portSTUN
 
 	return localDERPregion, nil
 }

--- a/integration_test/etc_embedded_derp/config.yaml
+++ b/integration_test/etc_embedded_derp/config.yaml
@@ -24,6 +24,5 @@ derp:
     region_id: 999
     region_code: "headscale"
     region_name: "Headscale Embedded DERP"
-    stun:
-      enabled: true
-      listen_addr: "0.0.0.0:3478"
+
+    stun_listen_addr: "0.0.0.0:3478"


### PR DESCRIPTION
This commit also allows to set an external STUN server, while running the embedded DERP server (without embedded STUN)
