### PR TITLE
Make sure all clients of a user are ready

### DIFF
--- a/integration/auth_oidc_test.go
+++ b/integration/auth_oidc_test.go
@@ -362,6 +362,15 @@ func (s *AuthOIDCScenario) runTailscaleUp(
 
 		user.joinWaitGroup.Wait()
 
+		for _, client := range user.Clients {
+			err := client.WaitForReady()
+			if err != nil {
+				log.Printf("client %s was not ready: %s", client.Hostname(), err)
+
+				return fmt.Errorf("failed to up tailscale node: %w", err)
+			}
+		}
+
 		return nil
 	}
 

--- a/integration/auth_web_flow_test.go
+++ b/integration/auth_web_flow_test.go
@@ -274,6 +274,15 @@ func (s *AuthWebFlowScenario) runTailscaleUp(
 		}
 		user.joinWaitGroup.Wait()
 
+		for _, client := range user.Clients {
+			err := client.WaitForReady()
+			if err != nil {
+				log.Printf("client %s was not ready: %s", client.Hostname(), err)
+
+				return fmt.Errorf("failed to up tailscale node: %w", err)
+			}
+		}
+
 		return nil
 	}
 

--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -356,6 +356,15 @@ func (s *Scenario) RunTailscaleUp(
 
 		user.joinWaitGroup.Wait()
 
+		for _, client := range user.Clients {
+			err := client.WaitForReady()
+			if err != nil {
+				log.Printf("client %s was not ready: %s", client.Hostname(), err)
+
+				return fmt.Errorf("failed to up tailscale node: %w", err)
+			}
+		}
+
 		return nil
 	}
 

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -430,6 +430,15 @@ func (t *TailscaleInContainer) WaitForReady() error {
 			return nil
 		}
 
+		// ipnstate.Status.CurrentTailnet was added in Tailscale 1.22.0
+		// https://github.com/tailscale/tailscale/pull/3865
+		//
+		// Before that, we can check the BackendState to see if the
+		// tailscaled daemon is connected to the control system.
+		if status.BackendState == "Running" {
+			return nil
+		}
+
 		return errTailscaleNotConnected
 	})
 }


### PR DESCRIPTION
This PR adds an extra check before leaving the Up() helpers, to better detect when a TS version is broken.