### PR TITLE
Do not explicitly set the protocols when omitted in ACL

### DIFF
--- a/acls.go
+++ b/acls.go
@@ -386,12 +386,7 @@ func generateACLPolicyDest(
 func parseProtocol(protocol string) ([]int, bool, error) {
 	switch protocol {
 	case "":
-		return []int{
-			protocolICMP,
-			protocolIPv6ICMP,
-			protocolTCP,
-			protocolUDP,
-		}, false, nil
+		return nil, false, nil
 	case "igmp":
 		return []int{protocolIGMP}, true, nil
 	case "ipv4", "ip-in-ip":


### PR DESCRIPTION
As per `tailcfg.FilterRule`, when the protocol of an ACL is omitted it "means TCP, UDP, and ICMP" - but to the client it is sent nil. It is up to the client to apply that special case.

The PR adheres Headscale to the behaviour of the SaaS