### PR TITLE
Remove ephemeral on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Report if a machine is online in CLI more accurately [#1062](https://github.com/juanfont/headscale/pull/1062)
 - Added config option for custom DNS records [#1035](https://github.com/juanfont/headscale/pull/1035)
 - Expire nodes based on OIDC token expiry [#1067](https://github.com/juanfont/headscale/pull/1067)
-- Remote ephemeral nodes on logout [#1098](https://github.com/juanfont/headscale/pull/1098)
+- Remove ephemeral nodes on logout [#1098](https://github.com/juanfont/headscale/pull/1098)
 
 ## 0.17.1 (2022-12-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Report if a machine is online in CLI more accurately [#1062](https://github.com/juanfont/headscale/pull/1062)
 - Added config option for custom DNS records [#1035](https://github.com/juanfont/headscale/pull/1035)
 - Expire nodes based on OIDC token expiry [#1067](https://github.com/juanfont/headscale/pull/1067)
+- Remote ephemeral nodes on logout [#1098](https://github.com/juanfont/headscale/pull/1098)
 
 ## 0.17.1 (2022-12-05)
 

--- a/app.go
+++ b/app.go
@@ -257,8 +257,7 @@ func (h *Headscale) expireEphemeralNodesWorker() {
 
 		expiredFound := false
 		for _, machine := range machines {
-			if machine.AuthKey != nil && machine.LastSeen != nil &&
-				machine.AuthKey.Ephemeral &&
+			if machine.isEphemeral() && machine.LastSeen != nil &&
 				time.Now().
 					After(machine.LastSeen.Add(h.cfg.EphemeralNodeInactivityTimeout)) {
 				expiredFound = true

--- a/integration/control.go
+++ b/integration/control.go
@@ -11,7 +11,7 @@ type ControlServer interface {
 	GetEndpoint() string
 	WaitForReady() error
 	CreateNamespace(namespace string) error
-	CreateAuthKey(namespace string) (*v1.PreAuthKey, error)
+	CreateAuthKey(namespace string, reusable bool, ephemeral bool) (*v1.PreAuthKey, error)
 	ListMachinesInNamespace(namespace string) ([]*v1.Machine, error)
 	GetCert() []byte
 	GetHostname() string

--- a/integration/hsic/hsic.go
+++ b/integration/hsic/hsic.go
@@ -316,6 +316,8 @@ func (t *HeadscaleInContainer) CreateNamespace(
 
 func (t *HeadscaleInContainer) CreateAuthKey(
 	namespace string,
+	reusable bool,
+	ephemeral bool,
 ) (*v1.PreAuthKey, error) {
 	command := []string{
 		"headscale",
@@ -323,11 +325,18 @@ func (t *HeadscaleInContainer) CreateAuthKey(
 		namespace,
 		"preauthkeys",
 		"create",
-		"--reusable",
 		"--expiration",
 		"24h",
 		"--output",
 		"json",
+	}
+
+	if reusable {
+		command = append(command, "--reusable")
+	}
+
+	if ephemeral {
+		command = append(command, "--ephemeral")
 	}
 
 	result, _, err := dockertestutil.ExecuteCommand(

--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -194,9 +194,9 @@ func (s *Scenario) Headscale(opts ...hsic.Option) (ControlServer, error) {
 	return headscale, nil
 }
 
-func (s *Scenario) CreatePreAuthKey(namespace string) (*v1.PreAuthKey, error) {
+func (s *Scenario) CreatePreAuthKey(namespace string, reusable bool, ephemeral bool) (*v1.PreAuthKey, error) {
 	if headscale, err := s.Headscale(); err == nil {
-		key, err := headscale.CreateAuthKey(namespace)
+		key, err := headscale.CreateAuthKey(namespace, reusable, ephemeral)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create namespace: %w", err)
 		}
@@ -368,7 +368,7 @@ func (s *Scenario) CreateHeadscaleEnv(
 			return err
 		}
 
-		key, err := s.CreatePreAuthKey(namespaceName)
+		key, err := s.CreatePreAuthKey(namespaceName, true, false)
 		if err != nil {
 			return err
 		}

--- a/integration/scenario_test.go
+++ b/integration/scenario_test.go
@@ -62,7 +62,7 @@ func TestHeadscale(t *testing.T) {
 	})
 
 	t.Run("create-auth-key", func(t *testing.T) {
-		_, err := scenario.CreatePreAuthKey(namespace)
+		_, err := scenario.CreatePreAuthKey(namespace, true, false)
 		if err != nil {
 			t.Errorf("failed to create preauthkey: %s", err)
 		}
@@ -166,7 +166,7 @@ func TestTailscaleNodesJoiningHeadcale(t *testing.T) {
 	})
 
 	t.Run("join-headscale", func(t *testing.T) {
-		key, err := scenario.CreatePreAuthKey(namespace)
+		key, err := scenario.CreatePreAuthKey(namespace, true, false)
 		if err != nil {
 			t.Errorf("failed to create preauthkey: %s", err)
 		}

--- a/machine.go
+++ b/machine.go
@@ -392,7 +392,7 @@ func (h *Headscale) GetMachineByGivenName(namespace string, givenName string) (*
 // GetMachineByID finds a Machine by ID and returns the Machine struct.
 func (h *Headscale) GetMachineByID(id uint64) (*Machine, error) {
 	m := Machine{}
-	if result := h.db.Preload("Namespace").Find(&Machine{ID: id}).First(&m); result.Error != nil {
+	if result := h.db.Preload("AuthKey").Preload("Namespace").Find(&Machine{ID: id}).First(&m); result.Error != nil {
 		return nil, result.Error
 	}
 
@@ -404,7 +404,7 @@ func (h *Headscale) GetMachineByMachineKey(
 	machineKey key.MachinePublic,
 ) (*Machine, error) {
 	m := Machine{}
-	if result := h.db.Preload("Namespace").First(&m, "machine_key = ?", MachinePublicKeyStripPrefix(machineKey)); result.Error != nil {
+	if result := h.db.Preload("AuthKey").Preload("Namespace").First(&m, "machine_key = ?", MachinePublicKeyStripPrefix(machineKey)); result.Error != nil {
 		return nil, result.Error
 	}
 
@@ -416,7 +416,7 @@ func (h *Headscale) GetMachineByNodeKey(
 	nodeKey key.NodePublic,
 ) (*Machine, error) {
 	machine := Machine{}
-	if result := h.db.Preload("Namespace").First(&machine, "node_key = ?",
+	if result := h.db.Preload("AuthKey").Preload("Namespace").First(&machine, "node_key = ?",
 		NodePublicKeyStripPrefix(nodeKey)); result.Error != nil {
 		return nil, result.Error
 	}
@@ -429,7 +429,7 @@ func (h *Headscale) GetMachineByAnyKey(
 	machineKey key.MachinePublic, nodeKey key.NodePublic, oldNodeKey key.NodePublic,
 ) (*Machine, error) {
 	machine := Machine{}
-	if result := h.db.Preload("Namespace").First(&machine, "machine_key = ? OR node_key = ? OR node_key = ?",
+	if result := h.db.Preload("AuthKey").Preload("Namespace").First(&machine, "machine_key = ? OR node_key = ? OR node_key = ?",
 		MachinePublicKeyStripPrefix(machineKey),
 		NodePublicKeyStripPrefix(nodeKey),
 		NodePublicKeyStripPrefix(oldNodeKey)); result.Error != nil {

--- a/machine.go
+++ b/machine.go
@@ -153,6 +153,12 @@ func (machine *Machine) isOnline() bool {
 	return machine.LastSeen.After(time.Now().Add(-keepAliveInterval))
 }
 
+// isEphemeral returns if the machine is registered as an Ephemeral node.
+// https://tailscale.com/kb/1111/ephemeral-nodes/
+func (machine *Machine) isEphemeral() bool {
+	return machine.AuthKey != nil && machine.AuthKey.Ephemeral
+}
+
 func containsAddresses(inputs []string, addrs []string) bool {
 	for _, addr := range addrs {
 		if containsStr(inputs, addr) {

--- a/protocol_common.go
+++ b/protocol_common.go
@@ -622,6 +622,20 @@ func (h *Headscale) handleMachineLogOutCommon(
 			Caller().
 			Err(err).
 			Msg("Failed to write response")
+
+		return
+	}
+
+	if machine.isEphemeral() {
+		err = h.HardDeleteMachine(&machine)
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str("machine", machine.Hostname).
+				Msg("Cannot delete ephemeral machine from the database")
+		}
+
+		return
 	}
 
 	log.Info().


### PR DESCRIPTION
This PR implements #1087, to better adhere to a change on how ephemeral nodes behave on logout in the SaaS https://tailscale.com/blog/ephemeral-logout/.


