### PR TITLE
Releases: use flavor to set the tag suffix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest
             type=sha
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -125,13 +124,12 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/headscale
             ghcr.io/${{ github.repository_owner }}/headscale
           flavor: |
-            latest=false
+            suffix=-debug,onlatest=true
           tags: |
-            type=semver,pattern={{version}}-debug
-            type=semver,pattern={{major}}.{{minor}}-debug
-            type=semver,pattern={{major}}-debug
-            type=raw,value=latest-debug
-            type=sha,suffix=-debug
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

Moves to using the `suffix` option in `flavor` from [metadata-action](https://github.com/docker/metadata-action) to ensure  the suffix is applied to all tags. Without this the Alpine image was ending up with the `<version>` tag instead of the Debian image.

Also removed the `type=raw,value=latest` and equivalent options from all three images, as the default behavior of `latest=auto` in `flavor` should take care of this. The `onlatest=true` in the `suffix` option will ensure the Debug and Alpine images will be `latest-debug` and `latest-alpine` respectively.