### PR TITLE
Fix remote CLI when there is no config file present

### DIFF
--- a/config.go
+++ b/config.go
@@ -597,6 +597,13 @@ func GetHeadscaleConfig() (*Config, error) {
 
 		ACL: GetACLConfig(),
 
+		CLI: CLIConfig{
+			Address:  viper.GetString("cli.address"),
+			APIKey:   viper.GetString("cli.api_key"),
+			Timeout:  viper.GetDuration("cli.timeout"),
+			Insecure: viper.GetBool("cli.insecure"),
+		},
+
 		Log: GetLogConfig(),
 	}, nil
 }


### PR DESCRIPTION
If users are following https://github.com/juanfont/headscale/blob/main/docs/remote-cli.md, headscale CLI fails to connect to the remove server because no config file is set up (i.e., the remote CLI is fully configured via env vars).

This PR allows headscale running in CLI mode to be run only with env vars.
