### PR TITLE
Added 1.38.4 in the new tests

### DIFF
--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -33,7 +33,8 @@ var (
 	tailscaleVersions2021 = []string{
 		"head",
 		"unstable",
-		"1.36.0",
+		"1.38.4",
+		"1.36.2",
 		"1.34.2",
 		"1.32.3",
 		"1.30.2",


### PR DESCRIPTION
In the last PR I only added the new version in the legacy tests. This PR corrects it.
