### PR TITLE
Add build flag to enable TS2019

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,8 @@ builds:
       - -mod=readonly
     ldflags:
       - -s -w -X github.com/juanfont/headscale/cmd/headscale/cli.Version=v{{.Version}}
+    tags:
+      - ts2019
 
   - id: darwin-arm64
     main: ./cmd/headscale/headscale.go
@@ -34,6 +36,8 @@ builds:
       - -mod=readonly
     ldflags:
       - -s -w -X github.com/juanfont/headscale/cmd/headscale/cli.Version=v{{.Version}}
+    tags:
+      - ts2019
 
   - id: linux-amd64
     mod_timestamp: "{{ .CommitTimestamp }}"
@@ -46,6 +50,8 @@ builds:
     main: ./cmd/headscale/headscale.go
     ldflags:
       - -s -w -X github.com/juanfont/headscale/cmd/headscale/cli.Version=v{{.Version}}
+    tags:
+      - ts2019
 
   - id: linux-arm64
     mod_timestamp: "{{ .CommitTimestamp }}"
@@ -58,6 +64,8 @@ builds:
     main: ./cmd/headscale/headscale.go
     ldflags:
       - -s -w -X github.com/juanfont/headscale/cmd/headscale/cli.Version=v{{.Version}}
+    tags:
+      - ts2019
 
 archives:
   - id: golang-cross

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Remove `ip_prefix` configuration option and warning [#899](https://github.com/juanfont/headscale/pull/899)
 - Add `dns_config.override_local_dns` option [#905](https://github.com/juanfont/headscale/pull/905)
 - Fix some DNS config issues [#660](https://github.com/juanfont/headscale/issues/660)
+- Make it possible to disable TS2019 with build flag [#928](https://github.com/juanfont/headscale/pull/928)
 
 ## 0.16.4 (2022-08-21)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go install -ldflags="-s -w -X github.com/juanfont/headscale/cmd/headscale/cli.Version=$VERSION" -a ./cmd/headscale
+RUN CGO_ENABLED=0 GOOS=linux go install -tags ts2019 -ldflags="-s -w -X github.com/juanfont/headscale/cmd/headscale/cli.Version=$VERSION" -a ./cmd/headscale
 RUN strip /go/bin/headscale
 RUN test -e /go/bin/headscale
 

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -9,7 +9,7 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go install -ldflags="-s -w -X github.com/juanfont/headscale/cmd/headscale/cli.Version=$VERSION" -a ./cmd/headscale
+RUN CGO_ENABLED=0 GOOS=linux go install -tags ts2019 -ldflags="-s -w -X github.com/juanfont/headscale/cmd/headscale/cli.Version=$VERSION" -a ./cmd/headscale
 RUN test -e /go/bin/headscale
 
 # Debug image

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifeq ($(filter $(GOOS), openbsd netbsd soloaris plan9), )
 else
 endif
 
-TAGS = -tags "ts2019"
+TAGS = -tags ts2019
 
 # GO_SOURCES = $(wildcard *.go)
 # PROTO_SOURCES = $(wildcard **/*.proto)
@@ -66,7 +66,7 @@ test_integration_v2_general:
 		-v $$PWD:$$PWD -w $$PWD/integration \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		golang:1 \
-		go test $(TAGS) ./... -timeout 60m -parallel 6
+		go test $(TAGS) -failfast ./... -timeout 60m -parallel 6
 
 coverprofile_func:
 	go tool cover -func=coverage.out

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ ifeq ($(filter $(GOOS), openbsd netbsd soloaris plan9), )
 else
 endif
 
+TAGS = -tags "ts2019"
+
 # GO_SOURCES = $(wildcard *.go)
 # PROTO_SOURCES = $(wildcard **/*.proto)
 GO_SOURCES = $(call rwildcard,,*.go)
@@ -17,12 +19,12 @@ PROTO_SOURCES = $(call rwildcard,,*.proto)
 
 
 build:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -trimpath $(pieflags) -mod=readonly -ldflags "-s -w -X github.com/juanfont/headscale/cmd/headscale/cli.Version=$(version)" cmd/headscale/headscale.go
+	nix build
 
 dev: lint test build
 
 test:
-	@go test -short -coverprofile=coverage.out ./...
+	@go test $(TAGS) -short -coverprofile=coverage.out ./...
 
 test_integration: test_integration_cli test_integration_derp test_integration_oidc test_integration_v2_general
 
@@ -34,7 +36,7 @@ test_integration_cli:
 		-v ~/.cache/hs-integration-go:/go \
 		-v $$PWD:$$PWD -w $$PWD \
 		-v /var/run/docker.sock:/var/run/docker.sock golang:1 \
-		go test -failfast -timeout 30m -count=1 -run IntegrationCLI ./...
+		go test $(TAGS) -failfast -timeout 30m -count=1 -run IntegrationCLI ./...
 
 test_integration_derp:
 	docker network rm $$(docker network ls --filter name=headscale --quiet) || true
@@ -44,7 +46,7 @@ test_integration_derp:
 		-v ~/.cache/hs-integration-go:/go \
 		-v $$PWD:$$PWD -w $$PWD \
 		-v /var/run/docker.sock:/var/run/docker.sock golang:1 \
-		go test -failfast -timeout 30m -count=1 -run IntegrationDERP ./...
+		go test $(TAGS) -failfast -timeout 30m -count=1 -run IntegrationDERP ./...
 
 test_integration_oidc:
 	docker network rm $$(docker network ls --filter name=headscale --quiet) || true
@@ -54,7 +56,7 @@ test_integration_oidc:
 		-v ~/.cache/hs-integration-go:/go \
 		-v $$PWD:$$PWD -w $$PWD \
 		-v /var/run/docker.sock:/var/run/docker.sock golang:1 \
-		go test -failfast -timeout 30m -count=1 -run IntegrationOIDC ./...
+		go test $(TAGS) -failfast -timeout 30m -count=1 -run IntegrationOIDC ./...
 
 test_integration_v2_general:
 	docker run \
@@ -64,7 +66,7 @@ test_integration_v2_general:
 		-v $$PWD:$$PWD -w $$PWD/integration \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		golang:1 \
-		go test ./... -timeout 60m -parallel 6
+		go test $(TAGS) ./... -timeout 60m -parallel 6
 
 coverprofile_func:
 	go tool cover -func=coverage.out

--- a/app.go
+++ b/app.go
@@ -454,9 +454,6 @@ func (h *Headscale) createRouter(grpcMux *runtime.ServeMux) *mux.Router {
 	router.HandleFunc("/health", h.HealthHandler).Methods(http.MethodGet)
 	router.HandleFunc("/key", h.KeyHandler).Methods(http.MethodGet)
 	router.HandleFunc("/register/{nkey}", h.RegisterWebAPI).Methods(http.MethodGet)
-	router.HandleFunc("/machine/{mkey}/map", h.PollNetMapHandler).
-		Methods(http.MethodPost)
-	router.HandleFunc("/machine/{mkey}", h.RegistrationHandler).Methods(http.MethodPost)
 	router.HandleFunc("/oidc/register/{nkey}", h.RegisterOIDC).Methods(http.MethodGet)
 	router.HandleFunc("/oidc/callback", h.OIDCCallback).Methods(http.MethodGet)
 	router.HandleFunc("/apple", h.AppleConfigMessage).Methods(http.MethodGet)
@@ -468,6 +465,8 @@ func (h *Headscale) createRouter(grpcMux *runtime.ServeMux) *mux.Router {
 	router.HandleFunc("/swagger", SwaggerUI).Methods(http.MethodGet)
 	router.HandleFunc("/swagger/v1/openapiv2.json", SwaggerAPIv1).
 		Methods(http.MethodGet)
+
+	h.addLegacyHandlers(router)
 
 	if h.cfg.DERP.ServerEnabled {
 		router.HandleFunc("/derp", h.DERPHandler)

--- a/app.go
+++ b/app.go
@@ -454,6 +454,8 @@ func (h *Headscale) createRouter(grpcMux *runtime.ServeMux) *mux.Router {
 	router.HandleFunc("/health", h.HealthHandler).Methods(http.MethodGet)
 	router.HandleFunc("/key", h.KeyHandler).Methods(http.MethodGet)
 	router.HandleFunc("/register/{nkey}", h.RegisterWebAPI).Methods(http.MethodGet)
+	h.addLegacyHandlers(router)
+
 	router.HandleFunc("/oidc/register/{nkey}", h.RegisterOIDC).Methods(http.MethodGet)
 	router.HandleFunc("/oidc/callback", h.OIDCCallback).Methods(http.MethodGet)
 	router.HandleFunc("/apple", h.AppleConfigMessage).Methods(http.MethodGet)
@@ -465,8 +467,6 @@ func (h *Headscale) createRouter(grpcMux *runtime.ServeMux) *mux.Router {
 	router.HandleFunc("/swagger", SwaggerUI).Methods(http.MethodGet)
 	router.HandleFunc("/swagger/v1/openapiv2.json", SwaggerAPIv1).
 		Methods(http.MethodGet)
-
-	h.addLegacyHandlers(router)
 
 	if h.cfg.DERP.ServerEnabled {
 		router.HandleFunc("/derp", h.DERPHandler)

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,8 @@
           version = headscaleVersion;
           src = pkgs.lib.cleanSource self;
 
+          tags = ["ts2019"];
+
           # Only run unit tests when testing a build
           checkFlags = ["-short"];
 

--- a/flake.nix
+++ b/flake.nix
@@ -137,7 +137,7 @@
         buildInputs = devDeps;
 
         shellHook = ''
-          export GOFLAGS=-tags="integration,integration_general,integration_oidc,integration_cli,integration_derp"
+          export GOFLAGS=-tags="ts2019"
         '';
       };
 

--- a/handler_legacy.go
+++ b/handler_legacy.go
@@ -1,0 +1,15 @@
+//go:build ts2019
+
+package headscale
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func (h *Headscale) addLegacyHandlers(router *mux.Router) {
+	router.HandleFunc("/machine/{mkey}/map", h.PollNetMapHandler).
+		Methods(http.MethodPost)
+	router.HandleFunc("/machine/{mkey}", h.RegistrationHandler).Methods(http.MethodPost)
+}

--- a/handler_placeholder.go
+++ b/handler_placeholder.go
@@ -1,0 +1,8 @@
+//go:build !ts2019
+
+package headscale
+
+import "github.com/gorilla/mux"
+
+func (h *Headscale) addLegacyHandlers(router *mux.Router) {
+}

--- a/protocol_legacy.go
+++ b/protocol_legacy.go
@@ -1,3 +1,5 @@
+//go:build ts2019
+
 package headscale
 
 import (

--- a/protocol_legacy_poll.go
+++ b/protocol_legacy_poll.go
@@ -1,3 +1,5 @@
+//go:build ts2019
+
 package headscale
 
 import (


### PR DESCRIPTION
This commit starts an experiment to disable TS2019 (we also call it
legacy).

The two main goals for this right now is:

- Diasble TS2019, and verify that the integration test clients with the
  appropriate TS2021 support works as expected
- Get an overview of how coupled the protocol code is, if this is easy,
  it will be easy to remove when the time comes.

Also, users with "crazy" desires like only supporting the most modern
protocol _can_ build this version.

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>