### PR TITLE
Fix duplicate nodes due to incorrect implementation of the protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Reworked routing and added support for subnet router failover [#1024](https://github.com/juanfont/headscale/pull/1024)
 - Added an OIDC AllowGroups Configuration options and authorization check [#1041](https://github.com/juanfont/headscale/pull/1041)
 - Set `db_ssl` to false by default [#1052](https://github.com/juanfont/headscale/pull/1052)
+- Fix duplicate nodes due to incorrect implementation of the protocol [#1058](https://github.com/juanfont/headscale/pull/1058)
 - Report if a machine is online in CLI more accurately [#1062](https://github.com/juanfont/headscale/pull/1062)
 
 ## 0.17.1 (2022-12-05)

--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -469,6 +469,7 @@ func nodesToPtables(
 		"ID",
 		"Hostname",
 		"Name",
+		"MachineKey",
 		"NodeKey",
 		"Namespace",
 		"IP addresses",
@@ -504,8 +505,16 @@ func nodesToPtables(
 			expiry = machine.Expiry.AsTime()
 		}
 
+		var machineKey key.MachinePublic
+		err := machineKey.UnmarshalText(
+			[]byte(headscale.MachinePublicKeyEnsurePrefix(machine.MachineKey)),
+		)
+		if err != nil {
+			machineKey = key.MachinePublic{}
+		}
+
 		var nodeKey key.NodePublic
-		err := nodeKey.UnmarshalText(
+		err = nodeKey.UnmarshalText(
 			[]byte(headscale.NodePublicKeyEnsurePrefix(machine.NodeKey)),
 		)
 		if err != nil {
@@ -568,6 +577,7 @@ func nodesToPtables(
 			strconv.FormatUint(machine.Id, headscale.Base10),
 			machine.Name,
 			machine.GetGivenName(),
+			machineKey.ShortString(),
 			nodeKey.ShortString(),
 			namespace,
 			strings.Join([]string{IPV4Address, IPV6Address}, ", "),

--- a/integration/tailscale.go
+++ b/integration/tailscale.go
@@ -7,7 +7,7 @@ import (
 	"tailscale.com/ipn/ipnstate"
 )
 
-//nolint
+// nolint
 type TailscaleClient interface {
 	Hostname() string
 	Shutdown() error
@@ -19,6 +19,7 @@ type TailscaleClient interface {
 	FQDN() (string, error)
 	Status() (*ipnstate.Status, error)
 	WaitForReady() error
+	WaitForLogout() error
 	WaitForPeers(expected int) error
 	Ping(hostnameOrIP string) error
 	ID() string

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -30,6 +30,7 @@ var (
 	errTailscaleWrongPeerCount         = errors.New("wrong peer count")
 	errTailscaleCannotUpWithoutAuthkey = errors.New("cannot up without authkey")
 	errTailscaleNotConnected           = errors.New("tailscale not connected")
+	errTailscaleNotLoggedOut           = errors.New("tailscale not logged out")
 )
 
 type TailscaleInContainer struct {
@@ -347,6 +348,21 @@ func (t *TailscaleInContainer) WaitForReady() error {
 		}
 
 		return errTailscaleNotConnected
+	})
+}
+
+func (t *TailscaleInContainer) WaitForLogout() error {
+	return t.pool.Retry(func() error {
+		status, err := t.Status()
+		if err != nil {
+			return fmt.Errorf("failed to fetch tailscale status: %w", err)
+		}
+
+		if status.CurrentTailnet == nil {
+			return nil
+		}
+
+		return errTailscaleNotLoggedOut
 	})
 }
 

--- a/machine_test.go
+++ b/machine_test.go
@@ -77,10 +77,11 @@ func (s *Suite) TestGetMachineByNodeKey(c *check.C) {
 	c.Assert(err, check.NotNil)
 
 	nodeKey := key.NewNode()
+	machineKey := key.NewMachine()
 
 	machine := Machine{
 		ID:             0,
-		MachineKey:     "foo",
+		MachineKey:     MachinePublicKeyStripPrefix(machineKey.Public()),
 		NodeKey:        NodePublicKeyStripPrefix(nodeKey.Public()),
 		DiscoKey:       "faa",
 		Hostname:       "testmachine",
@@ -107,9 +108,11 @@ func (s *Suite) TestGetMachineByAnyNodeKey(c *check.C) {
 	nodeKey := key.NewNode()
 	oldNodeKey := key.NewNode()
 
+	machineKey := key.NewMachine()
+
 	machine := Machine{
 		ID:             0,
-		MachineKey:     "foo",
+		MachineKey:     MachinePublicKeyStripPrefix(machineKey.Public()),
 		NodeKey:        NodePublicKeyStripPrefix(nodeKey.Public()),
 		DiscoKey:       "faa",
 		Hostname:       "testmachine",
@@ -119,7 +122,7 @@ func (s *Suite) TestGetMachineByAnyNodeKey(c *check.C) {
 	}
 	app.db.Save(&machine)
 
-	_, err = app.GetMachineByAnyNodeKey(nodeKey.Public(), oldNodeKey.Public())
+	_, err = app.GetMachineByAnyKey(machineKey.Public(), nodeKey.Public(), oldNodeKey.Public())
 	c.Assert(err, check.IsNil)
 }
 

--- a/protocol_legacy.go
+++ b/protocol_legacy.go
@@ -56,5 +56,5 @@ func (h *Headscale) RegistrationHandler(
 		return
 	}
 
-	h.handleRegisterCommon(writer, req, registerRequest, machineKey)
+	h.handleRegisterCommon(writer, req, registerRequest, machineKey, false)
 }

--- a/protocol_noise.go
+++ b/protocol_noise.go
@@ -7,11 +7,10 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"tailscale.com/tailcfg"
-	"tailscale.com/types/key"
 )
 
 // // NoiseRegistrationHandler handles the actual registration process of a machine.
-func (h *Headscale) NoiseRegistrationHandler(
+func (t *ts2021App) NoiseRegistrationHandler(
 	writer http.ResponseWriter,
 	req *http.Request,
 ) {
@@ -34,5 +33,5 @@ func (h *Headscale) NoiseRegistrationHandler(
 		return
 	}
 
-	h.handleRegisterCommon(writer, req, registerRequest, key.MachinePublic{})
+	t.headscale.handleRegisterCommon(writer, req, registerRequest, t.conn.Peer(), true)
 }

--- a/protocol_noise_poll.go
+++ b/protocol_noise_poll.go
@@ -21,7 +21,7 @@ import (
 // only after their first request (marked with the ReadOnly field).
 //
 // At this moment the updates are sent in a quite horrendous way, but they kinda work.
-func (h *Headscale) NoisePollNetMapHandler(
+func (t *ts2021App) NoisePollNetMapHandler(
 	writer http.ResponseWriter,
 	req *http.Request,
 ) {
@@ -41,7 +41,7 @@ func (h *Headscale) NoisePollNetMapHandler(
 		return
 	}
 
-	machine, err := h.GetMachineByAnyNodeKey(mapRequest.NodeKey, key.NodePublic{})
+	machine, err := t.headscale.GetMachineByAnyKey(t.conn.Peer(), mapRequest.NodeKey, key.NodePublic{})
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			log.Warn().
@@ -63,5 +63,5 @@ func (h *Headscale) NoisePollNetMapHandler(
 		Str("machine", machine.Hostname).
 		Msg("A machine is entering polling via the Noise protocol")
 
-	h.handlePollCommon(writer, req.Context(), machine, mapRequest, true)
+	t.headscale.handlePollCommon(writer, req.Context(), machine, mapRequest, true)
 }


### PR DESCRIPTION
Under certain conditions we could get duplicated nodes (e.g., after logout/login, reported in #1054) - due to a misunderstanding from my side on the role of MachineKey in TS2021.

`MachineKey` in TS2021 (the permanent-ish key associated to a client) is no longer sent in the body of the protocol requests, but obtained from the method `Peer()` in the `controlbase.Conn` struct. I was not aware of this (cheers @awsong for the heads up!). Our TS2021 was completely dropping `MachineKey`


Fixes #1054
