### PR TITLE
Add logout method to Tailscale interface

### DIFF
--- a/integration/auth_web_flow_test.go
+++ b/integration/auth_web_flow_test.go
@@ -141,7 +141,7 @@ func TestAuthWebFlowLogoutAndRelogin(t *testing.T) {
 	}
 
 	for _, client := range allClients {
-		_, _, err = client.Execute([]string{"tailscale", "logout"})
+		err := client.Logout()
 		if err != nil {
 			t.Errorf("failed to logout client %s: %s", client.Hostname(), err)
 		}

--- a/integration/tailscale.go
+++ b/integration/tailscale.go
@@ -15,6 +15,7 @@ type TailscaleClient interface {
 	Execute(command []string) (string, string, error)
 	Up(loginServer, authKey string) error
 	UpWithLoginURL(loginServer string) (*url.URL, error)
+	Logout() error
 	IPs() ([]netip.Addr, error)
 	FQDN() (string, error)
 	Status() (*ipnstate.Status, error)

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -270,6 +270,15 @@ func (t *TailscaleInContainer) UpWithLoginURL(
 	return loginURL, nil
 }
 
+func (t *TailscaleInContainer) Logout() error {
+	_, _, err := t.Execute([]string{"tailscale", "logout"})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (t *TailscaleInContainer) IPs() ([]netip.Addr, error) {
 	if t.ips != nil && len(t.ips) != 0 {
 		return t.ips, nil


### PR DESCRIPTION
Add a helper method to logout a tailscale client in integration tests.