### PR TITLE
Add option to allow headscale to start if OIDC fails to initialise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added support for JSON logs [#653](https://github.com/juanfont/headscale/issues/653)
 - Add support for generating pre-auth keys with tags [#767](https://github.com/juanfont/headscale/pull/767)
 - Add support for evaluating `autoApprovers` ACL entries when a machine is registered [#763](https://github.com/juanfont/headscale/pull/763)
+- Add config flag to allow Headscale to start if OIDC provider is down [#829](https://github.com/juanfont/headscale/pull/829)
 
 ## 0.16.4 (2022-08-21)
 

--- a/app.go
+++ b/app.go
@@ -193,7 +193,7 @@ func NewHeadscale(cfg *Config) (*Headscale, error) {
 	if cfg.OIDC.Issuer != "" {
 		err = app.initOIDC()
 		if err != nil {
-			return nil, err
+			log.Warn().Err(err).Msg("failed to set up OIDC provider, falling back to CLI based authentication")
 		}
 	}
 

--- a/app.go
+++ b/app.go
@@ -192,7 +192,9 @@ func NewHeadscale(cfg *Config) (*Headscale, error) {
 
 	if cfg.OIDC.Issuer != "" {
 		err = app.initOIDC()
-		if err != nil {
+		if err != nil && cfg.OIDC.OnlyStartIfOIDCIsAvailable {
+			return nil, err
+		} else {
 			log.Warn().Err(err).Msg("failed to set up OIDC provider, falling back to CLI based authentication")
 		}
 	}

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -230,6 +230,7 @@ unix_socket_permission: "0770"
 # help us test it.
 # OpenID Connect
 # oidc:
+#   only_start_if_oidc_is_available: true
 #   issuer: "https://your-oidc.issuer.com/path"
 #   client_id: "your-oidc-client-id"
 #   client_secret: "your-oidc-client-secret"

--- a/config.go
+++ b/config.go
@@ -90,14 +90,15 @@ type LetsEncryptConfig struct {
 }
 
 type OIDCConfig struct {
-	Issuer           string
-	ClientID         string
-	ClientSecret     string
-	Scope            []string
-	ExtraParams      map[string]string
-	AllowedDomains   []string
-	AllowedUsers     []string
-	StripEmaildomain bool
+	OnlyStartIfOIDCIsAvailable bool
+	Issuer                     string
+	ClientID                   string
+	ClientSecret               string
+	Scope                      []string
+	ExtraParams                map[string]string
+	AllowedDomains             []string
+	AllowedUsers               []string
+	StripEmaildomain           bool
 }
 
 type DERPConfig struct {
@@ -174,6 +175,7 @@ func LoadConfig(path string, isFile bool) error {
 
 	viper.SetDefault("oidc.scope", []string{oidc.ScopeOpenID, "profile", "email"})
 	viper.SetDefault("oidc.strip_email_domain", true)
+	viper.SetDefault("oidc.only_start_if_oidc_is_available", true)
 
 	viper.SetDefault("logtail.enabled", false)
 	viper.SetDefault("randomize_client_port", false)
@@ -559,6 +561,9 @@ func GetHeadscaleConfig() (*Config, error) {
 		UnixSocketPermission: GetFileMode("unix_socket_permission"),
 
 		OIDC: OIDCConfig{
+			OnlyStartIfOIDCIsAvailable: viper.GetBool(
+				"oidc.only_start_if_oidc_is_available",
+			),
 			Issuer:           viper.GetString("oidc.issuer"),
 			ClientID:         viper.GetString("oidc.client_id"),
 			ClientSecret:     viper.GetString("oidc.client_secret"),

--- a/integration_test/etc/alt-config.dump.gold.yaml
+++ b/integration_test/etc/alt-config.dump.gold.yaml
@@ -35,6 +35,7 @@ logtail:
   enabled: false
 metrics_listen_addr: 127.0.0.1:19090
 oidc:
+  only_start_if_oidc_is_available: true
   scope:
     - openid
     - profile

--- a/integration_test/etc/alt-env-config.dump.gold.yaml
+++ b/integration_test/etc/alt-env-config.dump.gold.yaml
@@ -34,6 +34,7 @@ logtail:
   enabled: false
 metrics_listen_addr: 127.0.0.1:19090
 oidc:
+  only_start_if_oidc_is_available: true
   scope:
     - openid
     - profile

--- a/integration_test/etc/config.dump.gold.yaml
+++ b/integration_test/etc/config.dump.gold.yaml
@@ -35,6 +35,7 @@ logtail:
   enabled: false
 metrics_listen_addr: 127.0.0.1:9090
 oidc:
+  only_start_if_oidc_is_available: true
   scope:
     - openid
     - profile

--- a/protocol_common.go
+++ b/protocol_common.go
@@ -483,7 +483,7 @@ func (h *Headscale) handleNewMachineCommon(
 		Bool("noise", machineKey.IsZero()).
 		Str("machine", registerRequest.Hostinfo.Hostname).
 		Msg("The node seems to be new, sending auth url")
-	if h.cfg.OIDC.Issuer != "" {
+	if h.oauth2Config != nil {
 		resp.AuthURL = fmt.Sprintf(
 			"%s/oidc/register/%s",
 			strings.TrimSuffix(h.cfg.ServerURL, "/"),
@@ -716,7 +716,7 @@ func (h *Headscale) handleMachineExpiredCommon(
 		return
 	}
 
-	if h.cfg.OIDC.Issuer != "" {
+	if h.oauth2Config != nil {
 		resp.AuthURL = fmt.Sprintf("%s/oidc/register/%s",
 			strings.TrimSuffix(h.cfg.ServerURL, "/"),
 			NodePublicKeyStripPrefix(registerRequest.NodeKey))


### PR DESCRIPTION
OIDC might be configured, but unable to be initialised, this only runs
the oidc cycle if it is actually successfully set up/initialised.

Fixes #827 

Signed-off-by: Kristoffer Dalby <kristoffer@dalby.cc><!-- Please tick if the following things apply. You… -->

- [ ] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
