### PR TITLE
Migrate DB: rename table is plural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### BREAKING
 
 - Rename Namespace to User [#1144](https://github.com/juanfont/headscale/pull/1144)
+  - **BACKUP your database before upgrading**
 
 ## 0.18.0 (2022-01-14)
 

--- a/db.go
+++ b/db.go
@@ -41,6 +41,13 @@ func (h *Headscale) initDB() error {
 		db.Exec(`create extension if not exists "uuid-ossp";`)
 	}
 
+	_ = db.Migrator().RenameTable("namespaces", "users")
+
+	err = db.AutoMigrate(&User{})
+	if err != nil {
+		return err
+	}
+
 	_ = db.Migrator().RenameColumn(&Machine{}, "ip_address", "ip_addresses")
 	_ = db.Migrator().RenameColumn(&Machine{}, "name", "hostname")
 
@@ -183,13 +190,6 @@ func (h *Headscale) initDB() error {
 	}
 
 	err = db.AutoMigrate(&KV{})
-	if err != nil {
-		return err
-	}
-
-	_ = db.Migrator().RenameTable("Namespace", "User")
-
-	err = db.AutoMigrate(&User{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The calls to AutoMigrate to other classes that refer to users will
create the table and it will break, it needs to be done before
everything else.

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>