### PR TITLE
Target Go 1.19 for Headscale

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.0
+          go-version: 1.19.0
 
       - name: Install dependencies
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 ---
 before:
   hooks:
-    - go mod tidy -compat=1.18
+    - go mod tidy -compat=1.19
 
 release:
   prerelease: auto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added support for Tailscale TS2021 protocol [#738](https://github.com/juanfont/headscale/pull/738)
 - Add ability to specify config location via env var `HEADSCALE_CONFIG` [#674](https://github.com/juanfont/headscale/issues/674)
+- Target Go 1.19 for Headscale [#778](https://github.com/juanfont/headscale/pull/778)
 
 ## 0.16.4 (2022-08-21)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder image
-FROM docker.io/golang:1.18.0-bullseye AS build
+FROM docker.io/golang:1.19.0-bullseye AS build
 ARG VERSION=dev
 ENV GOPATH /go
 WORKDIR /go/src/headscale

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # Builder image
-FROM docker.io/golang:1.18.0-alpine AS build
+FROM docker.io/golang:1.19.0-alpine AS build
 ARG VERSION=dev
 ENV GOPATH /go
 WORKDIR /go/src/headscale

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,5 +1,5 @@
 # Builder image
-FROM docker.io/golang:1.18.0-bullseye AS build
+FROM docker.io/golang:1.19.0-bullseye AS build
 ARG VERSION=dev
 ENV GOPATH /go
 WORKDIR /go/src/headscale

--- a/docs/running-headscale-openbsd.md
+++ b/docs/running-headscale-openbsd.md
@@ -17,7 +17,7 @@ describing how to make `headscale` run properly in a server environment.
 
 ```shell
 # Install prerequistes
-# 1. go v1.18+: headscale newer than 0.15 needs go 1.18+ to compile
+# 1. go v1.19+: headscale newer than 0.17 needs go 1.19+ to compile
 # 2. gmake: Makefile in the headscale repo is written in GNU make syntax
 pkg_add -D snap go
 pkg_add gmake
@@ -46,7 +46,7 @@ cp headscale /usr/local/sbin
 
 ```shell
 # Install prerequistes
-# 1. go v1.18+: headscale newer than 0.15 needs go 1.18+ to compile
+# 1. go v1.19+: headscale newer than 0.17 needs go 1.19+ to compile
 # 2. gmake: Makefile in the headscale repo is written in GNU make syntax
 
 git clone https://github.com/juanfont/headscale.git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juanfont/headscale
 
-go 1.18
+go 1.19
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.5


### PR DESCRIPTION
Tailscale v1.30+ requires Go 1.19 for us to be able to import it.

This PR switches Headscale to Go 1.19, as a prerequisite for a PR moving use towards their latest version.