### PR TITLE
Fix labels cardinality error when registering unknown pre-auth key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.16.0 (2022-xx-xx)
 
+### Changes
+
+- Fix labels cardinality error when registering unknown pre-auth key [#519](https://github.com/juanfont/headscale/pull/519)
+
 ## 0.15.0 (2022-03-20)
 
 **Note:** Take a backup of your database before upgrading.

--- a/api.go
+++ b/api.go
@@ -573,7 +573,7 @@ func (h *Headscale) handleAuthKey(
 			machineRegistrations.WithLabelValues("new", RegisterMethodAuthKey, "error", pak.Namespace.Name).
 				Inc()
 		} else {
-			machineRegistrations.WithLabelValues("new", RegisterMethodAuthKey, "error").Inc()
+			machineRegistrations.WithLabelValues("new", RegisterMethodAuthKey, "error", "unknown").Inc()
 		}
 
 		return


### PR DESCRIPTION
<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#user-content-contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

I fat-fingered an auth-key, and observed this error:

```
2022-03-21T02:57:35Z INF New machine machine=localhost-live
2022-03-21T02:57:35Z DBG Processing auth key for localhost-live func=handleAuthKey machine=localhost-live
2022-03-21T02:57:35Z ERR ../home/runner/work/headscale/headscale/api.go:544 > Failed authentication via AuthKey error="AuthKey not found" func=handleAuthKey machine=localhost-live
2022-03-21T02:57:35Z ERR ../home/runner/work/headscale/headscale/api.go:567 > Failed authentication via AuthKey func=handleAuthKey machine=localhost-live


[GIN-debug] [WARNING] Headers were already written. Wanted to override status code 401 with 500
2022/03/21 09:57:35 [Recovery] 2022/03/21 - 09:57:35 panic recovered:
POST /machine/snip.machine.key HTTP/1.0
Host: snip-host
Connection: close
Connection: close
Content-Length: 867
User-Agent: Go-http-client/1.1
X-Forwarded-For: 123.snip
X-Forwarded-Proto: https
X-Real-Ip: 123.snip


inconsistent label cardinality: expected 4 label values but got 3 in []string{"new", "authkey", "error"}
/home/runner/go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/counter.go:252 (0xb9fc04)
/home/runner/work/headscale/headscale/api.go:576 (0xf11bb6)
/home/runner/work/headscale/headscale/api.go:132 (0xf0e8c7)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.7.7/context.go:168 (0x9b4281)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.7.7/recovery.go:99 (0x9b426c)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.7.7/context.go:168 (0x9b33a6)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.7.7/logger.go:241 (0x9b3389)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.7.7/context.go:168 (0x9b2470)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.7.7/gin.go:555 (0x9b20d8)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.7.7/gin.go:511 (0x9b1c11)
/opt/hostedtoolcache/go/1.18.0/x64/src/net/http/server.go:2916 (0x7c3b9a)
/opt/hostedtoolcache/go/1.18.0/x64/src/net/http/server.go:1966 (0x7beb96)
/opt/hostedtoolcache/go/1.18.0/x64/src/runtime/asm_amd64.s:1571 (0x467700)
```