### PR TITLE
Update discord link so it does not grant temp memberships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ derp.yaml
 .idea
 
 test_output/ 
+
+# Nix and direnv
+.direnv/
+result

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 An open source, self-hosted implementation of the Tailscale control server.
 
-Join our [Discord](https://discord.gg/xGj2TuqyxY) server for a chat.
+Join our [Discord](https://discord.gg/c84AZQhmpx) server for a chat.
 
 **Note:** Always select the same GitHub tag as the released version you use
 to ensure you have the correct example configuration and documentation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 This page contains the official and community contributed documentation for `headscale`.
 
 If you are having trouble with following the documentation or get unexpected results,
-please ask on [Discord](https://discord.gg/XcQxk2VHjx) instead of opening an Issue.
+please ask on [Discord](https://discord.gg/c84AZQhmpx) instead of opening an Issue.
 
 ## Official documentation
 


### PR DESCRIPTION
The current link grants temp memberships which means people loose the server.