### PR TITLE
Enhancement: Enable Account Switching for Non-Ephemeral Devices on Logout

### DIFF
--- a/hscontrol/auth.go
+++ b/hscontrol/auth.go
@@ -551,16 +551,13 @@ func (h *Headscale) handleMachineLogOut(
 		return
 	}
 
-	if machine.IsEphemeral() {
-		err = h.db.HardDeleteMachine(&machine)
-		if err != nil {
-			log.Error().
-				Err(err).
-				Str("machine", machine.Hostname).
-				Msg("Cannot delete ephemeral machine from the database")
-		}
-
-		return
+	// Machine is not need after logout
+	err = h.db.HardDeleteMachine(&machine)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("machine", machine.Hostname).
+			Msg("Cannot delete ephemeral machine from the database")
 	}
 
 	log.Info().


### PR DESCRIPTION
Hello! I find myself saying this in almost every PR or ticket, but I'd like to take a moment to thank you once again for this fantastic product. I truly hope to see it thrive and evolve over time.

This PR addresses a user story and resolves a bug. Fixes: #1522 and #1310.

**User Story:**
As a user, I want the ability to switch between accounts that I'm logged into, either via OIDC or through an auth-key.

**Existing Issues:**
- When logging in via OIDC as User A, then logging out and trying to log in as User B, there's a web interface error stating `could not register machine`.
- If you log in using the auth-key for User A, log out, and then try to authenticate with the auth-key for User B, the authentication seems to work. However, you remain logged in as User A.

These scenarios are works for non-ephemeral devices. Ephemeral devices don't face this problem as they get removed upon logout. While these issues might be addressed in #1492, it got me thinking: Why not always remove devices on logout? What value do they have post-logout?

Hence, I'm suggesting this as either a temporary or permanent fix for the aforementioned issues.

