### PR TITLE
Set OpenID Connect Expiry

### DIFF
--- a/.github/workflows/test-integration-v2-TestOIDCExpireNodesBasedOnTokenExpiry.yaml
+++ b/.github/workflows/test-integration-v2-TestOIDCExpireNodesBasedOnTokenExpiry.yaml
@@ -2,7 +2,7 @@
 # DO NOT EDIT, generated with cmd/gh-action-integration-generator/main.go
 # To regenerate, run "go generate" in cmd/gh-action-integration-generator/
 
-name: Integration Test v2 - TestOIDCExpireNodes
+name: Integration Test v2 - TestOIDCExpireNodesBasedOnTokenExpiry
 
 on: [pull_request]
 
@@ -49,7 +49,7 @@ jobs:
                   -failfast \
                   -timeout 120m \
                   -parallel 1 \
-                  -run "^TestOIDCExpireNodes$"
+                  -run "^TestOIDCExpireNodesBasedOnTokenExpiry$"
 
       - uses: actions/upload-artifact@v3
         if: always() && steps.changed-files.outputs.any_changed == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Fix wrong behaviour in exit nodes [#1159](https://github.com/juanfont/headscale/pull/1159)
 - Align behaviour of `dns_config.restricted_nameservers` to tailscale [#1162](https://github.com/juanfont/headscale/pull/1162)
+- Make OpenID Connect authenticated client expiry time configurable [#1191](https://github.com/juanfont/headscale/pull/1191)
+  - defaults to 180 days like Tailscale SaaS
+  - adds option to use the expiry time from the OpenID token for the node (see config-example.yaml)
 
 ## 0.19.0 (2023-01-29)
 

--- a/cmd/gh-action-integration-generator/main.go
+++ b/cmd/gh-action-integration-generator/main.go
@@ -90,7 +90,7 @@ func main() {
 		"TestHeadscale",
 		"TestUserCommand",
 		"TestOIDCAuthenticationPingAll",
-		"TestOIDCExpireNodes",
+		"TestOIDCExpireNodesBasedOnTokenExpiry",
 		"TestPingAllByHostname",
 		"TestPingAllByIP",
 		"TestPreAuthKeyCommand",

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -282,27 +282,38 @@ unix_socket_permission: "0770"
 #   client_secret_path: "${CREDENTIALS_DIRECTORY}/oidc_client_secret"
 #   # client_secret and client_secret_path are mutually exclusive.
 #
-#   Customize the scopes used in the OIDC flow, defaults to "openid", "profile" and "email" and add custom query
-#   parameters to the Authorize Endpoint request. Scopes default to "openid", "profile" and "email".
+#   # The amount of time from a node is authenticated with OpenID until it
+#   # expires and needs to reauthenticate.
+#   # Setting the value to "0" will mean no expiry.
+#   expiry: 180d
+#
+#   # Use the expiry from the token received from OpenID when the user logged
+#   # in, this will typically lead to frequent need to reauthenticate and should
+#   # only been enabled if you know what you are doing.
+#   # Note: enabling this will cause `oidc.expiry` to be ignored.
+#   use_expiry_from_token: false
+#
+#   # Customize the scopes used in the OIDC flow, defaults to "openid", "profile" and "email" and add custom query
+#   # parameters to the Authorize Endpoint request. Scopes default to "openid", "profile" and "email".
 #
 #   scope: ["openid", "profile", "email", "custom"]
 #   extra_params:
 #     domain_hint: example.com
 #
-#   List allowed principal domains and/or users. If an authenticated user's domain is not in this list, the
-#   authentication request will be rejected.
+#   # List allowed principal domains and/or users. If an authenticated user's domain is not in this list, the
+#   # authentication request will be rejected.
 #
 #   allowed_domains:
 #     - example.com
-# Groups from keycloak have a leading '/'
+#   # Note: Groups from keycloak have a leading '/'
 #   allowed_groups:
 #     - /headscale
 #   allowed_users:
 #     - alice@example.com
 #
-#   If `strip_email_domain` is set to `true`, the domain part of the username email address will be removed.
-#   This will transform `first-name.last-name@example.com` to the user `first-name.last-name`
-#   If `strip_email_domain` is set to `false` the domain part will NOT be removed resulting to the following
+#   # If `strip_email_domain` is set to `true`, the domain part of the username email address will be removed.
+#   # This will transform `first-name.last-name@example.com` to the user `first-name.last-name`
+#   # If `strip_email_domain` is set to `false` the domain part will NOT be removed resulting to the following
 #   user: `first-name.last-name.example.com`
 #
 #   strip_email_domain: true

--- a/integration/auth_oidc_test.go
+++ b/integration/auth_oidc_test.go
@@ -100,7 +100,7 @@ func TestOIDCAuthenticationPingAll(t *testing.T) {
 	}
 }
 
-func TestOIDCExpireNodes(t *testing.T) {
+func TestOIDCExpireNodesBasedOnTokenExpiry(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
@@ -125,10 +125,11 @@ func TestOIDCExpireNodes(t *testing.T) {
 	}
 
 	oidcMap := map[string]string{
-		"HEADSCALE_OIDC_ISSUER":             oidcConfig.Issuer,
-		"HEADSCALE_OIDC_CLIENT_ID":          oidcConfig.ClientID,
-		"HEADSCALE_OIDC_CLIENT_SECRET":      oidcConfig.ClientSecret,
-		"HEADSCALE_OIDC_STRIP_EMAIL_DOMAIN": fmt.Sprintf("%t", oidcConfig.StripEmaildomain),
+		"HEADSCALE_OIDC_ISSUER":                oidcConfig.Issuer,
+		"HEADSCALE_OIDC_CLIENT_ID":             oidcConfig.ClientID,
+		"HEADSCALE_OIDC_CLIENT_SECRET":         oidcConfig.ClientSecret,
+		"HEADSCALE_OIDC_STRIP_EMAIL_DOMAIN":    fmt.Sprintf("%t", oidcConfig.StripEmaildomain),
+		"HEADSCALE_OIDC_USE_EXPIRY_FROM_TOKEN": "1",
 	}
 
 	err = scenario.CreateHeadscaleEnv(
@@ -278,7 +279,10 @@ func (s *AuthOIDCScenario) runMockOIDC(accessTTL time.Duration) (*headscale.OIDC
 	log.Printf("headscale mock oidc is ready for tests at %s", hostEndpoint)
 
 	return &headscale.OIDCConfig{
-		Issuer:                     fmt.Sprintf("http://%s/oidc", net.JoinHostPort(s.mockOIDC.GetIPInNetwork(s.network), strconv.Itoa(port))),
+		Issuer: fmt.Sprintf(
+			"http://%s/oidc",
+			net.JoinHostPort(s.mockOIDC.GetIPInNetwork(s.network), strconv.Itoa(port)),
+		),
 		ClientID:                   "superclient",
 		ClientSecret:               "supersecret",
 		StripEmaildomain:           true,

--- a/integration_test/etc/alt-config.dump.gold.yaml
+++ b/integration_test/etc/alt-config.dump.gold.yaml
@@ -37,12 +37,14 @@ logtail:
   enabled: false
 metrics_listen_addr: 127.0.0.1:19090
 oidc:
+  expiry: 180d
   only_start_if_oidc_is_available: true
   scope:
     - openid
     - profile
     - email
   strip_email_domain: true
+  use_expiry_from_token: false
 private_key_path: private.key
 noise:
   private_key_path: noise_private.key

--- a/integration_test/etc/alt-env-config.dump.gold.yaml
+++ b/integration_test/etc/alt-env-config.dump.gold.yaml
@@ -36,12 +36,14 @@ logtail:
   enabled: false
 metrics_listen_addr: 127.0.0.1:19090
 oidc:
+  expiry: 180d
   only_start_if_oidc_is_available: true
   scope:
     - openid
     - profile
     - email
   strip_email_domain: true
+  use_expiry_from_token: false
 private_key_path: private.key
 noise:
   private_key_path: noise_private.key

--- a/integration_test/etc/config.dump.gold.yaml
+++ b/integration_test/etc/config.dump.gold.yaml
@@ -37,12 +37,14 @@ logtail:
   enabled: false
 metrics_listen_addr: 127.0.0.1:9090
 oidc:
+  expiry: 180d
   only_start_if_oidc_is_available: true
   scope:
     - openid
     - profile
     - email
   strip_email_domain: true
+  use_expiry_from_token: false
 private_key_path: private.key
 noise:
   private_key_path: noise_private.key


### PR DESCRIPTION
This commit adds a default OpenID Connect expiry to `180d` to align with Tailscale SaaS (previously infinite or based on token expiry).

In addition, it adds an option use the expiry time from the Token sent by the OpenID provider. This will typically cause really short expiry and you should only turn on this option if you know what you are desiring.

This fixes #1176.
