### PR TITLE
Allow setting ForcedTags using the acls.hujson config file

### DIFF
--- a/hscontrol/acls_types.go
+++ b/hscontrol/acls_types.go
@@ -14,6 +14,7 @@ type ACLPolicy struct {
 	Groups        Groups        `json:"groups"        yaml:"groups"`
 	Hosts         Hosts         `json:"hosts"         yaml:"hosts"`
 	TagOwners     TagOwners     `json:"tagOwners"     yaml:"tagOwners"`
+	ForcedTags    ForcedTags    `json:"forcedTags"    yaml:"forcedTags"`
 	ACLs          []ACL         `json:"acls"          yaml:"acls"`
 	Tests         []ACLTest     `json:"tests"         yaml:"tests"`
 	AutoApprovers AutoApprovers `json:"autoApprovers" yaml:"autoApprovers"`
@@ -27,6 +28,9 @@ type ACL struct {
 	Sources      []string `json:"src"    yaml:"src"`
 	Destinations []string `json:"dst"    yaml:"dst"`
 }
+
+// ForcedTags specifies which tags are applied to which hosts by the server
+type ForcedTags map[string][]string
 
 // Groups references a series of alias in the ACL rules.
 type Groups map[string][]string


### PR DESCRIPTION
This pull request introduces a declarative way to set ForcedTags for machines.

If a "forcedTags" field is set in the acls.hujson file, the ForcedTags of machines will be overriden in the database based on the tags defined in the config file.

```json
{
    "hosts": {
        "a": "fd7a:115c:a1e0::1",
        "b": "fd7a:115c:a1e0::2"
    },
    "forcedTags": {
        "tag:some-tag": [
            "a",
            "tag:some-other-tag"
        ],
        "tag:some-other-tag": [
            "b"
        ]
    }
}
```

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
