### PR TITLE
docs/reverse-proxy: use standard map, correct X-Forwarded-Proto varia…

### DIFF
--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -33,8 +33,7 @@ The following example configuration can be used in your nginx setup, substitutin
 
 ```Nginx
 map $http_upgrade $connection_upgrade {
-    default      keep-alive;
-    'websocket'  upgrade;
+    default      upgrade;
     ''           close;
 }
 
@@ -61,7 +60,7 @@ server {
         proxy_buffering off;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header X-Forwarded-Proto $scheme;
         add_header Strict-Transport-Security "max-age=15552000; includeSubDomains" always;
     }
 }


### PR DESCRIPTION
…ble for nginx

I tested this on NixOS. After switching from postgres back to sqlite and with the standard websocket proxy config, everything started to work.

Initially the none standard map which differs from upstreams docs https://nginx.org/en/docs/http/websocket.html got me very confused and I thought this would be somehow required.

Also $http_x_forwarded_proto doesn't exist, NixOS uses $scheme instead and I am going with that.

proxy_redirect also didn't work for me but that might be on my rather big config.

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
