### PR TITLE
Make tailnet updates check interval configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,10 @@
 - Add -c option to specify config file from command line [#285](https://github.com/juanfont/headscale/issues/285) [#612](https://github.com/juanfont/headscale/pull/601)
 - Add configuration option to allow Tailscale clients to use a random WireGuard port. [kb/1181/firewalls](https://tailscale.com/kb/1181/firewalls) [#624](https://github.com/juanfont/headscale/pull/624)
 - Improve obtuse UX regarding missing configuration (`ephemeral_node_inactivity_timeout` not set) [#639](https://github.com/juanfont/headscale/pull/639)
-- Fix nodes being shown as 'offline' in `tailscale status` [648](https://github.com/juanfont/headscale/pull/648)
 - Fix nodes being shown as 'offline' in `tailscale status` [#648](https://github.com/juanfont/headscale/pull/648)
 - Improve shutdown behaviour [#651](https://github.com/juanfont/headscale/pull/651)
 - Drop Gin as web framework in Headscale [648](https://github.com/juanfont/headscale/pull/648)
-
+- Make tailnet updates check interval configurable [#675](https://github.com/juanfont/headscale/pull/675)
 
 ## 0.15.0 (2022-03-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Fix nodes being shown as 'offline' in `tailscale status` [#648](https://github.com/juanfont/headscale/pull/648)
 - Improve shutdown behaviour [#651](https://github.com/juanfont/headscale/pull/651)
 - Drop Gin as web framework in Headscale [648](https://github.com/juanfont/headscale/pull/648)
-- Make tailnet updates check interval configurable [#675](https://github.com/juanfont/headscale/pull/675)
+- Make tailnet node updates check interval configurable [#675](https://github.com/juanfont/headscale/pull/675)
 
 ## 0.15.0 (2022-03-20)
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -103,11 +103,11 @@ disable_check_updates: false
 # Time before an inactive ephemeral node is deleted?
 ephemeral_node_inactivity_timeout: 30m
 
-# Period to check for changes in the tailnet. A value too low will severily affect
+# Period to check for node updates in the tailnet. A value too low will severily affect
 # CPU consumption of Headscale. A value too high (over 60s) will cause problems
-# to the nodes, as they won't get updates or keep alive messages on time.
+# to the nodes, as they won't get updates or keep alive messages in time.
 # In case of doubts, do not touch the default 10s.
-changes_check_interval: 10s
+node_update_check_interval: 10s
 
 # SQLite config
 db_type: sqlite3

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -103,6 +103,12 @@ disable_check_updates: false
 # Time before an inactive ephemeral node is deleted?
 ephemeral_node_inactivity_timeout: 30m
 
+# Period to check for changes in the tailnet. A value too low will severily affect
+# CPU consumption of Headscale. A value too high (over 60s) will cause problems
+# to the nodes, as they won't get updates or keep alive messages on time.
+# In case of doubts, do not touch the default 10s.
+changes_check_interval: 10s
+
 # SQLite config
 db_type: sqlite3
 db_path: /var/lib/headscale/db.sqlite

--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	GRPCAddr                       string
 	GRPCAllowInsecure              bool
 	EphemeralNodeInactivityTimeout time.Duration
+	ChangesCheckInterval           time.Duration
 	IPPrefixes                     []netaddr.IPPrefix
 	PrivateKeyPath                 string
 	BaseDomain                     string
@@ -162,6 +163,8 @@ func LoadConfig(path string, isFile bool) error {
 
 	viper.SetDefault("ephemeral_node_inactivity_timeout", "120s")
 
+	viper.SetDefault("changes_check_interval", "10s")
+
 	if err := viper.ReadInConfig(); err != nil {
 		log.Warn().Err(err).Msg("Failed to read configuration from disk")
 
@@ -214,6 +217,15 @@ func LoadConfig(path string, isFile bool) error {
 			"Fatal config error: ephemeral_node_inactivity_timeout (%s) is set too low, must be more than %s",
 			viper.GetString("ephemeral_node_inactivity_timeout"),
 			minInactivityTimeout,
+		)
+	}
+
+	maxChangesCheckInterval, _ := time.ParseDuration("60s")
+	if viper.GetDuration("changes_check_interval") > maxChangesCheckInterval {
+		errorText += fmt.Sprintf(
+			"Fatal config error: changes_check_interval (%s) is set too high, must be less than %s",
+			viper.GetString("changes_check_interval"),
+			maxChangesCheckInterval,
 		)
 	}
 
@@ -476,6 +488,10 @@ func GetHeadscaleConfig() (*Config, error) {
 
 		EphemeralNodeInactivityTimeout: viper.GetDuration(
 			"ephemeral_node_inactivity_timeout",
+		),
+
+		ChangesCheckInterval: viper.GetDuration(
+			"changes_check_interval",
 		),
 
 		DBtype: viper.GetString("db_type"),

--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	GRPCAddr                       string
 	GRPCAllowInsecure              bool
 	EphemeralNodeInactivityTimeout time.Duration
-	ChangesCheckInterval           time.Duration
+	NodeUpdateCheckInterval        time.Duration
 	IPPrefixes                     []netaddr.IPPrefix
 	PrivateKeyPath                 string
 	BaseDomain                     string
@@ -163,7 +163,7 @@ func LoadConfig(path string, isFile bool) error {
 
 	viper.SetDefault("ephemeral_node_inactivity_timeout", "120s")
 
-	viper.SetDefault("changes_check_interval", "10s")
+	viper.SetDefault("node_update_check_interval", "10s")
 
 	if err := viper.ReadInConfig(); err != nil {
 		log.Warn().Err(err).Msg("Failed to read configuration from disk")
@@ -220,12 +220,12 @@ func LoadConfig(path string, isFile bool) error {
 		)
 	}
 
-	maxChangesCheckInterval, _ := time.ParseDuration("60s")
-	if viper.GetDuration("changes_check_interval") > maxChangesCheckInterval {
+	maxNodeUpdateCheckInterval, _ := time.ParseDuration("60s")
+	if viper.GetDuration("node_update_check_interval") > maxNodeUpdateCheckInterval {
 		errorText += fmt.Sprintf(
-			"Fatal config error: changes_check_interval (%s) is set too high, must be less than %s",
-			viper.GetString("changes_check_interval"),
-			maxChangesCheckInterval,
+			"Fatal config error: node_update_check_interval (%s) is set too high, must be less than %s",
+			viper.GetString("node_update_check_interval"),
+			maxNodeUpdateCheckInterval,
 		)
 	}
 
@@ -490,8 +490,8 @@ func GetHeadscaleConfig() (*Config, error) {
 			"ephemeral_node_inactivity_timeout",
 		),
 
-		ChangesCheckInterval: viper.GetDuration(
-			"changes_check_interval",
+		NodeUpdateCheckInterval: viper.GetDuration(
+			"node_update_check_interval",
 		),
 
 		DBtype: viper.GetString("db_type"),

--- a/integration_test/etc/alt-config.dump.gold.yaml
+++ b/integration_test/etc/alt-config.dump.gold.yaml
@@ -20,6 +20,7 @@ dns_config:
   nameservers:
     - 1.1.1.1
 ephemeral_node_inactivity_timeout: 30m
+node_update_check_interval: 10s
 grpc_allow_insecure: false
 grpc_listen_addr: :50443
 ip_prefixes:

--- a/integration_test/etc/alt-config.yaml
+++ b/integration_test/etc/alt-config.yaml
@@ -2,6 +2,7 @@ log_level: trace
 acl_policy_path: ""
 db_type: sqlite3
 ephemeral_node_inactivity_timeout: 30m
+node_update_check_interval: 10s
 ip_prefixes:
   - fd7a:115c:a1e0::/48
   - 100.64.0.0/10

--- a/integration_test/etc/config.dump.gold.yaml
+++ b/integration_test/etc/config.dump.gold.yaml
@@ -20,6 +20,7 @@ dns_config:
   nameservers:
     - 1.1.1.1
 ephemeral_node_inactivity_timeout: 30m
+node_update_check_interval: 10s
 grpc_allow_insecure: false
 grpc_listen_addr: :50443
 ip_prefixes:

--- a/integration_test/etc/config.yaml
+++ b/integration_test/etc/config.yaml
@@ -2,6 +2,7 @@ log_level: trace
 acl_policy_path: ""
 db_type: sqlite3
 ephemeral_node_inactivity_timeout: 30m
+node_update_check_interval: 10s
 ip_prefixes:
   - fd7a:115c:a1e0::/48
   - 100.64.0.0/10

--- a/integration_test/etc_embedded_derp/config.yaml
+++ b/integration_test/etc_embedded_derp/config.yaml
@@ -2,6 +2,7 @@ log_level: trace
 acl_policy_path: ""
 db_type: sqlite3
 ephemeral_node_inactivity_timeout: 30m
+node_update_check_interval: 10s
 ip_prefixes:
   - fd7a:115c:a1e0::/48
   - 100.64.0.0/10

--- a/poll.go
+++ b/poll.go
@@ -16,8 +16,7 @@ import (
 )
 
 const (
-	keepAliveInterval   = 60 * time.Second
-	updateCheckInterval = 10 * time.Second
+	keepAliveInterval = 60 * time.Second
 )
 
 type contextKey string
@@ -640,7 +639,7 @@ func (h *Headscale) scheduledPollWorker(
 	machine *Machine,
 ) {
 	keepAliveTicker := time.NewTicker(keepAliveInterval)
-	updateCheckerTicker := time.NewTicker(updateCheckInterval)
+	updateCheckerTicker := time.NewTicker(h.cfg.ChangesCheckInterval)
 
 	defer closeChanWithLog(
 		updateChan,

--- a/poll.go
+++ b/poll.go
@@ -639,7 +639,7 @@ func (h *Headscale) scheduledPollWorker(
 	machine *Machine,
 ) {
 	keepAliveTicker := time.NewTicker(keepAliveInterval)
-	updateCheckerTicker := time.NewTicker(h.cfg.ChangesCheckInterval)
+	updateCheckerTicker := time.NewTicker(h.cfg.NodeUpdateCheckInterval)
 
 	defer closeChanWithLog(
 		updateChan,


### PR DESCRIPTION
A user with >150 machines in their tailnet reported high CPU consumption. Although for sure we have other bottlenecks, a 10 second check interval for updates might be a bit too much.

This PR allows an advanced user to change this (until now hardcoded) setting. 

