### PR TITLE
Bump meta action and always include latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,12 +55,14 @@ jobs:
             ${{ runner.os }}-buildx-
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           # list of Docker images to use as base name for tags
           images: |
             ${{ secrets.DOCKERHUB_USERNAME }}/headscale
             ghcr.io/${{ github.repository_owner }}/headscale
+          flavor: |
+            latest=true
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -117,13 +119,14 @@ jobs:
             ${{ runner.os }}-buildx-debug-
       - name: Docker meta
         id: meta-debug
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           # list of Docker images to use as base name for tags
           images: |
             ${{ secrets.DOCKERHUB_USERNAME }}/headscale
             ghcr.io/${{ github.repository_owner }}/headscale
           flavor: |
+            latest=true
             suffix=-debug,onlatest=true
           tags: |
             type=semver,pattern={{version}}


### PR DESCRIPTION
<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

A regression from https://github.com/juanfont/headscale/pull/959 is that the auto `latest` handling will intentionally avoid labeling a pre-release version, such as a beta, as `latest`.

I gather we want `latest` to point to the latest release regardless of if it is a pre-release like the previous behavior? If not, then the new behavior can be left alone, with only stable releases being tagged as `latest`. Though we'll probably want to create a new tag to use to reference the latest pre-release version for those who want to following along with development.