### PR TITLE
Return 404 on unmatched routes

### DIFF
--- a/app.go
+++ b/app.go
@@ -521,7 +521,7 @@ func (h *Headscale) createRouter(grpcMux *runtime.ServeMux) *mux.Router {
 	apiRouter.Use(h.httpAuthenticationMiddleware)
 	apiRouter.PathPrefix("/v1/").HandlerFunc(grpcMux.ServeHTTP)
 
-	router.PathPrefix("/").HandlerFunc(stdoutHandler)
+	router.PathPrefix("/").HandlerFunc(notFoundHandler)
 
 	return router
 }
@@ -957,7 +957,7 @@ func (h *Headscale) getLastStateChange(users ...User) time.Time {
 	}
 }
 
-func stdoutHandler(
+func notFoundHandler(
 	writer http.ResponseWriter,
 	req *http.Request,
 ) {
@@ -969,6 +969,7 @@ func stdoutHandler(
 		Interface("url", req.URL).
 		Bytes("body", body).
 		Msg("Request did not match")
+	writer.WriteHeader(http.StatusNotFound)
 }
 
 func readOrCreatePrivateKey(path string) (*key.MachinePrivate, error) {


### PR DESCRIPTION
This commit makes headscale return
HTTP status code 404 (not found) for any
requests it doesn't know how to handle.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
