### PR TITLE
Provide LoginName when registering with pre-auth key

### DIFF
--- a/protocol_common.go
+++ b/protocol_common.go
@@ -435,6 +435,10 @@ func (h *Headscale) handleAuthKeyCommon(
 
 	resp.MachineAuthorized = true
 	resp.User = *pak.Namespace.toUser()
+	// Provide LoginName when registering with pre-auth key
+	// Otherwise it will need to exec `tailscale up` twice to fetch the *LoginName*
+	resp.Login = *pak.Namespace.toLogin()
+
 	respBody, err := h.marshalResponse(resp, machineKey)
 	if err != nil {
 		log.Error().


### PR DESCRIPTION
- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

When register with pre-auth key, headscale doesn't provide `LoginName` which is needed by `tailscaled.state`.
So it has to execute `tailscale up` twice to fetch the property.
```json
{
	"ControlURL": "",
	"RouteAll": false,
	"AllowSingleHosts": true,
	"ExitNodeID": "",
	"ExitNodeIP": "",
	"ExitNodeAllowLANAccess": false,
	"CorpDNS": false,
	"RunSSH": false,
	"WantRunning": true,
	"LoggedOut": false,
	"ShieldsUp": false,
	"AdvertiseTags": null,
	"Hostname": "",
	"NotepadURLs": false,
	"AdvertiseRoutes": [],
	"NoSNAT": false,
	"NetfilterMode": 2,
	"Config": {
		"PrivateMachineKey": "privkey:0",
		"PrivateNodeKey": "privkey:0",
		"OldPrivateNodeKey": "privkey:0",
		"Provider": "",
		"LoginName": ""
	}

```
