### PR TITLE
Warn when Headscale is running behind an improperly configured proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add ability to specify config location via env var `HEADSCALE_CONFIG` [#674](https://github.com/juanfont/headscale/issues/674)
 - Target Go 1.19 for Headscale [#778](https://github.com/juanfont/headscale/pull/778)
 - Target Tailscale v1.30.0 to build Headscale [#780](https://github.com/juanfont/headscale/pull/780)
+- Give a warning when running Headscale with reverse proxy improperly configured for WebSockets [#788](https://github.com/juanfont/headscale/pull/788)
 
 ## 0.16.4 (2022-08-21)
 

--- a/derp_server.go
+++ b/derp_server.go
@@ -99,10 +99,13 @@ func (h *Headscale) DERPHandler(
 	req *http.Request,
 ) {
 	log.Trace().Caller().Msgf("/derp request from %v", req.RemoteAddr)
-	up := strings.ToLower(req.Header.Get("Upgrade"))
-	if up != "websocket" && up != "derp" {
-		if up != "" {
-			log.Warn().Caller().Msgf("Weird websockets connection upgrade: %q", up)
+	upgrade := strings.ToLower(req.Header.Get("Upgrade"))
+
+	if upgrade != "websocket" && upgrade != "derp" {
+		if upgrade != "" {
+			log.Warn().
+				Caller().
+				Msg("No Upgrade header in DERP server request. If headscale is behind a reverse proxy, make sure it is configured to pass WebSockets through.")
 		}
 		writer.Header().Set("Content-Type", "text/plain")
 		writer.WriteHeader(http.StatusUpgradeRequired)

--- a/noise.go
+++ b/noise.go
@@ -23,6 +23,19 @@ func (h *Headscale) NoiseUpgradeHandler(
 ) {
 	log.Trace().Caller().Msgf("Noise upgrade handler for client %s", req.RemoteAddr)
 
+	upgrade := req.Header.Get("Upgrade")
+	if upgrade == "" {
+		// This probably means that the user is running Headscale behind an
+		// improperly configured reverse proxy. TS2021 requires WebSockets to
+		// be passed to Headscale. Let's give them a hint.
+		log.Warn().
+			Caller().
+			Msg("No Upgrade header found in TS2021 request. If running headscale behind a reverse proxy, make sure it is configured to pass WebSockets through.")
+		http.Error(writer, "Internal error", http.StatusInternalServerError)
+
+		return
+	}
+
 	noiseConn, err := controlhttp.AcceptHTTP(req.Context(), writer, req, *h.noisePrivateKey)
 	if err != nil {
 		log.Error().Err(err).Msg("noise upgrade failed")

--- a/noise.go
+++ b/noise.go
@@ -30,7 +30,7 @@ func (h *Headscale) NoiseUpgradeHandler(
 		// be passed to Headscale. Let's give them a hint.
 		log.Warn().
 			Caller().
-			Msg("No Upgrade header found in TS2021 request. If running headscale behind a reverse proxy, make sure it is configured to pass WebSockets through.")
+			Msg("No Upgrade header in TS2021 request. If headscale is behind a reverse proxy, make sure it is configured to pass WebSockets through.")
 		http.Error(writer, "Internal error", http.StatusInternalServerError)
 
 		return


### PR DESCRIPTION
TS2021 absolutely requires to have WebSockets proxified to Headscale if running it behind a reverse proxy. 

Although we do not support reverse proxy-ed setups, giving a hint in the logs will result in less issues opened (like #775). 

