### PR TITLE
Trim client secret after reading from file

### DIFF
--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -590,7 +590,7 @@ func GetHeadscaleConfig() (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		oidcClientSecret = string(secretBytes)
+		oidcClientSecret = strings.TrimSpace(string(secretBytes))
 	}
 
 	return &Config{


### PR DESCRIPTION
Reading client secret from file will include a line break, which results in a mismatching client secret compared to reading directly from the config. This ensures that the string is trimmed before building the config.

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
Fixes #1696.