### PR TITLE
Correction in the sample config file

### DIFF
--- a/docs/running-headscale-container.md
+++ b/docs/running-headscale-container.md
@@ -58,6 +58,7 @@ private_key_path: /etc/headscale/private.key
 noise:
   private_key_path: /etc/headscale/noise_private.key
 # The default /var/lib/headscale path is not writable  in the container
+db_type: sqlite3
 db_path: /etc/headscale/db.sqlite
 ```
 


### PR DESCRIPTION
Added the db_type in the sample config.yaml  Without this entry, the container throws Unsupported DB error
`db_type: sqlite3`

<!-- Please tick if the following things apply. You… -->

- [ ] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
