### PR TITLE
Fix AuthURL on machine expiration when using OIDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add `dns_config.override_local_dns` option [#905](https://github.com/juanfont/headscale/pull/905)
 - Fix some DNS config issues [#660](https://github.com/juanfont/headscale/issues/660)
 - Make it possible to disable TS2019 with build flag [#928](https://github.com/juanfont/headscale/pull/928)
+- Fix OIDC registration issues [#960](https://github.com/juanfont/headscale/pull/960) and [#971](https://github.com/juanfont/headscale/pull/971)
 
 ## 0.16.4 (2022-08-21)
 

--- a/oidc.go
+++ b/oidc.go
@@ -77,9 +77,10 @@ func (h *Headscale) RegisterOIDC(
 	vars := mux.Vars(req)
 	nodeKeyStr, ok := vars["nkey"]
 
-	log.Trace().
+	log.Debug().
 		Caller().
 		Str("node_key", nodeKeyStr).
+		Bool("ok", ok).
 		Msg("Received oidc register call")
 
 	if !NodePublicKeyRegex.Match([]byte(nodeKeyStr)) {
@@ -107,7 +108,9 @@ func (h *Headscale) RegisterOIDC(
 	)
 
 	if !ok || nodeKeyStr == "" || err != nil {
-		log.Warn().Err(err).Msg("Failed to parse incoming nodekey")
+		log.Warn().
+			Err(err).
+			Msg("Failed to parse incoming nodekey in OIDC registration")
 
 		writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		writer.WriteHeader(http.StatusBadRequest)

--- a/protocol_common.go
+++ b/protocol_common.go
@@ -490,6 +490,7 @@ func (h *Headscale) handleNewMachineCommon(
 		Bool("noise", machineKey.IsZero()).
 		Str("machine", registerRequest.Hostinfo.Hostname).
 		Msg("The node seems to be new, sending auth url")
+
 	if h.oauth2Config != nil {
 		resp.AuthURL = fmt.Sprintf(
 			"%s/oidc/register/%s",
@@ -727,7 +728,7 @@ func (h *Headscale) handleMachineExpiredCommon(
 	if h.oauth2Config != nil {
 		resp.AuthURL = fmt.Sprintf("%s/oidc/register/%s",
 			strings.TrimSuffix(h.cfg.ServerURL, "/"),
-			NodePublicKeyStripPrefix(registerRequest.NodeKey))
+			registerRequest.NodeKey)
 	} else {
 		resp.AuthURL = fmt.Sprintf("%s/register/%s",
 			strings.TrimSuffix(h.cfg.ServerURL, "/"),

--- a/protocol_common.go
+++ b/protocol_common.go
@@ -528,6 +528,7 @@ func (h *Headscale) handleNewMachineCommon(
 	log.Info().
 		Caller().
 		Bool("noise", machineKey.IsZero()).
+		Str("AuthURL", resp.AuthURL).
 		Str("machine", registerRequest.Hostinfo.Hostname).
 		Msg("Successfully sent auth url")
 }


### PR DESCRIPTION
We were sending the stripped nodekey on the AuthURL when using OIDC on nodekey expired. 

This PR fixes it.