### PR TITLE
add the possibility for custom DNS records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Set `db_ssl` to false by default [#1052](https://github.com/juanfont/headscale/pull/1052)
 - Fix duplicate nodes due to incorrect implementation of the protocol [#1058](https://github.com/juanfont/headscale/pull/1058)
 - Report if a machine is online in CLI more accurately [#1062](https://github.com/juanfont/headscale/pull/1062)
+- Added config option for custom DNS records [#1035](https://github.com/juanfont/headscale/pull/1035)
 
 ## 0.17.1 (2022-12-05)
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -235,6 +235,17 @@ dns_config:
   # Search domains to inject.
   domains: []
 
+  # Extra DNS records
+  # so far only A-records are supported (on the tailscale side)
+  # See https://github.com/juanfont/headscale/blob/main/docs/dns-records.md#Limitations
+  # extra_records:
+  #   - name: "grafana.myvpn.example.com"
+  #     type: "A"
+  #     value: "100.64.0.3"
+  #
+  #   # you can also put it in one line
+  #   - { name: "prometheus.myvpn.example.com", type: "A", value: "100.64.0.3" }
+
   # Whether to use [MagicDNS](https://tailscale.com/kb/1081/magicdns/).
   # Only works if there is at least a nameserver defined.
   magic_dns: true

--- a/config.go
+++ b/config.go
@@ -448,6 +448,20 @@ func GetDNSConfig() (*tailcfg.DNSConfig, string) {
 			}
 		}
 
+		if viper.IsSet("dns_config.extra_records") {
+			var extraRecords []tailcfg.DNSRecord
+
+			err := viper.UnmarshalKey("dns_config.extra_records", &extraRecords)
+			if err != nil {
+				log.Error().
+					Str("func", "getDNSConfig").
+					Err(err).
+					Msgf("Could not parse dns_config.extra_records")
+			}
+
+			dnsConfig.ExtraRecords = extraRecords
+		}
+
 		if viper.IsSet("dns_config.magic_dns") {
 			dnsConfig.Proxied = viper.GetBool("dns_config.magic_dns")
 		}

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ written by community members. It is _not_ verified by `headscale` developers.
 - [Running headscale in a container](running-headscale-container.md)
 - [Running headscale on OpenBSD](running-headscale-openbsd.md)
 - [Running headscale behind a reverse proxy](reverse-proxy.md)
+- [Set Custom DNS records](dns-records.md)
 
 ## Misc
 

--- a/docs/dns-records.md
+++ b/docs/dns-records.md
@@ -2,8 +2,8 @@
 
 ## Goal
 
-This documentation has the goal of showing how a user can set custom DNS records client with `headscale`s magic dns.
-An example usecase is to serve apps on the same host via a reverse proxy like NGinX, in this case a prometheus monitoring stack. This allows to nicely access the service with "http://grafana.myvpn.example.com" instead of the hostname and portnum combination "http://hostname-in-magic-dns.myvpn.example.com:3000".
+This documentation has the goal of showing how a user can set custom DNS records with `headscale`s magic dns.
+An example use case is to serve apps on the same host via a reverse proxy like NGINX, in this case a Prometheus monitoring stack. This allows to nicely access the service with "http://grafana.myvpn.example.com" instead of the hostname and portnum combination "http://hostname-in-magic-dns.myvpn.example.com:3000".
 
 ## Setup
 
@@ -80,4 +80,4 @@ server {
 
 ## Limitations
 
-[Not all types of Records are Supported](https://github.com/tailscale/tailscale/blob/main/ipn/ipnlocal/local.go#L2891-L2909), especially no CNAME records.
+[Not all types of records are supported](https://github.com/tailscale/tailscale/blob/main/ipn/ipnlocal/local.go#L2891-L2909), especially no CNAME records.

--- a/docs/dns-records.md
+++ b/docs/dns-records.md
@@ -1,0 +1,83 @@
+# Setting custom DNS records
+
+## Goal
+
+This documentation has the goal of showing how a user can set custom DNS records client with `headscale`s magic dns.
+An example usecase is to serve apps on the same host via a reverse proxy like NGinX, in this case a prometheus monitoring stack. This allows to nicely access the service with "http://grafana.myvpn.example.com" instead of the hostname and portnum combination "http://hostname-in-magic-dns.myvpn.example.com:3000".
+
+## Setup
+
+### Change the configuration
+
+1. Change the `config.yaml` to contain the desired records like so:
+
+```yaml
+dns_config:
+  ...
+  extra_records:
+    - name: "prometheus.myvpn.example.com"
+      type: "A"
+      value: "100.64.0.3"
+
+    - name: "grafana.myvpn.example.com"
+      type: "A"
+      value: "100.64.0.3"
+  ...
+```
+
+Restart your headscale instance.
+
+Beware of the limitations listed later on!
+
+### Verify that the records are set
+
+You can use a DNS querying tool of your choice on one of your hosts to verify that your newly set records are actually available in MagicDNS, here we used [`dig`](https://man.archlinux.org/man/dig.1.en):
+
+```
+$ dig grafana.myvpn.example.com
+
+; <<>> DiG 9.18.10 <<>> grafana.myvpn.example.com
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 44054
+;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 65494
+;; QUESTION SECTION:
+;grafana.myvpn.example.com.         IN      A
+
+;; ANSWER SECTION:
+grafana.myvpn.example.com.  593     IN      A       100.64.0.3
+
+;; Query time: 0 msec
+;; SERVER: 127.0.0.53#53(127.0.0.53) (UDP)
+;; WHEN: Sat Dec 31 11:46:55 CET 2022
+;; MSG SIZE  rcvd: 66
+```
+
+### Optional: Setup the reverse proxy
+
+The motivating example here was to be able to access internal monitoring services on the same host without specifying a port:
+
+```
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name grafana.myvpn.example.com;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+}
+```
+
+## Limitations
+
+[Not all types of Records are Supported](https://github.com/tailscale/tailscale/blob/main/ipn/ipnlocal/local.go#L2891-L2909), especially no CNAME records.

--- a/docs/dns-records.md
+++ b/docs/dns-records.md
@@ -7,7 +7,7 @@ An example usecase is to serve apps on the same host via a reverse proxy like NG
 
 ## Setup
 
-### Change the configuration
+### 1. Change the configuration
 
 1. Change the `config.yaml` to contain the desired records like so:
 
@@ -25,11 +25,11 @@ dns_config:
   ...
 ```
 
-Restart your headscale instance.
+2. Restart your headscale instance.
 
 Beware of the limitations listed later on!
 
-### Verify that the records are set
+### 2. Verify that the records are set
 
 You can use a DNS querying tool of your choice on one of your hosts to verify that your newly set records are actually available in MagicDNS, here we used [`dig`](https://man.archlinux.org/man/dig.1.en):
 
@@ -56,7 +56,7 @@ grafana.myvpn.example.com.  593     IN      A       100.64.0.3
 ;; MSG SIZE  rcvd: 66
 ```
 
-### Optional: Setup the reverse proxy
+### 3. Optional: Setup the reverse proxy
 
 The motivating example here was to be able to access internal monitoring services on the same host without specifying a port:
 


### PR DESCRIPTION
This PR adds the code of https://github.com/madjam002/headscale/commit/b9f05fca8d7fcc246b44a0495587b9de1582049c but patched into the correct file as the code location now has been updated.
I have run the latest headscale for the last month with this change and it works great! 🥳

My usecase is serving some internal applications such as `grafana.vpn.my.domain` and a have reverse proxy on the host that correctly maps the requests 👍🏻 

I would be willing to add documentation, tests and more if needed, just let me know what you think of merging this before I invest the work ^^  

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
related to https://github.com/juanfont/headscale/issues/762
Also notifying @madjam002 since the code was originally from him 😊 