### PR TITLE
Update all nodes after ACL has been reloaded with sighup

### DIFF
--- a/app.go
+++ b/app.go
@@ -657,7 +657,9 @@ func (h *Headscale) Serve() error {
 					}
 					log.Info().
 						Str("path", aclPath).
-						Msg("ACL policy successfully reloaded")
+						Msg("ACL policy successfully reloaded, notifying nodes of change")
+
+					h.setLastStateChangeToNow()
 				}
 
 			default:

--- a/app.go
+++ b/app.go
@@ -756,13 +756,25 @@ func (h *Headscale) getTLSSettings() (*tls.Config, error) {
 	}
 }
 
-func (h *Headscale) setLastStateChangeToNow(namespace string) {
+func (h *Headscale) setLastStateChangeToNow(namespaces ...string) {
+	var err error
+
 	now := time.Now().UTC()
-	lastStateUpdate.WithLabelValues("", "headscale").Set(float64(now.Unix()))
-	if h.lastStateChange == nil {
-		h.lastStateChange = xsync.NewMapOf[time.Time]()
+
+	if len(namespaces) == 0 {
+		namespaces, err = h.ListNamespacesStr()
+		if err != nil {
+			log.Error().Caller().Err(err).Msg("failed to fetch all namespaces, failing to update last changed state.")
+		}
 	}
-	h.lastStateChange.Store(namespace, now)
+
+	for _, namespace := range namespaces {
+		lastStateUpdate.WithLabelValues(namespace, "headscale").Set(float64(now.Unix()))
+		if h.lastStateChange == nil {
+			h.lastStateChange = xsync.NewMapOf[time.Time]()
+		}
+		h.lastStateChange.Store(namespace, now)
+	}
 }
 
 func (h *Headscale) getLastStateChange(namespaces ...string) time.Time {

--- a/namespaces.go
+++ b/namespaces.go
@@ -148,6 +148,21 @@ func (h *Headscale) ListNamespaces() ([]Namespace, error) {
 	return namespaces, nil
 }
 
+func (h *Headscale) ListNamespacesStr() ([]string, error) {
+	namespaces, err := h.ListNamespaces()
+	if err != nil {
+		return []string{}, err
+	}
+
+	namespaceStrs := make([]string, len(namespaces))
+
+	for index, namespace := range namespaces {
+		namespaceStrs[index] = namespace.Name
+	}
+
+	return namespaceStrs, nil
+}
+
 // ListMachinesInNamespace gets all the nodes in a given namespace.
 func (h *Headscale) ListMachinesInNamespace(name string) ([]Machine, error) {
 	err := CheckForFQDNRules(name)


### PR DESCRIPTION
This PR makes the setLastStateChangeToNow function take a list of
namespaces instead of a single namespace. If no namespaces is passed,
all namespaces will be updated. This means that the argument acts like a
filter.

Update the nodes after we have reloaded the ACL policy with sighup