### PR TITLE
Remove mTLS code

### DIFF
--- a/app.go
+++ b/app.go
@@ -101,27 +101,6 @@ type Headscale struct {
 	pollNetMapStreamWG sync.WaitGroup
 }
 
-// Look up the TLS constant relative to user-supplied TLS client
-// authentication mode. If an unknown mode is supplied, the default
-// value, tls.RequireAnyClientCert, is returned. The returned boolean
-// indicates if the supplied mode was valid.
-func LookupTLSClientAuthMode(mode string) (tls.ClientAuthType, bool) {
-	switch mode {
-	case DisabledClientAuth:
-		// Client cert is _not_ required.
-		return tls.NoClientCert, true
-	case RelaxedClientAuth:
-		// Client cert required, but _not verified_.
-		return tls.RequireAnyClientCert, true
-	case EnforcedClientAuth:
-		// Client cert is _required and verified_.
-		return tls.RequireAndVerifyClientCert, true
-	default:
-		// Return the default when an unknown value is supplied.
-		return tls.RequireAnyClientCert, false
-	}
-}
-
 func NewHeadscale(cfg *Config) (*Headscale, error) {
 	privateKey, err := readOrCreatePrivateKey(cfg.PrivateKeyPath)
 	if err != nil {
@@ -855,12 +834,7 @@ func (h *Headscale) getTLSSettings() (*tls.Config, error) {
 			log.Warn().Msg("Listening with TLS but ServerURL does not start with https://")
 		}
 
-		log.Info().Msg(fmt.Sprintf(
-			"Client authentication (mTLS) is \"%s\". See the docs to learn about configuring this setting.",
-			h.cfg.TLS.ClientAuthMode))
-
 		tlsConfig := &tls.Config{
-			ClientAuth:   h.cfg.TLS.ClientAuthMode,
 			NextProtos:   []string{"http/1.1"},
 			Certificates: make([]tls.Certificate, 1),
 			MinVersion:   tls.VersionTLS12,

--- a/app_test.go
+++ b/app_test.go
@@ -59,20 +59,3 @@ func (s *Suite) ResetDB(c *check.C) {
 	}
 	app.db = db
 }
-
-// Enusre an error is returned when an invalid auth mode
-// is supplied.
-func (s *Suite) TestInvalidClientAuthMode(c *check.C) {
-	_, isValid := LookupTLSClientAuthMode("invalid")
-	c.Assert(isValid, check.Equals, false)
-}
-
-// Ensure that all client auth modes return a nil error.
-func (s *Suite) TestAuthModes(c *check.C) {
-	modes := []string{"disabled", "relaxed", "enforced"}
-
-	for _, v := range modes {
-		_, isValid := LookupTLSClientAuthMode(v)
-		c.Assert(isValid, check.Equals, true)
-	}
-}

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -161,13 +161,6 @@ acme_email: ""
 # Domain name to request a TLS certificate for:
 tls_letsencrypt_hostname: ""
 
-# Client (Tailscale/Browser) authentication mode (mTLS)
-# Acceptable values:
-# - disabled: client authentication disabled
-# - relaxed: client certificate is required but not verified
-# - enforced: client certificate is required and verified
-tls_client_auth_mode: relaxed
-
 # Path to store certificates and metadata needed by
 # letsencrypt
 # For production:

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -29,17 +29,3 @@ headscale can also be configured to expose its web service via TLS. To configure
 tls_cert_path: ""
 tls_key_path: ""
 ```
-
-### Configuring Mutual TLS Authentication (mTLS)
-
-mTLS is a method by which an HTTPS server authenticates clients, e.g. Tailscale, using TLS certificates. This can be configured by applying one of the following values to the `tls_client_auth_mode` setting in the configuration file.
-
-| Value               | Behavior                                                   |
-| ------------------- | ---------------------------------------------------------- |
-| `disabled`          | Disable mTLS.                                              |
-| `relaxed` (default) | A client certificate is required, but it is not verified.  |
-| `enforced`          | Requires clients to supply a certificate that is verified. |
-
-```yaml
-tls_client_auth_mode: ""
-```

--- a/integration/hsic/hsic.go
+++ b/integration/hsic/hsic.go
@@ -71,7 +71,6 @@ func WithTLS() Option {
 		// TODO(kradalby): Move somewhere appropriate
 		hsic.env = append(hsic.env, fmt.Sprintf("HEADSCALE_TLS_CERT_PATH=%s", tlsCertPath))
 		hsic.env = append(hsic.env, fmt.Sprintf("HEADSCALE_TLS_KEY_PATH=%s", tlsKeyPath))
-		hsic.env = append(hsic.env, "HEADSCALE_TLS_CLIENT_AUTH_MODE=disabled")
 
 		hsic.tlsCert = cert
 		hsic.tlsKey = key
@@ -371,7 +370,7 @@ func (t *HeadscaleInContainer) WriteFile(path string, data []byte) error {
 	return integrationutil.WriteFileToContainer(t.pool, t.container, path, data)
 }
 
-//nolint
+// nolint
 func createCertificate() ([]byte, []byte, error) {
 	// From:
 	// https://shaneutt.com/blog/golang-ca-and-signed-cert-go/

--- a/integration_test/etc/alt-config.dump.gold.yaml
+++ b/integration_test/etc/alt-config.dump.gold.yaml
@@ -46,7 +46,6 @@ private_key_path: private.key
 noise:
   private_key_path: noise_private.key
 server_url: http://headscale:18080
-tls_client_auth_mode: relaxed
 tls_letsencrypt_cache_dir: /var/www/.cache
 tls_letsencrypt_challenge_type: HTTP-01
 unix_socket: /var/run/headscale.sock

--- a/integration_test/etc/alt-env-config.dump.gold.yaml
+++ b/integration_test/etc/alt-env-config.dump.gold.yaml
@@ -45,7 +45,6 @@ private_key_path: private.key
 noise:
   private_key_path: noise_private.key
 server_url: http://headscale:18080
-tls_client_auth_mode: relaxed
 tls_letsencrypt_cache_dir: /var/www/.cache
 tls_letsencrypt_challenge_type: HTTP-01
 unix_socket: /var/run/headscale.sock

--- a/integration_test/etc/config.dump.gold.yaml
+++ b/integration_test/etc/config.dump.gold.yaml
@@ -46,7 +46,6 @@ private_key_path: private.key
 noise:
   private_key_path: noise_private.key
 server_url: http://headscale:8080
-tls_client_auth_mode: relaxed
 tls_letsencrypt_cache_dir: /var/www/.cache
 tls_letsencrypt_challenge_type: HTTP-01
 unix_socket: /var/run/headscale.sock

--- a/integration_test/etc_oidc/base_config.yaml
+++ b/integration_test/etc_oidc/base_config.yaml
@@ -14,7 +14,6 @@ listen_addr: 0.0.0.0:8443
 server_url: https://headscale-oidc:8443
 tls_cert_path: "/etc/headscale/tls/server.crt"
 tls_key_path: "/etc/headscale/tls/server.key"
-tls_client_auth_mode: disabled
 derp:
   urls:
     - https://controlplane.tailscale.com/derpmap/default


### PR DESCRIPTION
mTLS was added in one of our first PRs, and it has never been used - as Tailscale clients do not support it.

This PR just removes all the code and references.