### PR TITLE
Add WaitForReady in TSIC

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -36,6 +36,9 @@ linters:
     - makezero
     - maintidx
 
+    # Limits the methods of an interface to 10. We have more in integration tests
+    - interfacebloat
+
     # We might want to enable this, but it might be a lot of work
     - cyclop
     - nestif

--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -258,7 +258,13 @@ func (s *Scenario) RunTailscaleUp(
 				// TODO(kradalby): error handle this
 				_ = c.Up(loginServer, authKey)
 			}(client)
+
+			err := client.WaitForReady()
+			if err != nil {
+				log.Printf("error waiting for client %s to be ready: %s", client.Hostname(), err)
+			}
 		}
+
 		namespace.joinWaitGroup.Wait()
 
 		return nil

--- a/integration/tailscale.go
+++ b/integration/tailscale.go
@@ -15,6 +15,7 @@ type TailscaleClient interface {
 	IPs() ([]netip.Addr, error)
 	FQDN() (string, error)
 	Status() (*ipnstate.Status, error)
+	WaitForReady() error
 	WaitForPeers(expected int) error
 	Ping(hostnameOrIP string) error
 }

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -25,6 +25,7 @@ var (
 	errTailscalePingFailed     = errors.New("ping failed")
 	errTailscaleNotLoggedIn    = errors.New("tailscale not logged in")
 	errTailscaleWrongPeerCount = errors.New("wrong peer count")
+	errTailscaleNotConnected   = errors.New("tailscale not connected")
 )
 
 type TailscaleInContainer struct {
@@ -220,6 +221,21 @@ func (t *TailscaleInContainer) FQDN() (string, error) {
 	}
 
 	return status.Self.DNSName, nil
+}
+
+func (t *TailscaleInContainer) WaitForReady() error {
+	return t.pool.Retry(func() error {
+		status, err := t.Status()
+		if err != nil {
+			return fmt.Errorf("failed to fetch tailscale status: %w", err)
+		}
+
+		if status.CurrentTailnet != nil {
+			return nil
+		}
+
+		return errTailscaleNotConnected
+	})
 }
 
 func (t *TailscaleInContainer) WaitForPeers(expected int) error {


### PR DESCRIPTION
This small PR adds a WaitForReady method in the Tailscale interface for the integration tests. 

This is used after `tailscale up` to make sure that the clients are ready. 
