### PR TITLE
feat: remove user if machine is tagged

### DIFF
--- a/api_common.go
+++ b/api_common.go
@@ -15,7 +15,7 @@ func (h *Headscale) generateMapResponse(
 		Str("func", "generateMapResponse").
 		Str("machine", mapRequest.Hostinfo.Hostname).
 		Msg("Creating Map response")
-	node, err := h.toNode(*machine, h.cfg.BaseDomain, h.cfg.DNSConfig)
+	node, err := h.toNode(*machine, h.cfg.BaseDomain, h.cfg.RemoveUserFromTaggedDNS, h.cfg.DNSConfig)
 	if err != nil {
 		log.Error().
 			Caller().
@@ -39,7 +39,7 @@ func (h *Headscale) generateMapResponse(
 
 	profiles := h.getMapResponseUserProfiles(*machine, peers)
 
-	nodePeers, err := h.toNodes(peers, h.cfg.BaseDomain, h.cfg.DNSConfig)
+	nodePeers, err := h.toNodes(peers, h.cfg.BaseDomain, h.cfg.RemoveUserFromTaggedDNS, h.cfg.DNSConfig)
 	if err != nil {
 		log.Error().
 			Caller().

--- a/cmd/headscale/headscale_test.go
+++ b/cmd/headscale/headscale_test.go
@@ -140,12 +140,13 @@ func (*Suite) TestDNSConfigLoading(c *check.C) {
 	err = headscale.LoadConfig(tmpDir, false)
 	c.Assert(err, check.IsNil)
 
-	dnsConfig, baseDomain := headscale.GetDNSConfig()
+	dnsConfig, baseDomain, removeUserFromTaggedDNS := headscale.GetDNSConfig()
 
 	c.Assert(dnsConfig.Nameservers[0].String(), check.Equals, "1.1.1.1")
 	c.Assert(dnsConfig.Resolvers[0].Addr, check.Equals, "1.1.1.1")
 	c.Assert(dnsConfig.Proxied, check.Equals, true)
 	c.Assert(baseDomain, check.Equals, "example.com")
+	c.Assert(removeUserFromTaggedDNS, check.Equals, false)
 }
 
 func writeConfig(c *check.C, tmpDir string, configYaml []byte) {

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -254,10 +254,10 @@ dns_config:
   # `hostname.user.base_domain` (e.g., _myhost.myuser.example.com_).
   base_domain: example.com
 
-  # Defines if a tagged node should ditch the user in magic dns FQDN.
+  # Defines if a tagged node should ditch the user in MagicDNS FQDN.
   # Would result in `<machine.given_name>.<base_domain>` instead of 
   # `<machine.given_name>.<machine.user.name>.<base_domain>`
-  remove_user_from_tagged_DNS: false
+  remove_user_from_tagged_dns: false
 
 # Unix socket used for the CLI to connect without authentication
 # Note: for production you will want to set this to something like:

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -254,6 +254,11 @@ dns_config:
   # `hostname.user.base_domain` (e.g., _myhost.myuser.example.com_).
   base_domain: example.com
 
+  # Defines if a tagged node should ditch the user in magic dns FQDN.
+  # Would result in `<machine.given_name>.<base_domain>` instead of 
+  # `<machine.given_name>.<machine.user.name>.<base_domain>`
+  remove_user_from_tagged_DNS: false
+
 # Unix socket used for the CLI to connect without authentication
 # Note: for production you will want to set this to something like:
 unix_socket: /var/run/headscale/headscale.sock

--- a/config.go
+++ b/config.go
@@ -486,8 +486,8 @@ func GetDNSConfig() (*tailcfg.DNSConfig, string, bool) {
 		}
 
 		var removeUserFromTaggedDNS bool
-		if viper.IsSet("dns_config.remove_user_from_tagged_DNS") {
-			removeUserFromTaggedDNS = viper.GetBool("dns_config.remove_user_from_tagged_DNS")
+		if viper.IsSet("dns_config.remove_user_from_tagged_dns") {
+			removeUserFromTaggedDNS = viper.GetBool("dns_config.remove_user_from_tagged_dns")
 		} else {
 			removeUserFromTaggedDNS = false // does not really matter when MagicDNS is not enabled
 		}

--- a/routes_test.go
+++ b/routes_test.go
@@ -439,7 +439,7 @@ func (s *Suite) TestAllowedIPRoutes(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(len(enabledRoutes1), check.Equals, 3)
 
-	peer, err := app.toNode(machine1, "headscale.net", nil)
+	peer, err := app.toNode(machine1, "headscale.net", false, nil)
 	c.Assert(err, check.IsNil)
 
 	c.Assert(len(peer.AllowedIPs), check.Equals, 3)


### PR DESCRIPTION
This MR adds the user setting to ditch the user in MagicDNS FQDNs if at least one tag is defined for the project.
A new config option is added. If the option is omited, the MagicDNS FQDN will look the same as it used to (with user).

- [X] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
