### PR TITLE
fix test fail keep user.Clients  from concurrent map writes

### DIFF
--- a/integration/embedded_derp_test.go
+++ b/integration/embedded_derp_test.go
@@ -197,7 +197,9 @@ func (s *EmbeddedDERPServerScenario) CreateTailscaleIsolatedNodesInUser(
 					)
 				}
 
+				s.headscaleLock.Lock()
 				user.Clients[tsClient.Hostname()] = tsClient
+				s.headscaleLock.Unlock()
 
 				return nil
 			})

--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -328,7 +328,9 @@ func (s *Scenario) CreateTailscaleNodesInUser(
 					)
 				}
 
+				s.headscaleLock.Lock()
 				user.Clients[tsClient.Hostname()] = tsClient
+				s.headscaleLock.Unlock()
 
 				return nil
 			})


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [X] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

```console
fatal error: concurrent map writes

goroutine 259 [running]:
github.com/juanfont/headscale/integration.(*EmbeddedDERPServerScenario).CreateTailscaleIsolatedNodesInUser.func1()
```
