### PR TITLE
Use strings.Cut to simplify logic

### DIFF
--- a/api_key.go
+++ b/api_key.go
@@ -13,7 +13,6 @@ import (
 const (
 	apiPrefixLength = 7
 	apiKeyLength    = 32
-	apiKeyParts     = 2
 
 	errAPIKeyFailedToParse = Error("Failed to parse ApiKey")
 )
@@ -115,9 +114,9 @@ func (h *Headscale) ExpireAPIKey(key *APIKey) error {
 }
 
 func (h *Headscale) ValidateAPIKey(keyStr string) (bool, error) {
-	prefix, hash, err := splitAPIKey(keyStr)
-	if err != nil {
-		return false, fmt.Errorf("failed to validate api key: %w", err)
+	prefix, hash, found := strings.Cut(keyStr, ".")
+	if !found {
+		return false, errAPIKeyFailedToParse
 	}
 
 	key, err := h.GetAPIKey(prefix)
@@ -134,15 +133,6 @@ func (h *Headscale) ValidateAPIKey(keyStr string) (bool, error) {
 	}
 
 	return true, nil
-}
-
-func splitAPIKey(key string) (string, string, error) {
-	parts := strings.Split(key, ".")
-	if len(parts) != apiKeyParts {
-		return "", "", errAPIKeyFailedToParse
-	}
-
-	return parts[0], parts[1], nil
 }
 
 func (key *APIKey) toProto() *v1.ApiKey {


### PR DESCRIPTION
One of the glory enhancements of go-1.18 was the introduction of `strings.Cut` which reduces the burden of counting the length of the result slice, also makes code much more readable in such cases where only two results are expected.

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
