### PR TITLE
Add ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN test -e /go/bin/headscale
 # Production image
 FROM docker.io/debian:bullseye-slim
 
+RUN apt-get update \
+    && apt-get install -y ca-certificates
+
 COPY --from=build /go/bin/headscale /bin/headscale
 ENV TZ UTC
 


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

Add ca-certificates package to fix headscale not being able to resolve OIDC providers correctly due to LetsEncrypt not being in the default certificate registry.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
If possible, would be nice to also push this to v0.22.2 so a new version isn't required to be able to use headscale correctly without building your own image.
Fixes #1462 