### PR TITLE
Improve signal handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add option to enable/disable logtail (Tailscale's logging infrastructure) [#596](https://github.com/juanfont/headscale/pull/596)
   - This change disables the logs by default
 - Use [Prometheus]'s duration parser, supporting days (`d`), weeks (`w`) and years (`y`) [#598](https://github.com/juanfont/headscale/pull/598)
+- Add support for reloading ACLs and configuration with SIGHUP [#600](https://github.com/juanfont/headscale/pull/600)
 
 ## 0.15.0 (2022-03-20)
 

--- a/app.go
+++ b/app.go
@@ -115,6 +115,8 @@ type Config struct {
 	LogTail LogTailConfig
 
 	CLI CLIConfig
+
+	ACL ACLConfig
 }
 
 type OIDCConfig struct {
@@ -149,6 +151,10 @@ type CLIConfig struct {
 	APIKey   string
 	Timeout  time.Duration
 	Insecure bool
+}
+
+type ACLConfig struct {
+	PolicyPath string
 }
 
 // Headscale represents the base app of the service.

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -177,6 +177,14 @@ func GetLogTailConfig() headscale.LogTailConfig {
 	}
 }
 
+func GetACLConfig() headscale.ACLConfig {
+	policyPath := viper.GetString("acl_policy_path")
+
+	return headscale.ACLConfig{
+		PolicyPath: policyPath,
+	}
+}
+
 func GetDNSConfig() (*tailcfg.DNSConfig, string) {
 	if viper.IsSet("dns_config") {
 		dnsConfig := &tailcfg.DNSConfig{}
@@ -397,6 +405,8 @@ func GetHeadscaleConfig() headscale.Config {
 			Timeout:  viper.GetDuration("cli.timeout"),
 			Insecure: viper.GetBool("cli.insecure"),
 		},
+
+		ACL: GetACLConfig(),
 	}
 }
 

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -272,7 +272,7 @@ func GetDNSConfig() (*tailcfg.DNSConfig, string) {
 	return nil, ""
 }
 
-func absPath(path string) string {
+func AbsolutePathFromConfigPath(path string) string {
 	// If a relative path is provided, prefix it with the the directory where
 	// the config file was found.
 	if (path != "") && !strings.HasPrefix(path, string(os.PathSeparator)) {
@@ -350,7 +350,7 @@ func GetHeadscaleConfig() headscale.Config {
 		GRPCAllowInsecure: viper.GetBool("grpc_allow_insecure"),
 
 		IPPrefixes:     prefixes,
-		PrivateKeyPath: absPath(viper.GetString("private_key_path")),
+		PrivateKeyPath: AbsolutePathFromConfigPath(viper.GetString("private_key_path")),
 		BaseDomain:     baseDomain,
 
 		DERP: derpConfig,
@@ -360,7 +360,7 @@ func GetHeadscaleConfig() headscale.Config {
 		),
 
 		DBtype: viper.GetString("db_type"),
-		DBpath: absPath(viper.GetString("db_path")),
+		DBpath: AbsolutePathFromConfigPath(viper.GetString("db_path")),
 		DBhost: viper.GetString("db_host"),
 		DBport: viper.GetInt("db_port"),
 		DBname: viper.GetString("db_name"),
@@ -369,13 +369,13 @@ func GetHeadscaleConfig() headscale.Config {
 
 		TLSLetsEncryptHostname: viper.GetString("tls_letsencrypt_hostname"),
 		TLSLetsEncryptListen:   viper.GetString("tls_letsencrypt_listen"),
-		TLSLetsEncryptCacheDir: absPath(
+		TLSLetsEncryptCacheDir: AbsolutePathFromConfigPath(
 			viper.GetString("tls_letsencrypt_cache_dir"),
 		),
 		TLSLetsEncryptChallengeType: viper.GetString("tls_letsencrypt_challenge_type"),
 
-		TLSCertPath:       absPath(viper.GetString("tls_cert_path")),
-		TLSKeyPath:        absPath(viper.GetString("tls_key_path")),
+		TLSCertPath:       AbsolutePathFromConfigPath(viper.GetString("tls_cert_path")),
+		TLSKeyPath:        AbsolutePathFromConfigPath(viper.GetString("tls_key_path")),
 		TLSClientAuthMode: tlsClientAuthMode,
 
 		DNSConfig: dnsConfig,
@@ -436,7 +436,7 @@ func getHeadscaleApp() (*headscale.Headscale, error) {
 	// We are doing this here, as in the future could be cool to have it also hot-reload
 
 	if cfg.ACL.PolicyPath != "" {
-		aclPath := absPath(cfg.ACL.PolicyPath)
+		aclPath := AbsolutePathFromConfigPath(cfg.ACL.PolicyPath)
 		err = app.LoadACLPolicy(aclPath)
 		if err != nil {
 			log.Fatal().

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -435,8 +435,8 @@ func getHeadscaleApp() (*headscale.Headscale, error) {
 
 	// We are doing this here, as in the future could be cool to have it also hot-reload
 
-	if viper.GetString("acl_policy_path") != "" {
-		aclPath := absPath(viper.GetString("acl_policy_path"))
+	if cfg.ACL.PolicyPath != "" {
+		aclPath := absPath(cfg.ACL.PolicyPath)
 		err = app.LoadACLPolicy(aclPath)
 		if err != nil {
 			log.Fatal().

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -277,7 +277,7 @@ func absPath(path string) string {
 	return path
 }
 
-func getHeadscaleConfig() headscale.Config {
+func GetHeadscaleConfig() headscale.Config {
 	dnsConfig, baseDomain := GetDNSConfig()
 	derpConfig := GetDERPConfig()
 	logConfig := GetLogTailConfig()
@@ -416,7 +416,7 @@ func getHeadscaleApp() (*headscale.Headscale, error) {
 		return nil, err
 	}
 
-	cfg := getHeadscaleConfig()
+	cfg := GetHeadscaleConfig()
 
 	app, err := headscale.NewHeadscale(cfg)
 	if err != nil {
@@ -440,7 +440,7 @@ func getHeadscaleApp() (*headscale.Headscale, error) {
 }
 
 func getHeadscaleCLIClient() (context.Context, v1.HeadscaleServiceClient, *grpc.ClientConn, context.CancelFunc) {
-	cfg := getHeadscaleConfig()
+	cfg := GetHeadscaleConfig()
 
 	log.Debug().
 		Dur("timeout", cfg.CLI.Timeout).

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -9,7 +9,6 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -272,19 +271,6 @@ func GetDNSConfig() (*tailcfg.DNSConfig, string) {
 	return nil, ""
 }
 
-func AbsolutePathFromConfigPath(path string) string {
-	// If a relative path is provided, prefix it with the the directory where
-	// the config file was found.
-	if (path != "") && !strings.HasPrefix(path, string(os.PathSeparator)) {
-		dir, _ := filepath.Split(viper.ConfigFileUsed())
-		if dir != "" {
-			path = filepath.Join(dir, path)
-		}
-	}
-
-	return path
-}
-
 func GetHeadscaleConfig() headscale.Config {
 	dnsConfig, baseDomain := GetDNSConfig()
 	derpConfig := GetDERPConfig()
@@ -350,7 +336,7 @@ func GetHeadscaleConfig() headscale.Config {
 		GRPCAllowInsecure: viper.GetBool("grpc_allow_insecure"),
 
 		IPPrefixes:     prefixes,
-		PrivateKeyPath: AbsolutePathFromConfigPath(viper.GetString("private_key_path")),
+		PrivateKeyPath: headscale.AbsolutePathFromConfigPath(viper.GetString("private_key_path")),
 		BaseDomain:     baseDomain,
 
 		DERP: derpConfig,
@@ -360,7 +346,7 @@ func GetHeadscaleConfig() headscale.Config {
 		),
 
 		DBtype: viper.GetString("db_type"),
-		DBpath: AbsolutePathFromConfigPath(viper.GetString("db_path")),
+		DBpath: headscale.AbsolutePathFromConfigPath(viper.GetString("db_path")),
 		DBhost: viper.GetString("db_host"),
 		DBport: viper.GetInt("db_port"),
 		DBname: viper.GetString("db_name"),
@@ -369,13 +355,13 @@ func GetHeadscaleConfig() headscale.Config {
 
 		TLSLetsEncryptHostname: viper.GetString("tls_letsencrypt_hostname"),
 		TLSLetsEncryptListen:   viper.GetString("tls_letsencrypt_listen"),
-		TLSLetsEncryptCacheDir: AbsolutePathFromConfigPath(
+		TLSLetsEncryptCacheDir: headscale.AbsolutePathFromConfigPath(
 			viper.GetString("tls_letsencrypt_cache_dir"),
 		),
 		TLSLetsEncryptChallengeType: viper.GetString("tls_letsencrypt_challenge_type"),
 
-		TLSCertPath:       AbsolutePathFromConfigPath(viper.GetString("tls_cert_path")),
-		TLSKeyPath:        AbsolutePathFromConfigPath(viper.GetString("tls_key_path")),
+		TLSCertPath:       headscale.AbsolutePathFromConfigPath(viper.GetString("tls_cert_path")),
+		TLSKeyPath:        headscale.AbsolutePathFromConfigPath(viper.GetString("tls_key_path")),
 		TLSClientAuthMode: tlsClientAuthMode,
 
 		DNSConfig: dnsConfig,
@@ -436,7 +422,7 @@ func getHeadscaleApp() (*headscale.Headscale, error) {
 	// We are doing this here, as in the future could be cool to have it also hot-reload
 
 	if cfg.ACL.PolicyPath != "" {
-		aclPath := AbsolutePathFromConfigPath(cfg.ACL.PolicyPath)
+		aclPath := headscale.AbsolutePathFromConfigPath(cfg.ACL.PolicyPath)
 		err = app.LoadACLPolicy(aclPath)
 		if err != nil {
 			log.Fatal().

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -169,7 +169,7 @@ func GetDERPConfig() headscale.DERPConfig {
 	}
 }
 
-func GetLogConfig() headscale.LogTailConfig {
+func GetLogTailConfig() headscale.LogTailConfig {
 	enabled := viper.GetBool("logtail.enabled")
 
 	return headscale.LogTailConfig{
@@ -280,7 +280,7 @@ func absPath(path string) string {
 func getHeadscaleConfig() headscale.Config {
 	dnsConfig, baseDomain := GetDNSConfig()
 	derpConfig := GetDERPConfig()
-	logConfig := GetLogConfig()
+	logConfig := GetLogTailConfig()
 
 	configuredPrefixes := viper.GetStringSlice("ip_prefixes")
 	parsedPrefixes := make([]netaddr.IPPrefix, 0, len(configuredPrefixes)+1)

--- a/utils.go
+++ b/utils.go
@@ -12,10 +12,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 	"inet.af/netaddr"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
@@ -320,4 +323,17 @@ func IsStringInSlice(slice []string, str string) bool {
 	}
 
 	return false
+}
+
+func AbsolutePathFromConfigPath(path string) string {
+	// If a relative path is provided, prefix it with the the directory where
+	// the config file was found.
+	if (path != "") && !strings.HasPrefix(path, string(os.PathSeparator)) {
+		dir, _ := filepath.Split(viper.ConfigFileUsed())
+		if dir != "" {
+			path = filepath.Join(dir, path)
+		}
+	}
+
+	return path
 }


### PR DESCRIPTION
This PR resolves #173, allowing the users to send a reload signal (SIGHUP) to headscale to reload its config and ACLs.

In addition, sending a SIGTERM, SIGINT etc, will now attempt to shutdown headscale gracefully.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [x] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
