### PR TITLE
implement selfupdate and pass expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ after improving the test harness as part of adopting [#1460](https://github.com/
 - Code reorganisation, a lot of code has moved, please review the following PRs accordingly [#1473](https://github.com/juanfont/headscale/pull/1473)
 - API: Machine is now Node [#1553](https://github.com/juanfont/headscale/pull/1553)
 - Remove support for older Tailscale clients [#1611](https://github.com/juanfont/headscale/pull/1611)
-  - The latest supported client is 1.32
+  - The latest supported client is 1.36
 - Headscale checks that _at least_ one DERP is defined at start [#1564](https://github.com/juanfont/headscale/pull/1564)
   - If no DERP is configured, the server will fail to start, this can be because it cannot load the DERPMap from file or url.
 - Embedded DERP server requires a private key [#1611](https://github.com/juanfont/headscale/pull/1611)

--- a/hscontrol/mapper/mapper.go
+++ b/hscontrol/mapper/mapper.go
@@ -459,6 +459,8 @@ func (m *Mapper) marshalMapResponse(
 		switch {
 		case resp.Peers != nil && len(resp.Peers) > 0:
 			responseType = "full"
+		case resp.Peers == nil && resp.PeersChanged == nil && resp.PeersChangedPatch == nil:
+			responseType = "lite"
 		case resp.PeersChanged != nil && len(resp.PeersChanged) > 0:
 			responseType = "changed"
 		case resp.PeersChangedPatch != nil && len(resp.PeersChangedPatch) > 0:

--- a/hscontrol/mapper/mapper.go
+++ b/hscontrol/mapper/mapper.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juanfont/headscale/hscontrol/util"
 	"github.com/klauspost/compress/zstd"
 	"github.com/rs/zerolog/log"
-	"github.com/samber/lo"
 	"golang.org/x/exp/maps"
 	"tailscale.com/envknob"
 	"tailscale.com/smallzstd"
@@ -595,15 +594,6 @@ func nodeMapToList(nodes map[uint64]*types.Node) types.Nodes {
 	return ret
 }
 
-func filterExpiredAndNotReady(peers types.Nodes) types.Nodes {
-	return lo.Filter(peers, func(item *types.Node, index int) bool {
-		// Filter out nodes that are expired OR
-		// nodes that has no endpoints, this typically means they have
-		// registered, but are not configured.
-		return !item.IsExpired() || len(item.Endpoints) > 0
-	})
-}
-
 // appendPeerChanges mutates a tailcfg.MapResponse with all the
 // necessary changes when peers have changed.
 func appendPeerChanges(
@@ -628,9 +618,6 @@ func appendPeerChanges(
 	if err != nil {
 		return err
 	}
-
-	// Filter out peers that have expired.
-	changed = filterExpiredAndNotReady(changed)
 
 	// If there are filter rules present, see if there are any nodes that cannot
 	// access eachother at all and remove them from the peers.

--- a/hscontrol/notifier/notifier.go
+++ b/hscontrol/notifier/notifier.go
@@ -95,6 +95,21 @@ func (n *Notifier) NotifyWithIgnore(update types.StateUpdate, ignore ...string) 
 	}
 }
 
+func (n *Notifier) NotifyByMachineKey(update types.StateUpdate, mKey key.MachinePublic) {
+	log.Trace().Caller().Interface("type", update.Type).Msg("acquiring lock to notify")
+	defer log.Trace().
+		Caller().
+		Interface("type", update.Type).
+		Msg("releasing lock, finished notifing")
+
+	n.l.RLock()
+	defer n.l.RUnlock()
+
+	if c, ok := n.nodes[mKey.String()]; ok {
+		c <- update
+	}
+}
+
 func (n *Notifier) String() string {
 	n.l.RLock()
 	defer n.l.RUnlock()

--- a/hscontrol/poll.go
+++ b/hscontrol/poll.go
@@ -397,6 +397,14 @@ func (h *Headscale) handlePoll(
 			case types.StatePeerRemoved:
 				logInfo("Sending PeerRemoved MapResponse")
 				data, err = mapp.PeerRemovedResponse(mapRequest, node, update.Removed)
+			case types.StateSelfUpdate:
+				if len(update.ChangeNodes) == 1 {
+					logInfo("Sending SelfUpdate MapResponse")
+					node = update.ChangeNodes[0]
+					data, err = mapp.LiteMapResponse(mapRequest, node, h.ACLPolicy)
+				} else {
+					logInfo("SelfUpdate contained too many nodes, this is likely a bug in the code, please report.")
+				}
 			case types.StateDERPUpdated:
 				logInfo("Sending DERPUpdate MapResponse")
 				data, err = mapp.DERPMapResponse(mapRequest, node, update.DERPMap)

--- a/hscontrol/poll_noise.go
+++ b/hscontrol/poll_noise.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	MinimumCapVersion tailcfg.CapabilityVersion = 36
+	MinimumCapVersion tailcfg.CapabilityVersion = 56
 )
 
 // NoisePollNetMapHandler takes care of /machine/:id/map using the Noise protocol

--- a/hscontrol/types/common.go
+++ b/hscontrol/types/common.go
@@ -91,6 +91,12 @@ const (
 	StatePeerChanged
 	StatePeerChangedPatch
 	StatePeerRemoved
+	// StateSelfUpdate is used to indicate that the node
+	// has changed in control, and the client needs to be
+	// informed.
+	// The updated node is inside the ChangeNodes field
+	// which should have a length of one.
+	StateSelfUpdate
 	StateDERPUpdated
 )
 
@@ -141,6 +147,10 @@ func (su *StateUpdate) Valid() bool {
 	case StatePeerRemoved:
 		if su.Removed == nil {
 			panic("Mandatory field Removed is not set on StatePeerRemove update")
+		}
+	case StateSelfUpdate:
+		if su.ChangeNodes == nil || len(su.ChangeNodes) != 1 {
+			panic("Mandatory field ChangeNodes is not set for StateSelfUpdate or has more than one node")
 		}
 	case StateDERPUpdated:
 		if su.DERPMap == nil {

--- a/integration/general_test.go
+++ b/integration/general_test.go
@@ -537,7 +537,7 @@ func TestExpireNode(t *testing.T) {
 		assertNoErr(t, err)
 
 		// Assert that we have the original count - self
-		assert.Len(t, status.Peers(), len(MustTestVersions)-1)
+		assert.Len(t, status.Peers(), spec["user1"]-1)
 	}
 
 	headscale, err := scenario.Headscale()

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -13,8 +13,10 @@ run_tests() {
 
 	for ((i = 1; i <= num_tests; i++)); do
 		docker network prune -f >/dev/null 2>&1
-		docker rm headscale-test-suite || true
-		docker kill "$(docker ps -q)" || true
+		docker rm headscale-test-suite >/dev/null 2>&1 || true
+		docker kill "$(docker ps -q)" >/dev/null 2>&1 || true
+
+		echo "Run $i"
 
 		start=$(date +%s)
 		docker run \

--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -47,19 +47,19 @@ var (
 	tailscaleVersions2021 = map[string]bool{
 		"head":     true,
 		"unstable": true,
-		"1.56":     true, // CapVer: 82
-		"1.54":     true, // CapVer: 79
-		"1.52":     true, // CapVer: 79
-		"1.50":     true, // CapVer: 74
-		"1.48":     true, // CapVer: 68
-		"1.46":     true, // CapVer: 65
-		"1.44":     true, // CapVer: 63
-		"1.42":     true, // CapVer: 61
-		"1.40":     true, // CapVer: 61
-		"1.38":     true, // CapVer: 58
-		"1.36":     true, // CapVer: 56
-		"1.34":     true, // CapVer: 51
-		"1.32":     true, // Oldest supported version, CapVer: 46
+		"1.56":     true,  // CapVer: 82
+		"1.54":     true,  // CapVer: 79
+		"1.52":     true,  // CapVer: 79
+		"1.50":     true,  // CapVer: 74
+		"1.48":     true,  // CapVer: 68
+		"1.46":     true,  // CapVer: 65
+		"1.44":     true,  // CapVer: 63
+		"1.42":     true,  // CapVer: 61
+		"1.40":     true,  // CapVer: 61
+		"1.38":     true,  // CapVer: 58
+		"1.36":     true,  // Oldest supported version, CapVer: 56
+		"1.34":     false, // CapVer: 51
+		"1.32":     false, // CapVer: 46
 		"1.30":     false,
 	}
 

--- a/integration/scenario_test.go
+++ b/integration/scenario_test.go
@@ -142,7 +142,7 @@ func TestTailscaleNodesJoiningHeadcale(t *testing.T) {
 	})
 
 	t.Run("create-tailscale", func(t *testing.T) {
-		err := scenario.CreateTailscaleNodesInUser(user, "1.30.2", count)
+		err := scenario.CreateTailscaleNodesInUser(user, "unstable", count)
 		if err != nil {
 			t.Fatalf("failed to add tailscale nodes: %s", err)
 		}


### PR DESCRIPTION
Currently we support informing nodes upon change, but do not have a mechanism for updating the node from control and down.

This commits add a SelfUpdate state change and it is used to inform a node if it keys has been expired control side.

This PR makes 1.36 the last supported version as it exposes keyexpiry information.

fixes #1645 