### PR TITLE
Add SSH ACL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix OIDC registration issues [#960](https://github.com/juanfont/headscale/pull/960) and [#971](https://github.com/juanfont/headscale/pull/971)
 - Add support for specifying NextDNS DNS-over-HTTPS resolver [#940](https://github.com/juanfont/headscale/pull/940)
 - Make more sslmode available for postgresql connection [#927](https://github.com/juanfont/headscale/pull/927)
+- Add support for [SSH ACL](https://tailscale.com/kb/1018/acls/#tailscale-ssh) blocks [#847](https://github.com/juanfont/headscale/pull/847)
 
 ## 0.16.4 (2022-08-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,14 @@
 - Fix OIDC registration issues [#960](https://github.com/juanfont/headscale/pull/960) and [#971](https://github.com/juanfont/headscale/pull/971)
 - Add support for specifying NextDNS DNS-over-HTTPS resolver [#940](https://github.com/juanfont/headscale/pull/940)
 - Make more sslmode available for postgresql connection [#927](https://github.com/juanfont/headscale/pull/927)
-- Add support for [SSH ACL](https://tailscale.com/kb/1018/acls/#tailscale-ssh) blocks [#847](https://github.com/juanfont/headscale/pull/847)
+- Add experimental support for [SSH ACL](https://tailscale.com/kb/1018/acls/#tailscale-ssh) (see docs for limitations) [#847](https://github.com/juanfont/headscale/pull/847)
+  - Please note that this support should be considered _partially_ implemented
+  - SSH ACLs status:
+    - Support `accept` and `check` (SSH can be enabled and used for connecting and authentication)
+    - Rejecting connections **are not supported**, meaning that if you enable SSH, then assume that _all_ `ssh` connections **will be allowed**.
+    - If you decied to try this feature, please carefully managed permissions by blocking port `22` with regular ACLs or do _not_ set `--ssh` on your clients.
+    - We are currently improving our testing of the SSH ACLs, help us get an overview by testing and giving feedback.
+  - This feature should be considered dangerous and it is disabled by default. Enable by setting `HEADSCALE_EXPERIMENTAL_FEATURE_SSH=1`.
 
 ## 0.16.4 (2022-08-21)
 

--- a/Dockerfile.tailscale
+++ b/Dockerfile.tailscale
@@ -4,12 +4,16 @@ ARG TAILSCALE_VERSION=*
 ARG TAILSCALE_CHANNEL=stable
 
 RUN apt-get update \
-    && apt-get install -y gnupg curl \
+    && apt-get install -y gnupg curl ssh \
     && curl -fsSL https://pkgs.tailscale.com/${TAILSCALE_CHANNEL}/ubuntu/focal.gpg | apt-key add - \
     && curl -fsSL https://pkgs.tailscale.com/${TAILSCALE_CHANNEL}/ubuntu/focal.list | tee /etc/apt/sources.list.d/tailscale.list \
     && apt-get update \
     && apt-get install -y ca-certificates tailscale=${TAILSCALE_VERSION} dnsutils \
     && rm -rf /var/lib/apt/lists/*
+
+RUN adduser --shell=/bin/bash ssh-it-user
+
+RUN service ssh start
 
 ADD integration_test/etc_embedded_derp/tls/server.crt /usr/local/share/ca-certificates/
 RUN chmod 644 /usr/local/share/ca-certificates/server.crt 

--- a/Dockerfile.tailscale
+++ b/Dockerfile.tailscale
@@ -13,9 +13,7 @@ RUN apt-get update \
 
 RUN adduser --shell=/bin/bash ssh-it-user
 
-RUN service ssh start
-
 ADD integration_test/etc_embedded_derp/tls/server.crt /usr/local/share/ca-certificates/
-RUN chmod 644 /usr/local/share/ca-certificates/server.crt 
+RUN chmod 644 /usr/local/share/ca-certificates/server.crt
 
 RUN update-ca-certificates

--- a/Dockerfile.tailscale-HEAD
+++ b/Dockerfile.tailscale-HEAD
@@ -6,8 +6,6 @@ RUN apt-get update \
 
 RUN useradd --shell=/bin/bash --create-home ssh-it-user
 
-RUN service ssh start
-
 RUN git clone https://github.com/tailscale/tailscale.git
 
 WORKDIR /go/tailscale
@@ -21,6 +19,6 @@ RUN cp tailscale /usr/local/bin/
 RUN cp tailscaled /usr/local/bin/
 
 ADD integration_test/etc_embedded_derp/tls/server.crt /usr/local/share/ca-certificates/
-RUN chmod 644 /usr/local/share/ca-certificates/server.crt 
+RUN chmod 644 /usr/local/share/ca-certificates/server.crt
 
 RUN update-ca-certificates

--- a/Dockerfile.tailscale-HEAD
+++ b/Dockerfile.tailscale-HEAD
@@ -1,9 +1,12 @@
 FROM golang:latest
 
 RUN apt-get update \
-    && apt-get install -y ca-certificates dnsutils git iptables \
+    && apt-get install -y ca-certificates dnsutils git iptables ssh \
     && rm -rf /var/lib/apt/lists/*
 
+RUN useradd --shell=/bin/bash --create-home ssh-it-user
+
+RUN service ssh start
 
 RUN git clone https://github.com/tailscale/tailscale.git
 

--- a/acls.go
+++ b/acls.go
@@ -56,7 +56,7 @@ const (
 	ProtocolFC       = 133 // Fibre Channel
 )
 
-var featureEnableSSH = envknob.RegisterBool("HEADSCALE_FEATURE_SSH")
+var featureEnableSSH = envknob.RegisterBool("HEADSCALE_EXPERIMENTAL_FEATURE_SSH")
 
 // LoadACLPolicy loads the ACL policy from the specify path, and generates the ACL rules.
 func (h *Headscale) LoadACLPolicy(path string) error {
@@ -135,7 +135,7 @@ func (h *Headscale) UpdateACLRules() error {
 		}
 		h.sshPolicy.Rules = sshRules
 	} else if h.aclPolicy != nil && len(h.aclPolicy.SSHs) > 0 {
-		log.Info().Msg("SSH ACLs has been defined, but HEADSCALE_FEATURE_SSH is not enabled, this is a unstable feature, check docs before activating")
+		log.Info().Msg("SSH ACLs has been defined, but HEADSCALE_EXPERIMENTAL_FEATURE_SSH is not enabled, this is a unstable feature, check docs before activating")
 	}
 
 	return nil

--- a/acls_test.go
+++ b/acls_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"gopkg.in/check.v1"
+	"tailscale.com/envknob"
 	"tailscale.com/tailcfg"
 )
 
@@ -74,6 +75,8 @@ func (s *Suite) TestInvalidAction(c *check.C) {
 }
 
 func (s *Suite) TestSshRules(c *check.C) {
+	envknob.Setenv("HEADSCALE_EXPERIMENTAL_FEATURE_SSH", "1")
+
 	namespace, err := app.CreateNamespace("user1")
 	c.Assert(err, check.IsNil)
 

--- a/acls_types.go
+++ b/acls_types.go
@@ -17,6 +17,7 @@ type ACLPolicy struct {
 	ACLs          []ACL         `json:"acls"          yaml:"acls"`
 	Tests         []ACLTest     `json:"tests"         yaml:"tests"`
 	AutoApprovers AutoApprovers `json:"autoApprovers" yaml:"autoApprovers"`
+	SSHs          []SSH         `json:"ssh"           yaml:"ssh"`
 }
 
 // ACL is a basic rule for the ACL Policy.
@@ -48,6 +49,15 @@ type ACLTest struct {
 type AutoApprovers struct {
 	Routes   map[string][]string `json:"routes"   yaml:"routes"`
 	ExitNode []string            `json:"exitNode" yaml:"exitNode"`
+}
+
+// SSH controls who can ssh into which machines.
+type SSH struct {
+	Action       string   `json:"action"                yaml:"action"`
+	Sources      []string `json:"src"                   yaml:"src"`
+	Destinations []string `json:"dst"                   yaml:"dst"`
+	Users        []string `json:"users"                 yaml:"users"`
+	CheckPeriod  string   `json:"checkPeriod,omitempty" yaml:"checkPeriod,omitempty"`
 }
 
 // UnmarshalJSON allows to parse the Hosts directly into netip objects.

--- a/api_common.go
+++ b/api_common.go
@@ -62,6 +62,7 @@ func (h *Headscale) generateMapResponse(
 		DNSConfig:    dnsConfig,
 		Domain:       h.cfg.BaseDomain,
 		PacketFilter: h.aclRules,
+		SSHPolicy:    h.sshPolicy,
 		DERPMap:      h.DERPMap,
 		UserProfiles: profiles,
 		Debug: &tailcfg.Debug{

--- a/app.go
+++ b/app.go
@@ -88,6 +88,7 @@ type Headscale struct {
 
 	aclPolicy *ACLPolicy
 	aclRules  []tailcfg.FilterRule
+	sshPolicy *tailcfg.SSHPolicy
 
 	lastStateChange *xsync.MapOf[string, time.Time]
 

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -8,6 +8,7 @@ import (
 
 	v1 "github.com/juanfont/headscale/gen/go/headscale/v1"
 	"github.com/juanfont/headscale/integration/hsic"
+	"github.com/juanfont/headscale/integration/tsic"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,7 +38,7 @@ func TestNamespaceCommand(t *testing.T) {
 		"namespace2": 0,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("clins"))
+	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
 	assert.NoError(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -118,7 +119,7 @@ func TestPreAuthKeyCommand(t *testing.T) {
 		namespace: 0,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("clipak"))
+	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clipak"))
 	assert.NoError(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -258,7 +259,7 @@ func TestPreAuthKeyCommandWithoutExpiry(t *testing.T) {
 		namespace: 0,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("clipaknaexp"))
+	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clipaknaexp"))
 	assert.NoError(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -323,7 +324,7 @@ func TestPreAuthKeyCommandReusableEphemeral(t *testing.T) {
 		namespace: 0,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("clipakresueeph"))
+	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clipakresueeph"))
 	assert.NoError(t, err)
 
 	headscale, err := scenario.Headscale()

--- a/integration/general_test.go
+++ b/integration/general_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juanfont/headscale/integration/hsic"
+	"github.com/juanfont/headscale/integration/tsic"
 	"github.com/rs/zerolog/log"
 )
 
@@ -24,7 +25,7 @@ func TestPingAllByIP(t *testing.T) {
 		"namespace2": len(TailscaleVersions),
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("pingallbyip"))
+	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("pingallbyip"))
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
 	}
@@ -80,7 +81,7 @@ func TestPingAllByHostname(t *testing.T) {
 		"namespace4": len(TailscaleVersions) - 1,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("pingallbyname"))
+	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("pingallbyname"))
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
 	}
@@ -148,7 +149,7 @@ func TestTaildrop(t *testing.T) {
 		"taildrop": len(TailscaleVersions) - 1,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("taildrop"))
+	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("taildrop"))
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
 	}
@@ -276,7 +277,7 @@ func TestResolveMagicDNS(t *testing.T) {
 		"magicdns2": len(TailscaleVersions) - 1,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("magicdns"))
+	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("magicdns"))
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
 	}

--- a/integration/hsic/hsic.go
+++ b/integration/hsic/hsic.go
@@ -79,13 +79,9 @@ func WithTLS() Option {
 
 func WithConfigEnv(configEnv map[string]string) Option {
 	return func(hsic *HeadscaleInContainer) {
-		env := []string{}
-
 		for key, value := range configEnv {
-			env = append(env, fmt.Sprintf("%s=%s", key, value))
+			hsic.env = append(hsic.env, fmt.Sprintf("%s=%s", key, value))
 		}
-
-		hsic.env = env
 	}
 }
 

--- a/integration/scenario_test.go
+++ b/integration/scenario_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/juanfont/headscale/integration/dockertestutil"
 )
 
-// This file is intendet to "test the test framework", by proxy it will also test
+// This file is intended to "test the test framework", by proxy it will also test
 // some Headcsale/Tailscale stuff, but mostly in very simple ways.
 
 func IntegrationSkip(t *testing.T) {

--- a/integration/ssh_test.go
+++ b/integration/ssh_test.go
@@ -12,14 +12,15 @@ import (
 func TestSSHOneNamespaceAllToAll(t *testing.T) {
 	IntegrationSkip(t)
 
-	retry := func(times int, sleepInverval time.Duration, doWork func() (string, error)) (string, error) {
+	retry := func(times int, sleepInterval time.Duration, doWork func() (string, error)) (string, error) {
 		var err error
 		for attempts := 0; attempts < times; attempts++ {
-			result, err := doWork()
+			var result string
+			result, err = doWork()
 			if err == nil {
 				return result, nil
 			}
-			time.Sleep(sleepInverval)
+			time.Sleep(sleepInterval)
 		}
 
 		return "", err

--- a/integration/ssh_test.go
+++ b/integration/ssh_test.go
@@ -2,13 +2,28 @@ package integration
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/juanfont/headscale"
 )
 
-func TestSSHIntoAll(t *testing.T) {
+func TestSSHOneNamespaceAllToAll(t *testing.T) {
 	IntegrationSkip(t)
+
+	retry := func(times int, sleepInverval time.Duration, doWork func() (string, error)) (string, error) {
+		var err error
+		for attempts := 0; attempts < times; attempts++ {
+			result, err := doWork()
+			if err == nil {
+				return result, nil
+			}
+			time.Sleep(sleepInverval)
+		}
+
+		return "", err
+	}
 
 	scenario, err := NewScenario()
 	if err != nil {
@@ -17,14 +32,12 @@ func TestSSHIntoAll(t *testing.T) {
 
 	spec := &HeadscaleSpec{
 		namespaces: map[string]int{
-			// Omit versions before 1.24 because they don't support SSH
-			"namespace1": len(TailscaleVersions) - 4,
-			"namespace2": len(TailscaleVersions) - 4,
+			"namespace1": len(TailscaleVersions) - 5,
 		},
 		enableSSH: true,
 		acl: &headscale.ACLPolicy{
 			Groups: map[string][]string{
-				"group:integration-test": {"namespace1", "namespace2"},
+				"group:integration-test": {"namespace1"},
 			},
 			ACLs: []headscale.ACL{
 				{
@@ -48,68 +61,73 @@ func TestSSHIntoAll(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
 	}
+
+	allClients, err := scenario.ListTailscaleClients()
+	if err != nil {
+		t.Errorf("failed to get clients: %s", err)
+	}
+
 	err = scenario.WaitForTailscaleSync()
 	if err != nil {
 		t.Errorf("failed wait for tailscale clients to be in sync: %s", err)
 	}
 
-	for namespace := range spec.namespaces {
-		// This will essentially fetch and cache all the FQDNs for the given namespace
-		nsFQDNs, err := scenario.ListTailscaleClientsFQDNs(namespace)
-		if err != nil {
-			t.Errorf("failed to get FQDNs: %s", err)
-		}
+	_, err = scenario.ListTailscaleClientsFQDNs()
+	if err != nil {
+		t.Errorf("failed to get FQDNs: %s", err)
+	}
 
-		nsClients, err := scenario.ListTailscaleClients(namespace)
-		if err != nil {
-			t.Errorf("failed to get clients: %s", err)
-		}
+	success := 0
 
-		for _, client := range nsClients {
-			currentClientFqdn, _ := client.FQDN()
-			sshTargets := removeFromSlice(nsFQDNs, currentClientFqdn)
-
-			for _, target := range sshTargets {
-				t.Run(
-					fmt.Sprintf("%s-%s", currentClientFqdn, target),
-					func(t *testing.T) {
-						command := []string{
-							"ssh", "-o StrictHostKeyChecking=no",
-							fmt.Sprintf("%s@%s", "ssh-it-user", target),
-							"'hostname'",
-						}
-
-						result, err := client.Execute(command)
-						if err != nil {
-							t.Errorf("failed to execute command over SSH: %s", err)
-						}
-
-						if result != target {
-							t.Logf("result=%s, target=%s", result, target)
-							t.Fail()
-						}
-
-						t.Logf("Result for %s: %s\n", target, result)
-					},
-				)
+	for _, client := range allClients {
+		for _, peer := range allClients {
+			if client.Hostname() == peer.Hostname() {
+				continue
 			}
 
-			// t.Logf("%s wants to SSH into %+v", currentClientFqdn, sshTargets)
+			clientFQDN, _ := client.FQDN()
+			peerFQDN, _ := peer.FQDN()
+
+			t.Run(
+				fmt.Sprintf("%s-%s", clientFQDN, peerFQDN),
+				func(t *testing.T) {
+					command := []string{
+						"ssh", "-o StrictHostKeyChecking=no", "-o ConnectTimeout=1",
+						fmt.Sprintf("%s@%s", "ssh-it-user", peer.Hostname()),
+						"'hostname'",
+					}
+
+					result, err := retry(10, 1*time.Second, func() (string, error) {
+						return client.Execute(command)
+					})
+					if err != nil {
+						t.Errorf("failed to execute command over SSH: %s", err)
+					}
+
+					if strings.Contains(peer.ID(), result) {
+						t.Logf(
+							"failed to get correct container ID from %s, expected: %s, got: %s",
+							peer.Hostname(),
+							peer.ID(),
+							result,
+						)
+						t.Fail()
+					} else {
+						success++
+					}
+				},
+			)
 		}
 	}
+
+	t.Logf(
+		"%d successful pings out of %d",
+		success,
+		(len(allClients)*len(allClients))-len(allClients),
+	)
 
 	err = scenario.Shutdown()
 	if err != nil {
 		t.Errorf("failed to tear down scenario: %s", err)
 	}
-}
-
-func removeFromSlice(haystack []string, needle string) []string {
-	for i, value := range haystack {
-		if needle == value {
-			return append(haystack[:i], haystack[i+1:]...)
-		}
-	}
-
-	return haystack
 }

--- a/integration/ssh_test.go
+++ b/integration/ssh_test.go
@@ -28,6 +28,13 @@ var retry = func(times int, sleepInterval time.Duration,
 		if err == nil {
 			return result, stderr, nil
 		}
+
+		// If we get a permission denied error, we can fail immediately
+		// since that is something we wont recover from by retrying.
+		if err != nil && strings.Contains(stderr, "Permission denied (tailscale)") {
+			return result, stderr, err
+		}
+
 		time.Sleep(sleepInterval)
 	}
 

--- a/integration/ssh_test.go
+++ b/integration/ssh_test.go
@@ -7,58 +7,61 @@ import (
 	"time"
 
 	"github.com/juanfont/headscale"
+	"github.com/juanfont/headscale/integration/hsic"
+	"github.com/juanfont/headscale/integration/tsic"
 )
+
+var retry = func(times int, sleepInterval time.Duration, doWork func() (string, error)) (string, error) {
+	var err error
+	for attempts := 0; attempts < times; attempts++ {
+		var result string
+		result, err = doWork()
+		if err == nil {
+			return result, nil
+		}
+		time.Sleep(sleepInterval)
+	}
+
+	return "", err
+}
 
 func TestSSHOneNamespaceAllToAll(t *testing.T) {
 	IntegrationSkip(t)
-
-	retry := func(times int, sleepInterval time.Duration, doWork func() (string, error)) (string, error) {
-		var err error
-		for attempts := 0; attempts < times; attempts++ {
-			var result string
-			result, err = doWork()
-			if err == nil {
-				return result, nil
-			}
-			time.Sleep(sleepInterval)
-		}
-
-		return "", err
-	}
 
 	scenario, err := NewScenario()
 	if err != nil {
 		t.Errorf("failed to create scenario: %s", err)
 	}
 
-	spec := &HeadscaleSpec{
-		namespaces: map[string]int{
-			"namespace1": len(TailscaleVersions) - 5,
-		},
-		enableSSH: true,
-		acl: &headscale.ACLPolicy{
-			Groups: map[string][]string{
-				"group:integration-test": {"namespace1"},
-			},
-			ACLs: []headscale.ACL{
-				{
-					Action:       "accept",
-					Sources:      []string{"*"},
-					Destinations: []string{"*:*"},
-				},
-			},
-			SSHs: []headscale.SSH{
-				{
-					Action:       "accept",
-					Sources:      []string{"group:integration-test"},
-					Destinations: []string{"group:integration-test"},
-					Users:        []string{"ssh-it-user"},
-				},
-			},
-		},
+	spec := map[string]int{
+		"namespace1": len(TailscaleVersions) - 5,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec)
+	err = scenario.CreateHeadscaleEnv(spec,
+		[]tsic.Option{tsic.WithSSH()},
+		hsic.WithACLPolicy(
+			&headscale.ACLPolicy{
+				Groups: map[string][]string{
+					"group:integration-test": {"namespace1"},
+				},
+				ACLs: []headscale.ACL{
+					{
+						Action:       "accept",
+						Sources:      []string{"*"},
+						Destinations: []string{"*:*"},
+					},
+				},
+				SSHs: []headscale.SSH{
+					{
+						Action:       "accept",
+						Sources:      []string{"group:integration-test"},
+						Destinations: []string{"group:integration-test"},
+						Users:        []string{"ssh-it-user"},
+					},
+				},
+			},
+		),
+	)
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
 	}
@@ -86,38 +89,9 @@ func TestSSHOneNamespaceAllToAll(t *testing.T) {
 				continue
 			}
 
-			clientFQDN, _ := client.FQDN()
-			peerFQDN, _ := peer.FQDN()
-
-			t.Run(
-				fmt.Sprintf("%s-%s", clientFQDN, peerFQDN),
-				func(t *testing.T) {
-					command := []string{
-						"ssh", "-o StrictHostKeyChecking=no", "-o ConnectTimeout=1",
-						fmt.Sprintf("%s@%s", "ssh-it-user", peer.Hostname()),
-						"'hostname'",
-					}
-
-					result, err := retry(10, 1*time.Second, func() (string, error) {
-						return client.Execute(command)
-					})
-					if err != nil {
-						t.Errorf("failed to execute command over SSH: %s", err)
-					}
-
-					if strings.Contains(peer.ID(), result) {
-						t.Logf(
-							"failed to get correct container ID from %s, expected: %s, got: %s",
-							peer.Hostname(),
-							peer.ID(),
-							result,
-						)
-						t.Fail()
-					} else {
-						success++
-					}
-				},
-			)
+			if doSSH(t, client, peer) {
+				success++
+			}
 		}
 	}
 
@@ -131,4 +105,136 @@ func TestSSHOneNamespaceAllToAll(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to tear down scenario: %s", err)
 	}
+}
+
+func TestSSHMultipleNamespacesAllToAll(t *testing.T) {
+	IntegrationSkip(t)
+
+	scenario, err := NewScenario()
+	if err != nil {
+		t.Errorf("failed to create scenario: %s", err)
+	}
+
+	spec := map[string]int{
+		"namespace1": len(TailscaleVersions) - 5,
+		"namespace2": len(TailscaleVersions) - 5,
+	}
+
+	err = scenario.CreateHeadscaleEnv(spec,
+		[]tsic.Option{tsic.WithSSH()},
+		hsic.WithACLPolicy(
+			&headscale.ACLPolicy{
+				Groups: map[string][]string{
+					"group:integration-test": {"namespace1", "namespace2"},
+				},
+				ACLs: []headscale.ACL{
+					{
+						Action:       "accept",
+						Sources:      []string{"*"},
+						Destinations: []string{"*:*"},
+					},
+				},
+				SSHs: []headscale.SSH{
+					{
+						Action:       "accept",
+						Sources:      []string{"group:integration-test"},
+						Destinations: []string{"group:integration-test"},
+						Users:        []string{"ssh-it-user"},
+					},
+				},
+			},
+		),
+	)
+	if err != nil {
+		t.Errorf("failed to create headscale environment: %s", err)
+	}
+
+	nsOneClients, err := scenario.ListTailscaleClients("namespace1")
+	if err != nil {
+		t.Errorf("failed to get clients: %s", err)
+	}
+
+	nsTwoClients, err := scenario.ListTailscaleClients("namespace2")
+	if err != nil {
+		t.Errorf("failed to get clients: %s", err)
+	}
+
+	err = scenario.WaitForTailscaleSync()
+	if err != nil {
+		t.Errorf("failed wait for tailscale clients to be in sync: %s", err)
+	}
+
+	_, err = scenario.ListTailscaleClientsFQDNs()
+	if err != nil {
+		t.Errorf("failed to get FQDNs: %s", err)
+	}
+
+	success := 0
+
+	testInterNamespaceSSH := func(sourceClients []TailscaleClient, targetClients []TailscaleClient) {
+		for _, client := range sourceClients {
+			for _, peer := range targetClients {
+				if doSSH(t, client, peer) {
+					success++
+				}
+			}
+		}
+	}
+
+	testInterNamespaceSSH(nsOneClients, nsTwoClients)
+	testInterNamespaceSSH(nsTwoClients, nsOneClients)
+
+	t.Logf(
+		"%d successful pings out of %d",
+		success,
+		((len(nsOneClients)*len(nsOneClients))-len(nsOneClients))*2,
+	)
+
+	err = scenario.Shutdown()
+	if err != nil {
+		t.Errorf("failed to tear down scenario: %s", err)
+	}
+}
+
+func doSSH(t *testing.T, client TailscaleClient, peer TailscaleClient) bool {
+	t.Helper()
+
+	clientFQDN, _ := client.FQDN()
+	peerFQDN, _ := peer.FQDN()
+
+	success := false
+
+	t.Run(
+		fmt.Sprintf("%s-%s", clientFQDN, peerFQDN),
+		func(t *testing.T) {
+			command := []string{
+				"ssh", "-o StrictHostKeyChecking=no", "-o ConnectTimeout=1",
+				fmt.Sprintf("%s@%s", "ssh-it-user", peerFQDN),
+				"'hostname'",
+			}
+
+			result, err := retry(10, 1*time.Second, func() (string, error) {
+				result, _, err := client.Execute(command)
+
+				return result, err
+			})
+			if err != nil {
+				t.Errorf("failed to execute command over SSH: %s", err)
+			}
+
+			if strings.Contains(peer.ID(), result) {
+				t.Logf(
+					"failed to get correct container ID from %s, expected: %s, got: %s",
+					peer.Hostname(),
+					peer.ID(),
+					result,
+				)
+				t.Fail()
+			} else {
+				success = true
+			}
+		},
+	)
+
+	return success
 }

--- a/integration/ssh_test.go
+++ b/integration/ssh_test.go
@@ -79,7 +79,7 @@ func TestSSHOneNamespaceAllToAll(t *testing.T) {
 			},
 		),
 		hsic.WithConfigEnv(map[string]string{
-			"HEADSCALE_FEATURE_SSH": "1",
+			"HEADSCALE_EXPERIMENTAL_FEATURE_SSH": "1",
 		}),
 	)
 	if err != nil {
@@ -156,7 +156,7 @@ func TestSSHMultipleNamespacesAllToAll(t *testing.T) {
 			},
 		),
 		hsic.WithConfigEnv(map[string]string{
-			"HEADSCALE_FEATURE_SSH": "1",
+			"HEADSCALE_EXPERIMENTAL_FEATURE_SSH": "1",
 		}),
 	)
 	if err != nil {
@@ -232,7 +232,7 @@ func TestSSHNoSSHConfigured(t *testing.T) {
 		),
 		hsic.WithTestName("sshnoneconfigured"),
 		hsic.WithConfigEnv(map[string]string{
-			"HEADSCALE_FEATURE_SSH": "1",
+			"HEADSCALE_EXPERIMENTAL_FEATURE_SSH": "1",
 		}),
 	)
 	if err != nil {
@@ -309,7 +309,7 @@ func TestSSHIsBlockedInACL(t *testing.T) {
 		),
 		hsic.WithTestName("sshisblockedinacl"),
 		hsic.WithConfigEnv(map[string]string{
-			"HEADSCALE_FEATURE_SSH": "1",
+			"HEADSCALE_EXPERIMENTAL_FEATURE_SSH": "1",
 		}),
 	)
 	if err != nil {
@@ -394,7 +394,7 @@ func TestSSNamespaceOnlyIsolation(t *testing.T) {
 		),
 		hsic.WithTestName("sshtwonamespaceaclblock"),
 		hsic.WithConfigEnv(map[string]string{
-			"HEADSCALE_FEATURE_SSH": "1",
+			"HEADSCALE_EXPERIMENTAL_FEATURE_SSH": "1",
 		}),
 	)
 	if err != nil {

--- a/integration/ssh_test.go
+++ b/integration/ssh_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -465,7 +466,7 @@ func assertSSHHostname(t *testing.T, client TailscaleClient, peer TailscaleClien
 	result, _, err := doSSH(t, client, peer)
 	assert.NoError(t, err)
 
-	assert.Contains(t, peer.ID(), result)
+	assert.Contains(t, peer.ID(), strings.ReplaceAll(result, "\n", ""))
 }
 
 func assertSSHPermissionDenied(t *testing.T, client TailscaleClient, peer TailscaleClient) {

--- a/integration/ssh_test.go
+++ b/integration/ssh_test.go
@@ -78,6 +78,9 @@ func TestSSHOneNamespaceAllToAll(t *testing.T) {
 				},
 			},
 		),
+		hsic.WithConfigEnv(map[string]string{
+			"HEADSCALE_FEATURE_SSH": "1",
+		}),
 	)
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
@@ -152,6 +155,9 @@ func TestSSHMultipleNamespacesAllToAll(t *testing.T) {
 				},
 			},
 		),
+		hsic.WithConfigEnv(map[string]string{
+			"HEADSCALE_FEATURE_SSH": "1",
+		}),
 	)
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
@@ -225,6 +231,9 @@ func TestSSHNoSSHConfigured(t *testing.T) {
 			},
 		),
 		hsic.WithTestName("sshnoneconfigured"),
+		hsic.WithConfigEnv(map[string]string{
+			"HEADSCALE_FEATURE_SSH": "1",
+		}),
 	)
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
@@ -299,6 +308,9 @@ func TestSSHIsBlockedInACL(t *testing.T) {
 			},
 		),
 		hsic.WithTestName("sshisblockedinacl"),
+		hsic.WithConfigEnv(map[string]string{
+			"HEADSCALE_FEATURE_SSH": "1",
+		}),
 	)
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
@@ -381,6 +393,9 @@ func TestSSNamespaceOnlyIsolation(t *testing.T) {
 			},
 		),
 		hsic.WithTestName("sshtwonamespaceaclblock"),
+		hsic.WithConfigEnv(map[string]string{
+			"HEADSCALE_FEATURE_SSH": "1",
+		}),
 	)
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)

--- a/integration/ssh_test.go
+++ b/integration/ssh_test.go
@@ -43,6 +43,7 @@ var retry = func(times int, sleepInterval time.Duration,
 
 func TestSSHOneNamespaceAllToAll(t *testing.T) {
 	IntegrationSkip(t)
+	t.Parallel()
 
 	scenario, err := NewScenario()
 	if err != nil {
@@ -115,6 +116,7 @@ func TestSSHOneNamespaceAllToAll(t *testing.T) {
 
 func TestSSHMultipleNamespacesAllToAll(t *testing.T) {
 	IntegrationSkip(t)
+	t.Parallel()
 
 	scenario, err := NewScenario()
 	if err != nil {
@@ -194,6 +196,7 @@ func TestSSHMultipleNamespacesAllToAll(t *testing.T) {
 
 func TestSSHNoSSHConfigured(t *testing.T) {
 	IntegrationSkip(t)
+	t.Parallel()
 
 	scenario, err := NewScenario()
 	if err != nil {
@@ -260,6 +263,7 @@ func TestSSHNoSSHConfigured(t *testing.T) {
 
 func TestSSHIsBlockedInACL(t *testing.T) {
 	IntegrationSkip(t)
+	t.Parallel()
 
 	scenario, err := NewScenario()
 	if err != nil {
@@ -333,6 +337,7 @@ func TestSSHIsBlockedInACL(t *testing.T) {
 
 func TestSSNamespaceOnlyIsolation(t *testing.T) {
 	IntegrationSkip(t)
+	t.Parallel()
 
 	scenario, err := NewScenario()
 	if err != nil {

--- a/integration/ssh_test.go
+++ b/integration/ssh_test.go
@@ -1,0 +1,115 @@
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/juanfont/headscale"
+)
+
+func TestSSHIntoAll(t *testing.T) {
+	IntegrationSkip(t)
+
+	scenario, err := NewScenario()
+	if err != nil {
+		t.Errorf("failed to create scenario: %s", err)
+	}
+
+	spec := &HeadscaleSpec{
+		namespaces: map[string]int{
+			// Omit versions before 1.24 because they don't support SSH
+			"namespace1": len(TailscaleVersions) - 4,
+			"namespace2": len(TailscaleVersions) - 4,
+		},
+		enableSSH: true,
+		acl: &headscale.ACLPolicy{
+			Groups: map[string][]string{
+				"group:integration-test": {"namespace1", "namespace2"},
+			},
+			ACLs: []headscale.ACL{
+				{
+					Action:       "accept",
+					Sources:      []string{"*"},
+					Destinations: []string{"*:*"},
+				},
+			},
+			SSHs: []headscale.SSH{
+				{
+					Action:       "accept",
+					Sources:      []string{"group:integration-test"},
+					Destinations: []string{"group:integration-test"},
+					Users:        []string{"ssh-it-user"},
+				},
+			},
+		},
+	}
+
+	err = scenario.CreateHeadscaleEnv(spec)
+	if err != nil {
+		t.Errorf("failed to create headscale environment: %s", err)
+	}
+	err = scenario.WaitForTailscaleSync()
+	if err != nil {
+		t.Errorf("failed wait for tailscale clients to be in sync: %s", err)
+	}
+
+	for namespace := range spec.namespaces {
+		// This will essentially fetch and cache all the FQDNs for the given namespace
+		nsFQDNs, err := scenario.ListTailscaleClientsFQDNs(namespace)
+		if err != nil {
+			t.Errorf("failed to get FQDNs: %s", err)
+		}
+
+		nsClients, err := scenario.ListTailscaleClients(namespace)
+		if err != nil {
+			t.Errorf("failed to get clients: %s", err)
+		}
+
+		for _, client := range nsClients {
+			currentClientFqdn, _ := client.FQDN()
+			sshTargets := removeFromSlice(nsFQDNs, currentClientFqdn)
+
+			for _, target := range sshTargets {
+				t.Run(
+					fmt.Sprintf("%s-%s", currentClientFqdn, target),
+					func(t *testing.T) {
+						command := []string{
+							"ssh", "-o StrictHostKeyChecking=no",
+							fmt.Sprintf("%s@%s", "ssh-it-user", target),
+							"'hostname'",
+						}
+
+						result, err := client.Execute(command)
+						if err != nil {
+							t.Errorf("failed to execute command over SSH: %s", err)
+						}
+
+						if result != target {
+							t.Logf("result=%s, target=%s", result, target)
+							t.Fail()
+						}
+
+						t.Logf("Result for %s: %s\n", target, result)
+					},
+				)
+			}
+
+			// t.Logf("%s wants to SSH into %+v", currentClientFqdn, sshTargets)
+		}
+	}
+
+	err = scenario.Shutdown()
+	if err != nil {
+		t.Errorf("failed to tear down scenario: %s", err)
+	}
+}
+
+func removeFromSlice(haystack []string, needle string) []string {
+	for i, value := range haystack {
+		if needle == value {
+			return append(haystack[:i], haystack[i+1:]...)
+		}
+	}
+
+	return haystack
+}

--- a/integration/tailscale.go
+++ b/integration/tailscale.go
@@ -7,6 +7,7 @@ import (
 	"tailscale.com/ipn/ipnstate"
 )
 
+//nolint
 type TailscaleClient interface {
 	Hostname() string
 	Shutdown() error

--- a/integration/tailscale.go
+++ b/integration/tailscale.go
@@ -20,4 +20,5 @@ type TailscaleClient interface {
 	WaitForReady() error
 	WaitForPeers(expected int) error
 	Ping(hostnameOrIP string) error
+	ID() string
 }

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -176,6 +176,10 @@ func (t *TailscaleInContainer) Version() string {
 	return t.version
 }
 
+func (t *TailscaleInContainer) ID() string {
+	return t.container.Container.ID
+}
+
 func (t *TailscaleInContainer) Execute(
 	command []string,
 ) (string, string, error) {

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -47,6 +47,7 @@ type TailscaleInContainer struct {
 	// optional config
 	headscaleCert     []byte
 	headscaleHostname string
+	withSSH           bool
 }
 
 type Option = func(c *TailscaleInContainer)
@@ -80,6 +81,12 @@ func WithOrCreateNetwork(network *dockertest.Network) Option {
 func WithHeadscaleName(hsName string) Option {
 	return func(tsic *TailscaleInContainer) {
 		tsic.headscaleHostname = hsName
+	}
+}
+
+func WithSSH() Option {
+	return func(tsic *TailscaleInContainer) {
+		tsic.withSSH = true
 	}
 }
 
@@ -217,6 +224,10 @@ func (t *TailscaleInContainer) Up(
 		authKey,
 		"--hostname",
 		t.hostname,
+	}
+
+	if t.withSSH {
+		command = append(command, "--ssh")
 	}
 
 	if _, _, err := t.Execute(command); err != nil {

--- a/machine.go
+++ b/machine.go
@@ -744,7 +744,11 @@ func (machine Machine) toNode(
 
 		KeepAlive:         true,
 		MachineAuthorized: !machine.isExpired(),
-		Capabilities:      []string{tailcfg.CapabilityFileSharing},
+		Capabilities: []string{
+			tailcfg.CapabilityFileSharing,
+			tailcfg.CapabilityAdmin,
+			tailcfg.CapabilitySSH,
+		},
 	}
 
 	return &node, nil


### PR DESCRIPTION
Based on the fork of @db48x from #661. Doesn’t support the ‘autogroup’ ACL functionality.

This ACL works for us (formatted slightly for readability)
```json
{
  "acls":[{
      "action":"accept",
      "src":["group:employees"],
      "dst":["tag:proxy:*"]
    }
  ],
  "hosts":{},
  "groups":{
    "group:employees":[
      "john.doe",
      "jane.doe"
    ],
    "group:proxy":[
      "mycorp"
    ]
  },
  "tagOwners":{
    "tag:proxy":[
      "group:proxy"
    ]
  },
  "ssh":[
    {
      "action":"check",
      "src":["group:employees"],
      "dst":["tag:proxy"],
      "users":["some-allowlisted-user"],
      "checkPeriod":"8h"
    }
  ],
  "disableIPv4":false,
  "randomizeClientPort":false
}
```

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [x] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
