### PR TITLE
Fix API router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Improve shutdown behaviour [#651](https://github.com/juanfont/headscale/pull/651)
 - Drop Gin as web framework in Headscale [648](https://github.com/juanfont/headscale/pull/648) [677](https://github.com/juanfont/headscale/pull/677)
 - Make tailnet node updates check interval configurable [#675](https://github.com/juanfont/headscale/pull/675)
+- Fix regression with HTTP API [#684](https://github.com/juanfont/headscale/pull/684)
 
 ## 0.15.0 (2022-03-20)
 

--- a/app.go
+++ b/app.go
@@ -445,11 +445,9 @@ func (h *Headscale) createRouter(grpcMux *runtime.ServeMux) *mux.Router {
 		router.HandleFunc("/bootstrap-dns", h.DERPBootstrapDNSHandler)
 	}
 
-	api := router.PathPrefix("/api").Subrouter()
-	api.Use(h.httpAuthenticationMiddleware)
-	{
-		api.HandleFunc("/v1/*any", grpcMux.ServeHTTP)
-	}
+	apiRouter := router.PathPrefix("/api").Subrouter()
+	apiRouter.Use(h.httpAuthenticationMiddleware)
+	apiRouter.PathPrefix("/v1/").HandlerFunc(grpcMux.ServeHTTP)
 
 	router.PathPrefix("/").HandlerFunc(stdoutHandler)
 


### PR DESCRIPTION
This PR fixes a regression introduced in the HTTP API (fixes #681), when migrating out of Gin.