### PR TITLE
Fix forced Tags with legitimate tagOwners

### DIFF
--- a/acls_test.go
+++ b/acls_test.go
@@ -1056,6 +1056,52 @@ func Test_expandAlias(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Forced tag with legitimate tagOwner",
+			args: args{
+				alias: "tag:hr-webserver",
+				machines: []Machine{
+					{
+						IPAddresses: MachineAddresses{
+							netaddr.MustParseIP("100.64.0.1"),
+						},
+						Namespace:  Namespace{Name: "joe"},
+						ForcedTags: []string{"tag:hr-webserver"},
+					},
+					{
+						IPAddresses: MachineAddresses{
+							netaddr.MustParseIP("100.64.0.2"),
+						},
+						Namespace: Namespace{Name: "joe"},
+						HostInfo: HostInfo{
+							OS:          "centos",
+							Hostname:    "foo",
+							RequestTags: []string{"tag:hr-webserver"},
+						},
+					},
+					{
+						IPAddresses: MachineAddresses{
+							netaddr.MustParseIP("100.64.0.3"),
+						},
+						Namespace: Namespace{Name: "marc"},
+					},
+					{
+						IPAddresses: MachineAddresses{
+							netaddr.MustParseIP("100.64.0.4"),
+						},
+						Namespace: Namespace{Name: "mickael"},
+					},
+				},
+				aclPolicy: ACLPolicy{
+					TagOwners: TagOwners{
+						"tag:hr-webserver": []string{"joe"},
+					},
+				},
+				stripEmailDomain: true,
+			},
+			want:    []string{"100.64.0.1", "100.64.0.2"},
+			wantErr: false,
+		},
+		{
 			name: "list host in namespace without correctly tagged servers",
 			args: args{
 				alias: "joe",


### PR DESCRIPTION
Basically always check whether a tag is forced instead of just on tagOwners failure. Also replace loops with contains.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
