### PR TITLE
Fix occasional panic on registration

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -325,11 +325,17 @@ func GenerateRandomStringURLSafe(n int) (string, error) {
 // number generator fails to function correctly, in which
 // case the caller should not continue.
 func GenerateRandomStringDNSSafe(n int) (string, error) {
-	str, err := GenerateRandomStringURLSafe(n)
+	var str string
+	var err error
+	for len(str) < n {
+		str, err = GenerateRandomStringURLSafe(n)
+		if err != nil {
+			return "", err
+		}
+		str = strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(str, "_", ""), "-", ""))
+	}
 
-	str = strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(str, "_", ""), "-", ""))
-
-	return str[:n], err
+	return str[:n], nil
 }
 
 func IsStringInSlice(slice []string, str string) bool {

--- a/utils_test.go
+++ b/utils_test.go
@@ -34,7 +34,7 @@ func (s *Suite) TestGetUsedIps(c *check.C) {
 		MachineKey:     "foo",
 		NodeKey:        "bar",
 		DiscoKey:       "faa",
-		Hostname:           "testmachine",
+		Hostname:       "testmachine",
 		NamespaceID:    namespace.ID,
 		RegisterMethod: RegisterMethodAuthKey,
 		AuthKeyID:      uint(pak.ID),
@@ -82,7 +82,7 @@ func (s *Suite) TestGetMultiIp(c *check.C) {
 			MachineKey:     "foo",
 			NodeKey:        "bar",
 			DiscoKey:       "faa",
-			Hostname:           "testmachine",
+			Hostname:       "testmachine",
 			NamespaceID:    namespace.ID,
 			RegisterMethod: RegisterMethodAuthKey,
 			AuthKeyID:      uint(pak.ID),
@@ -172,7 +172,7 @@ func (s *Suite) TestGetAvailableIpMachineWithoutIP(c *check.C) {
 		MachineKey:     "foo",
 		NodeKey:        "bar",
 		DiscoKey:       "faa",
-		Hostname:           "testmachine",
+		Hostname:       "testmachine",
 		NamespaceID:    namespace.ID,
 		RegisterMethod: RegisterMethodAuthKey,
 		AuthKeyID:      uint(pak.ID),
@@ -184,4 +184,16 @@ func (s *Suite) TestGetAvailableIpMachineWithoutIP(c *check.C) {
 
 	c.Assert(len(ips2), check.Equals, 1)
 	c.Assert(ips2[0].String(), check.Equals, expected.String())
+}
+
+func (s *Suite) TestGenerateRandomStringDNSSafe(c *check.C) {
+	for i := 0; i < 100000; i++ {
+		str, err := GenerateRandomStringDNSSafe(8)
+		if err != nil {
+			c.Error(err)
+		}
+		if len(str) != 8 {
+			c.Error("invalid length", len(str), str)
+		}
+	}
 }


### PR DESCRIPTION
Introduced by random node suffix: GenerateRandomStringDNSSafe will panic occasionally if the random base64 string contains too many - and _ due to the replacement. Fix by looping.

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
