### PR TITLE
Enhance pipeline stability and automatically retry unstable tests

### DIFF
--- a/.github/workflows/test-integration-v2-TestACLAllowStarDst.yaml
+++ b/.github/workflows/test-integration-v2-TestACLAllowStarDst.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestACLAllowStarDst
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLAllowStarDst.yaml
+++ b/.github/workflows/test-integration-v2-TestACLAllowStarDst.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestACLAllowStarDst
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLAllowUser80Dst.yaml
+++ b/.github/workflows/test-integration-v2-TestACLAllowUser80Dst.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestACLAllowUser80Dst
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLAllowUser80Dst.yaml
+++ b/.github/workflows/test-integration-v2-TestACLAllowUser80Dst.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestACLAllowUser80Dst
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLAllowUserDst.yaml
+++ b/.github/workflows/test-integration-v2-TestACLAllowUserDst.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestACLAllowUserDst
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLAllowUserDst.yaml
+++ b/.github/workflows/test-integration-v2-TestACLAllowUserDst.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestACLAllowUserDst
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLDenyAllPort80.yaml
+++ b/.github/workflows/test-integration-v2-TestACLDenyAllPort80.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestACLDenyAllPort80
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLDenyAllPort80.yaml
+++ b/.github/workflows/test-integration-v2-TestACLDenyAllPort80.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestACLDenyAllPort80
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLDevice1CanAccessDevice2.yaml
+++ b/.github/workflows/test-integration-v2-TestACLDevice1CanAccessDevice2.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestACLDevice1CanAccessDevice2
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLDevice1CanAccessDevice2.yaml
+++ b/.github/workflows/test-integration-v2-TestACLDevice1CanAccessDevice2.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestACLDevice1CanAccessDevice2
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLHostsInNetMapTable.yaml
+++ b/.github/workflows/test-integration-v2-TestACLHostsInNetMapTable.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestACLHostsInNetMapTable
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLHostsInNetMapTable.yaml
+++ b/.github/workflows/test-integration-v2-TestACLHostsInNetMapTable.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestACLHostsInNetMapTable
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLNamedHostsCanReach.yaml
+++ b/.github/workflows/test-integration-v2-TestACLNamedHostsCanReach.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestACLNamedHostsCanReach
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLNamedHostsCanReach.yaml
+++ b/.github/workflows/test-integration-v2-TestACLNamedHostsCanReach.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestACLNamedHostsCanReach
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLNamedHostsCanReachBySubnet.yaml
+++ b/.github/workflows/test-integration-v2-TestACLNamedHostsCanReachBySubnet.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestACLNamedHostsCanReachBySubnet
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestACLNamedHostsCanReachBySubnet.yaml
+++ b/.github/workflows/test-integration-v2-TestACLNamedHostsCanReachBySubnet.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestACLNamedHostsCanReachBySubnet
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestApiKeyCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestApiKeyCommand.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestApiKeyCommand
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestApiKeyCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestApiKeyCommand.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestApiKeyCommand
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestAuthKeyLogoutAndRelogin.yaml
+++ b/.github/workflows/test-integration-v2-TestAuthKeyLogoutAndRelogin.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestAuthKeyLogoutAndRelogin
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestAuthKeyLogoutAndRelogin.yaml
+++ b/.github/workflows/test-integration-v2-TestAuthKeyLogoutAndRelogin.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestAuthKeyLogoutAndRelogin
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestAuthWebFlowAuthenticationPingAll.yaml
+++ b/.github/workflows/test-integration-v2-TestAuthWebFlowAuthenticationPingAll.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestAuthWebFlowAuthenticationPingAll
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestAuthWebFlowAuthenticationPingAll.yaml
+++ b/.github/workflows/test-integration-v2-TestAuthWebFlowAuthenticationPingAll.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestAuthWebFlowAuthenticationPingAll
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestAuthWebFlowLogoutAndRelogin.yaml
+++ b/.github/workflows/test-integration-v2-TestAuthWebFlowLogoutAndRelogin.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestAuthWebFlowLogoutAndRelogin
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestAuthWebFlowLogoutAndRelogin.yaml
+++ b/.github/workflows/test-integration-v2-TestAuthWebFlowLogoutAndRelogin.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestAuthWebFlowLogoutAndRelogin
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestCreateTailscale.yaml
+++ b/.github/workflows/test-integration-v2-TestCreateTailscale.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestCreateTailscale
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestCreateTailscale.yaml
+++ b/.github/workflows/test-integration-v2-TestCreateTailscale.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestCreateTailscale
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestDERPServerScenario.yaml
+++ b/.github/workflows/test-integration-v2-TestDERPServerScenario.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestDERPServerScenario
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestDERPServerScenario.yaml
+++ b/.github/workflows/test-integration-v2-TestDERPServerScenario.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestDERPServerScenario
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestEnablingRoutes.yaml
+++ b/.github/workflows/test-integration-v2-TestEnablingRoutes.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestEnablingRoutes
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestEnablingRoutes.yaml
+++ b/.github/workflows/test-integration-v2-TestEnablingRoutes.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestEnablingRoutes
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestEphemeral.yaml
+++ b/.github/workflows/test-integration-v2-TestEphemeral.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestEphemeral
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestEphemeral.yaml
+++ b/.github/workflows/test-integration-v2-TestEphemeral.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestEphemeral
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestExpireNode.yaml
+++ b/.github/workflows/test-integration-v2-TestExpireNode.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestExpireNode
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestExpireNode.yaml
+++ b/.github/workflows/test-integration-v2-TestExpireNode.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestExpireNode
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestHeadscale.yaml
+++ b/.github/workflows/test-integration-v2-TestHeadscale.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestHeadscale
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestHeadscale.yaml
+++ b/.github/workflows/test-integration-v2-TestHeadscale.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestHeadscale
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestNodeCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestNodeCommand.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestNodeCommand
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestNodeCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestNodeCommand.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestNodeCommand
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestNodeExpireCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestNodeExpireCommand.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestNodeExpireCommand
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestNodeExpireCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestNodeExpireCommand.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestNodeExpireCommand
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestNodeMoveCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestNodeMoveCommand.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestNodeMoveCommand
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestNodeMoveCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestNodeMoveCommand.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestNodeMoveCommand
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestNodeRenameCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestNodeRenameCommand.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestNodeRenameCommand
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestNodeRenameCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestNodeRenameCommand.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestNodeRenameCommand
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestNodeTagCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestNodeTagCommand.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestNodeTagCommand
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestNodeTagCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestNodeTagCommand.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestNodeTagCommand
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestOIDCAuthenticationPingAll.yaml
+++ b/.github/workflows/test-integration-v2-TestOIDCAuthenticationPingAll.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestOIDCAuthenticationPingAll
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestOIDCAuthenticationPingAll.yaml
+++ b/.github/workflows/test-integration-v2-TestOIDCAuthenticationPingAll.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestOIDCAuthenticationPingAll
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestOIDCExpireNodesBasedOnTokenExpiry.yaml
+++ b/.github/workflows/test-integration-v2-TestOIDCExpireNodesBasedOnTokenExpiry.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestOIDCExpireNodesBasedOnTokenExpiry
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestOIDCExpireNodesBasedOnTokenExpiry.yaml
+++ b/.github/workflows/test-integration-v2-TestOIDCExpireNodesBasedOnTokenExpiry.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestOIDCExpireNodesBasedOnTokenExpiry
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestPingAllByHostname.yaml
+++ b/.github/workflows/test-integration-v2-TestPingAllByHostname.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestPingAllByHostname
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestPingAllByHostname.yaml
+++ b/.github/workflows/test-integration-v2-TestPingAllByHostname.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestPingAllByHostname
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestPingAllByIP.yaml
+++ b/.github/workflows/test-integration-v2-TestPingAllByIP.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestPingAllByIP
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestPingAllByIP.yaml
+++ b/.github/workflows/test-integration-v2-TestPingAllByIP.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestPingAllByIP
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestPreAuthKeyCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestPreAuthKeyCommand.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestPreAuthKeyCommand
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestPreAuthKeyCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestPreAuthKeyCommand.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestPreAuthKeyCommand
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestPreAuthKeyCommandReusableEphemeral.yaml
+++ b/.github/workflows/test-integration-v2-TestPreAuthKeyCommandReusableEphemeral.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestPreAuthKeyCommandReusableEphemeral
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestPreAuthKeyCommandReusableEphemeral.yaml
+++ b/.github/workflows/test-integration-v2-TestPreAuthKeyCommandReusableEphemeral.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestPreAuthKeyCommandReusableEphemeral
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestPreAuthKeyCommandWithoutExpiry.yaml
+++ b/.github/workflows/test-integration-v2-TestPreAuthKeyCommandWithoutExpiry.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestPreAuthKeyCommandWithoutExpiry
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestPreAuthKeyCommandWithoutExpiry.yaml
+++ b/.github/workflows/test-integration-v2-TestPreAuthKeyCommandWithoutExpiry.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestPreAuthKeyCommandWithoutExpiry
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestResolveMagicDNS.yaml
+++ b/.github/workflows/test-integration-v2-TestResolveMagicDNS.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestResolveMagicDNS
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestResolveMagicDNS.yaml
+++ b/.github/workflows/test-integration-v2-TestResolveMagicDNS.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestResolveMagicDNS
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestSSHIsBlockedInACL.yaml
+++ b/.github/workflows/test-integration-v2-TestSSHIsBlockedInACL.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestSSHIsBlockedInACL
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestSSHIsBlockedInACL.yaml
+++ b/.github/workflows/test-integration-v2-TestSSHIsBlockedInACL.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestSSHIsBlockedInACL
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestSSHMultipleUsersAllToAll.yaml
+++ b/.github/workflows/test-integration-v2-TestSSHMultipleUsersAllToAll.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestSSHMultipleUsersAllToAll
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestSSHMultipleUsersAllToAll.yaml
+++ b/.github/workflows/test-integration-v2-TestSSHMultipleUsersAllToAll.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestSSHMultipleUsersAllToAll
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestSSHNoSSHConfigured.yaml
+++ b/.github/workflows/test-integration-v2-TestSSHNoSSHConfigured.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestSSHNoSSHConfigured
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestSSHNoSSHConfigured.yaml
+++ b/.github/workflows/test-integration-v2-TestSSHNoSSHConfigured.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestSSHNoSSHConfigured
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestSSHOneUserToAll.yaml
+++ b/.github/workflows/test-integration-v2-TestSSHOneUserToAll.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestSSHOneUserToAll
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestSSHOneUserToAll.yaml
+++ b/.github/workflows/test-integration-v2-TestSSHOneUserToAll.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestSSHOneUserToAll
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestSSHUserOnlyIsolation.yaml
+++ b/.github/workflows/test-integration-v2-TestSSHUserOnlyIsolation.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestSSHUserOnlyIsolation
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestSSHUserOnlyIsolation.yaml
+++ b/.github/workflows/test-integration-v2-TestSSHUserOnlyIsolation.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestSSHUserOnlyIsolation
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestTaildrop.yaml
+++ b/.github/workflows/test-integration-v2-TestTaildrop.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestTaildrop
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestTaildrop.yaml
+++ b/.github/workflows/test-integration-v2-TestTaildrop.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestTaildrop
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestTailscaleNodesJoiningHeadcale.yaml
+++ b/.github/workflows/test-integration-v2-TestTailscaleNodesJoiningHeadcale.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestTailscaleNodesJoiningHeadcale
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestTailscaleNodesJoiningHeadcale.yaml
+++ b/.github/workflows/test-integration-v2-TestTailscaleNodesJoiningHeadcale.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestTailscaleNodesJoiningHeadcale
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestUserCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestUserCommand.yaml
@@ -37,11 +37,10 @@ jobs:
       - name: Run TestUserCommand
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/.github/workflows/test-integration-v2-TestUserCommand.yaml
+++ b/.github/workflows/test-integration-v2-TestUserCommand.yaml
@@ -35,9 +35,13 @@ jobs:
             config-example.yaml
 
       - name: Run TestUserCommand
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/cmd/gh-action-integration-generator/main.go
+++ b/cmd/gh-action-integration-generator/main.go
@@ -56,9 +56,13 @@ jobs:
             config-example.yaml
 
       - name: Run {{.Name}}
+        uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-            nix develop --command -- docker run \
+        with:
+          attempt_limit: 5
+          command: |
+              nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \

--- a/cmd/gh-action-integration-generator/main.go
+++ b/cmd/gh-action-integration-generator/main.go
@@ -58,11 +58,10 @@ jobs:
       - name: Run {{.Name}}
         uses: Wandalen/wretry.action@master
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: |
         with:
           attempt_limit: 5
           command: |
-              nix develop --command -- docker run \
+            nix develop --command -- docker run \
               --tty --rm \
               --volume ~/.cache/hs-integration-go:/go \
               --name headscale-test-suite \


### PR DESCRIPTION
Hello there,

This Pull Request aims to introduce changes designed to enhance the overall stability of the pipeline and implement an automatic retry mechanism for tests that are currently unstable.

There is example, pipeline with retry: https://github.com/vsychov/headscale/pull/2
There is pipeline without retry: https://github.com/juanfont/headscale/pull/1562

Both of them contains same headscale file changes.

Another way to do that, is use `--rerun-fails` and `--rerun-fails-max-failures` arguments of `gotestsum`.

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)

