### PR TITLE
Reduce the number of containers in integration tests

### DIFF
--- a/app.go
+++ b/app.go
@@ -322,7 +322,8 @@ func (h *Headscale) expireEphemeralNodesWorker() {
 func (h *Headscale) grpcAuthenticationInterceptor(ctx context.Context,
 	req interface{},
 	info *grpc.UnaryServerInfo,
-	handler grpc.UnaryHandler) (interface{}, error) {
+	handler grpc.UnaryHandler,
+) (interface{}, error) {
 	// Check if the request is coming from the on-server client.
 	// This is not secure, but it is to maintain maintainability
 	// with the "legacy" database-based client

--- a/derp_server.go
+++ b/derp_server.go
@@ -122,7 +122,7 @@ func (h *Headscale) DERPHandler(ctx *gin.Context) {
 
 	if !fastStart {
 		pubKey := h.privateKey.Public()
-		pubKeyStr := pubKey.UntypedHexString() // nolint
+		pubKeyStr := pubKey.UntypedHexString()
 		fmt.Fprintf(conn, "HTTP/1.1 101 Switching Protocols\r\n"+
 			"Upgrade: DERP\r\n"+
 			"Connection: Upgrade\r\n"+

--- a/integration_test.go
+++ b/integration_test.go
@@ -47,11 +47,11 @@ func TestIntegrationTestSuite(t *testing.T) {
 
 	s.namespaces = map[string]TestNamespace{
 		"thisspace": {
-			count:      15,
+			count:      10,
 			tailscales: make(map[string]dockertest.Resource),
 		},
 		"otherspace": {
-			count:      5,
+			count:      2,
 			tailscales: make(map[string]dockertest.Resource),
 		},
 	}


### PR DESCRIPTION
As per https://github.com/juanfont/headscale/issues/567, I am temporarily reducing a bit the number of containers run in the integration tests.

This should make a little bit less of a PITA running the continuous integration