### PR TITLE
Fix cli registration of expired machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.17.0 (2022-XX-XX)
 
 - Add ability to connect to PostgreSQL over TLS/SSL [#745](https://github.com/juanfont/headscale/pull/745)
+- Fix CLI registration of expired machines [#754](https://github.com/juanfont/headscale/pull/754)
 
 ## 0.16.3 (2022-08-17)
 
@@ -24,8 +25,6 @@
 - Fix missing group expansion in function `excludeCorretlyTaggedNodes` [#563](https://github.com/juanfont/headscale/issues/563)
 - Improve registration protocol implementation and switch to NodeKey as main identifier [#725](https://github.com/juanfont/headscale/pull/725)
 - Add ability to connect to PostgreSQL via unix socket [#734](https://github.com/juanfont/headscale/pull/734)
-
-- Fix CLI registration of expired machines [#754](https://github.com/juanfont/headscale/pull/754)
 
 ## 0.16.0 (2022-07-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - Improve registration protocol implementation and switch to NodeKey as main identifier [#725](https://github.com/juanfont/headscale/pull/725)
 - Add ability to connect to PostgreSQL via unix socket [#734](https://github.com/juanfont/headscale/pull/734)
 
+- Fix CLI registration of expired machines [#754](https://github.com/juanfont/headscale/pull/754)
+
 ## 0.16.0 (2022-07-25)
 
 **Note:** Take a backup of your database before upgrading.

--- a/api.go
+++ b/api.go
@@ -348,7 +348,7 @@ func (h *Headscale) RegistrationHandler(
 
 		machine.Expiry = &time.Time{}
 		h.registrationCache.Set(
-			machineKeyStr,
+			NodePublicKeyStripPrefix(registerRequest.NodeKey),
 			*machine,
 			registerCacheExpiration,
 		)

--- a/api.go
+++ b/api.go
@@ -346,6 +346,13 @@ func (h *Headscale) RegistrationHandler(
 		// The machine has expired
 		h.handleMachineExpired(writer, req, machineKey, registerRequest, *machine)
 
+		machine.Expiry = &time.Time{}
+		h.registrationCache.Set(
+			machineKeyStr,
+			*machine,
+			registerCacheExpiration,
+		)
+
 		return
 	}
 }

--- a/machine.go
+++ b/machine.go
@@ -803,7 +803,7 @@ func (h *Headscale) RegisterMachineFromAuthCallback(
 			)
 
 			if err == nil {
-				h.registrationCache.Delete(machineKeyStr)
+				h.registrationCache.Delete(nodeKeyStr)
 			}
 
 			return machine, err

--- a/machine.go
+++ b/machine.go
@@ -24,9 +24,9 @@ const (
 	ErrMachineNotFoundRegistrationCache = Error(
 		"machine not found in registration cache",
 	)
-	errCouldNotConvertMachineInterface = Error("failed to convert machine interface")
-	errHostnameTooLong                 = Error("Hostname too long")
-	errDifferentRegisteredNamespace    = Error("machine was previously registered with a different namespace")
+	ErrCouldNotConvertMachineInterface = Error("failed to convert machine interface")
+	ErrHostnameTooLong                 = Error("Hostname too long")
+	ErrDifferentRegisteredNamespace    = Error("machine was previously registered with a different namespace")
 	MachineGivenNameHashLength         = 8
 	MachineGivenNameTrimSize           = 2
 )
@@ -792,7 +792,7 @@ func (h *Headscale) RegisterMachineFromAuthCallback(
 
 			// Registration of expired machine with different namespace
 			if registrationMachine.ID != 0 && registrationMachine.NamespaceID != namespace.ID {
-				return nil, errDifferentRegisteredNamespace
+				return nil, ErrDifferentRegisteredNamespace
 			}
 
 			registrationMachine.NamespaceID = namespace.ID


### PR DESCRIPTION
Fixes the CLI registration of machines already present in DB:
* Machines that logged out were not added to registration cache when joining again
* If the machine was still in cache (<15min after the first registration), expiry was not updated
* Registration cache was not cleaned up after successful machine registration

Checks that the machine is registered with the right namespace


<!-- Please tick if the following things apply. You… -->

- [X] read the [CONTRIBUTING guidelines](README.md#contributing)
- [X] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

Fixes #522 
