### PR TITLE
Fix hangs on SIGTERM.

### DIFF
--- a/hscontrol/app.go
+++ b/hscontrol/app.go
@@ -760,7 +760,6 @@ func (h *Headscale) Serve() error {
 				// Stop listening (and unlink the socket if unix type):
 				socketListener.Close()
 
-				<-h.cancelStateUpdateChan
 				close(h.stateUpdateChan)
 				close(h.cancelStateUpdateChan)
 
@@ -775,6 +774,7 @@ func (h *Headscale) Serve() error {
 
 				// And we're done:
 				cancel()
+				return
 			}
 		}
 	}


### PR DESCRIPTION
This fixes #1461, where two bugs prevent main from existing on SIGTERM.

The first is a blocking receiving from a cancel chanel which never have a, cancelStateUpdateChan. It seems closing the chanel should be all the is needed to signal the watching goroutines to exit.

The other is the signal hander never exiting an infinite for loop. The sigFunc is called in an errorGroup which blocks exiting Serve and thus main. It looks like a refactor in #1382 removed an os.Exit(0), replacing it with a return breaks out of the loop.

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [ ] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
