### PR TITLE
Add Tailscale unstable channel and repo HEAD to integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Users can now use emails in ACL's groups [#372](https://github.com/juanfont/headscale/issues/372)
 - Add shorthand aliases for commands and subcommands [#376](https://github.com/juanfont/headscale/pull/376)
 - Add `/windows` endpoint for Windows configuration instructions + registry file download [#392](https://github.com/juanfont/headscale/pull/392)
-- Added embedded DERP server into Headscale [#388](https://github.com/juanfont/headscale/pull/388)
+- Added embedded DERP (and STUN) server into Headscale [#388](https://github.com/juanfont/headscale/pull/388)
 
 ### Changes
 
@@ -30,6 +30,7 @@
 - Reduce the overhead of marshal/unmarshal for Hostinfo, routes and endpoints by using specific types in Machine [#371](https://github.com/juanfont/headscale/pull/371)
 - Apply normalization function to FQDN on hostnames when hosts registers and retrieve informations [#363](https://github.com/juanfont/headscale/issues/363)
 - Fix a bug that prevented the use of `tailscale logout` with OIDC [#508](https://github.com/juanfont/headscale/issues/508)
+- Added Tailscale repo HEAD and unstable releases channel to the integration tests targets [#513](https://github.com/juanfont/headscale/pull/513)
 
 ## 0.14.0 (2022-02-24)
 

--- a/Dockerfile.tailscale
+++ b/Dockerfile.tailscale
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 
-ARG TAILSCALE_VERSION
-ARG TAILSCALE_CHANNEL
+ARG TAILSCALE_VERSION=*
+ARG TAILSCALE_CHANNEL=stable
 
 RUN apt-get update \
     && apt-get install -y gnupg curl \

--- a/Dockerfile.tailscale
+++ b/Dockerfile.tailscale
@@ -1,11 +1,12 @@
 FROM ubuntu:latest
 
 ARG TAILSCALE_VERSION
+ARG TAILSCALE_CHANNEL
 
 RUN apt-get update \
     && apt-get install -y gnupg curl \
-    && curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.gpg | apt-key add - \
-    && curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/focal.list | tee /etc/apt/sources.list.d/tailscale.list \
+    && curl -fsSL https://pkgs.tailscale.com/${TAILSCALE_CHANNEL}/ubuntu/focal.gpg | apt-key add - \
+    && curl -fsSL https://pkgs.tailscale.com/${TAILSCALE_CHANNEL}/ubuntu/focal.list | tee /etc/apt/sources.list.d/tailscale.list \
     && apt-get update \
     && apt-get install -y ca-certificates tailscale=${TAILSCALE_VERSION} dnsutils \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.tailscale-HEAD
+++ b/Dockerfile.tailscale-HEAD
@@ -1,0 +1,21 @@
+FROM golang:latest
+
+RUN apt-get update \
+    && apt-get install -y ca-certificates dnsutils git \
+    && rm -rf /var/lib/apt/lists/*
+
+
+RUN git clone https://github.com/tailscale/tailscale.git
+
+WORKDIR tailscale
+
+RUN sh build_dist.sh tailscale.com/cmd/tailscale
+RUN sh build_dist.sh tailscale.com/cmd/tailscaled
+
+RUN cp tailscale /usr/local/
+RUN cp tailscaled /usr/local/
+
+ADD integration_test/etc_embedded_derp/tls/server.crt /usr/local/share/ca-certificates/
+RUN chmod 644 /usr/local/share/ca-certificates/server.crt 
+
+RUN update-ca-certificates

--- a/Dockerfile.tailscale-HEAD
+++ b/Dockerfile.tailscale-HEAD
@@ -12,8 +12,8 @@ WORKDIR tailscale
 RUN sh build_dist.sh tailscale.com/cmd/tailscale
 RUN sh build_dist.sh tailscale.com/cmd/tailscaled
 
-RUN cp tailscale /usr/local/
-RUN cp tailscaled /usr/local/
+RUN cp tailscale /usr/local/bin/
+RUN cp tailscaled /usr/local/bin/
 
 ADD integration_test/etc_embedded_derp/tls/server.crt /usr/local/share/ca-certificates/
 RUN chmod 644 /usr/local/share/ca-certificates/server.crt 

--- a/Dockerfile.tailscale-HEAD
+++ b/Dockerfile.tailscale-HEAD
@@ -1,7 +1,7 @@
 FROM golang:latest
 
 RUN apt-get update \
-    && apt-get install -y ca-certificates dnsutils git \
+    && apt-get install -y ca-certificates dnsutils git iptables \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/integration_cli_test.go
+++ b/integration_cli_test.go
@@ -72,7 +72,7 @@ func (s *IntegrationCLITestSuite) SetupTest() {
 	if pheadscale, err := s.pool.BuildAndRunWithBuildOptions(headscaleBuildOptions, headscaleOptions, DockerRestartPolicy); err == nil {
 		s.headscale = *pheadscale
 	} else {
-		log.Fatalf("Could not start resource: %s", err)
+		log.Fatalf("Could not start headscale container: %s", err)
 	}
 	fmt.Println("Created headscale container")
 

--- a/integration_common_test.go
+++ b/integration_common_test.go
@@ -20,7 +20,7 @@ var (
 	IpPrefix4 = netaddr.MustParseIPPrefix("100.64.0.0/10")
 	IpPrefix6 = netaddr.MustParseIPPrefix("fd7a:115c:a1e0::/48")
 
-	tailscaleVersions = []string{"1.22.0", "1.20.4", "1.18.2", "1.16.2", "1.14.3", "1.12.3"}
+	tailscaleVersions = []string{"HEAD", "unstable", "1.22.0", "1.20.4", "1.18.2", "1.16.2", "1.14.3", "1.12.3"}
 )
 
 type TestNamespace struct {
@@ -126,6 +126,49 @@ func DockerAllowNetworkAdministration(config *docker.HostConfig) {
 		Source: "/dev/net/tun",
 		Target: "/dev/net/tun",
 	})
+}
+
+func getDockerBuildOptions(version string) *dockertest.BuildOptions {
+	var tailscaleBuildOptions *dockertest.BuildOptions
+	switch version {
+	case "HEAD":
+		tailscaleBuildOptions = &dockertest.BuildOptions{
+			Dockerfile: "Dockerfile.tailscale-HEAD",
+			ContextDir: ".",
+			BuildArgs:  []docker.BuildArg{},
+		}
+	case "unstable":
+		tailscaleBuildOptions = &dockertest.BuildOptions{
+			Dockerfile: "Dockerfile.tailscale",
+			ContextDir: ".",
+			BuildArgs: []docker.BuildArg{
+				{
+					Name:  "TAILSCALE_VERSION",
+					Value: "*", // Installs the latest version https://askubuntu.com/a/824926
+				},
+				{
+					Name:  "TAILSCALE_CHANNEL",
+					Value: "unstable",
+				},
+			},
+		}
+	default:
+		tailscaleBuildOptions = &dockertest.BuildOptions{
+			Dockerfile: "Dockerfile.tailscale",
+			ContextDir: ".",
+			BuildArgs: []docker.BuildArg{
+				{
+					Name:  "TAILSCALE_VERSION",
+					Value: version,
+				},
+				{
+					Name:  "TAILSCALE_CHANNEL",
+					Value: "stable",
+				},
+			},
+		}
+	}
+	return tailscaleBuildOptions
 }
 
 func getIPs(

--- a/integration_common_test.go
+++ b/integration_common_test.go
@@ -20,7 +20,7 @@ var (
 	IpPrefix4 = netaddr.MustParseIPPrefix("100.64.0.0/10")
 	IpPrefix6 = netaddr.MustParseIPPrefix("fd7a:115c:a1e0::/48")
 
-	tailscaleVersions = []string{"HEAD", "unstable", "1.22.0", "1.20.4", "1.18.2", "1.16.2", "1.14.3", "1.12.3"}
+	tailscaleVersions = []string{"head", "unstable", "1.22.2", "1.20.4", "1.18.2", "1.16.2", "1.14.3", "1.12.3"}
 )
 
 type TestNamespace struct {
@@ -131,7 +131,7 @@ func DockerAllowNetworkAdministration(config *docker.HostConfig) {
 func getDockerBuildOptions(version string) *dockertest.BuildOptions {
 	var tailscaleBuildOptions *dockertest.BuildOptions
 	switch version {
-	case "HEAD":
+	case "head":
 		tailscaleBuildOptions = &dockertest.BuildOptions{
 			Dockerfile: "Dockerfile.tailscale-HEAD",
 			ContextDir: ".",

--- a/integration_embedded_derp_test.go
+++ b/integration_embedded_derp_test.go
@@ -245,16 +245,8 @@ func (s *IntegrationDERPTestSuite) Join(
 
 func (s *IntegrationDERPTestSuite) tailscaleContainer(identifier, version string, network dockertest.Network,
 ) (string, *dockertest.Resource) {
-	tailscaleBuildOptions := &dockertest.BuildOptions{
-		Dockerfile: "Dockerfile.tailscale",
-		ContextDir: ".",
-		BuildArgs: []docker.BuildArg{
-			{
-				Name:  "TAILSCALE_VERSION",
-				Value: version,
-			},
-		},
-	}
+	tailscaleBuildOptions := getDockerBuildOptions(version)
+
 	hostname := fmt.Sprintf(
 		"tailscale-%s-%s",
 		strings.Replace(version, ".", "-", -1),

--- a/integration_embedded_derp_test.go
+++ b/integration_embedded_derp_test.go
@@ -121,7 +121,7 @@ func (s *IntegrationDERPTestSuite) SetupSuite() {
 	if pheadscale, err := s.pool.BuildAndRunWithBuildOptions(headscaleBuildOptions, headscaleOptions, DockerRestartPolicy); err == nil {
 		s.headscale = *pheadscale
 	} else {
-		log.Fatalf("Could not start resource: %s", err)
+		log.Fatalf("Could not start headscale container: %s", err)
 	}
 	log.Println("Created headscale container to test DERP")
 
@@ -271,7 +271,7 @@ func (s *IntegrationDERPTestSuite) tailscaleContainer(identifier, version string
 		DockerAllowNetworkAdministration,
 	)
 	if err != nil {
-		log.Fatalf("Could not start resource: %s", err)
+		log.Fatalf("Could not start tailscale container version %s: %s", version, err)
 	}
 	log.Printf("Created %s container\n", hostname)
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -168,16 +168,8 @@ func (s *IntegrationTestSuite) Join(
 func (s *IntegrationTestSuite) tailscaleContainer(
 	namespace, identifier, version string,
 ) (string, *dockertest.Resource) {
-	tailscaleBuildOptions := &dockertest.BuildOptions{
-		Dockerfile: "Dockerfile.tailscale",
-		ContextDir: ".",
-		BuildArgs: []docker.BuildArg{
-			{
-				Name:  "TAILSCALE_VERSION",
-				Value: version,
-			},
-		},
-	}
+	tailscaleBuildOptions := getDockerBuildOptions(version)
+
 	hostname := fmt.Sprintf(
 		"%s-tailscale-%s-%s",
 		namespace,

--- a/integration_test.go
+++ b/integration_test.go
@@ -192,7 +192,7 @@ func (s *IntegrationTestSuite) tailscaleContainer(
 		DockerAllowNetworkAdministration,
 	)
 	if err != nil {
-		log.Fatalf("Could not start resource: %s", err)
+		log.Fatalf("Could not start tailscale container version %s: %s", version, err)
 	}
 	log.Printf("Created %s container\n", hostname)
 
@@ -241,7 +241,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	if pheadscale, err := s.pool.BuildAndRunWithBuildOptions(headscaleBuildOptions, headscaleOptions, DockerRestartPolicy); err == nil {
 		s.headscale = *pheadscale
 	} else {
-		log.Fatalf("Could not start resource: %s", err)
+		log.Fatalf("Could not start headscale container: %s", err)
 	}
 	log.Println("Created headscale container")
 


### PR DESCRIPTION
In preparation for the implementation of the new TS2021 protocol (Tailscale control protocol v2) we are expanding the test infrastructure

- [ ] added unit tests
- [x] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md
