### PR TITLE
Packaging and doc fixups

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,7 +65,7 @@ nfpms:
     bindir: /usr/bin
     formats:
       - deb
-      - rpm
+      # - rpm
     contents:
       - src: ./config-example.yaml
         dst: /etc/headscale/config.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Changes
 
-- Add `.deb` and `.rpm` packages to release process [#1297](https://github.com/juanfont/headscale/pull/1297)
+- Add `.deb` packages to release process [#1297](https://github.com/juanfont/headscale/pull/1297)
+- Update and simplify the documentation to use new `.deb` packages [#1349](https://github.com/juanfont/headscale/pull/1349)
 - Add 32-bit Arm platforms to release process [#1297](https://github.com/juanfont/headscale/pull/1297)
 - Fix longstanding bug that would prevent "\*" from working properly in ACLs (issue [#699](https://github.com/juanfont/headscale/issues/699)) [#1279](https://github.com/juanfont/headscale/pull/1279)
 - Target Go 1.20 and Tailscale 1.38 for Headscale [#1323](https://github.com/juanfont/headscale/pull/1323)

--- a/docs/packaging/postinstall.sh
+++ b/docs/packaging/postinstall.sh
@@ -64,6 +64,7 @@ summary() {
 	echo ""
 	echo " Please follow the next steps to start the software:"
 	echo ""
+	echo "    sudo systemctl enable headscale"
 	echo "    sudo systemctl start headscale"
 	echo ""
 	echo " Configuration settings can be adjusted here:"

--- a/docs/running-headscale-linux-manual.md
+++ b/docs/running-headscale-linux-manual.md
@@ -1,5 +1,9 @@
 # Running headscale on Linux
 
+## Note: Outdated and "advanced"
+This documentation is considered the "legacy"/advanced/manual version of the documentation, you most likely do not
+want to use this documentation and rather look at the distro specific documentation (TODO LINK)[].
+
 ## Goal
 
 This documentation has the goal of showing a user how-to set up and run `headscale` on Linux.
@@ -94,7 +98,7 @@ tailscale up --login-server YOUR_HEADSCALE_URL
 Register the machine:
 
 ```shell
-headscale --user myfirstuser nodes register --key <YOU_+MACHINE_KEY>
+headscale --user myfirstuser nodes register --key <YOUR_MACHINE_KEY>
 ```
 
 ### Register machine using a pre authenticated key
@@ -112,6 +116,8 @@ tailscale up --login-server <YOUR_HEADSCALE_URL> --authkey <YOUR_AUTH_KEY>
 ```
 
 ## Running `headscale` in the background with SystemD
+
+:warning: **Deprecated**: This part is very outdated and you should use the [pre-packaged Headscale for this](./running-headscale-linux.md
 
 This section demonstrates how to run `headscale` as a service in the background with [SystemD](https://www.freedesktop.org/wiki/Software/systemd/).
 This should work on most modern Linux distributions.

--- a/docs/running-headscale-linux-manual.md
+++ b/docs/running-headscale-linux-manual.md
@@ -1,6 +1,7 @@
 # Running headscale on Linux
 
 ## Note: Outdated and "advanced"
+
 This documentation is considered the "legacy"/advanced/manual version of the documentation, you most likely do not
 want to use this documentation and rather look at the distro specific documentation (TODO LINK)[].
 

--- a/docs/running-headscale-linux.md
+++ b/docs/running-headscale-linux.md
@@ -11,12 +11,12 @@ Get Headscale up and running.
 This includes running Headscale with SystemD.
 
 ## Migrating from manual install
+
 If you are migrating from the old manual install, the best thing would be to remove
 the files installed by following [the guide in reverse](./running-headscale-linux-manual.md).
 
 You should _not_ delete the database (`/var/headscale/db.sqlite`) and the
 configuration (`/etc/headscale/config.yaml`).
-
 
 ## Installation
 

--- a/docs/running-headscale-linux.md
+++ b/docs/running-headscale-linux.md
@@ -1,0 +1,95 @@
+# Running headscale on Linux
+
+## Requirements
+
+- Ubuntu 20.04 or newer, Debian 11 or newer.
+
+## Goal
+
+Get Headscale up and running.
+
+This includes running Headscale with SystemD.
+
+## Migrating from manual install
+If you are migrating from the old manual install, the best thing would be to remove
+the files installed by following [the guide in reverse](./running-headscale-linux-manual.md).
+
+You should _not_ delete the database (`/var/headscale/db.sqlite`) and the
+configuration (`/etc/headscale/config.yaml`).
+
+
+## Installation
+
+1. Download the lastest Headscale package for your platform (`.deb` for Ubuntu and Debian) from [Headscale's releases page]():
+
+```shell
+wget --output-document=headscale.deb \
+  https://github.com/juanfont/headscale/releases/download/v<HEADSCALE VERSION>/headscale_<HEADSCALE VERSION>_linux_<ARCH>.deb
+```
+
+2. Install Headscale:
+
+```shell
+sudo dpkg --install headscale.deb
+```
+
+3. Enable Headscale service, this will start Headscale at boot:
+
+```shell
+sudo systemctl enable headscale
+```
+
+4. Configure Headscale by editing the configuration file:
+
+```shell
+nano /etc/headscale/config.yaml
+```
+
+5. Start Headscale:
+
+```shell
+sudo systemctl start headscale
+```
+
+6. Check that Headscale is running as intended:
+
+```shell
+systemctl status headscale
+```
+
+## Using Headscale
+
+### Create a user
+
+```shell
+headscale users create myfirstuser
+```
+
+### Register a machine (normal login)
+
+On a client machine, run the `tailscale` login command:
+
+```shell
+tailscale up --login-server <YOUR_HEADSCALE_URL>
+```
+
+Register the machine:
+
+```shell
+headscale --user myfirstuser nodes register --key <YOUR_MACHINE_KEY>
+```
+
+### Register machine using a pre authenticated key
+
+Generate a key using the command line:
+
+```shell
+headscale --user myfirstuser preauthkeys create --reusable --expiration 24h
+```
+
+This will return a pre-authenticated key that is used to
+connect a node to `headscale` during the `tailscale` command:
+
+```shell
+tailscale up --login-server <YOUR_HEADSCALE_URL> --authkey <YOUR_AUTH_KEY>
+```


### PR DESCRIPTION
This PR replaces the installation instructions for Headscale with new `.deb` based docs, which should make the whole systemd stuff easier on our users.

It also disables rpm for now as per discussion in #1297.