### PR TITLE
Docker image improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@
 
 ### Changes
 
+## 0.22.2 (2023-05-10)
+
+### Changes
+
 - Add environment flags to enable pprof (profiling) [#1382](https://github.com/juanfont/headscale/pull/1382)
   - Profiles are continously generated in our integration tests.
 - Fix systemd service file location in `.deb` packages [#1391](https://github.com/juanfont/headscale/pull/1391)
 - Improvements on Noise implementation [#1379](https://github.com/juanfont/headscale/pull/1379)
 - Replace node filter logic, ensuring nodes with access can see eachother [#1381](https://github.com/juanfont/headscale/pull/1381)
 - Disable (or delete) both exit routes at the same time [#1428](https://github.com/juanfont/headscale/pull/1428)
+- Ditch distroless for Docker image, create default socket dir in `/var/run/headscale` [#1450](https://github.com/juanfont/headscale/pull/1450)
 
 ## 0.22.1 (2023-04-20)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN strip /go/bin/headscale
 RUN test -e /go/bin/headscale
 
 # Production image
-FROM gcr.io/distroless/base-debian11
+FROM docker.io/debian:bullseye-slim
 
 COPY --from=build /go/bin/headscale /bin/headscale
 ENV TZ UTC

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,7 @@ FROM docker.io/debian:bullseye-slim
 COPY --from=build /go/bin/headscale /bin/headscale
 ENV TZ UTC
 
+RUN mkdir -p /var/run/headscale
+
 EXPOSE 8080/tcp
 CMD ["headscale"]

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -18,6 +18,8 @@ FROM docker.io/golang:1.20.0-bullseye
 COPY --from=build /go/bin/headscale /bin/headscale
 ENV TZ UTC
 
+RUN mkdir -p /var/run/headscale
+
 # Need to reset the entrypoint or everything will run as a busybox script
 ENTRYPOINT []
 EXPOSE 8080/tcp

--- a/config.go
+++ b/config.go
@@ -175,7 +175,7 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("derp.server.enabled", false)
 	viper.SetDefault("derp.server.stun.enabled", true)
 
-	viper.SetDefault("unix_socket", "/var/run/headscale.sock")
+	viper.SetDefault("unix_socket", "/var/run/headscale/headscale.sock")
 	viper.SetDefault("unix_socket_permission", "0o770")
 
 	viper.SetDefault("grpc_listen_addr", ":50443")


### PR DESCRIPTION
This PR ditches distroless for Docker, and creates the /var/run/headscale path so user do not have issues when using the default config.