### PR TITLE
Fix excessive cpu usage

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -155,7 +155,7 @@ func (machine *Machine) isOnline() bool {
 
 func containsAddresses(inputs []string, addrs []string) bool {
 	for _, addr := range addrs {
-		if contains(inputs, addr) {
+		if containsStr(inputs, addr) {
 			return true
 		}
 	}

--- a/utils.go
+++ b/utils.go
@@ -269,6 +269,16 @@ func stringToIPPrefix(prefixes []string) ([]netip.Prefix, error) {
 	return result, nil
 }
 
+func containsStr(ts []string, t string) bool {
+	for _, v := range ts {
+		if v == t {
+			return true
+		}
+	}
+
+	return false
+}
+
 func contains[T string | netip.Prefix](ts []T, t T) bool {
 	for _, v := range ts {
 		if reflect.DeepEqual(v, t) {


### PR DESCRIPTION
…allocate memory

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

This pr modifies the comparison behavior of the `containsAddresses` function so that Golang does not continuously allocate memory and cause high cpu usage.

![before_modification](https://user-images.githubusercontent.com/23068780/210320172-b566d9fe-f409-4fd3-afad-995db16e0928.svg)

![after_modification](https://user-images.githubusercontent.com/23068780/210320281-7e4875fd-48f3-457d-90ce-3583757fd34e.svg)
