### PR TITLE
Add css to the /windows and /apple templates

### DIFF
--- a/templates/apple.html
+++ b/templates/apple.html
@@ -4,11 +4,25 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>Apple - headscale</title>
+    <style>
+      body {
+        margin: 40px auto;
+        max-width: 800px;
+        line-height: 1.5;
+        font-size: 16px;
+        color: #444;
+        padding: 0 10px;
+        font-family: Sans-serif
+      }
+      h1,h2,h3 {
+        line-height: 1.2;
+      }
+    </style>
   </head>
 
   <body>
-    <h1>headscale</h1>
+    <h1>headscale Apple configuration </h1>
     <h2>Recent Tailscale versions (1.34.0 and higher)</h2>
     <p>
       Tailscale added Fast User Switching in version 1.34 and you can now use

--- a/templates/apple.html
+++ b/templates/apple.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Apple - headscale</title>
+    <title>headscale - Apple</title>
     <style>
       body {
         margin: 40px auto;
@@ -22,7 +22,7 @@
   </head>
 
   <body>
-    <h1>headscale Apple configuration </h1>
+    <h1>headscale: Apple configuration </h1>
     <h2>Recent Tailscale versions (1.34.0 and higher)</h2>
     <p>
       Tailscale added Fast User Switching in version 1.34 and you can now use

--- a/templates/apple.html
+++ b/templates/apple.html
@@ -13,16 +13,18 @@
         font-size: 16px;
         color: #444;
         padding: 0 10px;
-        font-family: Sans-serif
+        font-family: Sans-serif;
       }
-      h1,h2,h3 {
+      h1,
+      h2,
+      h3 {
         line-height: 1.2;
       }
     </style>
   </head>
 
   <body>
-    <h1>headscale: Apple configuration </h1>
+    <h1>headscale: Apple configuration</h1>
     <h2>Recent Tailscale versions (1.34.0 and higher)</h2>
     <p>
       Tailscale added Fast User Switching in version 1.34 and you can now use

--- a/templates/windows.html
+++ b/templates/windows.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Windows - headscale</title>
+    <title>headscale - Windows</title>
     <style>
       body {
         margin: 40px auto;
@@ -22,7 +22,7 @@
   </head>
 
   <body>
-    <h1>headscale Windows configuration</h1>
+    <h1>headscale: Windows configuration</h1>
     <h2>Recent Tailscale versions (1.34.0 and higher)</h2>
     <p>
       Tailscale added Fast User Switching in version 1.34 and you can now use

--- a/templates/windows.html
+++ b/templates/windows.html
@@ -13,9 +13,11 @@
         font-size: 16px;
         color: #444;
         padding: 0 10px;
-        font-family: Sans-serif
+        font-family: Sans-serif;
       }
-      h1,h2,h3 {
+      h1,
+      h2,
+      h3 {
         line-height: 1.2;
       }
     </style>

--- a/templates/windows.html
+++ b/templates/windows.html
@@ -4,11 +4,25 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>Windows - headscale</title>
+    <style>
+      body {
+        margin: 40px auto;
+        max-width: 800px;
+        line-height: 1.5;
+        font-size: 16px;
+        color: #444;
+        padding: 0 10px;
+        font-family: Sans-serif
+      }
+      h1,h2,h3 {
+        line-height: 1.2;
+      }
+    </style>
   </head>
 
   <body>
-    <h1>headscale</h1>
+    <h1>headscale Windows configuration</h1>
     <h2>Recent Tailscale versions (1.34.0 and higher)</h2>
     <p>
       Tailscale added Fast User Switching in version 1.34 and you can now use


### PR DESCRIPTION
I added a bit of css to make the configuration guides look better, as they were very rough.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
