### PR TITLE
Target Tailscale 1.36.0

### DIFF
--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -32,7 +32,8 @@ var (
 	tailscaleVersions2021 = []string{
 		"head",
 		"unstable",
-		"1.34.0",
+		"1.36.0",
+		"1.34.2",
 		"1.32.3",
 		"1.30.2",
 	}


### PR DESCRIPTION
This PR adds the newly released Tailscale v1.36  to our integration tests.