### PR TITLE
Fix wrong metrics port in docs

### DIFF
--- a/docs/running-headscale-linux.md
+++ b/docs/running-headscale-linux.md
@@ -178,7 +178,7 @@ systemctl status headscale
 Verify `headscale` is available:
 
 ```shell
-curl http://127.0.0.1:8080/metrics
+curl http://127.0.0.1:9090/metrics
 ```
 
 `headscale` will now run in the background and start at boot.


### PR DESCRIPTION
It should be 9090.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#user-content-contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
