### PR TITLE
Added an OIDC AllowGroups option for authorization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.18.x (2022-xx-xx)
 
+- Added an OIDC AllowGroups Configuration options and authorization check [#1041](https://github.com/juanfont/headscale/pull/1041)
 - Reworked routing and added support for subnet router failover [#1024](https://github.com/juanfont/headscale/pull/1024)
 
 ### Changes

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -273,6 +273,9 @@ unix_socket_permission: "0770"
 #
 #   allowed_domains:
 #     - example.com
+# Groups from keycloak have a leading '/'
+#   allowed_groups:
+#     - /headscale
 #   allowed_users:
 #     - alice@example.com
 #

--- a/config.go
+++ b/config.go
@@ -96,6 +96,7 @@ type OIDCConfig struct {
 	ExtraParams                map[string]string
 	AllowedDomains             []string
 	AllowedUsers               []string
+	AllowedGroups              []string
 	StripEmaildomain           bool
 }
 
@@ -568,6 +569,7 @@ func GetHeadscaleConfig() (*Config, error) {
 			ExtraParams:      viper.GetStringMapString("oidc.extra_params"),
 			AllowedDomains:   viper.GetStringSlice("oidc.allowed_domains"),
 			AllowedUsers:     viper.GetStringSlice("oidc.allowed_users"),
+			AllowedGroups:    viper.GetStringSlice("oidc.allowed_groups"),
 			StripEmaildomain: viper.GetBool("oidc.strip_email_domain"),
 		},
 


### PR DESCRIPTION
Added an additional OIDC configuration option for a 'groups' claim. The allowed_groups config option is another OIDC authorization option. I tested this with Keycloak by adding a group membership client scope to the OIDC provider.