### PR TITLE
Do not setLastStateChangeToNow every expireEphemeralNodesWorker call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Headscale fails to serve if the ACL policy file cannot be parsed [#537](https://github.com/juanfont/headscale/pull/537)
 - Fix labels cardinality error when registering unknown pre-auth key [#519](https://github.com/juanfont/headscale/pull/519)
 - Fix send on closed channel crash in polling [#542](https://github.com/juanfont/headscale/pull/542)
+- Fixed spurious calls to setLastStateChangeToNow from ephemeral nodes [#566](https://github.com/juanfont/headscale/pull/566)
 
 ## 0.15.0 (2022-03-20)
 

--- a/app.go
+++ b/app.go
@@ -292,11 +292,13 @@ func (h *Headscale) expireEphemeralNodesWorker() {
 			return
 		}
 
+		expiredFound := false
 		for _, machine := range machines {
 			if machine.AuthKey != nil && machine.LastSeen != nil &&
 				machine.AuthKey.Ephemeral &&
 				time.Now().
 					After(machine.LastSeen.Add(h.cfg.EphemeralNodeInactivityTimeout)) {
+				expiredFound = true
 				log.Info().
 					Str("machine", machine.Name).
 					Msg("Ephemeral client removed from database")
@@ -311,7 +313,9 @@ func (h *Headscale) expireEphemeralNodesWorker() {
 			}
 		}
 
-		h.setLastStateChangeToNow(namespace.Name)
+		if expiredFound {
+			h.setLastStateChangeToNow(namespace.Name)
+		}
 	}
 }
 


### PR DESCRIPTION
`setLastStateChangeToNow` was being called everytime we run `expireEphemeralNodesWorker`, even if there are no nodes to expire.


- [x] updated CHANGELOG.md
