### PR TITLE
Add support for NextDNS resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fix some DNS config issues [#660](https://github.com/juanfont/headscale/issues/660)
 - Make it possible to disable TS2019 with build flag [#928](https://github.com/juanfont/headscale/pull/928)
 - Fix OIDC registration issues [#960](https://github.com/juanfont/headscale/pull/960) and [#971](https://github.com/juanfont/headscale/pull/971)
+- Add support for specifying NextDNS DNS-over-HTTPS resolver [#940](https://github.com/juanfont/headscale/pull/940)
 
 ## 0.16.4 (2022-08-21)
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -214,6 +214,18 @@ dns_config:
   nameservers:
     - 1.1.1.1
 
+  # NextDNS (see https://tailscale.com/kb/1218/nextdns/).
+  # "abc123" is example NextDNS ID, replace with yours.
+  #
+  # With metadata sharing:
+  # nameservers:
+  #   - https://dns.nextdns.io/abc123
+  #
+  # Without metadata sharing:
+  # nameservers:
+  #   - 2a07:a8c0::ab:c123
+  #   - 2a07:a8c1::ab:c123
+
   # Split DNS (see https://tailscale.com/kb/1054/dns/),
   # list of search domains and the DNS to query for each one.
   #


### PR DESCRIPTION
This adds support for easily using [NextDNS](https://nextdns.io/) as a DoH resolver in tailscale network controlled by Headscale. More info in #939 

To enable you would put the following in config:

```yaml
dns_config:
  nameservers:
    - nextdns:abcdef # Where abcdef is your NextDNS ID
```

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

Fixes #939 