### PR TITLE
Fix Github Actions docs pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
           key: ${{ github.ref }}
           path: .cache
       - name: Setup dependencies
-        run: pip install mkdocs-material pillow cairosvg mkdocs-minify-plugin
+        run: pip install -r docs/requirements.txt
       - name: Build docs
         run: mkdocs build --strict
       - name: Upload artifact

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+cairosvg~=2.7.1
+mkdocs-material~=9.4.14
+mkdocs-minify-plugin~=0.7.1
+pillow~=10.1.0
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,8 +94,8 @@ markdown_extensions:
   - pymdownx.caret
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_generator: !!python/name:materialx.emoji.to_svg
-      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
Latest mkdocs-material fails documentation building about unsupported extenstion. Updated extension and pinned Python packages in `docs/requirements.txt` to major versions to prevent uncontrolled breaking changes in future.

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
