### PR TITLE
Disable and Delete route must affect both exit routes (IPv4 and IPv6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Changes
 
 - Fix issue where systemd could not bind to port 80 [#1365](https://github.com/juanfont/headscale/pull/1365)
+- Disable (or delete) both exit routes at the same time [#1428](https://github.com/juanfont/headscale/pull/1428)
 
 ## 0.22.0 (2023-04-20)
 

--- a/routes_test.go
+++ b/routes_test.go
@@ -457,6 +457,37 @@ func (s *Suite) TestAllowedIPRoutes(c *check.C) {
 
 	c.Assert(foundExitNodeV4, check.Equals, true)
 	c.Assert(foundExitNodeV6, check.Equals, true)
+
+	// Now we disable only one of the exit routes
+	// and we see if both are disabled
+	var exitRouteV4 Route
+	for _, route := range routes {
+		if route.isExitRoute() && netip.Prefix(route.Prefix) == prefixExitNodeV4 {
+			exitRouteV4 = route
+
+			break
+		}
+	}
+
+	err = app.DisableRoute(uint64(exitRouteV4.ID))
+	c.Assert(err, check.IsNil)
+
+	enabledRoutes1, err = app.GetEnabledRoutes(&machine1)
+	c.Assert(err, check.IsNil)
+	c.Assert(len(enabledRoutes1), check.Equals, 1)
+
+	// and now we delete only one of the exit routes
+	// and we check if both are deleted
+	routes, err = app.GetMachineRoutes(&machine1)
+	c.Assert(err, check.IsNil)
+	c.Assert(len(routes), check.Equals, 4)
+
+	err = app.DeleteRoute(uint64(exitRouteV4.ID))
+	c.Assert(err, check.IsNil)
+
+	routes, err = app.GetMachineRoutes(&machine1)
+	c.Assert(err, check.IsNil)
+	c.Assert(len(routes), check.Equals, 2)
 }
 
 func (s *Suite) TestDeleteRoutes(c *check.C) {


### PR DESCRIPTION
We should disable (or delete) both exit routes of a node at the same time - the same way we already enable both.

As per https://github.com/juanfont/headscale/issues/804#issuecomment-1399314002

Fixes #1284
