### PR TITLE
Support hosting headscale with an HTTP path prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Fix systemd service file location in `.deb` packages [#1391](https://github.com/juanfont/headscale/pull/1391)
 - Improvements on Noise implementation [#1379](https://github.com/juanfont/headscale/pull/1379)
 - Replace node filter logic, ensuring nodes with access can see eachother [#1381](https://github.com/juanfont/headscale/pull/1381)
+- Support [hosting headscale behind a certain HTTP path](https://github.com/juanfont/headscale/issues/1126) [#1422](https://github.com/juanfont/headscale/pull/1422)
+  - For example, host at https://example.com/foo instead of https://example.com
+  - Some endpoints are always at the root of the server (`/`). See `config-example.yaml`
 
 ## 0.22.1 (2023-04-20)
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -10,6 +10,12 @@
 #
 # https://myheadscale.example.com:443
 #
+# You may optionaly specify a path prefix such as:
+# https://myheadscale.example.com:443/myheadscaleapp.
+# Note that in order to match the implementation in tailscale client,
+# the /myheadscaleapp prefix will NOT apply to the noise upgade path at /ts2021
+# the derp server at /derp.
+# The admin API at /api is also not affected by path prefix.
 server_url: http://127.0.0.1:8080
 
 # Address to listen to / bind to on the server

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -15,6 +15,42 @@ The reverse proxy MUST be configured to support WebSockets, as it is needed for 
 
 WebSockets support is required when using the headscale embedded DERP server. In this case, you will also need to expose the UDP port used for STUN (by default, udp/3478). Please check our [config-example.yaml](https://github.com/juanfont/headscale/blob/main/config-example.yaml).
 
+### Path prefix
+
+Headscale can be configured to host the tailscale API endpoints at specified HTTP path. This can be useful
+for reverse proxies where both headscale and another backend service sits behind the same reverse proxy.
+
+```yaml
+server_url: https://<YOUR_SERVER_NAME>/<PATH_PREFIX>
+```
+
+You would then use this path when connecting tailscale
+
+
+```sh
+tailscale login --login-server https://<YOUR_SERVER_NAME>/<PATH_PREFIX>
+```
+
+Note that in order to match the implementation in the tailscale client, the following paths will NOT
+use the PATH_PREFIX:
+* `/derp`
+* `/bootstrap-dns`
+* `/ts2021`
+* `/api` (the Headscale-specific admin API. You may wish to exclude this from your reverse proxy config for security)
+
+For example, to configure a reverse proxy for a Headscale app with configured `server_url: https://<YOUR_SERVER_NAME>/foo>`
+and WITHOUT forwarding the admin API, use the following regex for paths to forward to headscale:
+
+```
+\/(foo|derp|bootstrap-dns|ts2021).*
+```
+
+Or to also foward the admin API:
+
+```
+\/(foo|derp|bootstrap-dns|ts2021|api).*
+```
+
 ### TLS
 
 Headscale can be configured not to use TLS, leaving it to the reverse proxy to handle. Add the following configuration values to your headscale config file.


### PR DESCRIPTION
Add support for hosting headscale endpoints with a HTTP path prefix. This is a feature requested by several developers, mainly to support running headscale behind a reverse proxy where there are other backends which headscale should not conflict with.

Unfortunately, through testing the tailscale client implementation has some strange behavior when adding a path to `--login-server`. It respects this prefix for certain endpoints, but does not for `/derp`, `/ts2021`, and `/bootstrap-dns`. 

Additionally, the admin API at `/api/v1` breaks if you host it with a path prefix as the paths are hardcoded into the generated code from swagger. 

These considerations were applied to this implementation so that only the supports paths will use the path prefix, and documentation was updated to clarify this.

Closes #1126

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md
