### PR TITLE
Align behaviour of dns_config.restricted_nameservers to tailscale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - Fix wrong behaviour in exit nodes [#1159](https://github.com/juanfont/headscale/pull/1159)
+- Align behaviour of `dns_config.restricted_nameservers` to tailscale [#1162](https://github.com/juanfont/headscale/pull/1162)
 
 ## 0.19.0 (2023-01-29)
 


### PR DESCRIPTION
Fixes #1161 

Tailscale allows split DNS configuration without requiring global nameservers.

In addition, as per [the docs](https://tailscale.com/kb/1054/dns/#using-dns-settings-in-the-admin-console):

> These nameservers also configure search domains for your devices

~In addition, as stated in [the FAQ](https://tailscale.com/kb/1054/dns/#faq):~

> ~Previous versions of the DNS settings page allowed defining search domains separately from nameservers. However, due to cross-platform compatibility reasons, this is no longer possible. To define a search domain, you’ll need to add at least one nameserver along with it.~

This commit aligns headscale to tailscale by:

 * ~removing support for `dns_config.domains`~
 * honouring `dns_config.restricted_nameservers` regardless of whether any global resolvers are configured
 * adding a search domain for each nameserver in `restricted_nameservers`

~I realise "removing support for dns_config.domains" may be controversial as the tailscale client still supports search domains being defined separately, though it seems likely that this "undocumented" behaviour could (/should) be removed in future. Happy to adjust the change if required.~

EDIT: removed "removing support for dns_config.domains" as it is a breaking change.

If the changes look good, I'll update changelog etc.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
