### PR TITLE
Add ability to set randomizeClientPort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Use [Prometheus]'s duration parser, supporting days (`d`), weeks (`w`) and years (`y`) [#598](https://github.com/juanfont/headscale/pull/598)
 - Add support for reloading ACLs with SIGHUP [#601](https://github.com/juanfont/headscale/pull/601)
 - Add -c option to specify config file from command line [#285](https://github.com/juanfont/headscale/issues/285) [#612](https://github.com/juanfont/headscale/pull/601)
+- Add configuration option to allow Tailscale clients to use a random WireGuard port. [kb/1181/firewalls](https://tailscale.com/kb/1181/firewalls) [#624](https://github.com/juanfont/headscale/pull/624)
 
 ## 0.15.0 (2022-03-20)
 

--- a/api.go
+++ b/api.go
@@ -279,7 +279,8 @@ func (h *Headscale) getMapResponse(
 		DERPMap:      h.DERPMap,
 		UserProfiles: profiles,
 		Debug: &tailcfg.Debug{
-			DisableLogTail: !h.cfg.LogTail.Enabled,
+			DisableLogTail:      !h.cfg.LogTail.Enabled,
+			RandomizeClientPort: h.cfg.RandomizeClientPort,
 		},
 	}
 

--- a/cmd/headscale/headscale_test.go
+++ b/cmd/headscale/headscale_test.go
@@ -68,6 +68,7 @@ func (*Suite) TestConfigLoading(c *check.C) {
 		fs.FileMode(0o770),
 	)
 	c.Assert(viper.GetBool("logtail.enabled"), check.Equals, false)
+	c.Assert(viper.GetBool("randomize_client_port"), check.Equals, false)
 }
 
 func (*Suite) TestDNSConfigLoading(c *check.C) {

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -244,3 +244,8 @@ logtail:
   # As there is currently no support for overriding the log server in headscale, this is
   # disabled by default. Enabling this will make your clients send logs to Tailscale Inc.
   enabled: false
+
+# Enabling this option makes devices prefer a random port for WireGuard traffic over the
+# default static port 41641. This option is intended as a workaround for some buggy
+# firewall devices. See https://tailscale.com/kb/1181/firewalls/ for more information.
+randomize_client_port: false

--- a/config.go
+++ b/config.go
@@ -54,7 +54,8 @@ type Config struct {
 
 	OIDC OIDCConfig
 
-	LogTail LogTailConfig
+	LogTail             LogTailConfig
+	RandomizeClientPort bool
 
 	CLI CLIConfig
 
@@ -153,6 +154,7 @@ func LoadConfig(path string) error {
 	viper.SetDefault("oidc.strip_email_domain", true)
 
 	viper.SetDefault("logtail.enabled", false)
+	viper.SetDefault("randomize_client_port", false)
 
 	if err := viper.ReadInConfig(); err != nil {
 		return fmt.Errorf("fatal error reading config file: %w", err)
@@ -385,6 +387,7 @@ func GetHeadscaleConfig() (*Config, error) {
 	dnsConfig, baseDomain := GetDNSConfig()
 	derpConfig := GetDERPConfig()
 	logConfig := GetLogTailConfig()
+	randomizeClientPort := viper.GetBool("randomize_client_port")
 
 	configuredPrefixes := viper.GetStringSlice("ip_prefixes")
 	parsedPrefixes := make([]netaddr.IPPrefix, 0, len(configuredPrefixes)+1)
@@ -490,7 +493,8 @@ func GetHeadscaleConfig() (*Config, error) {
 			StripEmaildomain: viper.GetBool("oidc.strip_email_domain"),
 		},
 
-		LogTail: logConfig,
+		LogTail:             logConfig,
+		RandomizeClientPort: randomizeClientPort,
 
 		CLI: CLIConfig{
 			Address:  viper.GetString("cli.address"),

--- a/integration_test/etc/alt-config.dump.gold.yaml
+++ b/integration_test/etc/alt-config.dump.gold.yaml
@@ -43,4 +43,4 @@ tls_letsencrypt_cache_dir: /var/www/.cache
 tls_letsencrypt_challenge_type: HTTP-01
 unix_socket: /var/run/headscale.sock
 unix_socket_permission: "0o770"
-
+randomize_client_port: false

--- a/integration_test/etc/config.dump.gold.yaml
+++ b/integration_test/etc/config.dump.gold.yaml
@@ -43,4 +43,4 @@ tls_letsencrypt_cache_dir: /var/www/.cache
 tls_letsencrypt_challenge_type: HTTP-01
 unix_socket: /var/run/headscale.sock
 unix_socket_permission: "0o770"
-
+randomize_client_port: false


### PR DESCRIPTION
This allows tailscaled to pick a random udp port and lets direct connections succeed for broken fortinet enterprise firewalls.
https://tailscale.com/kb/1181/firewalls/

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
