### PR TITLE
Do not show IsPrimary field as false in exit nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-- TBD
+- Fix wrong behaviour in exit nodes [#1159](https://github.com/juanfont/headscale/pull/1159)
 
 ## 0.19.0 (2023-01-29)
 


### PR DESCRIPTION
Currently exit routes are shown as 'False' in the primary column of the CLI - which is not relevant for exit nodes.

This PR fixes that.

Also, adds a missing entry in the changelog.