### PR TITLE
Quick fix to segfault on CLI when Headscale is not running

### DIFF
--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -117,7 +117,7 @@ func getHeadscaleCLIClient() (context.Context, v1.HeadscaleServiceClient, *grpc.
 	conn, err := grpc.DialContext(ctx, address, grpcOptions...)
 	if err != nil {
 		log.Fatal().Caller().Err(err).Msgf("Could not connect: %v", err)
-		os.Exit(-1) // we get here if logging is supressed (i.e., json output)
+		os.Exit(-1) // we get here if logging is suppressed (i.e., json output)
 	}
 
 	client := v1.NewHeadscaleServiceClient(conn)

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -55,6 +55,7 @@ func getHeadscaleCLIClient() (context.Context, v1.HeadscaleServiceClient, *grpc.
 			Err(err).
 			Caller().
 			Msgf("Failed to load configuration")
+		os.Exit(-1) // we get here if logging is supressed (i.e., json output)
 	}
 
 	log.Debug().
@@ -116,6 +117,7 @@ func getHeadscaleCLIClient() (context.Context, v1.HeadscaleServiceClient, *grpc.
 	conn, err := grpc.DialContext(ctx, address, grpcOptions...)
 	if err != nil {
 		log.Fatal().Caller().Err(err).Msgf("Could not connect: %v", err)
+		os.Exit(-1) // we get here if logging is supressed (i.e., json output)
 	}
 
 	client := v1.NewHeadscaleServiceClient(conn)

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -55,7 +55,7 @@ func getHeadscaleCLIClient() (context.Context, v1.HeadscaleServiceClient, *grpc.
 			Err(err).
 			Caller().
 			Msgf("Failed to load configuration")
-		os.Exit(-1) // we get here if logging is supressed (i.e., json output)
+		os.Exit(-1) // we get here if logging is suppressed (i.e., json output)
 	}
 
 	log.Debug().


### PR DESCRIPTION
When we pass `--output json` or similar we suppress all the logs -which also deactivates the call to `os.Exit` when doing Fatal().

This is a quick fix for #652. 