### PR TITLE
Send peer deltas in MapResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 - Replace node filter logic, ensuring nodes with access can see eachother [#1381](https://github.com/juanfont/headscale/pull/1381)
 - Disable (or delete) both exit routes at the same time [#1428](https://github.com/juanfont/headscale/pull/1428)
 - Ditch distroless for Docker image, create default socket dir in `/var/run/headscale` [#1450](https://github.com/juanfont/headscale/pull/1450)
+- Send peer deltas in MapResponse [#1390](https://github.com/juanfont/headscale/pull/1390)
+  - Reduces data usage for larget tailnets when peers are changed, removed, or added
+  - Fixes a bug where where 1 peer is deleted in a tailnet of 2 peers, and the remaining peer is not notified of the removed peer
 
 ## 0.22.1 (2023-04-20)
 

--- a/hscontrol/api_common.go
+++ b/hscontrol/api_common.go
@@ -7,9 +7,15 @@ import (
 	"tailscale.com/tailcfg"
 )
 
+// generateMapResponse generate a map response message for this machine.
+//
+// streamState is persistent state maintained across a stream of mapResponse messages.
+// For first message in stream, send the address of a zero-initialized struct,
+// then send the same address in subsequent messages to enable sending of delta-only messages.
 func (h *Headscale) generateMapResponse(
 	mapRequest tailcfg.MapRequest,
 	machine *Machine,
+	streamState *mapResponseStreamState,
 ) (*tailcfg.MapResponse, error) {
 	log.Trace().
 		Str("func", "generateMapResponse").
@@ -39,17 +45,6 @@ func (h *Headscale) generateMapResponse(
 
 	profiles := h.getMapResponseUserProfiles(*machine, peers)
 
-	nodePeers, err := h.toNodes(peers, h.cfg.BaseDomain, h.cfg.DNSConfig)
-	if err != nil {
-		log.Error().
-			Caller().
-			Str("func", "generateMapResponse").
-			Err(err).
-			Msg("Failed to convert peers to Tailscale nodes")
-
-		return nil, err
-	}
-
 	dnsConfig := getMapResponseDNSConfig(
 		h.cfg.DNSConfig,
 		h.cfg.BaseDomain,
@@ -65,17 +60,6 @@ func (h *Headscale) generateMapResponse(
 
 		// TODO: Only send if updated
 		DERPMap: h.DERPMap,
-
-		// TODO: Only send if updated
-		Peers: nodePeers,
-
-		// TODO(kradalby): Implement:
-		// https://github.com/tailscale/tailscale/blob/main/tailcfg/tailcfg.go#L1351-L1374
-		// PeersChanged
-		// PeersRemoved
-		// PeersChangedPatch
-		// PeerSeenChange
-		// OnlineChange
 
 		// TODO: Only send if updated
 		DNSConfig: dnsConfig,
@@ -103,6 +87,20 @@ func (h *Headscale) generateMapResponse(
 		},
 	}
 
+	toNodes := func(machines Machines) ([]*tailcfg.Node, error) {
+		return h.toNodes(machines, h.cfg.BaseDomain, h.cfg.DNSConfig)
+	}
+	resp, err = applyMapResponseDelta(resp, streamState, peers, toNodes)
+	if err != nil {
+		log.Error().
+			Caller().
+			Str("func", "generateMapResponse").
+			Err(err).
+			Msg("Cannot apply map response deltas")
+
+		return nil, err
+	}
+
 	log.Trace().
 		Str("func", "generateMapResponse").
 		Str("machine", mapRequest.Hostinfo.Hostname).
@@ -110,4 +108,74 @@ func (h *Headscale) generateMapResponse(
 		Msgf("Generated map response: %s", tailMapResponseToString(resp))
 
 	return &resp, nil
+}
+
+// mapResponseStreamState tracks state associated with a stream of MapResponse messages,
+// which may optionally send only deltas from the previous message.
+type mapResponseStreamState struct {
+	// peersByID is the peers sent in the last stream message,
+	// for comparison in generating deltas in the new message.
+	peersByID map[uint64]Machine
+}
+
+// applyMapResponseDelta returns a modified MapResponse
+// with fields modified which make use of delta (send on changes).
+//
+// mapResponse the current mapResponse with delta fields not set.
+//
+// streamState is persistent state maintained across a stream of mapResponse messages.
+// For first message in stream, send the address of a zero-initialized struct,
+// then send the same address in subsequent messages to enable sending of delta-only messages.
+//
+// currentPeers list of peers currently available for the node that this mapResponse is for.
+//
+// toNodes a function to convert the Headscale Machines structure to Tailscale Nodes structure.
+func applyMapResponseDelta(
+	mapResponse tailcfg.MapResponse,
+	streamState *mapResponseStreamState,
+	currentPeers Machines,
+	toNodes func(Machines) ([]*tailcfg.Node, error)) (tailcfg.MapResponse, error,
+) {
+	// Peer deltas
+	currentPeersByID := machinesByID(currentPeers)
+	if streamState.peersByID == nil {
+		// First message, send full peers list
+		nodePeers, err := toNodes(currentPeers)
+		if err != nil {
+			return tailcfg.MapResponse{}, err
+		}
+		mapResponse.Peers = nodePeers
+	} else {
+		// Update PeersChanged with any peers which were removed or changed
+		var peersChanged []Machine
+		for id, peer := range currentPeersByID {
+			previousPeer, hadPrevious := streamState.peersByID[id]
+			if !hadPrevious || previousPeer.LastSuccessfulUpdate.Before(*peer.LastSuccessfulUpdate) {
+				peersChanged = append(peersChanged, peer)
+			}
+		}
+		nodesChanged, err := toNodes(peersChanged)
+		if err != nil {
+			return tailcfg.MapResponse{}, err
+		}
+		mapResponse.PeersChanged = nodesChanged
+
+		// Update PeersRemoved with any peers which are no longer present
+		for id := range streamState.peersByID {
+			if _, has := currentPeersByID[id]; !has {
+				mapResponse.PeersRemoved = append(mapResponse.PeersRemoved, tailcfg.NodeID(id))
+			}
+		}
+
+		// TODO(kallen): Also Implement the following deltas for even smaller
+		// message sizes:
+		//
+		// PeersChangedPatch
+		// PeerSeenChange
+		// OnlineChange
+	}
+	// Update previous peers list for next message in stream
+	streamState.peersByID = currentPeersByID
+
+	return mapResponse, nil
 }

--- a/hscontrol/api_common_test.go
+++ b/hscontrol/api_common_test.go
@@ -1,0 +1,146 @@
+package hscontrol
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"tailscale.com/tailcfg"
+)
+
+func Test_applyMapResponseDelta(t *testing.T) {
+	type TestParameters struct {
+		// Metadata
+		name string
+
+		// Setup
+		previousNodes Machines
+		currentNodes  Machines
+
+		// Assertions
+		wantPeers        []*tailcfg.Node
+		wantPeersChanges []*tailcfg.Node
+		wantPeersRemoved []tailcfg.NodeID
+	}
+
+	// Time series for indicating change in deltas
+	time0 := time.Now()
+	time1 := time0.Add(time.Millisecond)
+
+	tests := []TestParameters{
+		{
+			name:          "full update",
+			previousNodes: nil,
+			currentNodes: Machines{
+				{ID: 1},
+				{ID: 2},
+			},
+			// Full update sends full list in MapResponse.Peers
+			wantPeers: []*tailcfg.Node{
+				{ID: tailcfg.NodeID(1)},
+				{ID: tailcfg.NodeID(2)},
+			},
+			wantPeersChanges: nil,
+			wantPeersRemoved: nil,
+		},
+		{
+			name: "peer removed",
+			previousNodes: Machines{
+				{ID: 1, LastSuccessfulUpdate: &time0},
+				{ID: 2, LastSuccessfulUpdate: &time0},
+			},
+			currentNodes: Machines{
+				{ID: 2, LastSuccessfulUpdate: &time0},
+			},
+			wantPeers:        nil,
+			wantPeersChanges: nil,
+			wantPeersRemoved: []tailcfg.NodeID{
+				tailcfg.NodeID(1),
+			},
+		},
+		{
+			name: "peer added",
+			previousNodes: Machines{
+				{ID: 1, LastSuccessfulUpdate: &time0},
+			},
+			currentNodes: Machines{
+				{ID: 1, LastSuccessfulUpdate: &time0},
+				{ID: 2, LastSuccessfulUpdate: &time0},
+			},
+			wantPeers: nil,
+			wantPeersChanges: []*tailcfg.Node{
+				{ID: tailcfg.NodeID(2)},
+			},
+			wantPeersRemoved: nil,
+		},
+		{
+			name: "peer updated",
+			previousNodes: Machines{
+				{ID: 1, LastSuccessfulUpdate: &time0},
+				{ID: 2, LastSuccessfulUpdate: &time0},
+			},
+			currentNodes: Machines{
+				{ID: 1, LastSuccessfulUpdate: &time1},
+				{ID: 2, LastSuccessfulUpdate: &time0},
+			},
+			wantPeers: nil,
+			wantPeersChanges: []*tailcfg.Node{
+				{ID: tailcfg.NodeID(1)},
+			},
+			wantPeersRemoved: nil,
+		},
+		{
+			name: "no change",
+			previousNodes: Machines{
+				{ID: 1, LastSuccessfulUpdate: &time0},
+				{ID: 2, LastSuccessfulUpdate: &time0},
+			},
+			currentNodes: Machines{
+				{ID: 1, LastSuccessfulUpdate: &time0},
+				{ID: 2, LastSuccessfulUpdate: &time0},
+			},
+			wantPeers:        nil,
+			wantPeersChanges: nil,
+			wantPeersRemoved: nil,
+		},
+	}
+
+	// Dummy toNodes function which just converts the ID
+	toNodes := func(machines Machines) ([]*tailcfg.Node, error) {
+		var nodes []*tailcfg.Node
+		for _, machine := range machines {
+			nodes = append(nodes, &tailcfg.Node{
+				ID: tailcfg.NodeID(machine.ID),
+			})
+		}
+
+		return nodes, nil
+	}
+
+	for _, params := range tests {
+		t.Run(params.name, func(t *testing.T) {
+			streamState := &mapResponseStreamState{}
+			if params.previousNodes != nil {
+				streamState.peersByID = machinesByID(params.previousNodes)
+			}
+
+			mapResponse, err := applyMapResponseDelta(
+				tailcfg.MapResponse{},
+				streamState,
+				params.currentNodes,
+				toNodes,
+			)
+
+			// No error
+			assert.Nil(t, err)
+
+			// Peers
+			assert.Equal(t, mapResponse.Peers, params.wantPeers)
+			assert.Equal(t, mapResponse.PeersChanged, params.wantPeersChanges)
+			assert.Equal(t, mapResponse.PeersRemoved, params.wantPeersRemoved)
+
+			// streamState updated
+			assert.Equal(t, streamState.peersByID, machinesByID(params.currentNodes))
+		})
+	}
+}

--- a/hscontrol/machine.go
+++ b/hscontrol/machine.go
@@ -87,6 +87,16 @@ type (
 	MachinesP []*Machine
 )
 
+// machinesByID converts a slice of machines to a map from node id to machine.
+func machinesByID(machines Machines) map[uint64]Machine {
+	byID := make(map[uint64]Machine)
+	for _, machine := range machines {
+		byID[machine.ID] = machine
+	}
+
+	return byID
+}
+
 type MachineAddresses []netip.Addr
 
 func (ma MachineAddresses) ToStringSlice() []string {
@@ -494,6 +504,8 @@ func (h *Headscale) DeleteMachine(machine *Machine) error {
 		return err
 	}
 
+	h.setLastStateChangeToNow()
+
 	return nil
 }
 
@@ -515,6 +527,8 @@ func (h *Headscale) HardDeleteMachine(machine *Machine) error {
 	if err := h.db.Unscoped().Delete(&machine).Error; err != nil {
 		return err
 	}
+
+	h.setLastStateChangeToNow()
 
 	return nil
 }

--- a/hscontrol/protocol_common_poll.go
+++ b/hscontrol/protocol_common_poll.go
@@ -92,7 +92,8 @@ func (h *Headscale) handlePollCommon(
 		}
 	}
 
-	mapResp, err := h.getMapResponseData(mapRequest, machine, isNoise)
+	var mapResponseState mapResponseStreamState
+	mapResp, err := h.getMapResponseData(mapRequest, machine, isNoise, &mapResponseState)
 	if err != nil {
 		log.Error().
 			Str("handler", "PollNetMap").
@@ -225,6 +226,7 @@ func (h *Headscale) handlePollCommon(
 		ctx,
 		machine,
 		mapRequest,
+		&mapResponseState,
 		pollDataChan,
 		keepAliveChan,
 		updateChan,
@@ -245,6 +247,7 @@ func (h *Headscale) pollNetMapStream(
 	ctxReq context.Context,
 	machine *Machine,
 	mapRequest tailcfg.MapRequest,
+	streamState *mapResponseStreamState,
 	pollDataChan chan []byte,
 	keepAliveChan chan []byte,
 	updateChan chan struct{},
@@ -468,7 +471,7 @@ func (h *Headscale) pollNetMapStream(
 					Time("last_successful_update", lastUpdate).
 					Time("last_state_change", h.getLastStateChange(machine.User)).
 					Msgf("There has been updates since the last successful update to %s", machine.Hostname)
-				data, err := h.getMapResponseData(mapRequest, machine, isNoise)
+				data, err := h.getMapResponseData(mapRequest, machine, isNoise, streamState)
 				if err != nil {
 					log.Error().
 						Str("handler", "PollNetMapStream").

--- a/hscontrol/protocol_common_utils.go
+++ b/hscontrol/protocol_common_utils.go
@@ -12,12 +12,18 @@ import (
 	"tailscale.com/types/key"
 )
 
+// getMapResponseData genereates and encodes a MapResponse for the node.
+//
+// streamState is persistent state maintained across a stream of mapResponse messages.
+// For first message in stream, send the address of a zero-initialized struct,
+// then send the same address in subsequent messages to enable sending of delta-only messages.
 func (h *Headscale) getMapResponseData(
 	mapRequest tailcfg.MapRequest,
 	machine *Machine,
 	isNoise bool,
+	streamState *mapResponseStreamState,
 ) ([]byte, error) {
-	mapResponse, err := h.generateMapResponse(mapRequest, machine)
+	mapResponse, err := h.generateMapResponse(mapRequest, machine, streamState)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -466,7 +466,8 @@ func (t *TailscaleInContainer) WaitForLogout() error {
 			return fmt.Errorf("failed to fetch tailscale status: %w", err)
 		}
 
-		if status.CurrentTailnet == nil {
+		// Catch case where node is never logged in, or has a tailnet but was logged out /expired
+		if status.CurrentTailnet == nil || status.BackendState == "NeedsLogin" {
 			return nil
 		}
 


### PR DESCRIPTION
# Summary 
Implement the sending of peer list deltas in MapResponse, rather then sending the full list each time. Newer versions of tailscale support this, but it had not yet been implemented in Headscale and was left as a TODO. Sending peer list deltas reduces data usage of the control protocol, especially for larger tailnets. 

This also fixes a known bug described in #1383, where a peer would not be removed from the network if it is deleted and there are only 2 peers in the network. 

This is implemented in a way intended to later be expanded to other deltas being sent in MapResponse. It introduces a new struct `mapResponseStreamState` that is forwarded to sequential calls to generate a MapResponse. Over time, this struct can evolve to track more state to move more of the MapResponse to supporting the deltas.

Closes #1383

# Testing
This was tested locally by creating a small tailnet with 2 peers, and deleting one to verify that the other peer is notified of the deleted peer.

CI unit and integration tests should give reasonable assurance of no other regressions with this change.
