### PR TITLE
Fixing IPv6 Parsing in ACLs

### DIFF
--- a/hscontrol/policy/acls.go
+++ b/hscontrol/policy/acls.go
@@ -384,7 +384,13 @@ func (pol *ACLPolicy) getNetPortRangeFromDestination(
 		maybeIPv6Str := strings.TrimSuffix(dest, ":"+port)
 		log.Trace().Str("maybeIPv6Str", maybeIPv6Str).Msg("")
 
-		if maybeIPv6, err := netip.ParseAddr(maybeIPv6Str); err != nil && !maybeIPv6.Is6() {
+		filteredMaybeIPv6Str := maybeIPv6Str
+		if strings.Contains(maybeIPv6Str, "/") {
+			networkParts := strings.Split(maybeIPv6Str, "/")
+			filteredMaybeIPv6Str = networkParts[0]
+		}
+
+		if maybeIPv6, err := netip.ParseAddr(filteredMaybeIPv6Str); err != nil && !maybeIPv6.Is6() {
 			log.Trace().Err(err).Msg("trying to parse as IPv6")
 
 			return nil, fmt.Errorf(

--- a/integration/acl_test.go
+++ b/integration/acl_test.go
@@ -237,6 +237,24 @@ func TestACLHostsInNetMapTable(t *testing.T) {
 				"user2": 3, // ns1 + ns2 (return path)
 			},
 		},
+		"ipv6-acls-1470": {
+			users: map[string]int{
+				"user1": 2,
+				"user2": 2,
+			},
+			policy: policy.ACLPolicy{
+				ACLs: []policy.ACL{
+					{
+						Action:       "accept",
+						Sources:      []string{"*"},
+						Destinations: []string{"0.0.0.0/0:*", "::/0:*"},
+					},
+				},
+			}, want: map[string]int{
+				"user1": 3, // ns1 + ns2
+				"user2": 3, // ns2 + ns1
+			},
+		},
 	}
 
 	for name, testCase := range tests {


### PR DESCRIPTION
This pull request addresses a bug found in the ACLs' handling of IPv6 addresses. Previously, the ACLs would fail to correctly parse IPv6 addresses, especially those with network prefixes attached (CIDR notation).

The result of these changes is an improved ability to parse IPv6 addresses, including those with network prefixes attached. 

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [x] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md

