### PR TITLE
Send logs to stderr, rather than stdout

### DIFF
--- a/cmd/headscale/headscale.go
+++ b/cmd/headscale/headscale.go
@@ -48,7 +48,7 @@ func main() {
 
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	log.Logger = log.Output(zerolog.ConsoleWriter{
-		Out:        os.Stdout,
+		Out:        os.Stderr,
 		TimeFormat: time.RFC3339,
 		NoColor:    !colors,
 	})


### PR DESCRIPTION
We were sending the logs to stdout, rather that what seems to be the industry practice of stderr.

https://github.com/rs/zerolog#pretty-logging (our log library seems to prefer stderr)
https://www.reddit.com/r/golang/comments/jqvaft/why_does_the_log_package_always_output_to_stderr/ (go standard log sends to stderr)

But you can find other opinions, of course https://12factor.net/logs

Fixes https://github.com/juanfont/headscale/issues/1519
