### PR TITLE
Add unix_socket directive to the "likely wanted changes" area

### DIFF
--- a/docs/running-headscale-container.md
+++ b/docs/running-headscale-container.md
@@ -61,9 +61,11 @@ private_key_path: /etc/headscale/private.key
 # The default /var/lib/headscale path is not writable in the container
 noise:
   private_key_path: /etc/headscale/noise_private.key
-# The default /var/lib/headscale path is not writable  in the container
+# The default /var/lib/headscale path is not writable in the container
 db_type: sqlite3
 db_path: /etc/headscale/db.sqlite
+# The default /var/lib/headscale path is not writable in the container
+unix_socket: /etc/headscale/headscale.sock
 ```
 
 4. Start the headscale server while working in the host headscale directory:


### PR DESCRIPTION
The default config places the control socket in /var/lib/headscale/headscale.sock, causing an error. As noted for the other files this area is not writable in the docker image. I also fixed a double space while I was at it.

I'm not sure if protocol is to also create an issue and link it to this, but please let me know and I'll do that if it's needed.

<!-- Please tick if the following things apply. You… -->

- [ ] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
