### PR TITLE
adding some sleep on re-registration after machine expired

### DIFF
--- a/protocol_common.go
+++ b/protocol_common.go
@@ -131,11 +131,10 @@ func (h *Headscale) handleRegisterCommon(
 					Bool("noise", isNoise).
 					Msg("Machine is waiting for interactive login")
 
-				ticker := time.NewTicker(registrationHoldoff)
 				select {
 				case <-req.Context().Done():
 					return
-				case <-ticker.C:
+				case <-time.After(registrationHoldoff):
 					h.handleNewMachineCommon(writer, registerRequest, machineKey, isNoise)
 
 					return
@@ -263,6 +262,14 @@ func (h *Headscale) handleRegisterCommon(
 			)
 
 			return
+		}
+
+		if registerRequest.Followup != "" {
+			select {
+			case <-req.Context().Done():
+				return
+			case <-time.After(registrationHoldoff):
+			}
 		}
 
 		// The machine has expired or it is logged out


### PR DESCRIPTION
This PR does 2 things:
- replace time.NewTicker with time.After, because if you use time.Ticker and never stop it, it will leak some resource
- adding the same hacky logic on re-registration of expired machine, without it, the headsacle will got hammered by tailscale client