### PR TITLE
Bugfix: when db_type is set to postgres, tailscale client will be hang up for a long time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ integration_test/etc/config.dump.yaml
 /site
 
 __debug_bin
+.vscode
+.devcontainer

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PROTO_SOURCES = $(call rwildcard,,*.proto)
 
 
 build:
-	nix build
+	nix build --extra-experimental-features nix-command --extra-experimental-features flakes
 
 dev: lint test build
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -324,3 +324,7 @@ logtail:
 # default static port 41641. This option is intended as a workaround for some buggy
 # firewall devices. See https://tailscale.com/kb/1181/firewalls/ for more information.
 randomize_client_port: false
+
+# Client default expiration time is 365 days.
+# And Headscale will automatically update the client's expiration time.
+client_expiry_time: 365

--- a/hscontrol/config.go
+++ b/hscontrol/config.go
@@ -30,8 +30,6 @@ const (
 	TextLogFormat = "text"
 
 	defaultOIDCExpiryTime = 180 * 24 * time.Hour // 180 Days
-	// defaultClientExpiryTime               = 365 * 24 * time.Hour // 365 Days.
-	defaultClientExpiryTime               = 1 * time.Minute
 	maxDuration             time.Duration = 1<<63 - 1
 )
 
@@ -587,13 +585,10 @@ func GetHeadscaleConfig() (*Config, error) {
 		GRPCAddr:           viper.GetString("grpc_listen_addr"),
 		GRPCAllowInsecure:  viper.GetBool("grpc_allow_insecure"),
 		DisableUpdateCheck: viper.GetBool("disable_check_updates"),
-		DefaultExpiryTime: func() time.Duration {
-			switch viper.GetString("db_type") {
-			case "postgres":
-				return defaultClientExpiryTime
-			default:
-				return 0
-			}
+		DefaultExpiryTime:  func () time.Duration {
+			clientExpirtyTime := viper.GetDuration("client_expiry_time")
+			expiryTime :=  clientExpirtyTime * 24 * time.Hour
+			return expiryTime
 		}(),
 
 		IPPrefixes: prefixes,

--- a/hscontrol/db/machine.go
+++ b/hscontrol/db/machine.go
@@ -24,7 +24,6 @@ const (
 	MachineGivenNameHashLength = 8
 	MachineGivenNameTrimSize   = 2
 	MaxHostnameLength          = 255
-	DefaultKeyExpireTime       = 60 * time.Minute
 )
 
 var (
@@ -432,12 +431,7 @@ func (hsdb *HSDatabase) RegisterMachineFromAuthCallback(
 
 			registrationMachine.UserID = user.ID
 			registrationMachine.RegisterMethod = registrationMethod
-			expiryTime := time.Now().Add(DefaultKeyExpireTime)
-			if machineExpiry != nil {
-				registrationMachine.Expiry = machineExpiry
-			} else {
-				registrationMachine.Expiry = &expiryTime
-			}
+			registrationMachine.Expiry = machineExpiry
 
 			machine, err := hsdb.RegisterMachine(
 				registrationMachine,

--- a/hscontrol/db/machine.go
+++ b/hscontrol/db/machine.go
@@ -24,6 +24,7 @@ const (
 	MachineGivenNameHashLength = 8
 	MachineGivenNameTrimSize   = 2
 	MaxHostnameLength          = 255
+	DefaultKeyExpireTime       = 60 * time.Minute
 )
 
 var (
@@ -349,6 +350,7 @@ func (hsdb *HSDatabase) TouchMachine(machine *types.Machine) error {
 		ID:                   machine.ID,
 		LastSeen:             machine.LastSeen,
 		LastSuccessfulUpdate: machine.LastSuccessfulUpdate,
+		Expiry:               machine.Expiry,
 	}).Error
 }
 
@@ -430,9 +432,11 @@ func (hsdb *HSDatabase) RegisterMachineFromAuthCallback(
 
 			registrationMachine.UserID = user.ID
 			registrationMachine.RegisterMethod = registrationMethod
-
+			expiryTime := time.Now().Add(DefaultKeyExpireTime)
 			if machineExpiry != nil {
 				registrationMachine.Expiry = machineExpiry
+			} else {
+				registrationMachine.Expiry = &expiryTime
 			}
 
 			machine, err := hsdb.RegisterMachine(

--- a/hscontrol/grpcv1.go
+++ b/hscontrol/grpcv1.go
@@ -175,11 +175,13 @@ func (api headscaleV1APIServer) RegisterMachine(
 		Str("node_key", request.GetKey()).
 		Msg("Registering machine")
 
+	expiryTime := time.Now().Add(api.h.cfg.DefaultExpiryTime)
+	
 	machine, err := api.h.db.RegisterMachineFromAuthCallback(
 		api.h.registrationCache,
 		request.GetKey(),
 		request.GetUser(),
-		nil,
+		&expiryTime,
 		util.RegisterMethodCLI,
 	)
 	if err != nil {

--- a/hscontrol/protocol_common.go
+++ b/hscontrol/protocol_common.go
@@ -172,13 +172,14 @@ func (h *Headscale) handleRegisterCommon(
 		// that we rely on a method that calls back some how (OpenID or CLI)
 		// We create the machine and then keep it around until a callback
 		// happens
+		expiryTime := time.Now().Add(h.cfg.DefaultExpiryTime)
 		newMachine := types.Machine{
 			MachineKey: util.MachinePublicKeyStripPrefix(machineKey),
 			Hostname:   registerRequest.Hostinfo.Hostname,
 			GivenName:  givenName,
 			NodeKey:    util.NodePublicKeyStripPrefix(registerRequest.NodeKey),
 			LastSeen:   &now,
-			Expiry:     &time.Time{},
+			Expiry:     &expiryTime,
 		}
 
 		if !registerRequest.Expiry.IsZero() {
@@ -721,7 +722,8 @@ func (h *Headscale) handleMachineRefreshKeyCommon(
 		Bool("noise", isNoise).
 		Str("machine", machine.Hostname).
 		Msg("We have the OldNodeKey in the database. This is a key refresh")
-
+	expiryTime := time.Now().Add(h.cfg.DefaultExpiryTime)
+	machine.Expiry = &expiryTime
 	err := h.db.MachineSetNodeKey(&machine, registerRequest.NodeKey)
 	if err != nil {
 		log.Error().

--- a/hscontrol/protocol_common_poll.go
+++ b/hscontrol/protocol_common_poll.go
@@ -420,6 +420,8 @@ func (h *Headscale) pollNetMapStream(
 			}
 			now := time.Now().UTC()
 			machine.LastSeen = &now
+			expiryTime := now.Add(h.cfg.DefaultExpiryTime)
+			machine.Expiry = &expiryTime
 			err = h.db.TouchMachine(machine)
 			if err != nil {
 				log.Error().


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

Fixes #764 

When db_type is set to postgres, `tailscale login` and `tailscale up` can hang up for a long time. because expiry time is `0001-01-01 00:00:00`.

I'm not sure this change is make sense, but it‘s worked.

