### PR TITLE
Update priavet key lines in config-example.yaml

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -40,6 +40,10 @@ grpc_listen_addr: 127.0.0.1:50443
 # are doing.
 grpc_allow_insecure: false
 
+# Need to specify a private key path to write either the 
+# Noise or regular private keys.
+private_key_path: /var/lib/headscale/private.key
+
 # The Noise section includes specific configuration for the
 # TS2021 Noise protocol
 noise:


### PR DESCRIPTION
Added a line to correctly write/create private keys in a Docker compose setup using the example-config.yaml template.

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [ ] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
