### PR TITLE
fix(routes): ensure routes are correctly propagated

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -675,18 +675,13 @@ func (h *Headscale) toNode(
 		[]netip.Prefix{},
 		addrs...) // we append the node own IP, as it is required by the clients
 
-	enabledRoutes, err := h.GetEnabledRoutes(&machine)
-	if err != nil {
-		return nil, err
-	}
-
-	allowedIPs = append(allowedIPs, enabledRoutes...)
-
 	primaryRoutes, err := h.getMachinePrimaryRoutes(&machine)
 	if err != nil {
 		return nil, err
 	}
 	primaryPrefixes := Routes(primaryRoutes).toPrefixes()
+
+	allowedIPs = append(allowedIPs, primaryPrefixes...)
 
 	var derp string
 	if machine.HostInfo.NetInfo != nil {
@@ -1057,6 +1052,7 @@ func (h *Headscale) EnableRoutes(machine *Machine, routeStrs ...string) error {
 		}
 	}
 
+	h.setLastStateChangeToNow()
 	return nil
 }
 

--- a/routes.go
+++ b/routes.go
@@ -215,6 +215,7 @@ func (h *Headscale) handlePrimarySubnetFailover() error {
 		log.Error().Err(err).Msg("error getting routes")
 	}
 
+	routesChanged := false
 	for pos, route := range routes {
 		if route.isExitRoute() {
 			continue
@@ -235,6 +236,7 @@ func (h *Headscale) handlePrimarySubnetFailover() error {
 					return err
 				}
 
+				routesChanged = true
 				continue
 			}
 		}
@@ -306,9 +308,14 @@ func (h *Headscale) handlePrimarySubnetFailover() error {
 
 				return err
 			}
+
+			routesChanged = true
 		}
 	}
 
+	if routesChanged {
+		h.setLastStateChangeToNow()
+	}
 	return nil
 }
 


### PR DESCRIPTION
When using Tailscale v1.34.1, enabling or disabling a route does not effectively add or remove the route from the node's routing table. We must restart tailscale on the node to have a netmap update.

Fix this by refreshing last state change so that a netmap diff is sent.

Also do not include secondary routes in allowedIPs, otherwise secondary routes might be used by nodes instead of the primary route.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
Fixes #1075