### PR TITLE
document running exit nodes

### DIFF
--- a/docs/exit-node.md
+++ b/docs/exit-node.md
@@ -1,0 +1,47 @@
+# Exit Nodes
+
+## On the node
+
+Register the node and make it advertise itself as an exit node:
+
+```console
+$ sudo tailscale up --login-server https://my-server.com --advertise-exit-node
+```
+
+If the node is already registered, it can advertise exit capabilities like this:
+
+```console
+$ sudo tailscale set --advertise-exit-node
+```
+
+## On the control server
+
+```console
+$ # list nodes
+$ headscale routes list
+ID | Machine | Prefix    | Advertised | Enabled | Primary
+1  |         | 0.0.0.0/0 | false      | false   | -
+2  |         | ::/0      | false      | false   | -
+3  | phobos  | 0.0.0.0/0 | true       | false   | -
+4  | phobos  | ::/0      | true       | false   | -
+$ # enable routes for phobos
+$ headscale routes enable -r 3
+$ headscale routes enable -r 4
+$ # Check node list again. The routes are now enabled.
+$ headscale routes list
+ID | Machine | Prefix    | Advertised | Enabled | Primary
+1  |         | 0.0.0.0/0 | false      | false   | -
+2  |         | ::/0      | false      | false   | -
+3  | phobos  | 0.0.0.0/0 | true       | true    | -
+4  | phobos  | ::/0      | true       | true    | -
+```
+
+## On the client
+
+The exit node can now be used with:
+
+```console
+$ sudo tailscale set --exit-node phobos
+```
+
+Check the official [Tailscale documentation](https://tailscale.com/kb/1103/exit-nodes/?q=exit#step-3-use-the-exit-node) for how to do it on your device.


### PR DESCRIPTION
Currently the only kind-of documentation is #210 which is outdated. To remedy this, add a document describing the process.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
