### PR TITLE
Remove Tailscale v1.18.2 from test matrix

### DIFF
--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -43,11 +43,11 @@ var (
 		"1.24.2",
 		"1.22.2",
 		"1.20.4",
-		"1.18.2",
 	}
 
 	// tailscaleVersionsUnavailable = []string{
 	// 	// These versions seem to fail when fetching from apt.
+	//  "1.18.2",
 	// 	"1.16.2",
 	// 	"1.14.6",
 	// 	"1.12.4",


### PR DESCRIPTION
This PR removes Tailscale v1.18.2 from the test matrix, as it seems to fail downloading from the apt package repository.