### PR TITLE
PR: Add a config to verify clients on DERP

### DIFF
--- a/derp_server.go
+++ b/derp_server.go
@@ -33,6 +33,9 @@ type DERPServer struct {
 func (h *Headscale) NewDERPServer() (*DERPServer, error) {
 	log.Trace().Caller().Msg("Creating new embedded DERP server")
 	server := derp.NewServer(key.NodePrivate(*h.privateKey), log.Info().Msgf)
+	
+	server.SetVerifyClient(true)
+	
 	region, err := h.generateRegionLocalDERP()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md`

Solution to the #740 issue, my objective is to add an option in the config to enable or not the DERP client verification 

TO DO : 

- [ ] Check if native tailscale DERP client verify option works 
- [ ] Create the OPTION
- [ ] Bind the option to the actual DERP client verify function 
- [ ] Update the docs & changelog
- [ ] (if needed) create tests

