### PR TITLE
Allow more configuration over the OIDC flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix send on closed channel crash in polling [#542](https://github.com/juanfont/headscale/pull/542)
 - Fixed spurious calls to setLastStateChangeToNow from ephemeral nodes [#566](https://github.com/juanfont/headscale/pull/566)
 - Add command for moving nodes between namespaces [#362](https://github.com/juanfont/headscale/issues/362)
+- Added more configuration parameters for OpenID Connect (scopes, free-form paramters, domain and user allowlist)
 
 ## 0.15.0 (2022-03-20)
 

--- a/app.go
+++ b/app.go
@@ -119,6 +119,10 @@ type OIDCConfig struct {
 	Issuer           string
 	ClientID         string
 	ClientSecret     string
+	Scope            []string
+	ExtraParams      map[string]string
+	AllowedDomains   []string
+	AllowedUsers     []string
 	StripEmaildomain bool
 }
 

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/juanfont/headscale"
 	v1 "github.com/juanfont/headscale/gen/go/headscale/v1"
 	"github.com/rs/zerolog/log"
@@ -67,6 +68,7 @@ func LoadConfig(path string) error {
 	viper.SetDefault("cli.timeout", "5s")
 	viper.SetDefault("cli.insecure", false)
 
+	viper.SetDefault("oidc.scope", []string{oidc.ScopeOpenID, "profile", "email"})
 	viper.SetDefault("oidc.strip_email_domain", true)
 
 	if err := viper.ReadInConfig(); err != nil {
@@ -367,6 +369,10 @@ func getHeadscaleConfig() headscale.Config {
 			Issuer:           viper.GetString("oidc.issuer"),
 			ClientID:         viper.GetString("oidc.client_id"),
 			ClientSecret:     viper.GetString("oidc.client_secret"),
+			Scope:            viper.GetStringSlice("oidc.scope"),
+			ExtraParams:      viper.GetStringMapString("oidc.extra_params"),
+			AllowedDomains:   viper.GetStringSlice("oidc.allowed_domains"),
+			AllowedUsers:     viper.GetStringSlice("oidc.allowed_users"),
 			StripEmaildomain: viper.GetBool("oidc.strip_email_domain"),
 		},
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -214,6 +214,21 @@ unix_socket_permission: "0770"
 #   client_id: "your-oidc-client-id"
 #   client_secret: "your-oidc-client-secret"
 #
+#   Customize the scopes used in the OIDC flow, defaults to "openid", "profile" and "email" and add custom query
+#   parameters to the Authorize Endpoint request. Scopes default to "openid", "profile" and "email".
+#
+#   scope: ["openid", "profile", "email", "custom"]
+#   extra_params:
+#     domain_hint: example.com
+#
+#   List allowed principal domains and/or users. If an authenticated user's domain is not in this list, the
+#   authentication request will be rejected.
+#
+#   allowed_domains:
+#     - example.com
+#   allowed_users:
+#     - alice@example.com
+#
 #   If `strip_email_domain` is set to `true`, the domain part of the username email address will be removed.
 #   This will transform `first-name.last-name@example.com` to the namespace `first-name.last-name`
 #   If `strip_email_domain` is set to `false` the domain part will NOT be removed resulting to the following

--- a/utils.go
+++ b/utils.go
@@ -317,3 +317,13 @@ func GenerateRandomStringURLSafe(n int) (string, error) {
 
 	return base64.RawURLEncoding.EncodeToString(b), err
 }
+
+func IsStringInSlice(slice []string, str string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Adds knobs to configure three aspects of the OpenID Connect flow:

 * Custom scopes to override the default "openid profile email".
 * Custom parameters to be added to the Authorize Endpoint request.
 * Domain allowlisting for authenticated principals.
 * User allowlisting for authenticated principals.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#user-content-contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand (#561)
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md
