### PR TITLE
fix goroutine leak

### DIFF
--- a/protocol_common_poll.go
+++ b/protocol_common_poll.go
@@ -664,7 +664,11 @@ func (h *Headscale) scheduledPollWorker(
 				Str("machine", machine.Hostname).
 				Bool("noise", isNoise).
 				Msg("Sending keepalive")
-			keepAliveChan <- data
+			select {
+			case keepAliveChan <- data:
+			case <-ctx.Done():
+				return
+			}
 
 		case <-updateCheckerTicker.C:
 			log.Debug().
@@ -674,7 +678,11 @@ func (h *Headscale) scheduledPollWorker(
 				Msg("Sending update request")
 			updateRequestsFromNode.WithLabelValues(machine.Namespace.Name, machine.Hostname, "scheduled-update").
 				Inc()
-			updateChan <- struct{}{}
+			select {
+			case updateChan <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
Prometheus goroutine count:

<img width="872" alt="image" src="https://user-images.githubusercontent.com/1449133/209466427-11868d1a-ac27-4ed9-8564-1b7710477e4d.png">

After some debugging, I found the goroutine leak at `keepAliveChan`, if client is disconnected, server goroutine may block at write  `keepAliveChan`, with a select and check context fix this issue.


https://github.com/juanfont/headscale/blob/3e9ee816f9394f2f40bede40797695cf02ac064e/protocol_common_poll.go#L667

```
goroutine profile: total 153
86 @ 0x43cab6 0x405ecc 0x405a7d 0xfe26ee 0x46dda1
#	0xfe26ed	github.com/juanfont/headscale.(*Headscale).scheduledPollWorker+0x56d	github.com/juanfont/headscale/protocol_common_poll.go:667
```


<!-- Please tick if the following things apply. You… -->

- [ ] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
