### PR TITLE
fix: possible panic in `Headscale.scheduledDERPMapUpdateWorker`

### DIFF
--- a/derp.go
+++ b/derp.go
@@ -148,7 +148,9 @@ func (h *Headscale) scheduledDERPMapUpdateWorker(cancelChan <-chan struct{}) {
 		case <-ticker.C:
 			log.Info().Msg("Fetching DERPMap updates")
 			h.DERPMap = GetDERPMap(h.cfg.DERP)
-			h.DERPMap.Regions[h.DERPServer.region.RegionID] = &h.DERPServer.region
+			if h.cfg.DERP.ServerEnabled {
+				h.DERPMap.Regions[h.DERPServer.region.RegionID] = &h.DERPServer.region
+			}
 
 			namespaces, err := h.ListNamespaces()
 			if err != nil {


### PR DESCRIPTION
There is a possible nil pointer dereference panic in the `Headscale.scheduledDERPMapUpdateWorker`. Such as when the embedded DERP server is disabled.