### PR TITLE
Allow setting ForcedTags using the acls.hujson config file

### DIFF
--- a/hscontrol/policy/acls.go
+++ b/hscontrol/policy/acls.go
@@ -767,6 +767,15 @@ func (pol *ACLPolicy) expandIPsFromTag(
 		}
 	}
 
+	for _, alias := range pol.ForcedTags[alias] {
+		ips, err := pol.ExpandAlias(nodes, alias)
+		if err != nil {
+			return nil, err
+		}
+
+		build.AddSet(ips)
+	}
+
 	// find tag owners
 	owners, err := expandOwnersFromTag(pol, alias)
 	if err != nil {

--- a/hscontrol/policy/acls_test.go
+++ b/hscontrol/policy/acls_test.go
@@ -1383,6 +1383,40 @@ func Test_expandAlias(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Declarative forced tag defined",
+			field: field{
+				pol: ACLPolicy{
+					Hosts: Hosts{
+						"user1": netip.MustParsePrefix("100.64.0.1/32"),
+						"user2": netip.MustParsePrefix("100.64.0.2/32"),
+					},
+					ForcedTags: ForcedTags{
+						"tag:a": []string{"tag:b", "user1"},
+						"tag:b": []string{"user2"},
+					},
+				},
+			},
+			args: args{
+				alias: "tag:a",
+				nodes: types.Nodes{
+					&types.Node{
+						IPAddresses: types.NodeAddresses{
+							netip.MustParseAddr("100.64.0.1"),
+							netip.MustParseAddr("fd1d:ddfe:ae2::1"),
+						},
+					},
+					&types.Node{
+						IPAddresses: types.NodeAddresses{
+							netip.MustParseAddr("100.64.0.2"),
+							netip.MustParseAddr("fd1d:ddfe:ae2::2"),
+						},
+					},
+				},
+			},
+			want:    set([]string{"100.64.0.1", "100.64.0.2", "fd1d:ddfe:ae2::1", "fd1d:ddfe:ae2::2"}, []string{}),
+			wantErr: false,
+		},
+		{
 			name: "Forced tag with legitimate tagOwner",
 			field: field{
 				pol: ACLPolicy{

--- a/hscontrol/policy/acls_types.go
+++ b/hscontrol/policy/acls_types.go
@@ -14,6 +14,7 @@ type ACLPolicy struct {
 	Groups        Groups        `json:"groups"        yaml:"groups"`
 	Hosts         Hosts         `json:"hosts"         yaml:"hosts"`
 	TagOwners     TagOwners     `json:"tagOwners"     yaml:"tagOwners"`
+	ForcedTags    ForcedTags    `json:"forcedTags"    yaml:"forcedTags"`
 	ACLs          []ACL         `json:"acls"          yaml:"acls"`
 	Tests         []ACLTest     `json:"tests"         yaml:"tests"`
 	AutoApprovers AutoApprovers `json:"autoApprovers" yaml:"autoApprovers"`
@@ -27,6 +28,9 @@ type ACL struct {
 	Sources      []string `json:"src"    yaml:"src"`
 	Destinations []string `json:"dst"    yaml:"dst"`
 }
+
+// ForcedTags specifies which tags are applied to which hosts by the server
+type ForcedTags map[string][]string
 
 // Groups references a series of alias in the ACL rules.
 type Groups map[string][]string


### PR DESCRIPTION
This pull request introduces a declarative way to set `ForcedTags` on nodes by recursively expanding aliases. These declarative forced tags are considered separately from the ones stored in the database.

Continuation of #1490 

```json
{
    "hosts": {
        "a": "fd7a:115c:a1e0::1",
        "b": "fd7a:115c:a1e0::2"
    },
    "forcedTags": {
        "tag:some-tag": [
            "a",
            "tag:some-other-tag"
        ],
        "tag:some-other-tag": [
            "b"
        ]
    }
}
```

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md
