### PR TITLE
Enable both exit routes at the same time

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -1047,8 +1047,8 @@ func (h *Headscale) IsRoutesEnabled(machine *Machine, routeStr string) bool {
 	return false
 }
 
-// EnableRoutes enables new routes based on a list of new routes.
-func (h *Headscale) EnableRoutes(machine *Machine, routeStrs ...string) error {
+// enableRoutes enables new routes based on a list of new routes.
+func (h *Headscale) enableRoutes(machine *Machine, routeStrs ...string) error {
 	newRoutes := make([]netip.Prefix, len(routeStrs))
 	for index, routeStr := range routeStrs {
 		route, err := netip.ParsePrefix(routeStr)

--- a/routes.go
+++ b/routes.go
@@ -90,7 +90,14 @@ func (h *Headscale) EnableRoute(id uint64) error {
 		return err
 	}
 
-	return h.EnableRoutes(&route.Machine, netip.Prefix(route.Prefix).String())
+	// Tailscale requires both IPv4 and IPv6 exit routes to
+	// be enabled at the same time, as per
+	// https://github.com/juanfont/headscale/issues/804#issuecomment-1399314002
+	if route.isExitRoute() {
+		return h.enableRoutes(&route.Machine, ExitRouteV4.String(), ExitRouteV6.String())
+	}
+
+	return h.enableRoutes(&route.Machine, netip.Prefix(route.Prefix).String())
 }
 
 func (h *Headscale) DisableRoute(id uint64) error {


### PR DESCRIPTION
As indicated by @bradfitz (thanks!!) at https://github.com/juanfont/headscale/issues/804#issuecomment-1399314002, both routes (IPv4 and IPv6) need to enabled for an exit node to be considered.

This PR makes sure that when enabling 0.0.0.0/0 or ::/0 the other gets enabled too.