### PR TITLE
WaitForReady in web auth flow integration tests outside up goroutine

### DIFF
--- a/integration/auth_web_flow_test.go
+++ b/integration/auth_web_flow_test.go
@@ -134,12 +134,12 @@ func (s *AuthWebFlowScenario) runTailscaleUp(
 				if err != nil {
 					log.Printf("failed to register client: %s", err)
 				}
-
-				err = c.WaitForReady()
-				if err != nil {
-					log.Printf("error waiting for client %s to be ready: %s", c.Hostname(), err)
-				}
 			}(client)
+
+			err := client.WaitForReady()
+			if err != nil {
+				log.Printf("error waiting for client %s to be ready: %s", client.Hostname(), err)
+			}
 		}
 		namespace.joinWaitGroup.Wait()
 


### PR DESCRIPTION
This minor PR runs the WaitForReady outside the up goroutine, to fix intermittent issues when running the integration tests.
