### PR TITLE
Temporary fix integration tests with dedicated Dockerfile

### DIFF
--- a/Dockerfile.tmp-integration
+++ b/Dockerfile.tmp-integration
@@ -1,0 +1,21 @@
+# Builder image
+FROM docker.io/golang:1.18.0-bullseye AS build
+ARG VERSION=dev
+ENV GOPATH /go
+WORKDIR /go/src/headscale
+
+COPY go.mod go.sum /go/src/headscale/
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 go build -o /go/bin/headscale -ldflags="-s -w -X github.com/juanfont/headscale/cmd/headscale/cli.Version=$VERSION" -a ./cmd/headscale 
+RUN test -e /go/bin/headscale
+
+# Production image
+FROM gcr.io/distroless/base-debian11
+
+COPY --from=build /go/bin/headscale /bin/headscale
+ENV TZ UTC
+
+EXPOSE 8080/tcp
+CMD ["headscale"]

--- a/integration_cli_test.go
+++ b/integration_cli_test.go
@@ -50,7 +50,7 @@ func (s *IntegrationCLITestSuite) SetupTest() {
 	}
 
 	headscaleBuildOptions := &dockertest.BuildOptions{
-		Dockerfile: "Dockerfile",
+		Dockerfile: "Dockerfile.tmp-integration",
 		ContextDir: ".",
 	}
 

--- a/integration_embedded_derp_test.go
+++ b/integration_embedded_derp_test.go
@@ -104,7 +104,7 @@ func (s *IntegrationDERPTestSuite) SetupSuite() {
 	}
 
 	headscaleBuildOptions := &dockertest.BuildOptions{
-		Dockerfile: "Dockerfile",
+		Dockerfile: "Dockerfile.tmp-integration",
 		ContextDir: ".",
 	}
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -53,7 +53,7 @@ func TestIntegrationTestSuite(t *testing.T) {
 
 	s.namespaces = map[string]TestNamespace{
 		"thisspace": {
-			count:      10,
+			count:      5,
 			tailscales: make(map[string]dockertest.Resource),
 		},
 		"otherspace": {

--- a/integration_test.go
+++ b/integration_test.go
@@ -228,7 +228,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	}
 
 	headscaleBuildOptions := &dockertest.BuildOptions{
-		Dockerfile: "Dockerfile",
+		Dockerfile: "Dockerfile.tmp-integration",
 		ContextDir: ".",
 	}
 


### PR DESCRIPTION
Currently our integration tests are broken due to the changes in the Dockerfile to add multi-arch support. 

This is due to the lack of support in the dockertest library for the new BuildKit library from docker/moby. I have set a PR to dockertest to fix that https://github.com/ory/dockertest/pull/374

In the meantime, this PR adds a temporary extra Dockerfile in the old format, so we can keep working.