### PR TITLE
Remove private key constant errors from NewHeadscale

### DIFF
--- a/app.go
+++ b/app.go
@@ -51,12 +51,6 @@ const (
 	errUnsupportedLetsEncryptChallengeType = Error(
 		"unknown value for Lets Encrypt challenge type",
 	)
-
-	ErrFailedPrivateKey      = Error("failed to read or create private key")
-	ErrFailedNoisePrivateKey = Error(
-		"failed to read or create Noise protocol private key",
-	)
-	ErrSamePrivateKeys = Error("private key and noise private key are the same")
 )
 
 const (
@@ -131,17 +125,17 @@ func LookupTLSClientAuthMode(mode string) (tls.ClientAuthType, bool) {
 func NewHeadscale(cfg *Config) (*Headscale, error) {
 	privateKey, err := readOrCreatePrivateKey(cfg.PrivateKeyPath)
 	if err != nil {
-		return nil, ErrFailedPrivateKey
+		return nil, fmt.Errorf("failed to read or create private key: %w", err)
 	}
 
 	// TS2021 requires to have a different key from the legacy protocol.
 	noisePrivateKey, err := readOrCreatePrivateKey(cfg.NoisePrivateKeyPath)
 	if err != nil {
-		return nil, ErrFailedNoisePrivateKey
+		return nil, fmt.Errorf("failed to read or create Noise protocol private key: %w", err)
 	}
 
 	if privateKey.Equal(*noisePrivateKey) {
-		return nil, ErrSamePrivateKeys
+		return nil, fmt.Errorf("private key and noise private key are the same: %w", err)
 	}
 
 	var dbString string


### PR DESCRIPTION
In [NewHeadscale](https://github.com/juanfont/headscale/blob/main/app.go#L131) function exported constant errors are used in case of private key problems. They overshadow lower level errors that happen during reading/creation of private keys.

It's probably safe to assume that function `NewHeadscale` is not used in other packages. So missing constant errors shouldn't be a big problem for a users(otherwise it can be fixed with a little bit hacky error's `Is` implementation on the user side). On the other hand, overshadowing lower level errors can be a problem for debugging when running Headscale server(which will be more common problem).
