### PR TITLE
Show clients offline when expired

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -146,6 +146,10 @@ func (machine *Machine) isOnline() bool {
 		return false
 	}
 
+	if machine.isExpired() {
+		return false
+	}
+
 	return machine.LastSeen.After(time.Now().Add(-keepAliveInterval))
 }
 


### PR DESCRIPTION
When a machine has logged out, it would still show online for the next keepAlivePeriod. 

With this small PR that is solved.
