### PR TITLE
fix: Remove days from expiry option value examples

### DIFF
--- a/cmd/headscale/cli/api_key.go
+++ b/cmd/headscale/cli/api_key.go
@@ -23,7 +23,7 @@ func init() {
 	apiKeysCmd.AddCommand(listAPIKeys)
 
 	createAPIKeyCmd.Flags().
-		DurationP("expiration", "e", DefaultAPIKeyExpiry, "Human-readable expiration of the key (30m, 24h, 365d...)")
+		DurationP("expiration", "e", DefaultAPIKeyExpiry, "Human-readable expiration of the key (e.g. 30m, 24h)")
 
 	apiKeysCmd.AddCommand(createAPIKeyCmd)
 

--- a/cmd/headscale/cli/preauthkeys.go
+++ b/cmd/headscale/cli/preauthkeys.go
@@ -31,7 +31,7 @@ func init() {
 	createPreAuthKeyCmd.PersistentFlags().
 		Bool("ephemeral", false, "Preauthkey for ephemeral nodes")
 	createPreAuthKeyCmd.Flags().
-		DurationP("expiration", "e", DefaultPreAuthKeyExpiry, "Human-readable expiration of the key (30m, 24h, 365d...)")
+		DurationP("expiration", "e", DefaultPreAuthKeyExpiry, "Human-readable expiration of the key (e.g. 30m, 24h)")
 }
 
 var preauthkeysCmd = &cobra.Command{


### PR DESCRIPTION
The `-e` option for `preauthkeys create` and `apikeys create` is processed with `time.ParseDuration` which does not support the `d` suffix (for days) and also no other "bigger" suffixes:

* https://pkg.go.dev/time#ParseDuration
* https://github.com/golang/go/issues/11473

First I thought I could fix the CLI code but as it's just using cobra to read the expiration flag, I changed the documentation for the commands accepting the `-e` flag.