### PR TITLE
Use result of fmt.Errorf call

### DIFF
--- a/hscontrol/tailsql.go
+++ b/hscontrol/tailsql.go
@@ -70,7 +70,7 @@ func runTailSQLService(ctx context.Context, logf logger.Logf, stateDir, dbPath s
 		// When serving TLS, add a redirect from HTTP on port 80 to HTTPS on 443.
 		certDomains := tsNode.CertDomains()
 		if len(certDomains) == 0 {
-			fmt.Errorf("no cert domains available for HTTPS")
+			return fmt.Errorf("no cert domains available for HTTPS")
 		}
 		base := "https://" + certDomains[0]
 		go http.Serve(lst, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

>Headscale is open to code contributions for bug fixes without discussion.

An error value in the `hscontrol` package is unused:

```go
// hscontrol/tailsql.go
certDomains := tsNode.CertDomains()
if len(certDomains) == 0 {
	fmt.Errorf("no cert domains available for HTTPS")
}
base := "https://" + certDomains[0]
```

I spotted it with `go vet`:

```text
$ go vet ./...
# github.com/juanfont/headscale/hscontrol
hscontrol/tailsql.go:73:14: result of fmt.Errorf call not used
```

This PR adds the missing return statement.