### PR TITLE
Run more tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test_integration_v2_general:
 		-v $$PWD:$$PWD -w $$PWD/integration \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		golang:1 \
-		go test ./... -timeout 60m
+		go test ./... -timeout 60m -parallel 6
 
 coverprofile_func:
 	go tool cover -func=coverage.out


### PR DESCRIPTION
These tests are "safe" to run in parallel, currently only CLI is marked for this, and it speeds them up quite a bit.

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>
