### PR TITLE
Make more sslmode available for postgresql connection (Fixes #925)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Make it possible to disable TS2019 with build flag [#928](https://github.com/juanfont/headscale/pull/928)
 - Fix OIDC registration issues [#960](https://github.com/juanfont/headscale/pull/960) and [#971](https://github.com/juanfont/headscale/pull/971)
 - Add support for specifying NextDNS DNS-over-HTTPS resolver [#940](https://github.com/juanfont/headscale/pull/940)
+- Make more sslmode available for postgresql connection [#927](https://github.com/juanfont/headscale/pull/927)
 
 ## 0.16.4 (2022-08-21)
 

--- a/app.go
+++ b/app.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -127,8 +128,12 @@ func NewHeadscale(cfg *Config) (*Headscale, error) {
 			cfg.DBuser,
 		)
 
-		if !cfg.DBssl {
-			dbString += " sslmode=disable"
+		if s, err := strconv.ParseBool(cfg.DBssl); err == nil {
+			if !s {
+				dbString += " sslmode=disable"
+			}
+		} else {
+			dbString += fmt.Sprintf(" sslmode=%s", cfg.DBssl)
 		}
 
 		if cfg.DBport != 0 {

--- a/app.go
+++ b/app.go
@@ -128,8 +128,8 @@ func NewHeadscale(cfg *Config) (*Headscale, error) {
 			cfg.DBuser,
 		)
 
-		if s, err := strconv.ParseBool(cfg.DBssl); err == nil {
-			if !s {
+		if sslEnabled, err := strconv.ParseBool(cfg.DBssl); err == nil {
+			if !sslEnabled {
 				dbString += " sslmode=disable"
 			}
 		} else {

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -137,14 +137,15 @@ db_path: ./db.sqlite
 
 # # Postgres config
 # If using a Unix socket to connect to Postgres, set the socket path in the 'host' field and leave 'port' blank.
-# Also if other 'sslmode' is required instead of 'require(true)' and 'disabled(false)', set the 'sslmode' you need
-# in the 'db_ssl' field. Refers to https://www.postgresql.org/docs/current/libpq-ssl.html Table 34.1.
 # db_type: postgres
 # db_host: localhost
 # db_port: 5432
 # db_name: headscale
 # db_user: foo
 # db_pass: bar
+
+# If other 'sslmode' is required instead of 'require(true)' and 'disabled(false)', set the 'sslmode' you need
+# in the 'db_ssl' field. Refers to https://www.postgresql.org/docs/current/libpq-ssl.html Table 34.1.
 # db_ssl: false
 
 ### TLS configuration

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -137,6 +137,8 @@ db_path: ./db.sqlite
 
 # # Postgres config
 # If using a Unix socket to connect to Postgres, set the socket path in the 'host' field and leave 'port' blank.
+# Also if other 'sslmode' is required instead of 'require(true)' and 'disabled(false)', set the 'sslmode' you need
+# in the 'db_ssl' field. Refers to https://www.postgresql.org/docs/current/libpq-ssl.html Table 34.1.
 # db_type: postgres
 # db_host: localhost
 # db_port: 5432

--- a/config.go
+++ b/config.go
@@ -51,7 +51,7 @@ type Config struct {
 	DBname string
 	DBuser string
 	DBpass string
-	DBssl  bool
+	DBssl  string
 
 	TLS TLSConfig
 
@@ -545,7 +545,7 @@ func GetHeadscaleConfig() (*Config, error) {
 		DBname: viper.GetString("db_name"),
 		DBuser: viper.GetString("db_user"),
 		DBpass: viper.GetString("db_pass"),
-		DBssl:  viper.GetBool("db_ssl"),
+		DBssl:  viper.GetString("db_ssl"),
 
 		TLS: GetTLSConfig(),
 


### PR DESCRIPTION
<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

#925 

Change `DBssl` to `String` while still compatible with old boolean configuration.