### PR TITLE
Add github stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 180
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 180 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We have a lot of issues that has gone stale, and to help us prioritise which ones to pick up, we are adding this stale action to close out issues that are no longer active.

The bot is configured as this:
- If an issue sees no activity for 6 months (180 days) it is marked as stale
- If an issue is not confirmed still being an issue within 14 days, it is closed.

This is of course not a perfect solution, but it will hopefully help us prioritise active issues with people who can help us debug.

We might tighten the activity requirement in the future.
