### PR TITLE
Add Tailscale v1.30.0 to the integration test roaster

### DIFF
--- a/integration_common_test.go
+++ b/integration_common_test.go
@@ -32,6 +32,7 @@ var (
 	tailscaleVersions = []string{
 		// "head",
 		// "unstable",
+		"1.30.0",
 		"1.28.0",
 		"1.26.2",
 		"1.24.2",


### PR DESCRIPTION
Tailscale has just released v1.30.0 https://tailscale.com/changelog/#2022-08-31-client

This is the first Tailscale version where Headscale will offer the TS2021 protocol.

And it seems to work in my dev env :)
