### PR TITLE
Add DERP generate_204 endpoint for captive portal detection.

### DIFF
--- a/.github/workflows/test-integration-v2-TestDERPValidateEmbedded.yaml
+++ b/.github/workflows/test-integration-v2-TestDERPValidateEmbedded.yaml
@@ -1,0 +1,67 @@
+# DO NOT EDIT, generated with cmd/gh-action-integration-generator/main.go
+# To regenerate, run "go generate" in cmd/gh-action-integration-generator/
+
+name: Integration Test v2 - TestDERPValidateEmbedded
+
+on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  TestDERPValidateEmbedded:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: satackey/action-docker-layer-caching@main
+        continue-on-error: true
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v34
+        with:
+          files: |
+            *.nix
+            go.*
+            **/*.go
+            integration_test/
+            config-example.yaml
+
+      - name: Run TestDERPValidateEmbedded
+        uses: Wandalen/wretry.action@master
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          attempt_limit: 5
+          command: |
+            nix develop --command -- docker run \
+              --tty --rm \
+              --volume ~/.cache/hs-integration-go:/go \
+              --name headscale-test-suite \
+              --volume $PWD:$PWD -w $PWD/integration \
+              --volume /var/run/docker.sock:/var/run/docker.sock \
+              --volume $PWD/control_logs:/tmp/control \
+              golang:1 \
+                go run gotest.tools/gotestsum@latest -- ./... \
+                  -failfast \
+                  -timeout 120m \
+                  -parallel 1 \
+                  -run "^TestDERPValidateEmbedded$"
+
+      - uses: actions/upload-artifact@v3
+        if: always() && steps.changed-files.outputs.any_changed == 'true'
+        with:
+          name: logs
+          path: "control_logs/*.log"
+
+      - uses: actions/upload-artifact@v3
+        if: always() && steps.changed-files.outputs.any_changed == 'true'
+        with:
+          name: pprof
+          path: "control_logs/*.pprof.tar"

--- a/hscontrol/app.go
+++ b/hscontrol/app.go
@@ -469,6 +469,7 @@ func (h *Headscale) createRouter(grpcMux *grpcRuntime.ServeMux) *mux.Router {
 		router.HandleFunc("/derp", h.DERPServer.DERPHandler)
 		router.HandleFunc("/derp/probe", derpServer.DERPProbeHandler)
 		router.HandleFunc("/bootstrap-dns", derpServer.DERPBootstrapDNSHandler(h.DERPMap))
+		router.HandleFunc("/generate_204", derpServer.DERPNoContextHandler)
 	}
 
 	apiRouter := router.PathPrefix("/api").Subrouter()

--- a/integration/hsic/hsic.go
+++ b/integration/hsic/hsic.go
@@ -119,7 +119,7 @@ func WithPort(port int) Option {
 }
 
 // WithExtraPorts exposes additional ports on the container (e.g. 3478/udp for STUN).
-func WithExtraPorts(ports []string) Option {
+func WithExtraPorts(ports ...string) Option {
 	return func(hsic *HeadscaleInContainer) {
 		hsic.extraPorts = ports
 	}

--- a/integration/hsic/hsic.go
+++ b/integration/hsic/hsic.go
@@ -112,6 +112,8 @@ func WithConfigEnv(configEnv map[string]string) Option {
 // WithPort sets the port on where to run Headscale.
 func WithPort(port int) Option {
 	return func(hsic *HeadscaleInContainer) {
+		hsic.env["HEADSCALE_LISTEN_ADDR"] = fmt.Sprintf("0.0.0.0:%d", port)
+		hsic.env["HEADSCALE_SERVER_URL"] = fmt.Sprintf("http://headscale:%d", port)
 		hsic.port = port
 	}
 }


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [X] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

When connecting to a DERP server the client makes a request to `/generate_204` endpoint with the header `X-Tailscale-Challenge`. In order to pass the captive portal test, the server must provider a 204 NoContent response with `X-Tailscale-Response` set.

The source for this simple endpoint was taken directly from [Derper source at the time of commit](https://github.com/tailscale/tailscale/blob/955e2fcbfb4fe7ff9b8dbd665ba24ef2008c676e/cmd/derper/derper.go#L324)