### PR TITLE
Extend TSIC integration interface for non-authkey logins

### DIFF
--- a/integration/general_test.go
+++ b/integration/general_test.go
@@ -168,7 +168,7 @@ func TestTaildrop(t *testing.T) {
 	for _, client := range allClients {
 		command := []string{"touch", fmt.Sprintf("/tmp/file_from_%s", client.Hostname())}
 
-		if _, err := client.Execute(command); err != nil {
+		if _, _, err := client.Execute(command); err != nil {
 			t.Errorf("failed to create taildrop file on %s, err: %s", client.Hostname(), err)
 		}
 
@@ -193,7 +193,7 @@ func TestTaildrop(t *testing.T) {
 						client.Hostname(),
 						peer.Hostname(),
 					)
-					_, err := client.Execute(command)
+					_, _, err := client.Execute(command)
 
 					return err
 				})
@@ -214,7 +214,7 @@ func TestTaildrop(t *testing.T) {
 			"get",
 			"/tmp/",
 		}
-		if _, err := client.Execute(command); err != nil {
+		if _, _, err := client.Execute(command); err != nil {
 			t.Errorf("failed to get taildrop file on %s, err: %s", client.Hostname(), err)
 		}
 
@@ -234,7 +234,7 @@ func TestTaildrop(t *testing.T) {
 					peer.Hostname(),
 				)
 
-				result, err := client.Execute(command)
+				result, _, err := client.Execute(command)
 				if err != nil {
 					t.Errorf("failed to execute command to ls taildrop: %s", err)
 				}
@@ -306,7 +306,7 @@ func TestResolveMagicDNS(t *testing.T) {
 				"tailscale",
 				"ip", peerFQDN,
 			}
-			result, err := client.Execute(command)
+			result, _, err := client.Execute(command)
 			if err != nil {
 				t.Errorf(
 					"failed to execute resolve/ip command %s from %s: %s",

--- a/integration/tailscale.go
+++ b/integration/tailscale.go
@@ -10,7 +10,7 @@ type TailscaleClient interface {
 	Hostname() string
 	Shutdown() error
 	Version() string
-	Execute(command []string) (string, error)
+	Execute(command []string) (string, string, error)
 	Up(loginServer, authKey string) error
 	IPs() ([]netip.Addr, error)
 	FQDN() (string, error)

--- a/integration/tailscale.go
+++ b/integration/tailscale.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"net/netip"
+	"net/url"
 
 	"tailscale.com/ipn/ipnstate"
 )
@@ -12,6 +13,7 @@ type TailscaleClient interface {
 	Version() string
 	Execute(command []string) (string, string, error)
 	Up(loginServer, authKey string) error
+	UpWithLoginURL(loginServer string) (*url.URL, error)
 	IPs() ([]netip.Addr, error)
 	FQDN() (string, error)
 	Status() (*ipnstate.Status, error)

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -172,7 +172,7 @@ func (t *TailscaleInContainer) UpWithLoginURL(
 	}
 
 	_, stderr, err := t.Execute(command)
-	if err != errTailscaleNotLoggedIn {
+	if errors.Is(err, errTailscaleNotLoggedIn) {
 		return nil, errTailscaleCannotUpWithoutAuthkey
 	}
 
@@ -180,14 +180,15 @@ func (t *TailscaleInContainer) UpWithLoginURL(
 	urlStr = strings.TrimSpace(urlStr)
 
 	// parse URL
-	loginUrl, err := url.Parse(urlStr)
+	loginURL, err := url.Parse(urlStr)
 	if err != nil {
 		log.Printf("Could not parse login URL: %s", err)
 		log.Printf("Original join command result: %s", stderr)
+
 		return nil, err
 	}
 
-	return loginUrl, nil
+	return loginURL, nil
 }
 
 func (t *TailscaleInContainer) IPs() ([]netip.Addr, error) {

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -111,7 +111,7 @@ func (t *TailscaleInContainer) Version() string {
 
 func (t *TailscaleInContainer) Execute(
 	command []string,
-) (string, error) {
+) (string, string, error) {
 	log.Println("command", command)
 	log.Printf("running command for %s\n", t.hostname)
 	stdout, stderr, err := dockertestutil.ExecuteCommand(
@@ -127,13 +127,13 @@ func (t *TailscaleInContainer) Execute(
 		}
 
 		if strings.Contains(stderr, "NeedsLogin") {
-			return "", errTailscaleNotLoggedIn
+			return stdout, stderr, errTailscaleNotLoggedIn
 		}
 
-		return "", err
+		return stdout, stderr, err
 	}
 
-	return stdout, nil
+	return stdout, stderr, nil
 }
 
 func (t *TailscaleInContainer) Up(
@@ -150,7 +150,7 @@ func (t *TailscaleInContainer) Up(
 		t.hostname,
 	}
 
-	if _, err := t.Execute(command); err != nil {
+	if _, _, err := t.Execute(command); err != nil {
 		return fmt.Errorf("failed to join tailscale client: %w", err)
 	}
 
@@ -169,7 +169,7 @@ func (t *TailscaleInContainer) IPs() ([]netip.Addr, error) {
 		"ip",
 	}
 
-	result, err := t.Execute(command)
+	result, _, err := t.Execute(command)
 	if err != nil {
 		return []netip.Addr{}, fmt.Errorf("failed to join tailscale client: %w", err)
 	}
@@ -196,7 +196,7 @@ func (t *TailscaleInContainer) Status() (*ipnstate.Status, error) {
 		"--json",
 	}
 
-	result, err := t.Execute(command)
+	result, _, err := t.Execute(command)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute tailscale status command: %w", err)
 	}
@@ -264,7 +264,7 @@ func (t *TailscaleInContainer) Ping(hostnameOrIP string) error {
 			hostnameOrIP,
 		}
 
-		result, err := t.Execute(command)
+		result, _, err := t.Execute(command)
 		if err != nil {
 			log.Printf(
 				"failed to run ping command from %s to %s, err: %s",


### PR DESCRIPTION
This PR extends the Tailscale interface to support running `tailscale up` and returning the result (ie. the login URL)