### PR TITLE
Add private key path to example config

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -40,6 +40,10 @@ grpc_listen_addr: 127.0.0.1:50443
 # are doing.
 grpc_allow_insecure: false
 
+# Private Key path for the service. 
+# See the container installation docs for alternate paths if you encounter an error.
+private_key_path: /var/lib/headscale/private.key
+
 # The Noise section includes specific configuration for the
 # TS2021 Noise protocol
 noise:


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

Adds private key path to the example config. 

This fixes an issue found in the discord where the service did not have a default private key path, so it errored with very little information for the end user. 

This config settings was previously only shown in the container installation docs.

<!-- Please tick if the following things apply. You… -->

- [X] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand (N/A)
- [ ] added unit tests (N/A)
- [ ] added integration tests (N/A)
- [X] updated documentation if needed
- [ ] updated CHANGELOG.md (N/A)

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
