### PR TITLE
Fix obtuse "ephemeral_node_inactivity_timeout" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Use new ACL syntax [#618](https://github.com/juanfont/headscale/pull/618)
 - Add -c option to specify config file from command line [#285](https://github.com/juanfont/headscale/issues/285) [#612](https://github.com/juanfont/headscale/pull/601)
 - Add configuration option to allow Tailscale clients to use a random WireGuard port. [kb/1181/firewalls](https://tailscale.com/kb/1181/firewalls) [#624](https://github.com/juanfont/headscale/pull/624)
+- Improve obtuse UX regarding missing configuration (`ephemeral_node_inactivity_timeout` not set) [#639](https://github.com/juanfont/headscale/pull/639)
 
 ## 0.15.0 (2022-03-20)
 

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -7,12 +7,10 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"time"
 
 	"github.com/juanfont/headscale"
 	v1 "github.com/juanfont/headscale/gen/go/headscale/v1"
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -27,21 +25,6 @@ func getHeadscaleApp() (*headscale.Headscale, error) {
 	cfg, err := headscale.GetHeadscaleConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configuration while creating headscale instance: %w", err)
-	}
-
-	// Minimum inactivity time out is keepalive timeout (60s) plus a few seconds
-	// to avoid races
-	minInactivityTimeout, _ := time.ParseDuration("65s")
-	if viper.GetDuration("ephemeral_node_inactivity_timeout") <= minInactivityTimeout {
-		// TODO: Find a better way to return this text
-		//nolint
-		err := fmt.Errorf(
-			"ephemeral_node_inactivity_timeout (%s) is set too low, must be more than %s",
-			viper.GetString("ephemeral_node_inactivity_timeout"),
-			minInactivityTimeout,
-		)
-
-		return nil, err
 	}
 
 	app, err := headscale.NewHeadscale(cfg)

--- a/config.go
+++ b/config.go
@@ -168,8 +168,6 @@ func LoadConfig(path string, isFile bool) error {
 		return fmt.Errorf("fatal error reading config file: %w", err)
 	}
 
-	log.Debug().Str("path", viper.ConfigFileUsed()).Msg("Read configuration from disk")
-
 	// Collect any validation errors and return them all at once
 	var errorText string
 	if (viper.GetString("tls_letsencrypt_hostname") != "") &&

--- a/config.go
+++ b/config.go
@@ -163,8 +163,12 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("ephemeral_node_inactivity_timeout", "120s")
 
 	if err := viper.ReadInConfig(); err != nil {
+		log.Warn().Err(err).Msg("Failed to read configuration from disk")
+
 		return fmt.Errorf("fatal error reading config file: %w", err)
 	}
+
+	log.Debug().Str("path", viper.ConfigFileUsed()).Msg("Read configuration from disk")
 
 	// Collect any validation errors and return them all at once
 	var errorText string

--- a/config.go
+++ b/config.go
@@ -160,6 +160,8 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("logtail.enabled", false)
 	viper.SetDefault("randomize_client_port", false)
 
+	viper.SetDefault("ephemeral_node_inactivity_timeout", "120s")
+
 	if err := viper.ReadInConfig(); err != nil {
 		return fmt.Errorf("fatal error reading config file: %w", err)
 	}

--- a/config.go
+++ b/config.go
@@ -202,6 +202,17 @@ func LoadConfig(path string, isFile bool) error {
 			EnforcedClientAuth)
 	}
 
+	// Minimum inactivity time out is keepalive timeout (60s) plus a few seconds
+	// to avoid races
+	minInactivityTimeout, _ := time.ParseDuration("65s")
+	if viper.GetDuration("ephemeral_node_inactivity_timeout") <= minInactivityTimeout {
+		errorText += fmt.Sprintf(
+			"Fatal config error: ephemeral_node_inactivity_timeout (%s) is set too low, must be more than %s",
+			viper.GetString("ephemeral_node_inactivity_timeout"),
+			minInactivityTimeout,
+		)
+	}
+
 	if errorText != "" {
 		//nolint
 		return errors.New(strings.TrimSuffix(errorText, "\n"))


### PR DESCRIPTION
This fixes #251 

This PR will:

- Move the configuration check for `ephemeral_node_inactivity_timeout` to where it should be
- Set a default for `ephemeral_node_inactivity_timeout`
- Add a warn if configuration could not be found.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [x] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
