### PR TITLE
Do not show IsPrimary field as false in exit nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
-## 0.19.0 (2022-11-26)
+## 0.20.0 (2023-x-x)
+
+### Changes
+
+- Fix wrong behaviour in exit nodes [#1159](https://github.com/juanfont/headscale/pull/1159)
+
+## 0.19.0 (2023-01-29)
 
 ### BREAKING
 
@@ -8,7 +14,7 @@
   - **BACKUP your database before upgrading**
 - Command line flags previously taking `--namespace` or `-n` will now require `--user` or `-u`
 
-## 0.18.0 (2022-01-14)
+## 0.18.0 (2023-01-14)
 
 ### Changes
 

--- a/machine.go
+++ b/machine.go
@@ -1047,8 +1047,8 @@ func (h *Headscale) IsRoutesEnabled(machine *Machine, routeStr string) bool {
 	return false
 }
 
-// EnableRoutes enables new routes based on a list of new routes.
-func (h *Headscale) EnableRoutes(machine *Machine, routeStrs ...string) error {
+// enableRoutes enables new routes based on a list of new routes.
+func (h *Headscale) enableRoutes(machine *Machine, routeStrs ...string) error {
 	newRoutes := make([]netip.Prefix, len(routeStrs))
 	for index, routeStr := range routeStrs {
 		route, err := netip.ParsePrefix(routeStr)

--- a/routes.go
+++ b/routes.go
@@ -90,7 +90,14 @@ func (h *Headscale) EnableRoute(id uint64) error {
 		return err
 	}
 
-	return h.EnableRoutes(&route.Machine, netip.Prefix(route.Prefix).String())
+	// Tailscale requires both IPv4 and IPv6 exit routes to
+	// be enabled at the same time, as per
+	// https://github.com/juanfont/headscale/issues/804#issuecomment-1399314002
+	if route.isExitRoute() {
+		return h.enableRoutes(&route.Machine, ExitRouteV4.String(), ExitRouteV6.String())
+	}
+
+	return h.enableRoutes(&route.Machine, netip.Prefix(route.Prefix).String())
 }
 
 func (h *Headscale) DisableRoute(id uint64) error {


### PR DESCRIPTION
Currently exit routes are shown as 'False' in the primary column of the CLI - which is not relevant for exit nodes.

This PR fixes that.

Also, adds a missing entry in the changelog.