### PR TITLE
Remove --rm flag from Docker example

### DIFF
--- a/docs/running-headscale-container.md
+++ b/docs/running-headscale-container.md
@@ -66,7 +66,6 @@ db_path: /etc/headscale/db.sqlite
 docker run \
   --name headscale \
   --detach \
-  --rm \
   --volume $(pwd)/config:/etc/headscale/ \
   --publish 127.0.0.1:8080:8080 \
   --publish 127.0.0.1:9090:9090 \


### PR DESCRIPTION
It appears to be causing confusion for users on Discord when copying/pasting from the example here, if Headscale crashes on launch then the container will be removed and logs can't be viewed with `docker logs`.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
