### PR TITLE
fix invalid discord channel links to instead reference server invite and name of channel

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -46,7 +46,7 @@ We currently support deploying `headscale` using our binaries and the DEB packag
 
 In addition to that, there are semi-official RPM packages by the Fedora infra team https://copr.fedorainfracloud.org/coprs/jonathanspw/headscale/
 
-For convenience, we also build Docker images with `headscale`. But **please be aware that we don't officially support deploying `headscale` using Docker**. We have a [Discord channel](https://discord.com/channels/896711691637780480/1070619770942148618) where you can ask for Docker-specific help to the community.
+For convenience, we also build Docker images with `headscale`. But **please be aware that we don't officially support deploying `headscale` using Docker**. On our [Discord server](https://discord.gg/c84AZQhmpx) we have a docker-issues channel where you can ask for Docker-specific help to the community.
 
 ## Why is my reverse proxy not working with Headscale?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -50,4 +50,4 @@ For convenience, we also build Docker images with `headscale`. But **please be a
 
 ## Why is my reverse proxy not working with Headscale?
 
-We don't know. We don't use reverse proxies with `headscale` ourselves, so we don't have any experience with them. We have [community documentation](https://headscale.net/reverse-proxy/) on how to configure various reverse proxies, and a dedicated [Discord channel](https://discord.com/channels/896711691637780480/1070619818346164324) where you can ask for help to the community.
+We don't know. We don't use reverse proxies with `headscale` ourselves, so we don't have any experience with them. We have [community documentation](https://headscale.net/reverse-proxy/) on how to configure various reverse proxies, and a dedicated reverse proxy issues channel on our [Discord server](https://discord.gg/c84AZQhmpx) where you can ask for help to the community.

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -11,4 +11,4 @@
 | headscale-ui    | [Github](https://github.com/gurucomputing/headscale-ui) | A web frontend for the headscale Tailscale-compatible coordination server | Alpha  |
 | HeadscaleUi     | [GitHub](https://github.com/simcu/headscale-ui)         | A static headscale admin ui, no backend enviroment required               | Alpha  |
 
-You can ask for support on our dedicated [Discord channel](https://discord.com/channels/896711691637780480/1105842846386356294).
+You can ask for support on our [Discord server](https://discord.gg/c84AZQhmpx) in the web-ui channel.


### PR DESCRIPTION
This edits the docs on faq.md and web-ui.md to remove channel links which were invalid and also not helpful if you aren't invited to the server already.

Instead, they are replaced with the server invite link, and the channel's name.