### PR TITLE
Fix linting issues warning incorrect t.Parallel() calls in tests

### DIFF
--- a/integration/general_test.go
+++ b/integration/general_test.go
@@ -124,7 +124,6 @@ func TestPingAllByHostname(t *testing.T) {
 
 func TestTaildrop(t *testing.T) {
 	IntegrationSkip(t)
-	t.Parallel()
 
 	retry := func(times int, sleepInverval time.Duration, doWork func() error) error {
 		var err error

--- a/integration/scenario_test.go
+++ b/integration/scenario_test.go
@@ -23,7 +23,6 @@ func IntegrationSkip(t *testing.T) {
 
 func TestHeadscale(t *testing.T) {
 	IntegrationSkip(t)
-	t.Parallel()
 
 	var err error
 
@@ -72,7 +71,6 @@ func TestHeadscale(t *testing.T) {
 
 func TestCreateTailscale(t *testing.T) {
 	IntegrationSkip(t)
-	t.Parallel()
 
 	namespace := "only-create-containers"
 
@@ -106,7 +104,6 @@ func TestCreateTailscale(t *testing.T) {
 
 func TestTailscaleNodesJoiningHeadcale(t *testing.T) {
 	IntegrationSkip(t)
-	t.Parallel()
 
 	var err error
 


### PR DESCRIPTION

Well, that