### PR TITLE
Make TLS setup work automatically

### DIFF
--- a/integration/auth_web_flow_test.go
+++ b/integration/auth_web_flow_test.go
@@ -82,7 +82,7 @@ func (s *AuthWebFlowScenario) CreateHeadscaleEnv(namespaces map[string]int) erro
 		return err
 	}
 
-	err = s.Headscale().WaitForReady()
+	err = s.MustHeadscale().WaitForReady()
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func (s *AuthWebFlowScenario) CreateHeadscaleEnv(namespaces map[string]int) erro
 			return err
 		}
 
-		err = s.runTailscaleUp(namespaceName, s.Headscale().GetEndpoint())
+		err = s.runTailscaleUp(namespaceName, s.MustHeadscale().GetEndpoint())
 		if err != nil {
 			return err
 		}
@@ -146,7 +146,7 @@ func (s *AuthWebFlowScenario) runTailscaleUp(
 
 func (s *AuthWebFlowScenario) runHeadscaleRegister(namespaceStr string, loginURL *url.URL) error {
 	log.Printf("loginURL: %s", loginURL)
-	loginURL.Host = fmt.Sprintf("%s:8080", s.Headscale().GetIP())
+	loginURL.Host = fmt.Sprintf("%s:8080", s.MustHeadscale().GetIP())
 	loginURL.Scheme = "http"
 
 	httpClient := &http.Client{}
@@ -178,7 +178,9 @@ func (s *AuthWebFlowScenario) runHeadscaleRegister(namespaceStr string, loginURL
 	log.Printf("registering node %s", key)
 
 	if headscale, ok := s.controlServers["headscale"]; ok {
-		_, err = headscale.Execute([]string{"headscale", "-n", namespaceStr, "nodes", "register", "--key", key})
+		_, err = headscale.Execute(
+			[]string{"headscale", "-n", namespaceStr, "nodes", "register", "--key", key},
+		)
 		if err != nil {
 			log.Printf("failed to register node: %s", err)
 

--- a/integration/auth_web_flow_test.go
+++ b/integration/auth_web_flow_test.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/juanfont/headscale/integration/hsic"
 )
 
 var errParseAuthPage = errors.New("failed to parse auth page")
@@ -35,7 +37,7 @@ func TestAuthWebFlowAuthenticationPingAll(t *testing.T) {
 		"namespace2": len(TailscaleVersions),
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec)
+	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("webauthping"))
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
 	}
@@ -76,8 +78,11 @@ func TestAuthWebFlowAuthenticationPingAll(t *testing.T) {
 	}
 }
 
-func (s *AuthWebFlowScenario) CreateHeadscaleEnv(namespaces map[string]int) error {
-	headscale, err := s.Headscale()
+func (s *AuthWebFlowScenario) CreateHeadscaleEnv(
+	namespaces map[string]int,
+	opts ...hsic.Option,
+) error {
+	headscale, err := s.Headscale(opts...)
 	if err != nil {
 		return err
 	}

--- a/integration/auth_web_flow_test.go
+++ b/integration/auth_web_flow_test.go
@@ -77,12 +77,12 @@ func TestAuthWebFlowAuthenticationPingAll(t *testing.T) {
 }
 
 func (s *AuthWebFlowScenario) CreateHeadscaleEnv(namespaces map[string]int) error {
-	err := s.StartHeadscale()
+	headscale, err := s.Headscale()
 	if err != nil {
 		return err
 	}
 
-	err = s.MustHeadscale().WaitForReady()
+	err = headscale.WaitForReady()
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func (s *AuthWebFlowScenario) CreateHeadscaleEnv(namespaces map[string]int) erro
 			return err
 		}
 
-		err = s.runTailscaleUp(namespaceName, s.MustHeadscale().GetEndpoint())
+		err = s.runTailscaleUp(namespaceName, headscale.GetEndpoint())
 		if err != nil {
 			return err
 		}
@@ -145,8 +145,13 @@ func (s *AuthWebFlowScenario) runTailscaleUp(
 }
 
 func (s *AuthWebFlowScenario) runHeadscaleRegister(namespaceStr string, loginURL *url.URL) error {
+	headscale, err := s.Headscale()
+	if err != nil {
+		return err
+	}
+
 	log.Printf("loginURL: %s", loginURL)
-	loginURL.Host = fmt.Sprintf("%s:8080", s.MustHeadscale().GetIP())
+	loginURL.Host = fmt.Sprintf("%s:8080", headscale.GetIP())
 	loginURL.Scheme = "http"
 
 	httpClient := &http.Client{}
@@ -177,7 +182,7 @@ func (s *AuthWebFlowScenario) runHeadscaleRegister(namespaceStr string, loginURL
 	key := keySep[1]
 	log.Printf("registering node %s", key)
 
-	if headscale, ok := s.controlServers["headscale"]; ok {
+	if headscale, err := s.Headscale(); err == nil {
 		_, err = headscale.Execute(
 			[]string{"headscale", "-n", namespaceStr, "nodes", "register", "--key", key},
 		)

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	v1 "github.com/juanfont/headscale/gen/go/headscale/v1"
+	"github.com/juanfont/headscale/integration/hsic"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,7 +37,7 @@ func TestNamespaceCommand(t *testing.T) {
 		"namespace2": 0,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec)
+	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("clins"))
 	assert.NoError(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -117,7 +118,7 @@ func TestPreAuthKeyCommand(t *testing.T) {
 		namespace: 0,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec)
+	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("clipak"))
 	assert.NoError(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -257,7 +258,7 @@ func TestPreAuthKeyCommandWithoutExpiry(t *testing.T) {
 		namespace: 0,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec)
+	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("clipaknaexp"))
 	assert.NoError(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -322,7 +323,7 @@ func TestPreAuthKeyCommandReusableEphemeral(t *testing.T) {
 		namespace: 0,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec)
+	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("clipakresueeph"))
 	assert.NoError(t, err)
 
 	headscale, err := scenario.Headscale()

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -40,7 +40,7 @@ func TestNamespaceCommand(t *testing.T) {
 	assert.NoError(t, err)
 
 	var listNamespaces []v1.Namespace
-	err = executeAndUnmarshal(scenario.Headscale(),
+	err = executeAndUnmarshal(scenario.MustHeadscale(),
 		[]string{
 			"headscale",
 			"namespaces",
@@ -61,7 +61,7 @@ func TestNamespaceCommand(t *testing.T) {
 		result,
 	)
 
-	_, err = scenario.Headscale().Execute(
+	_, err = scenario.MustHeadscale().Execute(
 		[]string{
 			"headscale",
 			"namespaces",
@@ -75,7 +75,7 @@ func TestNamespaceCommand(t *testing.T) {
 	assert.NoError(t, err)
 
 	var listAfterRenameNamespaces []v1.Namespace
-	err = executeAndUnmarshal(scenario.Headscale(),
+	err = executeAndUnmarshal(scenario.MustHeadscale(),
 		[]string{
 			"headscale",
 			"namespaces",
@@ -123,7 +123,7 @@ func TestPreAuthKeyCommand(t *testing.T) {
 	for index := 0; index < count; index++ {
 		var preAuthKey v1.PreAuthKey
 		err := executeAndUnmarshal(
-			scenario.Headscale(),
+			scenario.MustHeadscale(),
 			[]string{
 				"headscale",
 				"preauthkeys",
@@ -149,7 +149,7 @@ func TestPreAuthKeyCommand(t *testing.T) {
 
 	var listedPreAuthKeys []v1.PreAuthKey
 	err = executeAndUnmarshal(
-		scenario.Headscale(),
+		scenario.MustHeadscale(),
 		[]string{
 			"headscale",
 			"preauthkeys",
@@ -202,7 +202,7 @@ func TestPreAuthKeyCommand(t *testing.T) {
 	}
 
 	// Test key expiry
-	_, err = scenario.Headscale().Execute(
+	_, err = scenario.MustHeadscale().Execute(
 		[]string{
 			"headscale",
 			"preauthkeys",
@@ -216,7 +216,7 @@ func TestPreAuthKeyCommand(t *testing.T) {
 
 	var listedPreAuthKeysAfterExpire []v1.PreAuthKey
 	err = executeAndUnmarshal(
-		scenario.Headscale(),
+		scenario.MustHeadscale(),
 		[]string{
 			"headscale",
 			"preauthkeys",
@@ -256,7 +256,7 @@ func TestPreAuthKeyCommandWithoutExpiry(t *testing.T) {
 
 	var preAuthKey v1.PreAuthKey
 	err = executeAndUnmarshal(
-		scenario.Headscale(),
+		scenario.MustHeadscale(),
 		[]string{
 			"headscale",
 			"preauthkeys",
@@ -273,7 +273,7 @@ func TestPreAuthKeyCommandWithoutExpiry(t *testing.T) {
 
 	var listedPreAuthKeys []v1.PreAuthKey
 	err = executeAndUnmarshal(
-		scenario.Headscale(),
+		scenario.MustHeadscale(),
 		[]string{
 			"headscale",
 			"preauthkeys",
@@ -318,7 +318,7 @@ func TestPreAuthKeyCommandReusableEphemeral(t *testing.T) {
 
 	var preAuthReusableKey v1.PreAuthKey
 	err = executeAndUnmarshal(
-		scenario.Headscale(),
+		scenario.MustHeadscale(),
 		[]string{
 			"headscale",
 			"preauthkeys",
@@ -335,7 +335,7 @@ func TestPreAuthKeyCommandReusableEphemeral(t *testing.T) {
 
 	var preAuthEphemeralKey v1.PreAuthKey
 	err = executeAndUnmarshal(
-		scenario.Headscale(),
+		scenario.MustHeadscale(),
 		[]string{
 			"headscale",
 			"preauthkeys",
@@ -355,7 +355,7 @@ func TestPreAuthKeyCommandReusableEphemeral(t *testing.T) {
 
 	var listedPreAuthKeys []v1.PreAuthKey
 	err = executeAndUnmarshal(
-		scenario.Headscale(),
+		scenario.MustHeadscale(),
 		[]string{
 			"headscale",
 			"preauthkeys",

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -39,8 +39,11 @@ func TestNamespaceCommand(t *testing.T) {
 	err = scenario.CreateHeadscaleEnv(spec)
 	assert.NoError(t, err)
 
+	headscale, err := scenario.Headscale()
+	assert.NoError(t, err)
+
 	var listNamespaces []v1.Namespace
-	err = executeAndUnmarshal(scenario.MustHeadscale(),
+	err = executeAndUnmarshal(headscale,
 		[]string{
 			"headscale",
 			"namespaces",
@@ -61,7 +64,7 @@ func TestNamespaceCommand(t *testing.T) {
 		result,
 	)
 
-	_, err = scenario.MustHeadscale().Execute(
+	_, err = headscale.Execute(
 		[]string{
 			"headscale",
 			"namespaces",
@@ -75,7 +78,7 @@ func TestNamespaceCommand(t *testing.T) {
 	assert.NoError(t, err)
 
 	var listAfterRenameNamespaces []v1.Namespace
-	err = executeAndUnmarshal(scenario.MustHeadscale(),
+	err = executeAndUnmarshal(headscale,
 		[]string{
 			"headscale",
 			"namespaces",
@@ -117,13 +120,16 @@ func TestPreAuthKeyCommand(t *testing.T) {
 	err = scenario.CreateHeadscaleEnv(spec)
 	assert.NoError(t, err)
 
+	headscale, err := scenario.Headscale()
+	assert.NoError(t, err)
+
 	keys := make([]*v1.PreAuthKey, count)
 	assert.NoError(t, err)
 
 	for index := 0; index < count; index++ {
 		var preAuthKey v1.PreAuthKey
 		err := executeAndUnmarshal(
-			scenario.MustHeadscale(),
+			headscale,
 			[]string{
 				"headscale",
 				"preauthkeys",
@@ -149,7 +155,7 @@ func TestPreAuthKeyCommand(t *testing.T) {
 
 	var listedPreAuthKeys []v1.PreAuthKey
 	err = executeAndUnmarshal(
-		scenario.MustHeadscale(),
+		headscale,
 		[]string{
 			"headscale",
 			"preauthkeys",
@@ -202,7 +208,7 @@ func TestPreAuthKeyCommand(t *testing.T) {
 	}
 
 	// Test key expiry
-	_, err = scenario.MustHeadscale().Execute(
+	_, err = headscale.Execute(
 		[]string{
 			"headscale",
 			"preauthkeys",
@@ -216,7 +222,7 @@ func TestPreAuthKeyCommand(t *testing.T) {
 
 	var listedPreAuthKeysAfterExpire []v1.PreAuthKey
 	err = executeAndUnmarshal(
-		scenario.MustHeadscale(),
+		headscale,
 		[]string{
 			"headscale",
 			"preauthkeys",
@@ -254,9 +260,12 @@ func TestPreAuthKeyCommandWithoutExpiry(t *testing.T) {
 	err = scenario.CreateHeadscaleEnv(spec)
 	assert.NoError(t, err)
 
+	headscale, err := scenario.Headscale()
+	assert.NoError(t, err)
+
 	var preAuthKey v1.PreAuthKey
 	err = executeAndUnmarshal(
-		scenario.MustHeadscale(),
+		headscale,
 		[]string{
 			"headscale",
 			"preauthkeys",
@@ -273,7 +282,7 @@ func TestPreAuthKeyCommandWithoutExpiry(t *testing.T) {
 
 	var listedPreAuthKeys []v1.PreAuthKey
 	err = executeAndUnmarshal(
-		scenario.MustHeadscale(),
+		headscale,
 		[]string{
 			"headscale",
 			"preauthkeys",
@@ -316,9 +325,12 @@ func TestPreAuthKeyCommandReusableEphemeral(t *testing.T) {
 	err = scenario.CreateHeadscaleEnv(spec)
 	assert.NoError(t, err)
 
+	headscale, err := scenario.Headscale()
+	assert.NoError(t, err)
+
 	var preAuthReusableKey v1.PreAuthKey
 	err = executeAndUnmarshal(
-		scenario.MustHeadscale(),
+		headscale,
 		[]string{
 			"headscale",
 			"preauthkeys",
@@ -335,7 +347,7 @@ func TestPreAuthKeyCommandReusableEphemeral(t *testing.T) {
 
 	var preAuthEphemeralKey v1.PreAuthKey
 	err = executeAndUnmarshal(
-		scenario.MustHeadscale(),
+		headscale,
 		[]string{
 			"headscale",
 			"preauthkeys",
@@ -355,7 +367,7 @@ func TestPreAuthKeyCommandReusableEphemeral(t *testing.T) {
 
 	var listedPreAuthKeys []v1.PreAuthKey
 	err = executeAndUnmarshal(
-		scenario.MustHeadscale(),
+		headscale,
 		[]string{
 			"headscale",
 			"preauthkeys",

--- a/integration/control.go
+++ b/integration/control.go
@@ -13,4 +13,7 @@ type ControlServer interface {
 	CreateNamespace(namespace string) error
 	CreateAuthKey(namespace string) (*v1.PreAuthKey, error)
 	ListMachinesInNamespace(namespace string) ([]*v1.Machine, error)
+	GetCert() []byte
+	GetHostname() string
+	GetIP() string
 }

--- a/integration/general_test.go
+++ b/integration/general_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/juanfont/headscale/integration/hsic"
 	"github.com/rs/zerolog/log"
 )
 
@@ -22,7 +23,7 @@ func TestPingAllByIP(t *testing.T) {
 		"namespace2": len(TailscaleVersions),
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec)
+	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("pingallbyip"))
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
 	}
@@ -77,7 +78,7 @@ func TestPingAllByHostname(t *testing.T) {
 		"namespace4": len(TailscaleVersions) - 1,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec)
+	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("pingallbyname"))
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
 	}
@@ -144,7 +145,7 @@ func TestTaildrop(t *testing.T) {
 		"taildrop": len(TailscaleVersions) - 1,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec)
+	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("taildrop"))
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
 	}
@@ -271,7 +272,7 @@ func TestResolveMagicDNS(t *testing.T) {
 		"magicdns2": len(TailscaleVersions) - 1,
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec)
+	err = scenario.CreateHeadscaleEnv(spec, hsic.WithTestName("magicdns"))
 	if err != nil {
 		t.Errorf("failed to create headscale environment: %s", err)
 	}

--- a/integration/hsic/hsic.go
+++ b/integration/hsic/hsic.go
@@ -203,8 +203,6 @@ func (t *HeadscaleInContainer) Shutdown() error {
 func (t *HeadscaleInContainer) Execute(
 	command []string,
 ) (string, error) {
-	log.Println("command", command)
-	log.Printf("running command for %s\n", t.hostname)
 	stdout, stderr, err := dockertestutil.ExecuteCommand(
 		t.container,
 		command,
@@ -213,11 +211,11 @@ func (t *HeadscaleInContainer) Execute(
 	if err != nil {
 		log.Printf("command stderr: %s\n", stderr)
 
-		return "", err
-	}
+		if stdout != "" {
+			log.Printf("command stdout: %s\n", stdout)
+		}
 
-	if stdout != "" {
-		log.Printf("command stdout: %s\n", stdout)
+		return "", err
 	}
 
 	return stdout, nil

--- a/integration/hsic/hsic.go
+++ b/integration/hsic/hsic.go
@@ -263,8 +263,8 @@ func (t *HeadscaleInContainer) WaitForReady() error {
 	client := &http.Client{}
 
 	if t.hasTLS() {
-		insecureTransport := http.DefaultTransport.(*http.Transport).Clone()
-		insecureTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		insecureTransport := http.DefaultTransport.(*http.Transport).Clone()      //nolint
+		insecureTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint
 		client = &http.Client{Transport: insecureTransport}
 	}
 

--- a/integration/hsic/hsic.go
+++ b/integration/hsic/hsic.go
@@ -362,6 +362,7 @@ func (t *HeadscaleInContainer) WriteFile(path string, data []byte) error {
 	return integrationutil.WriteFileToContainer(t.pool, t.container, path, data)
 }
 
+//nolint
 func createCertificate() ([]byte, []byte, error) {
 	// From:
 	// https://shaneutt.com/blog/golang-ca-and-signed-cert-go/
@@ -388,11 +389,6 @@ func createCertificate() ([]byte, []byte, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
-	// if err != nil {
-	// 	return nil, err
-	// }
 
 	cert := &x509.Certificate{
 		SerialNumber: big.NewInt(1658),
@@ -444,11 +440,6 @@ func createCertificate() ([]byte, []byte, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-
-	// serverCert, err := tls.X509KeyPair(certPEM.Bytes(), certPrivKeyPEM.Bytes())
-	// if err != nil {
-	// 	return nil, err
-	// }
 
 	return certPEM.Bytes(), certPrivKeyPEM.Bytes(), nil
 }

--- a/integration/integrationutil/util.go
+++ b/integration/integrationutil/util.go
@@ -1,0 +1,77 @@
+package integrationutil
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"path/filepath"
+
+	"github.com/juanfont/headscale/integration/dockertestutil"
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+)
+
+func WriteFileToContainer(
+	pool *dockertest.Pool,
+	container *dockertest.Resource,
+	path string,
+	data []byte,
+) error {
+	dirPath, fileName := filepath.Split(path)
+
+	file := bytes.NewReader(data)
+
+	buf := bytes.NewBuffer([]byte{})
+
+	tarWriter := tar.NewWriter(buf)
+
+	header := &tar.Header{
+		Name: fileName,
+		Size: file.Size(),
+		// Mode:    int64(stat.Mode()),
+		// ModTime: stat.ModTime(),
+	}
+
+	err := tarWriter.WriteHeader(header)
+	if err != nil {
+		return fmt.Errorf("failed write file header to tar: %w", err)
+	}
+
+	_, err = io.Copy(tarWriter, file)
+	if err != nil {
+		return fmt.Errorf("failed to copy file to tar: %w", err)
+	}
+
+	err = tarWriter.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close tar: %w", err)
+	}
+
+	log.Printf("tar: %s", buf.String())
+
+	// Ensure the directory is present inside the container
+	_, _, err = dockertestutil.ExecuteCommand(
+		container,
+		[]string{"mkdir", "-p", dirPath},
+		[]string{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to ensure directory: %w", err)
+	}
+
+	err = pool.Client.UploadToContainer(
+		container.Container.ID,
+		docker.UploadToContainerOptions{
+			NoOverwriteDirNonDir: false,
+			Path:                 dirPath,
+			InputStream:          bytes.NewReader(buf.Bytes()),
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -21,7 +21,6 @@ import (
 const (
 	scenarioHashLength = 6
 	maxWait            = 60 * time.Second
-	headscalePort      = 8080
 )
 
 var (
@@ -50,7 +49,7 @@ var (
 	// 	"1.12.4",
 	// 	"1.10.2",
 	// 	"1.8.7",
-	// }
+	// }.
 
 	TailscaleVersions = append(
 		tailscaleVersions2021,

--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -26,25 +26,35 @@ const (
 var (
 	errNoHeadscaleAvailable = errors.New("no headscale available")
 	errNoNamespaceAvailable = errors.New("no namespace available")
-	TailscaleVersions       = []string{
+	tailscaleVersions2021   = []string{
 		"head",
 		"unstable",
 		"1.32.1",
 		"1.30.2",
 		"1.28.0",
 		"1.26.2",
+	}
+
+	tailscaleVersions2019 = []string{
 		"1.24.2",
 		"1.22.2",
 		"1.20.4",
 		"1.18.2",
 		"1.16.2",
-
-		// These versions seem to fail when fetching from apt.
-		// "1.14.6",
-		// "1.12.4",
-		// "1.10.2",
-		// "1.8.7",
 	}
+
+	// tailscaleVersionsUnavailable = []string{
+	// 	// These versions seem to fail when fetching from apt.
+	// 	"1.14.6",
+	// 	"1.12.4",
+	// 	"1.10.2",
+	// 	"1.8.7",
+	// }
+
+	TailscaleVersions = append(
+		tailscaleVersions2021,
+		tailscaleVersions2019...,
+	)
 )
 
 type Namespace struct {

--- a/integration/scenario_test.go
+++ b/integration/scenario_test.go
@@ -34,12 +34,12 @@ func TestHeadscale(t *testing.T) {
 	}
 
 	t.Run("start-headscale", func(t *testing.T) {
-		err = scenario.StartHeadscale()
+		headscale, err := scenario.Headscale()
 		if err != nil {
 			t.Errorf("failed to create start headcale: %s", err)
 		}
 
-		err = scenario.MustHeadscale().WaitForReady()
+		err = headscale.WaitForReady()
 		if err != nil {
 			t.Errorf("headscale failed to become ready: %s", err)
 		}
@@ -117,12 +117,11 @@ func TestTailscaleNodesJoiningHeadcale(t *testing.T) {
 	}
 
 	t.Run("start-headscale", func(t *testing.T) {
-		err = scenario.StartHeadscale()
+		headscale, err := scenario.Headscale()
 		if err != nil {
 			t.Errorf("failed to create start headcale: %s", err)
 		}
 
-		headscale := scenario.MustHeadscale()
 		err = headscale.WaitForReady()
 		if err != nil {
 			t.Errorf("headscale failed to become ready: %s", err)
@@ -157,7 +156,16 @@ func TestTailscaleNodesJoiningHeadcale(t *testing.T) {
 			t.Errorf("failed to create preauthkey: %s", err)
 		}
 
-		err = scenario.RunTailscaleUp(namespace, scenario.MustHeadscale().GetEndpoint(), key.GetKey())
+		headscale, err := scenario.Headscale()
+		if err != nil {
+			t.Errorf("failed to create start headcale: %s", err)
+		}
+
+		err = scenario.RunTailscaleUp(
+			namespace,
+			headscale.GetEndpoint(),
+			key.GetKey(),
+		)
 		if err != nil {
 			t.Errorf("failed to login: %s", err)
 		}

--- a/integration/scenario_test.go
+++ b/integration/scenario_test.go
@@ -39,7 +39,7 @@ func TestHeadscale(t *testing.T) {
 			t.Errorf("failed to create start headcale: %s", err)
 		}
 
-		err = scenario.Headscale().WaitForReady()
+		err = scenario.MustHeadscale().WaitForReady()
 		if err != nil {
 			t.Errorf("headscale failed to become ready: %s", err)
 		}
@@ -122,7 +122,7 @@ func TestTailscaleNodesJoiningHeadcale(t *testing.T) {
 			t.Errorf("failed to create start headcale: %s", err)
 		}
 
-		headscale := scenario.Headscale()
+		headscale := scenario.MustHeadscale()
 		err = headscale.WaitForReady()
 		if err != nil {
 			t.Errorf("headscale failed to become ready: %s", err)
@@ -157,7 +157,7 @@ func TestTailscaleNodesJoiningHeadcale(t *testing.T) {
 			t.Errorf("failed to create preauthkey: %s", err)
 		}
 
-		err = scenario.RunTailscaleUp(namespace, scenario.Headscale().GetEndpoint(), key.GetKey())
+		err = scenario.RunTailscaleUp(namespace, scenario.MustHeadscale().GetEndpoint(), key.GetKey())
 		if err != nil {
 			t.Errorf("failed to login: %s", err)
 		}

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -179,8 +179,6 @@ func (t *TailscaleInContainer) Version() string {
 func (t *TailscaleInContainer) Execute(
 	command []string,
 ) (string, string, error) {
-	log.Println("command", command)
-	log.Printf("running command for %s\n", t.hostname)
 	stdout, stderr, err := dockertestutil.ExecuteCommand(
 		t.container,
 		command,

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -176,6 +176,19 @@ func (t *TailscaleInContainer) Version() string {
 	return t.version
 }
 
+func (t *TailscaleInContainer) WaitForReady() error {
+	return t.pool.Retry(func() error {
+		// If tailscaled has not started yet, this will return a non-zero
+		// status code
+		_, err := t.Execute([]string{"tailscale", "status"})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
 func (t *TailscaleInContainer) Execute(
 	command []string,
 ) (string, string, error) {

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -176,19 +176,6 @@ func (t *TailscaleInContainer) Version() string {
 	return t.version
 }
 
-func (t *TailscaleInContainer) WaitForReady() error {
-	return t.pool.Retry(func() error {
-		// If tailscaled has not started yet, this will return a non-zero
-		// status code
-		_, err := t.Execute([]string{"tailscale", "status"})
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-}
-
 func (t *TailscaleInContainer) Execute(
 	command []string,
 ) (string, string, error) {


### PR DESCRIPTION
This commit injects the per-test-generated tls certs into the tailscale container and makes sure all can ping all. 

It adds several other helper functions

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>

<!-- Please tick if the following things apply. You… -->

- [ ] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
