### PR TITLE
NodePublicKeyRegex fix for Windows

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -65,7 +65,7 @@ const (
 	ZstdCompression = "zstd"
 )
 
-var NodePublicKeyRegex = regexp.MustCompile("nodekey:[a-fA-F0-9]+")
+var NodePublicKeyRegex = regexp.MustCompile("(nodekey:)?[a-fA-F0-9]+")
 
 func MachinePublicKeyStripPrefix(machineKey key.MachinePublic) string {
 	return strings.TrimPrefix(machineKey.String(), machinePublicHexPrefix)


### PR DESCRIPTION
Fix NodePublicKeyRegex to optionally use nodekey: prefix

<!-- Please tick if the following things apply. You… -->

- [X] read the [CONTRIBUTING guidelines](README.md#contributing)
- [X] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
