### PR TITLE
Add "configtest" CLI command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- Adding "configtest" CLI command.
+
 ## 0.20.0 (2023-x-x)
 
 ### Changes

--- a/cmd/headscale/cli/configtest.go
+++ b/cmd/headscale/cli/configtest.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/rs/zerolog/log"
+)
+
+func init() {
+	rootCmd.AddCommand(configTestCmd)
+}
+
+var configTestCmd = &cobra.Command{
+	Use:   "configtest",
+	Short: "Test the configuration.",
+	Long:  "Run a test of the configuration and exit.",
+	Run: func(cmd *cobra.Command, args []string) {
+		_, err := getHeadscaleApp()
+		if err != nil {
+			log.Fatal().Caller().Err(err).Msg("Error initializing")
+		}
+	},
+}


### PR DESCRIPTION
This adds a "configtest" command-line argument that sets up an instance of Headscale and exits, causing the configuration file and ACLs to be processed.

This solves a problem I've been having where the only way I know to test the ACLs syntax is to restart headscale, and if it fails to start I need to login via another system and correct the problem, then restart headscale.

This is the first time I've touched go, so if you ask too much of me in review I'm likely to be out of my element quickly.  :-)

Fixes #1229 

<!-- Please tick if the following things apply. You… -->

- [X] read the [CONTRIBUTING guidelines](README.md#contributing)
- [X] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [X] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
