### PR TITLE
Repeat ToStringSlice

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -194,6 +194,7 @@ func getFilteredByACLPeers(
 	peers := make(map[uint64]Machine)
 	// Aclfilter peers here. We are itering through machines in all namespaces and search through the computed aclRules
 	// for match between rule SrcIPs and DstPorts. If the rule is a match we allow the machine to be viewable.
+	machineIPs := machine.IPAddresses.ToStringSlice()
 	for _, peer := range machines {
 		if peer.ID == machine.ID {
 			continue
@@ -203,22 +204,23 @@ func getFilteredByACLPeers(
 			for _, d := range rule.DstPorts {
 				dst = append(dst, d.IP)
 			}
+			peerIPs := peer.IPAddresses.ToStringSlice()
 			if matchSourceAndDestinationWithRule(
 				rule.SrcIPs,
 				dst,
-				machine.IPAddresses.ToStringSlice(),
-				peer.IPAddresses.ToStringSlice(),
+				machineIPs,
+				peerIPs,
 			) || // match source and destination
 				matchSourceAndDestinationWithRule(
 					rule.SrcIPs,
 					dst,
-					peer.IPAddresses.ToStringSlice(),
-					machine.IPAddresses.ToStringSlice(),
+					peerIPs,
+					machineIPs,
 				) || // match return path
 				matchSourceAndDestinationWithRule(
 					rule.SrcIPs,
 					dst,
-					machine.IPAddresses.ToStringSlice(),
+					machineIPs,
 					[]string{"*"},
 				) || // match source and all destination
 				matchSourceAndDestinationWithRule(
@@ -231,13 +233,13 @@ func getFilteredByACLPeers(
 					rule.SrcIPs,
 					dst,
 					[]string{"*"},
-					peer.IPAddresses.ToStringSlice(),
+					peerIPs,
 				) || // match source and all destination
 				matchSourceAndDestinationWithRule(
 					rule.SrcIPs,
 					dst,
 					[]string{"*"},
-					machine.IPAddresses.ToStringSlice(),
+					machineIPs,
 				) { // match all sources and source
 				peers[peer.ID] = peer
 			}


### PR DESCRIPTION
…e cpu usage

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

I've been watching the cpu situation for the past few days, and I found that the cpu occasionally suddenly rises to 500%, so I used pprof to check and found that ToStringSlice causes the cpu to rise.

After optimizing it, the cpu is still rising occasionally, but not very much.

The final solution should be to use the cache to store the machine information for comparison, and modify the database data and cache information only when there are changes. I'm not familiar with it, so I haven't made the appropriate changes yet.

https://user-images.githubusercontent.com/23068780/210695313-54af7475-d527-4274-b33a-50838c44ed98.svg
https://user-images.githubusercontent.com/23068780/210695393-754f2a55-6894-42ac-8ecc-6294109e2f19.svg