### PR TITLE
Fix the proposed noise private_key_path

### DIFF
--- a/docs/running-headscale-container.md
+++ b/docs/running-headscale-container.md
@@ -55,7 +55,7 @@ metrics_listen_addr: 0.0.0.0:9090
 private_key_path: /etc/headscale/private.key
 # The default /var/lib/headscale path is not writable in the container
 noise:
-  private_key_path: /var/lib/headscale/noise_private.key
+  private_key_path: /etc/headscale/noise_private.key
 # The default /var/lib/headscale path is not writable  in the container
 db_path: /etc/headscale/db.sqlite
 ```


### PR DESCRIPTION
As indicated by the comment, the default /var/lib/headscale path is not writable in the container. However the sample setting is not following that like `private_key_path`

<!-- Please tick if the following things apply. You… -->

- [X] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
None of above applies as it's just a simple typo fix.