### PR TITLE
fix(db): sets max open and idle connections for postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Code reorganisation, a lot of code has moved, please review the following PRs accordingly [#1444](https://github.com/juanfont/headscale/pull/1444)
 
 ### Changes
+- Set max open and idle connections for postgres
 
 ## 0.22.3 (2023-05-12)
 
@@ -19,7 +20,7 @@
 ### Changes
 
 - Add environment flags to enable pprof (profiling) [#1382](https://github.com/juanfont/headscale/pull/1382)
-  - Profiles are continously generated in our integration tests.
+- Profiles are continously generated in our integration tests.
 - Fix systemd service file location in `.deb` packages [#1391](https://github.com/juanfont/headscale/pull/1391)
 - Improvements on Noise implementation [#1379](https://github.com/juanfont/headscale/pull/1379)
 - Replace node filter logic, ensuring nodes with access can see eachother [#1381](https://github.com/juanfont/headscale/pull/1381)

--- a/hscontrol/db.go
+++ b/hscontrol/db.go
@@ -251,10 +251,17 @@ func (h *Headscale) openDB() (*gorm.DB, error) {
 		sqlDB.SetConnMaxIdleTime(time.Hour)
 
 	case Postgres:
-		db, err = gorm.Open(postgres.Open(h.dbString), &gorm.Config{
+		db, err := gorm.Open(postgres.Open(h.dbString), &gorm.Config{
 			DisableForeignKeyConstraintWhenMigrating: true,
 			Logger:                                   log,
 		})
+
+		sqlDB, _ := db.DB()
+		sqlDB.SetMaxOpenConns(10)
+		sqlDB.SetMaxIdleConns(10)
+		sqlDB.SetConnMaxIdleTime(time.Hour)
+
+		return db, err
 	}
 
 	if err != nil {


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->
### Description

Enables connection pooling when postgres is the backing DB.

<!-- Please tick if the following things apply. You… -->

- [ ] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
