### PR TITLE
Replaced legacy ioutil usage

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1,7 +1,6 @@
 package headscale
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -35,7 +34,7 @@ func (s *Suite) ResetDB(c *check.C) {
 		os.RemoveAll(tmpDir)
 	}
 	var err error
-	tmpDir, err = ioutil.TempDir("", "autoygg-client-test")
+	tmpDir, err = os.MkdirTemp("", "autoygg-client-test")
 	if err != nil {
 		c.Fatal(err)
 	}

--- a/cmd/headscale/headscale_test.go
+++ b/cmd/headscale/headscale_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,7 +27,7 @@ func (s *Suite) TearDownSuite(c *check.C) {
 }
 
 func (*Suite) TestConfigFileLoading(c *check.C) {
-	tmpDir, err := ioutil.TempDir("", "headscale")
+	tmpDir, err := os.MkdirTemp("", "headscale")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -73,7 +72,7 @@ func (*Suite) TestConfigFileLoading(c *check.C) {
 }
 
 func (*Suite) TestConfigLoading(c *check.C) {
-	tmpDir, err := ioutil.TempDir("", "headscale")
+	tmpDir, err := os.MkdirTemp("", "headscale")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -117,7 +116,7 @@ func (*Suite) TestConfigLoading(c *check.C) {
 }
 
 func (*Suite) TestDNSConfigLoading(c *check.C) {
-	tmpDir, err := ioutil.TempDir("", "headscale")
+	tmpDir, err := os.MkdirTemp("", "headscale")
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -152,14 +151,14 @@ func (*Suite) TestDNSConfigLoading(c *check.C) {
 func writeConfig(c *check.C, tmpDir string, configYaml []byte) {
 	// Populate a custom config file
 	configFile := filepath.Join(tmpDir, "config.yaml")
-	err := ioutil.WriteFile(configFile, configYaml, 0o600)
+	err := os.WriteFile(configFile, configYaml, 0o600)
 	if err != nil {
 		c.Fatalf("Couldn't write file %s", configFile)
 	}
 }
 
 func (*Suite) TestTLSConfigValidation(c *check.C) {
-	tmpDir, err := ioutil.TempDir("", "headscale")
+	tmpDir, err := os.MkdirTemp("", "headscale")
 	if err != nil {
 		c.Fatal(err)
 	}

--- a/derp.go
+++ b/derp.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -50,7 +49,7 @@ func loadDERPMapFromURL(addr url.URL) (*tailcfg.DERPMap, error) {
 	}
 
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/integration_embedded_derp_test.go
+++ b/integration_embedded_derp_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -362,7 +361,7 @@ func (s *IntegrationDERPTestSuite) saveLog(
 
 	log.Printf("Saving logs for %s to %s\n", resource.Container.Name, basePath)
 
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		path.Join(basePath, resource.Container.Name+".stdout.log"),
 		[]byte(stdout.String()),
 		0o644,
@@ -371,7 +370,7 @@ func (s *IntegrationDERPTestSuite) saveLog(
 		return err
 	}
 
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		path.Join(basePath, resource.Container.Name+".stderr.log"),
 		[]byte(stdout.String()),
 		0o644,

--- a/integration_general_test.go
+++ b/integration_general_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -124,7 +123,7 @@ func (s *IntegrationTestSuite) saveLog(
 
 	log.Printf("Saving logs for %s to %s\n", resource.Container.Name, basePath)
 
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		path.Join(basePath, resource.Container.Name+".stdout.log"),
 		[]byte(stdout.String()),
 		0o644,
@@ -133,7 +132,7 @@ func (s *IntegrationTestSuite) saveLog(
 		return err
 	}
 
-	err = ioutil.WriteFile(
+	err = os.WriteFile(
 		path.Join(basePath, resource.Container.Name+".stderr.log"),
 		[]byte(stdout.String()),
 		0o644,


### PR DESCRIPTION
io/ioutil is deprecated since go1.16. 

This PR removes it.