### PR TITLE
Makefile: remove a missing target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ dev: lint test build
 test:
 	@go test $(TAGS) -short -coverprofile=coverage.out ./...
 
-test_integration: test_integration_cli test_integration_derp test_integration_oidc test_integration_v2_general
+test_integration: test_integration_cli test_integration_derp test_integration_v2_general
 
 test_integration_cli:
 	docker network rm $$(docker network ls --filter name=headscale --quiet) || true


### PR DESCRIPTION
test_integration_oidc was removed in 0525bea59310a8e3e8e7d9feebcbd909f482cc92

This change will make `make test_integration` work again.