### PR TITLE
Migrate namespace_id to user_id column in machine and pak

### DIFF
--- a/db.go
+++ b/db.go
@@ -48,6 +48,9 @@ func (h *Headscale) initDB() error {
 		return err
 	}
 
+	_ = db.Migrator().RenameColumn(&Machine{}, "namespace_id", "user_id")
+	_ = db.Migrator().RenameColumn(&PreAuthKey{}, "namespace_id", "user_id")
+
 	_ = db.Migrator().RenameColumn(&Machine{}, "ip_address", "ip_addresses")
 	_ = db.Migrator().RenameColumn(&Machine{}, "name", "hostname")
 


### PR DESCRIPTION
Fixes #1166

This will probably not work for people who has already upgraded to the beta-1.

Users who are using beta-1 should either:

- delete the _empty_ `user_id` column in `machines` and `pre_auth_keys` (make sure its empty...) and rerun with beta-2
- rename the column manually from `namespace_id` to `user_id`
- use beta-2 from their database backup of 0.18.x

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>
