### PR TITLE
Fixed docs metrics default endpoint

### DIFF
--- a/docs/running-headscale-container.md
+++ b/docs/running-headscale-container.md
@@ -55,6 +55,7 @@ docker run \
   --rm \
   --volume $(pwd)/config:/etc/headscale/ \
   --publish 127.0.0.1:8080:8080 \
+  --publish 127.0.0.1:9090:9090 \
   headscale/headscale:<VERSION> \
   headscale serve
 
@@ -80,7 +81,7 @@ docker ps
 Verify `headscale` is available:
 
 ```shell
-curl http://127.0.0.1:8080/metrics
+curl http://127.0.0.1:9090/metrics
 ```
 
 6. Create a namespace ([tailnet](https://tailscale.com/kb/1136/tailnet/)):

--- a/docs/running-headscale-linux.md
+++ b/docs/running-headscale-linux.md
@@ -67,7 +67,7 @@ To run `headscale` in the background, please follow the steps in the [SystemD se
 Verify `headscale` is available:
 
 ```shell
-curl http://127.0.0.1:8080/metrics
+curl http://127.0.0.1:9090/metrics
 ```
 
 8. Create a namespace ([tailnet](https://tailscale.com/kb/1136/tailnet/)):


### PR DESCRIPTION
Fixed docs `/metrics` default endpoint `8080 → 9090`.

Reference [`config-example.yaml`](https://github.com/juanfont/headscale/blob/1579ffb66ad3da3e76ea920734f78886405aac66/config-example.yaml#L23):

```
# Address to listen to /metrics, you may want
# to keep this endpoint private to your internal
# network
#
metrics_listen_addr: 127.0.0.1:9090
```

Verify `headscale` is available:

```shell
curl http://127.0.0.1:9090/metrics
```