### PR TITLE
Fixes #766 Feature optional hostname suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.17.0 (2022-XX-XX)
 
+### BREAKING
+
+- Optional (off by default) random node suffixes. Reverts default Node DNS random suffixes introduced in 0.16.0.
+
+### Changes
+
 - Added support for Tailscale TS2021 protocol [#738](https://github.com/juanfont/headscale/pull/738)
 - Add ability to specify config location via env var `HEADSCALE_CONFIG` [#674](https://github.com/juanfont/headscale/issues/674)
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -216,6 +216,12 @@ dns_config:
   # `hostname.namespace.base_domain` (e.g., _myhost.mynamespace.example.com_).
   base_domain: example.com
 
+# Assign random node DNS suffixes in the form of `hostname-<random suffix>.namespace.base_domain`.
+# The original hostname will be truncated if the hostname including the suffix is longer than 63 characters.
+# This setting avoids hostname collisions at the cost of hostnames configured on the physical device and over
+# the local network not matching the hostname over the VPN.
+hostname_random_suffix: false
+
 # Unix socket used for the CLI to connect without authentication
 # Note: for local development, you probably want to change this to:
 # unix_socket: ./headscale.sock

--- a/config.go
+++ b/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	PrivateKeyPath                 string
 	NoisePrivateKeyPath            string
 	BaseDomain                     string
+	HostnameRandomSuffix           bool
 	LogLevel                       zerolog.Level
 	DisableUpdateCheck             bool
 
@@ -149,6 +150,8 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("log_level", "info")
 
 	viper.SetDefault("dns_config", nil)
+
+	viper.SetDefault("hostname_random_suffix", false)
 
 	viper.SetDefault("derp.server.enabled", false)
 	viper.SetDefault("derp.server.stun.enabled", true)


### PR DESCRIPTION
This PR fixes #766 by making hostname suffixes optional and off by default.

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
