### PR TITLE
Refresh machines with correct new expiry

### DIFF
--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -475,6 +475,7 @@ func nodesToPtables(
 		"IP addresses",
 		"Ephemeral",
 		"Last seen",
+		"Expiration",
 		"Online",
 		"Expired",
 	}
@@ -501,8 +502,12 @@ func nodesToPtables(
 		}
 
 		var expiry time.Time
+		var expiryTime string
 		if machine.Expiry != nil {
 			expiry = machine.Expiry.AsTime()
+			expiryTime = expiry.Format("2006-01-02 15:04:05")
+		} else {
+			expiryTime = "N/A"
 		}
 
 		var machineKey key.MachinePublic
@@ -583,6 +588,7 @@ func nodesToPtables(
 			strings.Join([]string{IPV4Address, IPV6Address}, ", "),
 			strconv.FormatBool(ephemeral),
 			lastSeenTime,
+			expiryTime,
 			online,
 			expired,
 		}

--- a/machine.go
+++ b/machine.go
@@ -873,6 +873,7 @@ func (h *Headscale) RegisterMachineFromAuthCallback(
 		Str("nodeKey", nodeKey.ShortString()).
 		Str("namespaceName", namespaceName).
 		Str("registrationMethod", registrationMethod).
+		Str("expiresAt", fmt.Sprintf("%v", machineExpiry)).
 		Msg("Registering machine from API/CLI or auth callback")
 
 	if machineInterface, ok := h.registrationCache.Get(NodePublicKeyStripPrefix(nodeKey)); ok {


### PR DESCRIPTION
Whenever a machine should be refreshed, the new OIDC expiry time wouldn't be persisted. This PR adresses this critical bug. I've also expanded the `nodes list` command to show the expiration time.
