### PR TITLE
Integration, remove retry

### DIFF
--- a/.github/workflows/test-integration-cli.yml
+++ b/.github/workflows/test-integration-cli.yml
@@ -32,9 +32,4 @@ jobs:
 
       - name: Run CLI integration tests
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 240
-          max_attempts: 5
-          retry_on: error
-          command: nix develop --command -- make test_integration_cli
+        run: nix develop --command -- make test_integration_cli

--- a/.github/workflows/test-integration-derp.yml
+++ b/.github/workflows/test-integration-derp.yml
@@ -32,9 +32,4 @@ jobs:
 
       - name: Run Embedded DERP server integration tests
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 240
-          max_attempts: 5
-          retry_on: error
-          command: nix develop --command -- make test_integration_derp
+        run: nix develop --command -- make test_integration_derp

--- a/.github/workflows/test-integration-general.yml
+++ b/.github/workflows/test-integration-general.yml
@@ -32,9 +32,4 @@ jobs:
 
       - name: Run general integration tests
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 240
-          max_attempts: 5
-          retry_on: error
-          command: nix develop --command -- make test_integration_general
+        run: nix develop --command -- make test_integration_general

--- a/.github/workflows/test-integration-oidc.yml
+++ b/.github/workflows/test-integration-oidc.yml
@@ -32,5 +32,4 @@ jobs:
 
       - name: Run OIDC integration tests
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: nick-fields/retry@v2
         run: nix develop --command -- make test_integration_oidc

--- a/.github/workflows/test-integration-oidc.yml
+++ b/.github/workflows/test-integration-oidc.yml
@@ -33,8 +33,4 @@ jobs:
       - name: Run OIDC integration tests
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 240
-          max_attempts: 5
-          retry_on: error
-          command: nix develop --command -- make test_integration_oidc
+        run: nix develop --command -- make test_integration_oidc

--- a/.github/workflows/test-integration-v2-general.yml
+++ b/.github/workflows/test-integration-v2-general.yml
@@ -32,9 +32,4 @@ jobs:
 
       - name: Run general integration tests
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 240
-          max_attempts: 5
-          retry_on: error
-          command: nix develop --command -- make test_integration_v2_general
+        run: nix develop --command -- make test_integration_v2_general


### PR DESCRIPTION
The retry has no real function as it will just fail on "container exists" on the old tests and the new test will just try forever before it eventually fails.

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>
