### PR TITLE
Add sync errorgroup handling in integration tests

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -11,7 +11,7 @@ Tests are located in files ending with `_test.go` and the framework are located 
 
 ## Running integration tests locally
 
-The easiest way to run tests locally is to use `[act](INSERT LINK)`, a local GitHub Actions runner:
+The easiest way to run tests locally is to use `[act](https://github.com/nektos/act)`, a local GitHub Actions runner:
 
 ```
 act pull_request -W .github/workflows/test-integration-v2-TestPingAllByIP.yaml

--- a/integration/general_test.go
+++ b/integration/general_test.go
@@ -108,7 +108,9 @@ func TestAuthKeyLogoutAndRelogin(t *testing.T) {
 		}
 	}
 
-	scenario.WaitForTailscaleLogout()
+	if err = scenario.WaitForTailscaleLogout(); err != nil {
+		t.Errorf("failed to logout tailscale nodes: %s", err)
+	}
 
 	t.Logf("all clients logged out")
 
@@ -261,7 +263,9 @@ func TestEphemeral(t *testing.T) {
 		}
 	}
 
-	scenario.WaitForTailscaleLogout()
+	if err = scenario.WaitForTailscaleLogout(); err != nil {
+		t.Errorf("failed to logout tailscale nodes: %s", err)
+	}
 
 	t.Logf("all clients logged out")
 


### PR DESCRIPTION
Address TODOs in integration tests to handle errors from sync WaitGroup for things like bringing up a bunch of tailscale nodes. I ran into some confusing segfaults when running integration tests locally that would be helped by implementing this fail-on-error rather than log-on-error.

Closes #1459

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md -> internal change, no changelog update
