### PR TITLE
Allow headscale to enable/disable logtail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Add command to set tags on a node [#525](https://github.com/juanfont/headscale/issues/525)
 - Add command to view tags of nodes [#356](https://github.com/juanfont/headscale/issues/356)
 - Add --all (-a) flag to enable routes command [#360](https://github.com/juanfont/headscale/issues/360)
+- Add option to enable/disable logtail (Tailscale's logging infrastructure) [#596](https://github.com/juanfont/headscale/pull/596)
+  - This change disables the logs by default
 
 ## 0.15.0 (2022-03-20)
 

--- a/api.go
+++ b/api.go
@@ -279,6 +279,9 @@ func (h *Headscale) getMapResponse(
 		PacketFilter: h.aclRules,
 		DERPMap:      h.DERPMap,
 		UserProfiles: profiles,
+		Debug: &tailcfg.Debug{
+			DisableLogTail: !h.cfg.LogTail.Enabled,
+		},
 	}
 
 	log.Trace().

--- a/app.go
+++ b/app.go
@@ -112,6 +112,8 @@ type Config struct {
 
 	OIDC OIDCConfig
 
+	LogTail LogTailConfig
+
 	CLI CLIConfig
 }
 
@@ -136,6 +138,10 @@ type DERPConfig struct {
 	Paths            []string
 	AutoUpdate       bool
 	UpdateFrequency  time.Duration
+}
+
+type LogTailConfig struct {
+	Enabled bool
 }
 
 type CLIConfig struct {

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -72,6 +72,8 @@ func LoadConfig(path string) error {
 	viper.SetDefault("oidc.scope", []string{oidc.ScopeOpenID, "profile", "email"})
 	viper.SetDefault("oidc.strip_email_domain", true)
 
+	viper.SetDefault("logtail.enabled", false)
+
 	if err := viper.ReadInConfig(); err != nil {
 		return fmt.Errorf("fatal error reading config file: %w", err)
 	}
@@ -164,6 +166,14 @@ func GetDERPConfig() headscale.DERPConfig {
 		Paths:            paths,
 		AutoUpdate:       autoUpdate,
 		UpdateFrequency:  updateFrequency,
+	}
+}
+
+func GetLogConfig() headscale.LogTailConfig {
+	enabled := viper.GetBool("logtail.enabled")
+
+	return headscale.LogTailConfig{
+		Enabled: enabled,
 	}
 }
 
@@ -270,6 +280,7 @@ func absPath(path string) string {
 func getHeadscaleConfig() headscale.Config {
 	dnsConfig, baseDomain := GetDNSConfig()
 	derpConfig := GetDERPConfig()
+	logConfig := GetLogConfig()
 
 	configuredPrefixes := viper.GetStringSlice("ip_prefixes")
 	parsedPrefixes := make([]netaddr.IPPrefix, 0, len(configuredPrefixes)+1)
@@ -377,6 +388,8 @@ func getHeadscaleConfig() headscale.Config {
 			AllowedUsers:     viper.GetStringSlice("oidc.allowed_users"),
 			StripEmaildomain: viper.GetBool("oidc.strip_email_domain"),
 		},
+
+		LogTail: logConfig,
 
 		CLI: headscale.CLIConfig{
 			Address:  viper.GetString("cli.address"),

--- a/cmd/headscale/headscale_test.go
+++ b/cmd/headscale/headscale_test.go
@@ -67,6 +67,7 @@ func (*Suite) TestConfigLoading(c *check.C) {
 		check.Equals,
 		fs.FileMode(0o770),
 	)
+	c.Assert(viper.GetBool("logtail.enabled"), check.Equals, false)
 }
 
 func (*Suite) TestDNSConfigLoading(c *check.C) {

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -241,6 +241,6 @@ unix_socket_permission: "0770"
 # to instruct tailscale nodes to log their activity to a remote server.
 logtail:
   # Enable logtail for this headscales clients.
-  # As there is currently no support for overriding the log server in headscale, this is 
+  # As there is currently no support for overriding the log server in headscale, this is
   # disabled by default. Enabling this will make your clients send logs to Tailscale Inc.
   enabled: false

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -235,3 +235,12 @@ unix_socket_permission: "0770"
 #   namespace: `first-name.last-name.example.com`
 #
 #   strip_email_domain: true
+
+# Logtail configuration
+# Logtail is Tailscales logging and auditing infrastructure, it allows the control panel
+# to instruct tailscale nodes to log their activity to a remote server.
+logtail:
+  # Enable logtail for this headscales clients.
+  # As there is currently no support for overriding the log server in headscale, this is 
+  # disabled by default. Enabling this will make your clients send logs to Tailscale Inc.
+  enabled: false


### PR DESCRIPTION
This PR allows users to disable logtail in their Tailscale clients, essentially allowing them to stop sending logs to Tailscale.

This resolves #552.

LogTail is now disabled by default.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
