### PR TITLE
Send Online field of tailcfg.Node based on LastSeen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Use new ACL syntax [#618](https://github.com/juanfont/headscale/pull/618)
 - Add -c option to specify config file from command line [#285](https://github.com/juanfont/headscale/issues/285) [#612](https://github.com/juanfont/headscale/pull/601)
 - Add configuration option to allow Tailscale clients to use a random WireGuard port. [kb/1181/firewalls](https://tailscale.com/kb/1181/firewalls) [#624](https://github.com/juanfont/headscale/pull/624)
+- Fix nodes being shown as 'offline' in `tailscale status` [648](https://github.com/juanfont/headscale/pull/648)
 
 ## 0.15.0 (2022-03-20)
 

--- a/machine.go
+++ b/machine.go
@@ -637,6 +637,10 @@ func (machine Machine) toNode(
 
 	hostInfo := machine.GetHostInfo()
 
+	// A node is Online if it is connected to the control server,
+	// and we now we update LastSeen every keepAliveInterval duration at least.
+	online := machine.LastSeen.After(time.Now().Add(-keepAliveInterval))
+
 	node := tailcfg.Node{
 		ID: tailcfg.NodeID(machine.ID), // this is the actual ID
 		StableID: tailcfg.StableNodeID(
@@ -653,6 +657,7 @@ func (machine Machine) toNode(
 		Endpoints:  machine.Endpoints,
 		DERP:       derp,
 
+		Online:   &online,
 		Hostinfo: hostInfo.View(),
 		Created:  machine.CreatedAt,
 		LastSeen: machine.LastSeen,


### PR DESCRIPTION
Nodes were permantly shown offline because we are not sending the `Online` field of Node. Even when we are communicating from another client.

![image](https://user-images.githubusercontent.com/181059/174123872-7725310f-6424-408b-8eab-fa9e34e984cb.png)

This commit fixes it based on LastSeen with keepAliveInternal. Simple :)
