### PR TITLE
domains/restricted_nameservers: check dnsConfig.Resolvers instead

### DIFF
--- a/config.go
+++ b/config.go
@@ -408,7 +408,7 @@ func GetDNSConfig() (*tailcfg.DNSConfig, string) {
 		}
 
 		if viper.IsSet("dns_config.restricted_nameservers") {
-			if len(dnsConfig.Nameservers) > 0 {
+			if len(dnsConfig.Resolvers) > 0 {
 				dnsConfig.Routes = make(map[string][]*dnstype.Resolver)
 				restrictedDNS := viper.GetStringMapStringSlice(
 					"dns_config.restricted_nameservers",
@@ -440,7 +440,7 @@ func GetDNSConfig() (*tailcfg.DNSConfig, string) {
 
 		if viper.IsSet("dns_config.domains") {
 			domains := viper.GetStringSlice("dns_config.domains")
-			if len(dnsConfig.Nameservers) > 0 {
+			if len(dnsConfig.Resolvers) > 0 {
 				dnsConfig.Domains = domains
 			} else if domains != nil {
 				log.Warn().


### PR DESCRIPTION
With this change, domains are applied if there are any `dnsConfig.Resolvers` rather than any `dnsConfig.Nameservers`. Without this change, using nextdns doh would disallow setting any domains (because it checked `dnsConfig.Nameservers` which would be empty in the case of NextDNS DOH).

<!-- Please tick if the following things apply. You… -->

- [X] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
