### PR TITLE
Improve registration protocol implementation and switch to NodeKey as main identifier 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Updated dependencies (including the library that lacked armhf support) [#722](https://github.com/juanfont/headscale/pull/722)
 - Fix missing group expansion in function `excludeCorretlyTaggedNodes` [#563](https://github.com/juanfont/headscale/issues/563)
+- Improve registration protocol implementation and switch to NodeKey as main identifier [#725](https://github.com/juanfont/headscale/pull/725)
 
 ## 0.16.0 (2022-07-25)
 

--- a/api.go
+++ b/api.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	registrationHoldoff                      = time.Second * 5 // TODO(juan): remove this once https://github.com/juanfont/headscale/issues/727 is fixed
+	// TODO(juan): remove this once https://github.com/juanfont/headscale/issues/727 is fixed
+	registrationHoldoff                      = time.Second * 5
 	reservedResponseHeaderSize               = 4
 	RegisterMethodAuthKey                    = "authkey"
 	RegisterMethodOIDC                       = "oidc"

--- a/api.go
+++ b/api.go
@@ -234,9 +234,9 @@ func (h *Headscale) RegistrationHandler(
 				log.Debug().
 					Caller().
 					Str("machine", registerRequest.Hostinfo.Hostname).
-					Str("NodeKey", registerRequest.NodeKey.ShortString()).
-					Str("OldNodeKey", registerRequest.OldNodeKey.ShortString()).
-					Str("Followup", registerRequest.Followup).
+					Str("node_key", registerRequest.NodeKey.ShortString()).
+					Str("node_key_old", registerRequest.OldNodeKey.ShortString()).
+					Str("follow_up", registerRequest.Followup).
 					Msg("Machine is waiting for interactive login")
 
 				ticker := time.NewTicker(registrationHoldoff)

--- a/api.go
+++ b/api.go
@@ -254,9 +254,9 @@ func (h *Headscale) RegistrationHandler(
 		log.Info().
 			Caller().
 			Str("machine", registerRequest.Hostinfo.Hostname).
-			Str("NodeKey", registerRequest.NodeKey.ShortString()).
-			Str("OldNodeKey", registerRequest.OldNodeKey.ShortString()).
-			Str("Followup", registerRequest.Followup).
+			Str("node_key", registerRequest.NodeKey.ShortString()).
+			Str("node_key_old", registerRequest.OldNodeKey.ShortString()).
+			Str("follow_up", registerRequest.Followup).
 			Msg("New machine not yet in the database")
 
 		givenName, err := h.GenerateGivenName(registerRequest.Hostinfo.Hostname)

--- a/api.go
+++ b/api.go
@@ -112,8 +112,8 @@ func (h *Headscale) RegisterWebAPI(
 	writer http.ResponseWriter,
 	req *http.Request,
 ) {
-	machineKeyStr := req.URL.Query().Get("key")
-	if machineKeyStr == "" {
+	nodeKeyStr := req.URL.Query().Get("key")
+	if nodeKeyStr == "" {
 		writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		writer.WriteHeader(http.StatusBadRequest)
 		_, err := writer.Write([]byte("Wrong params"))
@@ -129,7 +129,7 @@ func (h *Headscale) RegisterWebAPI(
 
 	var content bytes.Buffer
 	if err := registerWebAPITemplate.Execute(&content, registerWebAPITemplateConfig{
-		Key: machineKeyStr,
+		Key: nodeKeyStr,
 	}); err != nil {
 		log.Error().
 			Str("func", "RegisterWebAPI").
@@ -251,7 +251,7 @@ func (h *Headscale) RegistrationHandler(
 		}
 
 		h.registrationCache.Set(
-			machineKeyStr,
+			newMachine.NodeKey,
 			newMachine,
 			registerCacheExpiration,
 		)

--- a/api.go
+++ b/api.go
@@ -108,6 +108,9 @@ var registerWebAPITemplate = template.Must(
 
 // RegisterWebAPI shows a simple message in the browser to point to the CLI
 // Listens in /register/:nkey.
+//
+// This is not part of the Tailscale control API, as we could send whatever URL
+// in the RegisterResponse.AuthURL field.
 func (h *Headscale) RegisterWebAPI(
 	writer http.ResponseWriter,
 	req *http.Request,

--- a/api.go
+++ b/api.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	// TODO(juan): remove this once https://github.com/juanfont/headscale/issues/727 is fixed
+	// TODO(juan): remove this once https://github.com/juanfont/headscale/issues/727 is fixed.
 	registrationHoldoff                      = time.Second * 5
 	reservedResponseHeaderSize               = 4
 	RegisterMethodAuthKey                    = "authkey"
@@ -221,7 +221,7 @@ func (h *Headscale) RegistrationHandler(
 			return
 		}
 
-		// Check if the node is waiting for interactive login
+		// Check if the node is waiting for interactive login.
 		//
 		// TODO(juan): We could use this field to improve our protocol implementation,
 		// and hold the request until the client closes it, or the interactive

--- a/app.go
+++ b/app.go
@@ -420,7 +420,7 @@ func (h *Headscale) createRouter(grpcMux *runtime.ServeMux) *mux.Router {
 	router.HandleFunc("/register/{nkey}", h.RegisterWebAPI).Methods(http.MethodGet)
 	router.HandleFunc("/machine/{mkey}/map", h.PollNetMapHandler).Methods(http.MethodPost)
 	router.HandleFunc("/machine/{mkey}", h.RegistrationHandler).Methods(http.MethodPost)
-	router.HandleFunc("/oidc/register/{mkey}", h.RegisterOIDC).Methods(http.MethodGet)
+	router.HandleFunc("/oidc/register/{nkey}", h.RegisterOIDC).Methods(http.MethodGet)
 	router.HandleFunc("/oidc/callback", h.OIDCCallback).Methods(http.MethodGet)
 	router.HandleFunc("/apple", h.AppleConfigMessage).Methods(http.MethodGet)
 	router.HandleFunc("/apple/{platform}", h.ApplePlatformConfig).Methods(http.MethodGet)

--- a/app.go
+++ b/app.go
@@ -417,7 +417,7 @@ func (h *Headscale) createRouter(grpcMux *runtime.ServeMux) *mux.Router {
 
 	router.HandleFunc("/health", h.HealthHandler).Methods(http.MethodGet)
 	router.HandleFunc("/key", h.KeyHandler).Methods(http.MethodGet)
-	router.HandleFunc("/register", h.RegisterWebAPI).Methods(http.MethodGet)
+	router.HandleFunc("/register/{nkey}", h.RegisterWebAPI).Methods(http.MethodGet)
 	router.HandleFunc("/machine/{mkey}/map", h.PollNetMapHandler).Methods(http.MethodPost)
 	router.HandleFunc("/machine/{mkey}", h.RegistrationHandler).Methods(http.MethodPost)
 	router.HandleFunc("/oidc/register/{mkey}", h.RegisterOIDC).Methods(http.MethodGet)

--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -108,7 +108,7 @@ var registerNodeCmd = &cobra.Command{
 		if err != nil {
 			ErrorOutput(
 				err,
-				fmt.Sprintf("Error getting machine key from flag: %s", err),
+				fmt.Sprintf("Error getting node key from flag: %s", err),
 				output,
 			)
 

--- a/grpcv1.go
+++ b/grpcv1.go
@@ -159,7 +159,7 @@ func (api headscaleV1APIServer) RegisterMachine(
 ) (*v1.RegisterMachineResponse, error) {
 	log.Trace().
 		Str("namespace", request.GetNamespace()).
-		Str("machine_key", request.GetKey()).
+		Str("node_key", request.GetKey()).
 		Msg("Registering machine")
 
 	machine, err := api.h.RegisterMachineFromAuthCallback(
@@ -199,7 +199,7 @@ func (api headscaleV1APIServer) SetTags(
 		err := validateTag(tag)
 		if err != nil {
 			return &v1.SetTagsResponse{
-					Machine: nil,
+				Machine: nil,
 			}, status.Error(codes.InvalidArgument, err.Error())
 		}
 	}

--- a/machine.go
+++ b/machine.go
@@ -362,7 +362,7 @@ func (h *Headscale) GetMachineByMachineKey(
 	return &m, nil
 }
 
-// GetMachineByNodeKey finds a Machine by its current NodeKey
+// GetMachineByNodeKey finds a Machine by its current NodeKey.
 func (h *Headscale) GetMachineByNodeKey(
 	nodeKey key.NodePublic,
 ) (*Machine, error) {

--- a/machine.go
+++ b/machine.go
@@ -350,7 +350,7 @@ func (h *Headscale) GetMachineByID(id uint64) (*Machine, error) {
 	return &m, nil
 }
 
-// GetMachineByMachineKey finds a Machine by ID and returns the Machine struct.
+// GetMachineByMachineKey finds a Machine by its MachineKey and returns the Machine struct.
 func (h *Headscale) GetMachineByMachineKey(
 	machineKey key.MachinePublic,
 ) (*Machine, error) {
@@ -360,6 +360,19 @@ func (h *Headscale) GetMachineByMachineKey(
 	}
 
 	return &m, nil
+}
+
+// GetMachineByNodeKey finds a Machine by its current NodeKey
+func (h *Headscale) GetMachineByNodeKey(
+	nodeKey key.NodePublic,
+) (*Machine, error) {
+	machine := Machine{}
+	if result := h.db.Preload("Namespace").First(&machine, "node_key = ?",
+		NodePublicKeyStripPrefix(nodeKey)); result.Error != nil {
+		return nil, result.Error
+	}
+
+	return &machine, nil
 }
 
 // UpdateMachineFromDatabase takes a Machine struct pointer (typically already loaded from database
@@ -762,11 +775,11 @@ func getTags(
 }
 
 func (h *Headscale) RegisterMachineFromAuthCallback(
-	machineKeyStr string,
+	nodeKeyStr string,
 	namespaceName string,
 	registrationMethod string,
 ) (*Machine, error) {
-	if machineInterface, ok := h.registrationCache.Get(machineKeyStr); ok {
+	if machineInterface, ok := h.registrationCache.Get(nodeKeyStr); ok {
 		if registrationMachine, ok := machineInterface.(Machine); ok {
 			namespace, err := h.GetNamespace(namespaceName)
 			if err != nil {

--- a/oidc.go
+++ b/oidc.go
@@ -68,8 +68,8 @@ func (h *Headscale) initOIDC() error {
 }
 
 // RegisterOIDC redirects to the OIDC provider for authentication
-// Puts node key in cache so the callback can retrieve it using the oidc state param
-// Listens in /oidc/register/:mKey.
+// Puts NodeKey in cache so the callback can retrieve it using the oidc state param
+// Listens in /oidc/register/:nKey.
 func (h *Headscale) RegisterOIDC(
 	writer http.ResponseWriter,
 	req *http.Request,
@@ -135,7 +135,7 @@ var oidcCallbackTemplate = template.Must(
 )
 
 // OIDCCallback handles the callback from the OIDC endpoint
-// Retrieves the mkey from the state cache and adds the machine to the users email namespace
+// Retrieves the nkey from the state cache and adds the machine to the users email namespace
 // TODO: A confirmation page for new machines should be added to avoid phishing vulnerabilities
 // TODO: Add groups information from OIDC tokens into machine HostInfo
 // Listens in /oidc/callback.


### PR DESCRIPTION
This PR lays the groundwork for the implementation of the TS2021 protocol (Tailscale control v2).

Under the Noise protocol the NaCl boxes encrypted with the `MachineKey` are dropped in favour of Noise sessions. `MachineKey` loses importance across the code base, and when using Noise they are not sent at all.

In headscale we were using the stripped version of the public MachineKey as a sort-of ID, for the iterative login process (including the registrationCache used in the web+CLI and the OIDC flows).

This PR addresses that, switching to NodeKey as identifier. 

In addition to it, it also improves a bit the handling of the registration process (and reduces the impact caused by #727 (although does not fully resolve it).