### PR TITLE
Update ACL syntax and add support for protocol filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.16.0 (2022-xx-xx)
 
+### BREAKING
+
+- Old ACL syntax is no longer supported ("users" & "ports" -> "src" & "dst"). Please check [the new syntax](https://tailscale.com/kb/1018/acls/).
+
 ### Changes
 
 - **Drop** armhf (32-bit ARM) support. [#609](https://github.com/juanfont/headscale/pull/609)
@@ -22,6 +26,7 @@
   - This change disables the logs by default
 - Use [Prometheus]'s duration parser, supporting days (`d`), weeks (`w`) and years (`y`) [#598](https://github.com/juanfont/headscale/pull/598)
 - Add support for reloading ACLs with SIGHUP [#601](https://github.com/juanfont/headscale/pull/601)
+- Use new ACL syntax [#618](https://github.com/juanfont/headscale/pull/618)
 
 ## 0.15.0 (2022-03-20)
 

--- a/acls.go
+++ b/acls.go
@@ -37,6 +37,23 @@ const (
 	expectedTokenItems = 2
 )
 
+// For some reason golang.org/x/net/internal/iana is an internal package
+const (
+	protocolICMP     = 1   // Internet Control Message
+	protocolIGMP     = 2   // Internet Group Management
+	protocolIPv4     = 4   // IPv4 encapsulation
+	protocolTCP      = 6   // Transmission Control
+	protocolEGP      = 8   // Exterior Gateway Protocol
+	protocolIGP      = 9   // any private interior gateway (used by Cisco for their IGRP)
+	protocolUDP      = 17  // User Datagram
+	protocolGRE      = 47  // Generic Routing Encapsulation
+	protocolESP      = 50  // Encap Security Payload
+	protocolAH       = 51  // Authentication Header
+	protocolIPv6ICMP = 58  // ICMP for IPv6
+	protocolSCTP     = 132 // Stream Control Transmission Protocol
+	ProtocolFC       = 133 // Fibre Channel
+)
+
 // LoadACLPolicy loads the ACL policy from the specify path, and generates the ACL rules.
 func (h *Headscale) LoadACLPolicy(path string) error {
 	log.Debug().
@@ -238,36 +255,36 @@ func (h *Headscale) generateACLPolicyDest(
 func parseProtocol(protocol string) ([]int, bool, error) {
 	switch protocol {
 	case "":
-		return []int{1, 58, 6, 17}, false, nil
+		return []int{protocolICMP, protocolIPv6ICMP, protocolTCP, protocolUDP}, false, nil
 	case "igmp":
-		return []int{2}, true, nil
+		return []int{protocolIGMP}, true, nil
 	case "ipv4", "ip-in-ip":
-		return []int{4}, true, nil
+		return []int{protocolIPv4}, true, nil
 	case "tcp":
-		return []int{6}, false, nil
+		return []int{protocolTCP}, false, nil
 	case "egp":
-		return []int{8}, true, nil
+		return []int{protocolEGP}, true, nil
 	case "igp":
-		return []int{9}, true, nil
+		return []int{protocolIGP}, true, nil
 	case "udp":
-		return []int{17}, false, nil
+		return []int{protocolUDP}, false, nil
 	case "gre":
-		return []int{47}, true, nil
+		return []int{protocolGRE}, true, nil
 	case "esp":
-		return []int{50}, true, nil
+		return []int{protocolESP}, true, nil
 	case "ah":
-		return []int{51}, true, nil
+		return []int{protocolAH}, true, nil
 	case "sctp":
-		return []int{132}, false, nil
+		return []int{protocolSCTP}, false, nil
 	case "icmp":
-		return []int{1, 58}, true, nil
+		return []int{protocolICMP, protocolIPv6ICMP}, true, nil
 
 	default:
 		protocolNumber, err := strconv.Atoi(protocol)
 		if err != nil {
 			return nil, false, err
 		}
-		needsWildcard := protocolNumber != 6 && protocolNumber != 17 && protocolNumber != 132 // nolint
+		needsWildcard := protocolNumber != protocolTCP && protocolNumber != protocolUDP && protocolNumber != protocolSCTP
 
 		return []int{protocolNumber}, needsWildcard, nil
 	}

--- a/acls.go
+++ b/acls.go
@@ -123,11 +123,11 @@ func (h *Headscale) generateACLRules() ([]tailcfg.FilterRule, error) {
 		}
 
 		srcIPs := []string{}
-		for innerIndex, user := range acl.Users {
-			srcs, err := h.generateACLPolicySrcIP(machines, *h.aclPolicy, user)
+		for innerIndex, src := range acl.Sources {
+			srcs, err := h.generateACLPolicySrcIP(machines, *h.aclPolicy, src)
 			if err != nil {
 				log.Error().
-					Msgf("Error parsing ACL %d, User %d", index, innerIndex)
+					Msgf("Error parsing ACL %d, Source %d", index, innerIndex)
 
 				return nil, err
 			}
@@ -135,11 +135,11 @@ func (h *Headscale) generateACLRules() ([]tailcfg.FilterRule, error) {
 		}
 
 		destPorts := []tailcfg.NetPortRange{}
-		for innerIndex, ports := range acl.Ports {
-			dests, err := h.generateACLPolicyDestPorts(machines, *h.aclPolicy, ports)
+		for innerIndex, dest := range acl.Destinations {
+			dests, err := h.generateACLPolicyDest(machines, *h.aclPolicy, dest)
 			if err != nil {
 				log.Error().
-					Msgf("Error parsing ACL %d, Port %d", index, innerIndex)
+					Msgf("Error parsing ACL %d, Destination %d", index, innerIndex)
 
 				return nil, err
 			}
@@ -158,17 +158,17 @@ func (h *Headscale) generateACLRules() ([]tailcfg.FilterRule, error) {
 func (h *Headscale) generateACLPolicySrcIP(
 	machines []Machine,
 	aclPolicy ACLPolicy,
-	u string,
+	src string,
 ) ([]string, error) {
-	return expandAlias(machines, aclPolicy, u, h.cfg.OIDC.StripEmaildomain)
+	return expandAlias(machines, aclPolicy, src, h.cfg.OIDC.StripEmaildomain)
 }
 
-func (h *Headscale) generateACLPolicyDestPorts(
+func (h *Headscale) generateACLPolicyDest(
 	machines []Machine,
 	aclPolicy ACLPolicy,
-	d string,
+	dest string,
 ) ([]tailcfg.NetPortRange, error) {
-	tokens := strings.Split(d, ":")
+	tokens := strings.Split(dest, ":")
 	if len(tokens) < expectedTokenItems || len(tokens) > 3 {
 		return nil, errInvalidPortFormat
 	}

--- a/acls.go
+++ b/acls.go
@@ -23,7 +23,7 @@ const (
 	errInvalidGroup      = Error("invalid group")
 	errInvalidTag        = Error("invalid tag")
 	errInvalidPortFormat = Error("invalid port format")
-	errWildcardIsNeeded  = Error("wildcard as port is required for the procotol")
+	errWildcardIsNeeded  = Error("wildcard as port is required for the protocol")
 )
 
 const (
@@ -267,7 +267,7 @@ func parseProtocol(protocol string) ([]int, bool, error) {
 		if err != nil {
 			return nil, false, err
 		}
-		needsWildcard := protocolNumber != 6 && protocolNumber != 17 && protocolNumber != 132
+		needsWildcard := protocolNumber != 6 && protocolNumber != 17 && protocolNumber != 132 // nolint
 
 		return []int{protocolNumber}, needsWildcard, nil
 	}

--- a/acls_test.go
+++ b/acls_test.go
@@ -330,9 +330,9 @@ func (s *Suite) TestProtocolParsing(c *check.C) {
 	c.Assert(rules, check.NotNil)
 
 	c.Assert(rules, check.HasLen, 3)
-	c.Assert(rules[0].IPProto[0], check.Equals, 6)  // tcp
-	c.Assert(rules[1].IPProto[0], check.Equals, 17) // udp
-	c.Assert(rules[2].IPProto[1], check.Equals, 58) // icmp v4
+	c.Assert(rules[0].IPProto[0], check.Equals, protocolTCP)
+	c.Assert(rules[1].IPProto[0], check.Equals, protocolUDP)
+	c.Assert(rules[2].IPProto[1], check.Equals, protocolIPv6ICMP)
 }
 
 func (s *Suite) TestPortWildcard(c *check.C) {

--- a/acls_test.go
+++ b/acls_test.go
@@ -321,6 +321,20 @@ func (s *Suite) TestPortRange(c *check.C) {
 	c.Assert(rules[0].DstPorts[0].Ports.Last, check.Equals, uint16(5500))
 }
 
+func (s *Suite) TestProtocolParsing(c *check.C) {
+	err := app.LoadACLPolicy("./tests/acls/acl_policy_basic_protocols.hujson")
+	c.Assert(err, check.IsNil)
+
+	rules, err := app.generateACLRules()
+	c.Assert(err, check.IsNil)
+	c.Assert(rules, check.NotNil)
+
+	c.Assert(rules, check.HasLen, 3)
+	c.Assert(rules[0].IPProto[0], check.Equals, 6)  // tcp
+	c.Assert(rules[1].IPProto[0], check.Equals, 17) // udp
+	c.Assert(rules[2].IPProto[1], check.Equals, 58) // icmp v4
+}
+
 func (s *Suite) TestPortWildcard(c *check.C) {
 	err := app.LoadACLPolicy("./tests/acls/acl_policy_basic_wildcards.hujson")
 	c.Assert(err, check.IsNil)

--- a/acls_test.go
+++ b/acls_test.go
@@ -144,7 +144,7 @@ func (s *Suite) TestValidExpandTagOwnersInSources(c *check.C) {
 // this test should validate that we can expand a group in a TagOWner section and
 // match properly the IP's of the related hosts. The owner is valid and the tag is also valid.
 // the tag is matched in the Destinations section.
-func (s *Suite) TestValidExpandTagOwnersInPorts(c *check.C) {
+func (s *Suite) TestValidExpandTagOwnersInDestinations(c *check.C) {
 	namespace, err := app.CreateNamespace("user1")
 	c.Assert(err, check.IsNil)
 

--- a/acls_test.go
+++ b/acls_test.go
@@ -62,7 +62,7 @@ func (s *Suite) TestBasicRule(c *check.C) {
 func (s *Suite) TestInvalidAction(c *check.C) {
 	app.aclPolicy = &ACLPolicy{
 		ACLs: []ACL{
-			{Action: "invalidAction", Users: []string{"*"}, Ports: []string{"*:*"}},
+			{Action: "invalidAction", Sources: []string{"*"}, Destinations: []string{"*:*"}},
 		},
 	}
 	err := app.UpdateACLRules()
@@ -70,14 +70,14 @@ func (s *Suite) TestInvalidAction(c *check.C) {
 }
 
 func (s *Suite) TestInvalidGroupInGroup(c *check.C) {
-	// this ACL is wrong because the group in users sections doesn't exist
+	// this ACL is wrong because the group in Sources sections doesn't exist
 	app.aclPolicy = &ACLPolicy{
 		Groups: Groups{
 			"group:test":  []string{"foo"},
 			"group:error": []string{"foo", "group:test"},
 		},
 		ACLs: []ACL{
-			{Action: "accept", Users: []string{"group:error"}, Ports: []string{"*:*"}},
+			{Action: "accept", Sources: []string{"group:error"}, Destinations: []string{"*:*"}},
 		},
 	}
 	err := app.UpdateACLRules()
@@ -88,7 +88,7 @@ func (s *Suite) TestInvalidTagOwners(c *check.C) {
 	// this ACL is wrong because no tagOwners own the requested tag for the server
 	app.aclPolicy = &ACLPolicy{
 		ACLs: []ACL{
-			{Action: "accept", Users: []string{"tag:foo"}, Ports: []string{"*:*"}},
+			{Action: "accept", Sources: []string{"tag:foo"}, Destinations: []string{"*:*"}},
 		},
 	}
 	err := app.UpdateACLRules()
@@ -97,8 +97,8 @@ func (s *Suite) TestInvalidTagOwners(c *check.C) {
 
 // this test should validate that we can expand a group in a TagOWner section and
 // match properly the IP's of the related hosts. The owner is valid and the tag is also valid.
-// the tag is matched in the Users section.
-func (s *Suite) TestValidExpandTagOwnersInUsers(c *check.C) {
+// the tag is matched in the Sources section.
+func (s *Suite) TestValidExpandTagOwnersInSources(c *check.C) {
 	namespace, err := app.CreateNamespace("user1")
 	c.Assert(err, check.IsNil)
 
@@ -131,7 +131,7 @@ func (s *Suite) TestValidExpandTagOwnersInUsers(c *check.C) {
 		Groups:    Groups{"group:test": []string{"user1", "user2"}},
 		TagOwners: TagOwners{"tag:test": []string{"user3", "group:test"}},
 		ACLs: []ACL{
-			{Action: "accept", Users: []string{"tag:test"}, Ports: []string{"*:*"}},
+			{Action: "accept", Sources: []string{"tag:test"}, Destinations: []string{"*:*"}},
 		},
 	}
 	err = app.UpdateACLRules()
@@ -143,7 +143,7 @@ func (s *Suite) TestValidExpandTagOwnersInUsers(c *check.C) {
 
 // this test should validate that we can expand a group in a TagOWner section and
 // match properly the IP's of the related hosts. The owner is valid and the tag is also valid.
-// the tag is matched in the Ports section.
+// the tag is matched in the Destinations section.
 func (s *Suite) TestValidExpandTagOwnersInPorts(c *check.C) {
 	namespace, err := app.CreateNamespace("user1")
 	c.Assert(err, check.IsNil)
@@ -177,7 +177,7 @@ func (s *Suite) TestValidExpandTagOwnersInPorts(c *check.C) {
 		Groups:    Groups{"group:test": []string{"user1", "user2"}},
 		TagOwners: TagOwners{"tag:test": []string{"user3", "group:test"}},
 		ACLs: []ACL{
-			{Action: "accept", Users: []string{"*"}, Ports: []string{"tag:test:*"}},
+			{Action: "accept", Sources: []string{"*"}, Destinations: []string{"tag:test:*"}},
 		},
 	}
 	err = app.UpdateACLRules()
@@ -222,7 +222,7 @@ func (s *Suite) TestInvalidTagValidNamespace(c *check.C) {
 	app.aclPolicy = &ACLPolicy{
 		TagOwners: TagOwners{"tag:test": []string{"user1"}},
 		ACLs: []ACL{
-			{Action: "accept", Users: []string{"user1"}, Ports: []string{"*:*"}},
+			{Action: "accept", Sources: []string{"user1"}, Destinations: []string{"*:*"}},
 		},
 	}
 	err = app.UpdateACLRules()
@@ -287,9 +287,9 @@ func (s *Suite) TestValidTagInvalidNamespace(c *check.C) {
 		TagOwners: TagOwners{"tag:webapp": []string{"user1"}},
 		ACLs: []ACL{
 			{
-				Action: "accept",
-				Users:  []string{"user1"},
-				Ports:  []string{"tag:webapp:80,443"},
+				Action:       "accept",
+				Sources:      []string{"user1"},
+				Destinations: []string{"tag:webapp:80,443"},
 			},
 		},
 	}
@@ -645,7 +645,7 @@ func Test_expandPorts(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "two ports",
+			name: "two Destinations",
 			args: args{portsStr: "80,443"},
 			want: &[]tailcfg.PortRange{
 				{First: 80, Last: 80},

--- a/acls_types.go
+++ b/acls_types.go
@@ -21,7 +21,7 @@ type ACLPolicy struct {
 // ACL is a basic rule for the ACL Policy.
 type ACL struct {
 	Action       string   `json:"action" yaml:"action"`
-	Protocol     string   `json:"protocol" yaml:"protocol"`
+	Protocol     string   `json:"proto" yaml:"proto"`
 	Sources      []string `json:"src"  yaml:"src"`
 	Destinations []string `json:"dst"  yaml:"dst"`
 }

--- a/acls_types.go
+++ b/acls_types.go
@@ -11,18 +11,19 @@ import (
 
 // ACLPolicy represents a Tailscale ACL Policy.
 type ACLPolicy struct {
-	Groups    Groups    `json:"Groups"    yaml:"Groups"`
-	Hosts     Hosts     `json:"Hosts"     yaml:"Hosts"`
-	TagOwners TagOwners `json:"TagOwners" yaml:"TagOwners"`
-	ACLs      []ACL     `json:"ACLs"      yaml:"ACLs"`
-	Tests     []ACLTest `json:"Tests"     yaml:"Tests"`
+	Groups    Groups    `json:"groups"    yaml:"groups"`
+	Hosts     Hosts     `json:"hosts"     yaml:"hosts"`
+	TagOwners TagOwners `json:"tagOwners" yaml:"tagOwners"`
+	ACLs      []ACL     `json:"acls"      yaml:"acls"`
+	Tests     []ACLTest `json:"tests"     yaml:"tests"`
 }
 
 // ACL is a basic rule for the ACL Policy.
 type ACL struct {
-	Action string   `json:"Action" yaml:"Action"`
-	Users  []string `json:"Users"  yaml:"Users"`
-	Ports  []string `json:"Ports"  yaml:"Ports"`
+	Action       string   `json:"action" yaml:"action"`
+	Protocol     string   `json:"protocol" yaml:"protocol"`
+	Sources      []string `json:"src"  yaml:"src"`
+	Destinations []string `json:"dst"  yaml:"dst"`
 }
 
 // Groups references a series of alias in the ACL rules.
@@ -36,9 +37,9 @@ type TagOwners map[string][]string
 
 // ACLTest is not implemented, but should be use to check if a certain rule is allowed.
 type ACLTest struct {
-	User  string   `json:"User"           yaml:"User"`
-	Allow []string `json:"Allow"          yaml:"Allow"`
-	Deny  []string `json:"Deny,omitempty" yaml:"Deny,omitempty"`
+	Source string   `json:"src"           yaml:"src"`
+	Accept []string `json:"accept"          yaml:"accept"`
+	Deny   []string `json:"deny,omitempty" yaml:"deny,omitempty"`
 }
 
 // UnmarshalJSON allows to parse the Hosts directly into netaddr objects.

--- a/docs/acls.md
+++ b/docs/acls.md
@@ -33,7 +33,7 @@ Note: Namespaces will be created automatically when users authenticate with the
 Headscale server.
 
 ACLs could be written either on [huJSON](https://github.com/tailscale/hujson)
-or Yaml. Check the [test ACLs](../tests/acls) for further information.
+or YAML. Check the [test ACLs](../tests/acls) for further information.
 
 When registering the servers we will need to add the flag
 `--advertised-tags=tag:<tag1>,tag:<tag2>`, and the user (namespace) that is
@@ -83,8 +83,8 @@ Here are the ACL's to implement the same permissions as above:
     // boss have access to all servers
     {
       "action": "accept",
-      "users": ["group:boss"],
-      "ports": [
+      "src": ["group:boss"],
+      "dst": [
         "tag:prod-databases:*",
         "tag:prod-app-servers:*",
         "tag:internal:*",
@@ -96,8 +96,8 @@ Here are the ACL's to implement the same permissions as above:
     // admin have only access to administrative ports of the servers
     {
       "action": "accept",
-      "users": ["group:admin"],
-      "ports": [
+      "src": ["group:admin"],
+      "dst": [
         "tag:prod-databases:22",
         "tag:prod-app-servers:22",
         "tag:internal:22",
@@ -110,8 +110,8 @@ Here are the ACL's to implement the same permissions as above:
     // they can only view the applications servers in prod and have no access to databases servers in production
     {
       "action": "accept",
-      "users": ["group:dev"],
-      "ports": [
+      "src": ["group:dev"],
+      "dst": [
         "tag:dev-databases:*",
         "tag:dev-app-servers:*",
         "tag:prod-app-servers:80,443"
@@ -124,37 +124,37 @@ Here are the ACL's to implement the same permissions as above:
     // https://github.com/juanfont/headscale/issues/502
     {
       "action": "accept",
-      "users": ["group:dev"],
-      "ports": ["10.20.0.0/16:443,5432", "router.internal:0"]
+      "src": ["group:dev"],
+      "dst": ["10.20.0.0/16:443,5432", "router.internal:0"]
     },
 
     // servers should be able to talk to database. Database should not be able to initiate connections to
     // applications servers
     {
       "action": "accept",
-      "users": ["tag:dev-app-servers"],
-      "ports": ["tag:dev-databases:5432"]
+      "src": ["tag:dev-app-servers"],
+      "dst": ["tag:dev-databases:5432"]
     },
     {
       "action": "accept",
-      "users": ["tag:prod-app-servers"],
-      "ports": ["tag:prod-databases:5432"]
+      "src": ["tag:prod-app-servers"],
+      "dst": ["tag:prod-databases:5432"]
     },
 
     // interns have access to dev-app-servers only in reading mode
     {
       "action": "accept",
-      "users": ["group:intern"],
-      "ports": ["tag:dev-app-servers:80,443"]
+      "src": ["group:intern"],
+      "dst": ["tag:dev-app-servers:80,443"]
     },
 
     // We still have to allow internal namespaces communications since nothing guarantees that each user have
     // their own namespaces.
-    { "action": "accept", "users": ["boss"], "ports": ["boss:*"] },
-    { "action": "accept", "users": ["dev1"], "ports": ["dev1:*"] },
-    { "action": "accept", "users": ["dev2"], "ports": ["dev2:*"] },
-    { "action": "accept", "users": ["admin1"], "ports": ["admin1:*"] },
-    { "action": "accept", "users": ["intern1"], "ports": ["intern1:*"] }
+    { "action": "accept", "src": ["boss"], "dst": ["boss:*"] },
+    { "action": "accept", "src": ["dev1"], "dst": ["dev1:*"] },
+    { "action": "accept", "src": ["dev2"], "dst": ["dev2:*"] },
+    { "action": "accept", "src": ["admin1"], "dst": ["admin1:*"] },
+    { "action": "accept", "src": ["intern1"], "dst": ["intern1:*"] }
   ]
 }
 ```

--- a/docs/acls.md
+++ b/docs/acls.md
@@ -93,16 +93,31 @@ Here are the ACL's to implement the same permissions as above:
       ]
     },
 
-    // admin have only access to administrative ports of the servers
+    // admin have only access to administrative ports of the servers, in tcp/22
     {
       "action": "accept",
       "src": ["group:admin"],
+      "proto": "tcp",
       "dst": [
         "tag:prod-databases:22",
         "tag:prod-app-servers:22",
         "tag:internal:22",
         "tag:dev-databases:22",
         "tag:dev-app-servers:22"
+      ]
+    },
+
+    // we also allow admin to ping the servers
+    {
+      "action": "accept",
+      "src": ["group:admin"],
+      "proto": "icmp",
+      "dst": [
+        "tag:prod-databases:*",
+        "tag:prod-app-servers:*",
+        "tag:internal:*",
+        "tag:dev-databases:*",
+        "tag:dev-app-servers:*"
       ]
     },
 
@@ -128,11 +143,12 @@ Here are the ACL's to implement the same permissions as above:
       "dst": ["10.20.0.0/16:443,5432", "router.internal:0"]
     },
 
-    // servers should be able to talk to database. Database should not be able to initiate connections to
+    // servers should be able to talk to database in tcp/5432. Database should not be able to initiate connections to
     // applications servers
     {
       "action": "accept",
       "src": ["tag:dev-app-servers"],
+      "proto": "tcp",
       "dst": ["tag:dev-databases:5432"]
     },
     {

--- a/machine_test.go
+++ b/machine_test.go
@@ -188,8 +188,8 @@ func (s *Suite) TestGetACLFilteredPeers(c *check.C) {
 		Hosts:     map[string]netaddr.IPPrefix{},
 		TagOwners: map[string][]string{},
 		ACLs: []ACL{
-			{Action: "accept", Users: []string{"admin"}, Ports: []string{"*:*"}},
-			{Action: "accept", Users: []string{"test"}, Ports: []string{"test:*"}},
+			{Action: "accept", Sources: []string{"admin"}, Destinations: []string{"*:*"}},
+			{Action: "accept", Sources: []string{"test"}, Destinations: []string{"test:*"}},
 		},
 		Tests: []ACLTest{},
 	}

--- a/tests/acls/acl_policy_1.hujson
+++ b/tests/acls/acl_policy_1.hujson
@@ -1,6 +1,6 @@
 {
     // Declare static groups of users beyond those in the identity service.
-    "Groups": {
+    "groups": {
         "group:example": [
             "user1@example.com",
             "user2@example.com",
@@ -11,12 +11,12 @@
         ],
     },
     // Declare hostname aliases to use in place of IP addresses or subnets.
-    "Hosts": {
+    "hosts": {
         "example-host-1": "100.100.100.100",
         "example-host-2": "100.100.101.100/24",
     },
     // Define who is allowed to use which tags.
-    "TagOwners": {
+    "tagOwners": {
         // Everyone in the montreal-admins or global-admins group are
         // allowed to tag servers as montreal-webserver.
         "tag:montreal-webserver": [
@@ -29,17 +29,18 @@
         ],
     },
     // Access control lists.
-    "ACLs": [
+    "acls": [
         // Engineering users, plus the president, can access port 22 (ssh)
         // and port 3389 (remote desktop protocol) on all servers, and all
         // ports on git-server or ci-server.
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "protocol": "tcp",
+            "src": [
                 "group:example2",
                 "192.168.1.0/24"
             ],
-            "Ports": [
+            "dst": [
                 "*:22,3389",
                 "git-server:*",
                 "ci-server:*"
@@ -48,22 +49,22 @@
         // Allow engineer users to access any port on a device tagged with
         // tag:production.
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "group:example"
             ],
-            "Ports": [
+            "dst": [
                 "tag:production:*"
             ],
         },
         // Allow servers in the my-subnet host and 192.168.1.0/24 to access hosts
         // on both networks.
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "example-host-2", 
             ],
-            "Ports": [
+            "dst": [
                 "example-host-1:*",
                 "192.168.1.0/24:*"
             ],
@@ -72,22 +73,22 @@
         // Comment out this section if you want to define specific ACL
         // restrictions above.
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "*"
             ],
-            "Ports": [
+            "dst": [
                 "*:*"
             ],
         },
         // All users in Montreal are allowed to access the Montreal web
         // servers.
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "example-host-1"
             ],
-            "Ports": [
+            "dst": [
                 "tag:montreal-webserver:80,443"
             ],
         },
@@ -96,30 +97,30 @@
         // In contrast, this doesn't grant API servers the right to initiate
         // any connections.
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "tag:montreal-webserver"
             ],
-            "Ports": [
+            "dst": [
                 "tag:api-server:443"
             ],
         },
     ],
     // Declare tests to check functionality of ACL rules
-    "Tests": [
+    "tests": [
         {
-            "User": "user1@example.com",
-            "Allow": [
+            "src": "user1@example.com",
+            "accept": [
                 "example-host-1:22",
                 "example-host-2:80"
             ],
-            "Deny": [
+            "deny": [
                 "exapmle-host-2:100"
             ],
         },
         {
-            "User": "user2@example.com",
-            "Allow": [
+            "src": "user2@example.com",
+            "accept": [
                 "100.60.3.4:22"
             ],
         },

--- a/tests/acls/acl_policy_1.hujson
+++ b/tests/acls/acl_policy_1.hujson
@@ -35,7 +35,6 @@
         // ports on git-server or ci-server.
         {
             "action": "accept",
-            "protocol": "tcp",
             "src": [
                 "group:example2",
                 "192.168.1.0/24"

--- a/tests/acls/acl_policy_basic_1.hujson
+++ b/tests/acls/acl_policy_basic_1.hujson
@@ -3,19 +3,19 @@
 
 
 {
-    "Hosts": {
+    "hosts": {
         "host-1": "100.100.100.100",
         "subnet-1": "100.100.101.100/24",
     },
 
-    "ACLs": [
+    "acls": [
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "subnet-1",
                 "192.168.1.0/24"
             ],
-            "Ports": [
+            "dst": [
                 "*:22,3389",
                 "host-1:*",
             ],

--- a/tests/acls/acl_policy_basic_groups.hujson
+++ b/tests/acls/acl_policy_basic_groups.hujson
@@ -1,24 +1,24 @@
 // This ACL is used to test group expansion
 
 {
-    "Groups": {
+    "groups": {
         "group:example": [
             "testnamespace",
         ],
     },
 
-    "Hosts": {
+    "hosts": {
         "host-1": "100.100.100.100",
         "subnet-1": "100.100.101.100/24",
     },
 
-    "ACLs": [
+    "acls": [
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "group:example",
             ],
-            "Ports": [
+            "dst": [
                 "host-1:*",
             ],
         },

--- a/tests/acls/acl_policy_basic_namespace_as_user.hujson
+++ b/tests/acls/acl_policy_basic_namespace_as_user.hujson
@@ -1,18 +1,18 @@
 // This ACL is used to test namespace expansion
 
 {
-    "Hosts": {
+    "hosts": {
         "host-1": "100.100.100.100",
         "subnet-1": "100.100.101.100/24",
     },
 
-    "ACLs": [
+    "acls": [
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "testnamespace",
             ],
-            "Ports": [
+            "dst": [
                 "host-1:*",
             ],
         },

--- a/tests/acls/acl_policy_basic_protocols.hujson
+++ b/tests/acls/acl_policy_basic_protocols.hujson
@@ -1,0 +1,41 @@
+// This ACL is used to test wildcards
+
+{
+    "hosts": {
+        "host-1": "100.100.100.100",
+        "subnet-1": "100.100.101.100/24",
+    },
+
+    "acls": [
+        {
+            "Action": "accept",
+            "src": [
+                "*",
+            ],
+            "proto": "tcp",
+            "dst": [
+                "host-1:*",
+            ],
+        },
+        {
+            "Action": "accept",
+            "src": [
+                "*",
+            ],
+            "proto": "udp",
+            "dst": [
+                "host-1:53",
+            ],
+        },
+        {
+            "Action": "accept",
+            "src": [
+                "*",
+            ],
+            "proto": "icmp",
+            "dst": [
+                "host-1:*",
+            ],
+        },
+    ],
+}

--- a/tests/acls/acl_policy_basic_range.hujson
+++ b/tests/acls/acl_policy_basic_range.hujson
@@ -1,18 +1,18 @@
 // This ACL is used to test the port range expansion
 
 {
-    "Hosts": {
+    "hosts": {
         "host-1": "100.100.100.100",
         "subnet-1": "100.100.101.100/24",
     },
 
-    "ACLs": [
+    "acls": [
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "subnet-1",
             ],
-            "Ports": [
+            "dst": [
                 "host-1:5400-5500",
             ],
         },

--- a/tests/acls/acl_policy_basic_wildcards.hujson
+++ b/tests/acls/acl_policy_basic_wildcards.hujson
@@ -1,18 +1,18 @@
 // This ACL is used to test wildcards
 
 {
-    "Hosts": {
+    "hosts": {
         "host-1": "100.100.100.100",
         "subnet-1": "100.100.101.100/24",
     },
 
-    "ACLs": [
+    "acls": [
         {
             "Action": "accept",
-            "Users": [
+            "src": [
                 "*",
             ],
-            "Ports": [
+            "dst": [
                 "host-1:*",
             ],
         },

--- a/tests/acls/acl_policy_basic_wildcards.yaml
+++ b/tests/acls/acl_policy_basic_wildcards.yaml
@@ -1,10 +1,10 @@
 ---
-Hosts:
+hosts:
   host-1: 100.100.100.100/32
   subnet-1: 100.100.101.100/24
-ACLs:
-  - Action: accept
-    Users:
+acls:
+  - action: accept
+    src:
       - "*"
-    Ports:
+    dst:
       - host-1:*

--- a/tests/acls/acl_policy_invalid.hujson
+++ b/tests/acls/acl_policy_invalid.hujson
@@ -1,18 +1,18 @@
 {
     // Declare static groups of users beyond those in the identity service.
-    "Groups": {
+    "groups": {
         "group:example": [
             "user1@example.com",
             "user2@example.com",
         ],
     },
     // Declare hostname aliases to use in place of IP addresses or subnets.
-    "Hosts": {
+    "hosts": {
         "example-host-1": "100.100.100.100",
         "example-host-2": "100.100.101.100/24",
     },
     // Define who is allowed to use which tags.
-    "TagOwners": {
+    "tagOwners": {
         // Everyone in the montreal-admins or global-admins group are
         // allowed to tag servers as montreal-webserver.
         "tag:montreal-webserver": [
@@ -26,17 +26,17 @@
         ],
     },
     // Access control lists.
-    "ACLs": [
+    "acls": [
         // Engineering users, plus the president, can access port 22 (ssh)
         // and port 3389 (remote desktop protocol) on all servers, and all
         // ports on git-server or ci-server.
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "group:engineering",
                 "president@example.com"
             ],
-            "Ports": [
+            "dst": [
                 "*:22,3389",
                 "git-server:*",
                 "ci-server:*"
@@ -45,23 +45,23 @@
         // Allow engineer users to access any port on a device tagged with
         // tag:production.
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "group:engineers"
             ],
-            "Ports": [
+            "dst": [
                 "tag:production:*"
             ],
         },
         // Allow servers in the my-subnet host and 192.168.1.0/24 to access hosts
         // on both networks.
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "my-subnet",
                 "192.168.1.0/24"
             ],
-            "Ports": [
+            "dst": [
                 "my-subnet:*",
                 "192.168.1.0/24:*"
             ],
@@ -70,22 +70,22 @@
         // Comment out this section if you want to define specific ACL
         // restrictions above.
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "*"
             ],
-            "Ports": [
+            "dst": [
                 "*:*"
             ],
         },
         // All users in Montreal are allowed to access the Montreal web
         // servers.
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "group:montreal-users"
             ],
-            "Ports": [
+            "dst": [
                 "tag:montreal-webserver:80,443"
             ],
         },
@@ -94,30 +94,30 @@
         // In contrast, this doesn't grant API servers the right to initiate
         // any connections.
         {
-            "Action": "accept",
-            "Users": [
+            "action": "accept",
+            "src": [
                 "tag:montreal-webserver"
             ],
-            "Ports": [
+            "dst": [
                 "tag:api-server:443"
             ],
         },
     ],
     // Declare tests to check functionality of ACL rules
-    "Tests": [
+    "tests": [
         {
-            "User": "user1@example.com",
-            "Allow": [
+            "src": "user1@example.com",
+            "accept": [
                 "example-host-1:22",
                 "example-host-2:80"
             ],
-            "Deny": [
+            "deny": [
                 "exapmle-host-2:100"
             ],
         },
         {
-            "User": "user2@example.com",
-            "Allow": [
+            "src": "user2@example.com",
+            "accept": [
                 "100.60.3.4:22"
             ],
         },


### PR DESCRIPTION
Implements #617.

Tailscale has changed the format of their ACLs to use a more firewall-y terms ("users" & "ports" -> "src" & "dst"). They have also started using all-lowercase tags. 

Also, protocol filtering support :)

This PR implements these changes.


