### PR TITLE
Replace database locks with transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ after improving the test harness as part of adopting [#1460](https://github.com/
 - Code reorganisation, a lot of code has moved, please review the following PRs accordingly [#1473](https://github.com/juanfont/headscale/pull/1473)
 - API: Machine is now Node [#1553](https://github.com/juanfont/headscale/pull/1553)
 - Remove support for older Tailscale clients [#1611](https://github.com/juanfont/headscale/pull/1611)
-  - The latest supported client is 1.36
+  - The latest supported client is 1.38
 - Headscale checks that _at least_ one DERP is defined at start [#1564](https://github.com/juanfont/headscale/pull/1564)
   - If no DERP is configured, the server will fail to start, this can be because it cannot load the DERPMap from file or url.
 - Embedded DERP server requires a private key [#1611](https://github.com/juanfont/headscale/pull/1611)

--- a/cmd/headscale/headscale.go
+++ b/cmd/headscale/headscale.go
@@ -6,25 +6,11 @@ import (
 
 	"github.com/efekarakus/termcolor"
 	"github.com/juanfont/headscale/cmd/headscale/cli"
-	"github.com/pkg/profile"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
 func main() {
-	if _, enableProfile := os.LookupEnv("HEADSCALE_PROFILING_ENABLED"); enableProfile {
-		if profilePath, ok := os.LookupEnv("HEADSCALE_PROFILING_PATH"); ok {
-			err := os.MkdirAll(profilePath, os.ModePerm)
-			if err != nil {
-				log.Fatal().Err(err).Msg("failed to create profiling directory")
-			}
-
-			defer profile.Start(profile.ProfilePath(profilePath)).Stop()
-		} else {
-			defer profile.Start().Stop()
-		}
-	}
-
 	var colors bool
 	switch l := termcolor.SupportLevel(os.Stderr); l {
 	case termcolor.Level16M:

--- a/hscontrol/db/api_key.go
+++ b/hscontrol/db/api_key.go
@@ -22,9 +22,6 @@ var ErrAPIKeyFailedToParse = errors.New("failed to parse ApiKey")
 func (hsdb *HSDatabase) CreateAPIKey(
 	expiration *time.Time,
 ) (string, *types.APIKey, error) {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
 	prefix, err := util.GenerateRandomStringURLSafe(apiPrefixLength)
 	if err != nil {
 		return "", nil, err
@@ -49,7 +46,7 @@ func (hsdb *HSDatabase) CreateAPIKey(
 		Expiration: expiration,
 	}
 
-	if err := hsdb.db.Save(&key).Error; err != nil {
+	if err := hsdb.DB.Save(&key).Error; err != nil {
 		return "", nil, fmt.Errorf("failed to save API key to database: %w", err)
 	}
 
@@ -58,11 +55,8 @@ func (hsdb *HSDatabase) CreateAPIKey(
 
 // ListAPIKeys returns the list of ApiKeys for a user.
 func (hsdb *HSDatabase) ListAPIKeys() ([]types.APIKey, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
 	keys := []types.APIKey{}
-	if err := hsdb.db.Find(&keys).Error; err != nil {
+	if err := hsdb.DB.Find(&keys).Error; err != nil {
 		return nil, err
 	}
 
@@ -71,11 +65,8 @@ func (hsdb *HSDatabase) ListAPIKeys() ([]types.APIKey, error) {
 
 // GetAPIKey returns a ApiKey for a given key.
 func (hsdb *HSDatabase) GetAPIKey(prefix string) (*types.APIKey, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
 	key := types.APIKey{}
-	if result := hsdb.db.First(&key, "prefix = ?", prefix); result.Error != nil {
+	if result := hsdb.DB.First(&key, "prefix = ?", prefix); result.Error != nil {
 		return nil, result.Error
 	}
 
@@ -84,11 +75,8 @@ func (hsdb *HSDatabase) GetAPIKey(prefix string) (*types.APIKey, error) {
 
 // GetAPIKeyByID returns a ApiKey for a given id.
 func (hsdb *HSDatabase) GetAPIKeyByID(id uint64) (*types.APIKey, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
 	key := types.APIKey{}
-	if result := hsdb.db.Find(&types.APIKey{ID: id}).First(&key); result.Error != nil {
+	if result := hsdb.DB.Find(&types.APIKey{ID: id}).First(&key); result.Error != nil {
 		return nil, result.Error
 	}
 
@@ -98,10 +86,7 @@ func (hsdb *HSDatabase) GetAPIKeyByID(id uint64) (*types.APIKey, error) {
 // DestroyAPIKey destroys a ApiKey. Returns error if the ApiKey
 // does not exist.
 func (hsdb *HSDatabase) DestroyAPIKey(key types.APIKey) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
-	if result := hsdb.db.Unscoped().Delete(key); result.Error != nil {
+	if result := hsdb.DB.Unscoped().Delete(key); result.Error != nil {
 		return result.Error
 	}
 
@@ -110,10 +95,7 @@ func (hsdb *HSDatabase) DestroyAPIKey(key types.APIKey) error {
 
 // ExpireAPIKey marks a ApiKey as expired.
 func (hsdb *HSDatabase) ExpireAPIKey(key *types.APIKey) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
-	if err := hsdb.db.Model(&key).Update("Expiration", time.Now()).Error; err != nil {
+	if err := hsdb.DB.Model(&key).Update("Expiration", time.Now()).Error; err != nil {
 		return err
 	}
 
@@ -121,9 +103,6 @@ func (hsdb *HSDatabase) ExpireAPIKey(key *types.APIKey) error {
 }
 
 func (hsdb *HSDatabase) ValidateAPIKey(keyStr string) (bool, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
 	prefix, hash, found := strings.Cut(keyStr, ".")
 	if !found {
 		return false, ErrAPIKeyFailedToParse

--- a/hscontrol/db/node.go
+++ b/hscontrol/db/node.go
@@ -34,22 +34,21 @@ var (
 	)
 )
 
-// ListPeers returns all peers of node, regardless of any Policy or if the node is expired.
 func (hsdb *HSDatabase) ListPeers(node *types.Node) (types.Nodes, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	return hsdb.listPeers(node)
+	return Read(hsdb.DB, func(rx *gorm.DB) (types.Nodes, error) {
+		return ListPeers(rx, node)
+	})
 }
 
-func (hsdb *HSDatabase) listPeers(node *types.Node) (types.Nodes, error) {
+// ListPeers returns all peers of node, regardless of any Policy or if the node is expired.
+func ListPeers(tx *gorm.DB, node *types.Node) (types.Nodes, error) {
 	log.Trace().
 		Caller().
 		Str("node", node.Hostname).
 		Msg("Finding direct peers")
 
 	nodes := types.Nodes{}
-	if err := hsdb.db.
+	if err := tx.
 		Preload("AuthKey").
 		Preload("AuthKey.User").
 		Preload("User").
@@ -64,16 +63,15 @@ func (hsdb *HSDatabase) listPeers(node *types.Node) (types.Nodes, error) {
 	return nodes, nil
 }
 
-func (hsdb *HSDatabase) ListNodes() ([]types.Node, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	return hsdb.listNodes()
+func (hsdb *HSDatabase) ListNodes() (types.Nodes, error) {
+	return Read(hsdb.DB, func(rx *gorm.DB) (types.Nodes, error) {
+		return ListNodes(rx)
+	})
 }
 
-func (hsdb *HSDatabase) listNodes() ([]types.Node, error) {
-	nodes := []types.Node{}
-	if err := hsdb.db.
+func ListNodes(tx *gorm.DB) (types.Nodes, error) {
+	nodes := types.Nodes{}
+	if err := tx.
 		Preload("AuthKey").
 		Preload("AuthKey.User").
 		Preload("User").
@@ -85,16 +83,9 @@ func (hsdb *HSDatabase) listNodes() ([]types.Node, error) {
 	return nodes, nil
 }
 
-func (hsdb *HSDatabase) ListNodesByGivenName(givenName string) (types.Nodes, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	return hsdb.listNodesByGivenName(givenName)
-}
-
-func (hsdb *HSDatabase) listNodesByGivenName(givenName string) (types.Nodes, error) {
+func listNodesByGivenName(tx *gorm.DB, givenName string) (types.Nodes, error) {
 	nodes := types.Nodes{}
-	if err := hsdb.db.
+	if err := tx.
 		Preload("AuthKey").
 		Preload("AuthKey.User").
 		Preload("User").
@@ -106,12 +97,15 @@ func (hsdb *HSDatabase) listNodesByGivenName(givenName string) (types.Nodes, err
 	return nodes, nil
 }
 
-// GetNode finds a Node by name and user and returns the Node struct.
-func (hsdb *HSDatabase) GetNode(user string, name string) (*types.Node, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
+func (hsdb *HSDatabase) getNode(user string, name string) (*types.Node, error) {
+	return Read(hsdb.DB, func(rx *gorm.DB) (*types.Node, error) {
+		return getNode(rx, user, name)
+	})
+}
 
-	nodes, err := hsdb.ListNodesByUser(user)
+// getNode finds a Node by name and user and returns the Node struct.
+func getNode(tx *gorm.DB, user string, name string) (*types.Node, error) {
+	nodes, err := ListNodesByUser(tx, user)
 	if err != nil {
 		return nil, err
 	}
@@ -125,34 +119,16 @@ func (hsdb *HSDatabase) GetNode(user string, name string) (*types.Node, error) {
 	return nil, ErrNodeNotFound
 }
 
-// GetNodeByGivenName finds a Node by given name and user and returns the Node struct.
-func (hsdb *HSDatabase) GetNodeByGivenName(
-	user string,
-	givenName string,
-) (*types.Node, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	node := types.Node{}
-	if err := hsdb.db.
-		Preload("AuthKey").
-		Preload("AuthKey.User").
-		Preload("User").
-		Preload("Routes").
-		Where("given_name = ?", givenName).First(&node).Error; err != nil {
-		return nil, err
-	}
-
-	return nil, ErrNodeNotFound
+func (hsdb *HSDatabase) GetNodeByID(id uint64) (*types.Node, error) {
+	return Read(hsdb.DB, func(rx *gorm.DB) (*types.Node, error) {
+		return GetNodeByID(rx, id)
+	})
 }
 
 // GetNodeByID finds a Node by ID and returns the Node struct.
-func (hsdb *HSDatabase) GetNodeByID(id uint64) (*types.Node, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
+func GetNodeByID(tx *gorm.DB, id uint64) (*types.Node, error) {
 	mach := types.Node{}
-	if result := hsdb.db.
+	if result := tx.
 		Preload("AuthKey").
 		Preload("AuthKey.User").
 		Preload("User").
@@ -164,21 +140,19 @@ func (hsdb *HSDatabase) GetNodeByID(id uint64) (*types.Node, error) {
 	return &mach, nil
 }
 
-// GetNodeByMachineKey finds a Node by its MachineKey and returns the Node struct.
-func (hsdb *HSDatabase) GetNodeByMachineKey(
-	machineKey key.MachinePublic,
-) (*types.Node, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	return hsdb.getNodeByMachineKey(machineKey)
+func (hsdb *HSDatabase) GetNodeByMachineKey(machineKey key.MachinePublic) (*types.Node, error) {
+	return Read(hsdb.DB, func(rx *gorm.DB) (*types.Node, error) {
+		return GetNodeByMachineKey(rx, machineKey)
+	})
 }
 
-func (hsdb *HSDatabase) getNodeByMachineKey(
+// GetNodeByMachineKey finds a Node by its MachineKey and returns the Node struct.
+func GetNodeByMachineKey(
+	tx *gorm.DB,
 	machineKey key.MachinePublic,
 ) (*types.Node, error) {
 	mach := types.Node{}
-	if result := hsdb.db.
+	if result := tx.
 		Preload("AuthKey").
 		Preload("AuthKey.User").
 		Preload("User").
@@ -190,36 +164,24 @@ func (hsdb *HSDatabase) getNodeByMachineKey(
 	return &mach, nil
 }
 
-// GetNodeByNodeKey finds a Node by its current NodeKey.
-func (hsdb *HSDatabase) GetNodeByNodeKey(
+func (hsdb *HSDatabase) GetNodeByAnyKey(
+	machineKey key.MachinePublic,
 	nodeKey key.NodePublic,
+	oldNodeKey key.NodePublic,
 ) (*types.Node, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	node := types.Node{}
-	if result := hsdb.db.
-		Preload("AuthKey").
-		Preload("AuthKey.User").
-		Preload("User").
-		Preload("Routes").
-		First(&node, "node_key = ?",
-			nodeKey.String()); result.Error != nil {
-		return nil, result.Error
-	}
-
-	return &node, nil
+	return Read(hsdb.DB, func(rx *gorm.DB) (*types.Node, error) {
+		return GetNodeByAnyKey(rx, machineKey, nodeKey, oldNodeKey)
+	})
 }
 
 // GetNodeByAnyKey finds a Node by its MachineKey, its current NodeKey or the old one, and returns the Node struct.
-func (hsdb *HSDatabase) GetNodeByAnyKey(
+// TODO(kradalby): see if we can remove this.
+func GetNodeByAnyKey(
+	tx *gorm.DB,
 	machineKey key.MachinePublic, nodeKey key.NodePublic, oldNodeKey key.NodePublic,
 ) (*types.Node, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
 	node := types.Node{}
-	if result := hsdb.db.
+	if result := tx.
 		Preload("AuthKey").
 		Preload("AuthKey.User").
 		Preload("User").
@@ -234,49 +196,34 @@ func (hsdb *HSDatabase) GetNodeByAnyKey(
 	return &node, nil
 }
 
-func (hsdb *HSDatabase) NodeReloadFromDatabase(node *types.Node) error {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	if result := hsdb.db.Find(node).First(&node); result.Error != nil {
-		return result.Error
-	}
-
-	return nil
+func (hsdb *HSDatabase) SetTags(
+	nodeID uint64,
+	tags []string,
+) error {
+	return hsdb.Write(func(tx *gorm.DB) error {
+		return SetTags(tx, nodeID, tags)
+	})
 }
 
 // SetTags takes a Node struct pointer and update the forced tags.
-func (hsdb *HSDatabase) SetTags(
-	node *types.Node,
+func SetTags(
+	tx *gorm.DB,
+	nodeID uint64,
 	tags []string,
 ) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
 	if len(tags) == 0 {
 		return nil
 	}
 
-	newTags := []string{}
+	newTags := types.StringList{}
 	for _, tag := range tags {
 		if !util.StringOrPrefixListContains(newTags, tag) {
 			newTags = append(newTags, tag)
 		}
 	}
 
-	if err := hsdb.db.Model(node).Updates(types.Node{
-		ForcedTags: newTags,
-	}).Error; err != nil {
+	if err := tx.Model(&types.Node{}).Where("id = ?", nodeID).Update("forced_tags", newTags).Error; err != nil {
 		return fmt.Errorf("failed to update tags for node in the database: %w", err)
-	}
-
-	stateUpdate := types.StateUpdate{
-		Type:        types.StatePeerChanged,
-		ChangeNodes: types.Nodes{node},
-		Message:     "called from db.SetTags",
-	}
-	if stateUpdate.Valid() {
-		hsdb.notifier.NotifyWithIgnore(stateUpdate, node.MachineKey.String())
 	}
 
 	return nil
@@ -284,10 +231,9 @@ func (hsdb *HSDatabase) SetTags(
 
 // RenameNode takes a Node struct and a new GivenName for the nodes
 // and renames it.
-func (hsdb *HSDatabase) RenameNode(node *types.Node, newName string) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
+func RenameNode(tx *gorm.DB,
+	nodeID uint64, newName string,
+) error {
 	err := util.CheckForFQDNRules(
 		newName,
 	)
@@ -295,102 +241,54 @@ func (hsdb *HSDatabase) RenameNode(node *types.Node, newName string) error {
 		log.Error().
 			Caller().
 			Str("func", "RenameNode").
-			Str("node", node.Hostname).
+			Uint64("nodeID", nodeID).
 			Str("newName", newName).
 			Err(err).
 			Msg("failed to rename node")
 
 		return err
 	}
-	node.GivenName = newName
 
-	if err := hsdb.db.Model(node).Updates(types.Node{
-		GivenName: newName,
-	}).Error; err != nil {
+	if err := tx.Model(&types.Node{}).Where("id = ?", nodeID).Update("given_name", newName).Error; err != nil {
 		return fmt.Errorf("failed to rename node in the database: %w", err)
 	}
 
-	stateUpdate := types.StateUpdate{
-		Type:        types.StatePeerChanged,
-		ChangeNodes: types.Nodes{node},
-		Message:     "called from db.RenameNode",
-	}
-	if stateUpdate.Valid() {
-		hsdb.notifier.NotifyWithIgnore(stateUpdate, node.MachineKey.String())
-	}
-
 	return nil
+}
+
+func (hsdb *HSDatabase) NodeSetExpiry(nodeID uint64, expiry time.Time) error {
+	return hsdb.Write(func(tx *gorm.DB) error {
+		return NodeSetExpiry(tx, nodeID, expiry)
+	})
 }
 
 // NodeSetExpiry takes a Node struct and  a new expiry time.
-func (hsdb *HSDatabase) NodeSetExpiry(node *types.Node, expiry time.Time) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
-	return hsdb.nodeSetExpiry(node, expiry)
+func NodeSetExpiry(tx *gorm.DB,
+	nodeID uint64, expiry time.Time,
+) error {
+	return tx.Model(&types.Node{}).Where("id = ?", nodeID).Update("expiry", expiry).Error
 }
 
-func (hsdb *HSDatabase) nodeSetExpiry(node *types.Node, expiry time.Time) error {
-	if err := hsdb.db.Model(node).Updates(types.Node{
-		Expiry: &expiry,
-	}).Error; err != nil {
-		return fmt.Errorf(
-			"failed to refresh node (update expiration) in the database: %w",
-			err,
-		)
-	}
-
-	node.Expiry = &expiry
-
-	stateSelfUpdate := types.StateUpdate{
-		Type:        types.StateSelfUpdate,
-		ChangeNodes: types.Nodes{node},
-	}
-	if stateSelfUpdate.Valid() {
-		hsdb.notifier.NotifyByMachineKey(stateSelfUpdate, node.MachineKey)
-	}
-
-	stateUpdate := types.StateUpdate{
-		Type: types.StatePeerChangedPatch,
-		ChangePatches: []*tailcfg.PeerChange{
-			{
-				NodeID:    tailcfg.NodeID(node.ID),
-				KeyExpiry: &expiry,
-			},
-		},
-	}
-	if stateUpdate.Valid() {
-		hsdb.notifier.NotifyWithIgnore(stateUpdate, node.MachineKey.String())
-	}
-
-	return nil
+func (hsdb *HSDatabase) DeleteNode(node *types.Node, isConnected map[key.MachinePublic]bool) error {
+	return hsdb.Write(func(tx *gorm.DB) error {
+		return DeleteNode(tx, node, isConnected)
+	})
 }
 
 // DeleteNode deletes a Node from the database.
-func (hsdb *HSDatabase) DeleteNode(node *types.Node) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
-	return hsdb.deleteNode(node)
-}
-
-func (hsdb *HSDatabase) deleteNode(node *types.Node) error {
-	err := hsdb.deleteNodeRoutes(node)
+// Caller is responsible for notifying all of change.
+func DeleteNode(tx *gorm.DB,
+	node *types.Node,
+	isConnected map[key.MachinePublic]bool,
+) error {
+	err := deleteNodeRoutes(tx, node, map[key.MachinePublic]bool{})
 	if err != nil {
 		return err
 	}
 
 	// Unscoped causes the node to be fully removed from the database.
-	if err := hsdb.db.Unscoped().Delete(&node).Error; err != nil {
+	if err := tx.Unscoped().Delete(&node).Error; err != nil {
 		return err
-	}
-
-	stateUpdate := types.StateUpdate{
-		Type:    types.StatePeerRemoved,
-		Removed: []tailcfg.NodeID{tailcfg.NodeID(node.ID)},
-	}
-	if stateUpdate.Valid() {
-		hsdb.notifier.NotifyAll(stateUpdate)
 	}
 
 	return nil
@@ -398,26 +296,19 @@ func (hsdb *HSDatabase) deleteNode(node *types.Node) error {
 
 // UpdateLastSeen sets a node's last seen field indicating that we
 // have recently communicating with this node.
-// This is mostly used to indicate if a node is online and is not
-// extremely important to make sure is fully correct and to avoid
-// holding up the hot path, does not contain any locks and isnt
-// concurrency safe. But that should be ok.
-func (hsdb *HSDatabase) UpdateLastSeen(node *types.Node) error {
-	return hsdb.db.Model(node).Updates(types.Node{
-		LastSeen: node.LastSeen,
-	}).Error
+func UpdateLastSeen(tx *gorm.DB, nodeID uint64, lastSeen time.Time) error {
+	return tx.Model(&types.Node{}).Where("id = ?", nodeID).Update("last_seen", lastSeen).Error
 }
 
-func (hsdb *HSDatabase) RegisterNodeFromAuthCallback(
+func RegisterNodeFromAuthCallback(
+	tx *gorm.DB,
 	cache *cache.Cache,
 	mkey key.MachinePublic,
 	userName string,
 	nodeExpiry *time.Time,
 	registrationMethod string,
+	ipPrefixes []netip.Prefix,
 ) (*types.Node, error) {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
 	log.Debug().
 		Str("machine_key", mkey.ShortString()).
 		Str("userName", userName).
@@ -427,7 +318,7 @@ func (hsdb *HSDatabase) RegisterNodeFromAuthCallback(
 
 	if nodeInterface, ok := cache.Get(mkey.String()); ok {
 		if registrationNode, ok := nodeInterface.(types.Node); ok {
-			user, err := hsdb.getUser(userName)
+			user, err := GetUser(tx, userName)
 			if err != nil {
 				return nil, fmt.Errorf(
 					"failed to find user in register node from auth callback, %w",
@@ -442,14 +333,17 @@ func (hsdb *HSDatabase) RegisterNodeFromAuthCallback(
 			}
 
 			registrationNode.UserID = user.ID
+			registrationNode.User = *user
 			registrationNode.RegisterMethod = registrationMethod
 
 			if nodeExpiry != nil {
 				registrationNode.Expiry = nodeExpiry
 			}
 
-			node, err := hsdb.registerNode(
+			node, err := RegisterNode(
+				tx,
 				registrationNode,
+				ipPrefixes,
 			)
 
 			if err == nil {
@@ -465,15 +359,14 @@ func (hsdb *HSDatabase) RegisterNodeFromAuthCallback(
 	return nil, ErrNodeNotFoundRegistrationCache
 }
 
-// RegisterNode is executed from the CLI to register a new Node using its MachineKey.
 func (hsdb *HSDatabase) RegisterNode(node types.Node) (*types.Node, error) {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
-	return hsdb.registerNode(node)
+	return Write(hsdb.DB, func(tx *gorm.DB) (*types.Node, error) {
+		return RegisterNode(tx, node, hsdb.ipPrefixes)
+	})
 }
 
-func (hsdb *HSDatabase) registerNode(node types.Node) (*types.Node, error) {
+// RegisterNode is executed from the CLI to register a new Node using its MachineKey.
+func RegisterNode(tx *gorm.DB, node types.Node, ipPrefixes []netip.Prefix) (*types.Node, error) {
 	log.Debug().
 		Str("node", node.Hostname).
 		Str("machine_key", node.MachineKey.ShortString()).
@@ -485,7 +378,7 @@ func (hsdb *HSDatabase) registerNode(node types.Node) (*types.Node, error) {
 	// so we store the node.Expire and node.Nodekey that has been set when
 	// adding it to the registrationCache
 	if len(node.IPAddresses) > 0 {
-		if err := hsdb.db.Save(&node).Error; err != nil {
+		if err := tx.Save(&node).Error; err != nil {
 			return nil, fmt.Errorf("failed register existing node in the database: %w", err)
 		}
 
@@ -500,10 +393,7 @@ func (hsdb *HSDatabase) registerNode(node types.Node) (*types.Node, error) {
 		return &node, nil
 	}
 
-	hsdb.ipAllocationMutex.Lock()
-	defer hsdb.ipAllocationMutex.Unlock()
-
-	ips, err := hsdb.getAvailableIPs()
+	ips, err := getAvailableIPs(tx, ipPrefixes)
 	if err != nil {
 		log.Error().
 			Caller().
@@ -516,7 +406,7 @@ func (hsdb *HSDatabase) registerNode(node types.Node) (*types.Node, error) {
 
 	node.IPAddresses = ips
 
-	if err := hsdb.db.Save(&node).Error; err != nil {
+	if err := tx.Save(&node).Error; err != nil {
 		return nil, fmt.Errorf("failed register(save) node in the database: %w", err)
 	}
 
@@ -530,61 +420,50 @@ func (hsdb *HSDatabase) registerNode(node types.Node) (*types.Node, error) {
 }
 
 // NodeSetNodeKey sets the node key of a node and saves it to the database.
-func (hsdb *HSDatabase) NodeSetNodeKey(node *types.Node, nodeKey key.NodePublic) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
-	if err := hsdb.db.Model(node).Updates(types.Node{
+func NodeSetNodeKey(tx *gorm.DB, node *types.Node, nodeKey key.NodePublic) error {
+	return tx.Model(node).Updates(types.Node{
 		NodeKey: nodeKey,
-	}).Error; err != nil {
-		return err
-	}
-
-	return nil
+	}).Error
 }
 
-// NodeSetMachineKey sets the node key of a node and saves it to the database.
 func (hsdb *HSDatabase) NodeSetMachineKey(
 	node *types.Node,
 	machineKey key.MachinePublic,
 ) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
+	return hsdb.Write(func(tx *gorm.DB) error {
+		return NodeSetMachineKey(tx, node, machineKey)
+	})
+}
 
-	if err := hsdb.db.Model(node).Updates(types.Node{
+// NodeSetMachineKey sets the node key of a node and saves it to the database.
+func NodeSetMachineKey(
+	tx *gorm.DB,
+	node *types.Node,
+	machineKey key.MachinePublic,
+) error {
+	return tx.Model(node).Updates(types.Node{
 		MachineKey: machineKey,
-	}).Error; err != nil {
-		return err
-	}
-
-	return nil
+	}).Error
 }
 
 // NodeSave saves a node object to the database, prefer to use a specific save method rather
 // than this. It is intended to be used when we are changing or.
-func (hsdb *HSDatabase) NodeSave(node *types.Node) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
+// TODO(kradalby): Remove this func, just use Save.
+func NodeSave(tx *gorm.DB, node *types.Node) error {
+	return tx.Save(node).Error
+}
 
-	if err := hsdb.db.Save(node).Error; err != nil {
-		return err
-	}
-
-	return nil
+func (hsdb *HSDatabase) GetAdvertisedRoutes(node *types.Node) ([]netip.Prefix, error) {
+	return Read(hsdb.DB, func(rx *gorm.DB) ([]netip.Prefix, error) {
+		return GetAdvertisedRoutes(rx, node)
+	})
 }
 
 // GetAdvertisedRoutes returns the routes that are be advertised by the given node.
-func (hsdb *HSDatabase) GetAdvertisedRoutes(node *types.Node) ([]netip.Prefix, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	return hsdb.getAdvertisedRoutes(node)
-}
-
-func (hsdb *HSDatabase) getAdvertisedRoutes(node *types.Node) ([]netip.Prefix, error) {
+func GetAdvertisedRoutes(tx *gorm.DB, node *types.Node) ([]netip.Prefix, error) {
 	routes := types.Routes{}
 
-	err := hsdb.db.
+	err := tx.
 		Preload("Node").
 		Where("node_id = ? AND advertised = ?", node.ID, true).Find(&routes).Error
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -605,18 +484,17 @@ func (hsdb *HSDatabase) getAdvertisedRoutes(node *types.Node) ([]netip.Prefix, e
 	return prefixes, nil
 }
 
-// GetEnabledRoutes returns the routes that are enabled for the node.
 func (hsdb *HSDatabase) GetEnabledRoutes(node *types.Node) ([]netip.Prefix, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	return hsdb.getEnabledRoutes(node)
+	return Read(hsdb.DB, func(rx *gorm.DB) ([]netip.Prefix, error) {
+		return GetEnabledRoutes(rx, node)
+	})
 }
 
-func (hsdb *HSDatabase) getEnabledRoutes(node *types.Node) ([]netip.Prefix, error) {
+// GetEnabledRoutes returns the routes that are enabled for the node.
+func GetEnabledRoutes(tx *gorm.DB, node *types.Node) ([]netip.Prefix, error) {
 	routes := types.Routes{}
 
-	err := hsdb.db.
+	err := tx.
 		Preload("Node").
 		Where("node_id = ? AND advertised = ? AND enabled = ?", node.ID, true, true).
 		Find(&routes).Error
@@ -638,16 +516,13 @@ func (hsdb *HSDatabase) getEnabledRoutes(node *types.Node) ([]netip.Prefix, erro
 	return prefixes, nil
 }
 
-func (hsdb *HSDatabase) IsRoutesEnabled(node *types.Node, routeStr string) bool {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
+func IsRoutesEnabled(tx *gorm.DB, node *types.Node, routeStr string) bool {
 	route, err := netip.ParsePrefix(routeStr)
 	if err != nil {
 		return false
 	}
 
-	enabledRoutes, err := hsdb.getEnabledRoutes(node)
+	enabledRoutes, err := GetEnabledRoutes(tx, node)
 	if err != nil {
 		log.Error().Err(err).Msg("Could not get enabled routes")
 
@@ -663,26 +538,37 @@ func (hsdb *HSDatabase) IsRoutesEnabled(node *types.Node, routeStr string) bool 
 	return false
 }
 
+func (hsdb *HSDatabase) enableRoutes(
+	node *types.Node,
+	routeStrs ...string,
+) (*types.StateUpdate, error) {
+	return Write(hsdb.DB, func(tx *gorm.DB) (*types.StateUpdate, error) {
+		return enableRoutes(tx, node, routeStrs...)
+	})
+}
+
 // enableRoutes enables new routes based on a list of new routes.
-func (hsdb *HSDatabase) enableRoutes(node *types.Node, routeStrs ...string) error {
+func enableRoutes(tx *gorm.DB,
+	node *types.Node, routeStrs ...string,
+) (*types.StateUpdate, error) {
 	newRoutes := make([]netip.Prefix, len(routeStrs))
 	for index, routeStr := range routeStrs {
 		route, err := netip.ParsePrefix(routeStr)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		newRoutes[index] = route
 	}
 
-	advertisedRoutes, err := hsdb.getAdvertisedRoutes(node)
+	advertisedRoutes, err := GetAdvertisedRoutes(tx, node)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, newRoute := range newRoutes {
 		if !util.StringOrPrefixListContains(advertisedRoutes, newRoute) {
-			return fmt.Errorf(
+			return nil, fmt.Errorf(
 				"route (%s) is not available on node %s: %w",
 				node.Hostname,
 				newRoute, ErrNodeRouteIsNotAvailable,
@@ -693,7 +579,7 @@ func (hsdb *HSDatabase) enableRoutes(node *types.Node, routeStrs ...string) erro
 	// Separate loop so we don't leave things in a half-updated state
 	for _, prefix := range newRoutes {
 		route := types.Route{}
-		err := hsdb.db.Preload("Node").
+		err := tx.Preload("Node").
 			Where("node_id = ? AND prefix = ?", node.ID, types.IPPrefix(prefix)).
 			First(&route).Error
 		if err == nil {
@@ -702,23 +588,23 @@ func (hsdb *HSDatabase) enableRoutes(node *types.Node, routeStrs ...string) erro
 			// Mark already as primary if there is only this node offering this subnet
 			// (and is not an exit route)
 			if !route.IsExitRoute() {
-				route.IsPrimary = hsdb.isUniquePrefix(route)
+				route.IsPrimary = isUniquePrefix(tx, route)
 			}
 
-			err = hsdb.db.Save(&route).Error
+			err = tx.Save(&route).Error
 			if err != nil {
-				return fmt.Errorf("failed to enable route: %w", err)
+				return nil, fmt.Errorf("failed to enable route: %w", err)
 			}
 		} else {
-			return fmt.Errorf("failed to find route: %w", err)
+			return nil, fmt.Errorf("failed to find route: %w", err)
 		}
 	}
 
 	// Ensure the node has the latest routes when notifying the other
 	// nodes
-	nRoutes, err := hsdb.getNodeRoutes(node)
+	nRoutes, err := GetNodeRoutes(tx, node)
 	if err != nil {
-		return fmt.Errorf("failed to read back routes: %w", err)
+		return nil, fmt.Errorf("failed to read back routes: %w", err)
 	}
 
 	node.Routes = nRoutes
@@ -729,30 +615,11 @@ func (hsdb *HSDatabase) enableRoutes(node *types.Node, routeStrs ...string) erro
 		Strs("routes", routeStrs).
 		Msg("enabling routes")
 
-	stateUpdate := types.StateUpdate{
+	return &types.StateUpdate{
 		Type:        types.StatePeerChanged,
 		ChangeNodes: types.Nodes{node},
-		Message:     "called from db.enableRoutes",
-	}
-	if stateUpdate.Valid() {
-		hsdb.notifier.NotifyWithIgnore(
-			stateUpdate, node.MachineKey.String())
-	}
-
-	// Send an update to the node itself with to ensure it
-	// has an updated packetfilter allowing the new route
-	// if it is defined in the ACL.
-	selfUpdate := types.StateUpdate{
-		Type:        types.StateSelfUpdate,
-		ChangeNodes: types.Nodes{node},
-	}
-	if selfUpdate.Valid() {
-		hsdb.notifier.NotifyByMachineKey(
-			selfUpdate,
-			node.MachineKey)
-	}
-
-	return nil
+		Message:     "created in db.enableRoutes",
+	}, nil
 }
 
 func generateGivenName(suppliedName string, randomSuffix bool) (string, error) {
@@ -785,16 +652,23 @@ func (hsdb *HSDatabase) GenerateGivenName(
 	mkey key.MachinePublic,
 	suppliedName string,
 ) (string, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
+	return Read(hsdb.DB, func(rx *gorm.DB) (string, error) {
+		return GenerateGivenName(rx, mkey, suppliedName)
+	})
+}
 
+func GenerateGivenName(
+	tx *gorm.DB,
+	mkey key.MachinePublic,
+	suppliedName string,
+) (string, error) {
 	givenName, err := generateGivenName(suppliedName, false)
 	if err != nil {
 		return "", err
 	}
 
 	// Tailscale rules (may differ) https://tailscale.com/kb/1098/machine-names/
-	nodes, err := hsdb.listNodesByGivenName(givenName)
+	nodes, err := listNodesByGivenName(tx, givenName)
 	if err != nil {
 		return "", err
 	}
@@ -818,29 +692,28 @@ func (hsdb *HSDatabase) GenerateGivenName(
 	return givenName, nil
 }
 
-func (hsdb *HSDatabase) ExpireEphemeralNodes(inactivityThreshhold time.Duration) {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
-	users, err := hsdb.listUsers()
+func ExpireEphemeralNodes(tx *gorm.DB,
+	inactivityThreshhold time.Duration,
+) (types.StateUpdate, bool) {
+	users, err := ListUsers(tx)
 	if err != nil {
 		log.Error().Err(err).Msg("Error listing users")
 
-		return
+		return types.StateUpdate{}, false
 	}
 
+	expired := make([]tailcfg.NodeID, 0)
 	for _, user := range users {
-		nodes, err := hsdb.listNodesByUser(user.Name)
+		nodes, err := ListNodesByUser(tx, user.Name)
 		if err != nil {
 			log.Error().
 				Err(err).
 				Str("user", user.Name).
 				Msg("Error listing nodes in user")
 
-			return
+			return types.StateUpdate{}, false
 		}
 
-		expired := make([]tailcfg.NodeID, 0)
 		for idx, node := range nodes {
 			if node.IsEphemeral() && node.LastSeen != nil &&
 				time.Now().
@@ -851,7 +724,8 @@ func (hsdb *HSDatabase) ExpireEphemeralNodes(inactivityThreshhold time.Duration)
 					Str("node", node.Hostname).
 					Msg("Ephemeral client removed from database")
 
-				err = hsdb.deleteNode(nodes[idx])
+					// empty isConnected map as ephemeral nodes are not routes
+				err = DeleteNode(tx, nodes[idx], map[key.MachinePublic]bool{})
 				if err != nil {
 					log.Error().
 						Err(err).
@@ -861,33 +735,35 @@ func (hsdb *HSDatabase) ExpireEphemeralNodes(inactivityThreshhold time.Duration)
 			}
 		}
 
-		if len(expired) > 0 {
-			hsdb.notifier.NotifyAll(types.StateUpdate{
-				Type:    types.StatePeerRemoved,
-				Removed: expired,
-			})
-		}
+		// TODO(kradalby): needs to be moved out of transaction
 	}
+	if len(expired) > 0 {
+		return types.StateUpdate{
+			Type:    types.StatePeerRemoved,
+			Removed: expired,
+		}, true
+	}
+
+	return types.StateUpdate{}, false
 }
 
-func (hsdb *HSDatabase) ExpireExpiredNodes(lastCheck time.Time) time.Time {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
+func ExpireExpiredNodes(tx *gorm.DB,
+	lastCheck time.Time,
+) (time.Time, types.StateUpdate, bool) {
 	// use the time of the start of the function to ensure we
 	// dont miss some nodes by returning it _after_ we have
 	// checked everything.
 	started := time.Now()
 
-	expiredNodes := make([]*types.Node, 0)
+	expired := make([]*tailcfg.PeerChange, 0)
 
-	nodes, err := hsdb.listNodes()
+	nodes, err := ListNodes(tx)
 	if err != nil {
 		log.Error().
 			Err(err).
 			Msg("Error listing nodes to find expired nodes")
 
-		return time.Unix(0, 0)
+		return time.Unix(0, 0), types.StateUpdate{}, false
 	}
 	for index, node := range nodes {
 		if node.IsExpired() &&
@@ -895,13 +771,17 @@ func (hsdb *HSDatabase) ExpireExpiredNodes(lastCheck time.Time) time.Time {
 			// It will notify about all nodes that has been expired.
 			// It should only notify about expired nodes since _last check_.
 			node.Expiry.After(lastCheck) {
-			expiredNodes = append(expiredNodes, &nodes[index])
+			expired = append(expired, &tailcfg.PeerChange{
+				NodeID:    tailcfg.NodeID(node.ID),
+				KeyExpiry: node.Expiry,
+			})
 
+			now := time.Now()
 			// Do not use setNodeExpiry as that has a notifier hook, which
 			// can cause a deadlock, we are updating all changed nodes later
 			// and there is no point in notifiying twice.
-			if err := hsdb.db.Model(&nodes[index]).Updates(types.Node{
-				Expiry: &started,
+			if err := tx.Model(&nodes[index]).Updates(types.Node{
+				Expiry: &now,
 			}).Error; err != nil {
 				log.Error().
 					Err(err).
@@ -917,33 +797,12 @@ func (hsdb *HSDatabase) ExpireExpiredNodes(lastCheck time.Time) time.Time {
 		}
 	}
 
-	expired := make([]*tailcfg.PeerChange, len(expiredNodes))
-	for idx, node := range expiredNodes {
-		expired[idx] = &tailcfg.PeerChange{
-			NodeID:    tailcfg.NodeID(node.ID),
-			KeyExpiry: &started,
-		}
+	if len(expired) > 0 {
+		return started, types.StateUpdate{
+			Type:          types.StatePeerChangedPatch,
+			ChangePatches: expired,
+		}, true
 	}
 
-	// Inform the peers of a node with a lightweight update.
-	stateUpdate := types.StateUpdate{
-		Type:          types.StatePeerChangedPatch,
-		ChangePatches: expired,
-	}
-	if stateUpdate.Valid() {
-		hsdb.notifier.NotifyAll(stateUpdate)
-	}
-
-	// Inform the node itself that it has expired.
-	for _, node := range expiredNodes {
-		stateSelfUpdate := types.StateUpdate{
-			Type:        types.StateSelfUpdate,
-			ChangeNodes: types.Nodes{node},
-		}
-		if stateSelfUpdate.Valid() {
-			hsdb.notifier.NotifyByMachineKey(stateSelfUpdate, node.MachineKey)
-		}
-	}
-
-	return started
+	return started, types.StateUpdate{}, false
 }

--- a/hscontrol/db/preauth_keys.go
+++ b/hscontrol/db/preauth_keys.go
@@ -20,7 +20,6 @@ var (
 	ErrPreAuthKeyACLTagInvalid     = errors.New("AuthKey tag is invalid")
 )
 
-// CreatePreAuthKey creates a new PreAuthKey in a user, and returns it.
 func (hsdb *HSDatabase) CreatePreAuthKey(
 	userName string,
 	reusable bool,
@@ -28,11 +27,21 @@ func (hsdb *HSDatabase) CreatePreAuthKey(
 	expiration *time.Time,
 	aclTags []string,
 ) (*types.PreAuthKey, error) {
-	// TODO(kradalby): figure out this lock
-	// hsdb.mu.Lock()
-	// defer hsdb.mu.Unlock()
+	return Write(hsdb.DB, func(tx *gorm.DB) (*types.PreAuthKey, error) {
+		return CreatePreAuthKey(tx, userName, reusable, ephemeral, expiration, aclTags)
+	})
+}
 
-	user, err := hsdb.GetUser(userName)
+// CreatePreAuthKey creates a new PreAuthKey in a user, and returns it.
+func CreatePreAuthKey(
+	tx *gorm.DB,
+	userName string,
+	reusable bool,
+	ephemeral bool,
+	expiration *time.Time,
+	aclTags []string,
+) (*types.PreAuthKey, error) {
+	user, err := GetUser(tx, userName)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +57,7 @@ func (hsdb *HSDatabase) CreatePreAuthKey(
 	}
 
 	now := time.Now().UTC()
-	kstr, err := hsdb.generateKey()
+	kstr, err := generateKey()
 	if err != nil {
 		return nil, err
 	}
@@ -63,29 +72,25 @@ func (hsdb *HSDatabase) CreatePreAuthKey(
 		Expiration: expiration,
 	}
 
-	err = hsdb.db.Transaction(func(db *gorm.DB) error {
-		if err := db.Save(&key).Error; err != nil {
-			return fmt.Errorf("failed to create key in the database: %w", err)
-		}
+	if err := tx.Save(&key).Error; err != nil {
+		return nil, fmt.Errorf("failed to create key in the database: %w", err)
+	}
 
-		if len(aclTags) > 0 {
-			seenTags := map[string]bool{}
+	if len(aclTags) > 0 {
+		seenTags := map[string]bool{}
 
-			for _, tag := range aclTags {
-				if !seenTags[tag] {
-					if err := db.Save(&types.PreAuthKeyACLTag{PreAuthKeyID: key.ID, Tag: tag}).Error; err != nil {
-						return fmt.Errorf(
-							"failed to ceate key tag in the database: %w",
-							err,
-						)
-					}
-					seenTags[tag] = true
+		for _, tag := range aclTags {
+			if !seenTags[tag] {
+				if err := tx.Save(&types.PreAuthKeyACLTag{PreAuthKeyID: key.ID, Tag: tag}).Error; err != nil {
+					return nil, fmt.Errorf(
+						"failed to ceate key tag in the database: %w",
+						err,
+					)
 				}
+				seenTags[tag] = true
 			}
 		}
-
-		return nil
-	})
+	}
 
 	if err != nil {
 		return nil, err
@@ -94,22 +99,21 @@ func (hsdb *HSDatabase) CreatePreAuthKey(
 	return &key, nil
 }
 
-// ListPreAuthKeys returns the list of PreAuthKeys for a user.
 func (hsdb *HSDatabase) ListPreAuthKeys(userName string) ([]types.PreAuthKey, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	return hsdb.listPreAuthKeys(userName)
+	return Read(hsdb.DB, func(rx *gorm.DB) ([]types.PreAuthKey, error) {
+		return ListPreAuthKeys(rx, userName)
+	})
 }
 
-func (hsdb *HSDatabase) listPreAuthKeys(userName string) ([]types.PreAuthKey, error) {
-	user, err := hsdb.getUser(userName)
+// ListPreAuthKeys returns the list of PreAuthKeys for a user.
+func ListPreAuthKeys(tx *gorm.DB, userName string) ([]types.PreAuthKey, error) {
+	user, err := GetUser(tx, userName)
 	if err != nil {
 		return nil, err
 	}
 
 	keys := []types.PreAuthKey{}
-	if err := hsdb.db.Preload("User").Preload("ACLTags").Where(&types.PreAuthKey{UserID: user.ID}).Find(&keys).Error; err != nil {
+	if err := tx.Preload("User").Preload("ACLTags").Where(&types.PreAuthKey{UserID: user.ID}).Find(&keys).Error; err != nil {
 		return nil, err
 	}
 
@@ -117,11 +121,8 @@ func (hsdb *HSDatabase) listPreAuthKeys(userName string) ([]types.PreAuthKey, er
 }
 
 // GetPreAuthKey returns a PreAuthKey for a given key.
-func (hsdb *HSDatabase) GetPreAuthKey(user string, key string) (*types.PreAuthKey, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	pak, err := hsdb.ValidatePreAuthKey(key)
+func GetPreAuthKey(tx *gorm.DB, user string, key string) (*types.PreAuthKey, error) {
+	pak, err := ValidatePreAuthKey(tx, key)
 	if err != nil {
 		return nil, err
 	}
@@ -135,15 +136,8 @@ func (hsdb *HSDatabase) GetPreAuthKey(user string, key string) (*types.PreAuthKe
 
 // DestroyPreAuthKey destroys a preauthkey. Returns error if the PreAuthKey
 // does not exist.
-func (hsdb *HSDatabase) DestroyPreAuthKey(pak types.PreAuthKey) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
-	return hsdb.destroyPreAuthKey(pak)
-}
-
-func (hsdb *HSDatabase) destroyPreAuthKey(pak types.PreAuthKey) error {
-	return hsdb.db.Transaction(func(db *gorm.DB) error {
+func DestroyPreAuthKey(tx *gorm.DB, pak types.PreAuthKey) error {
+	return tx.Transaction(func(db *gorm.DB) error {
 		if result := db.Unscoped().Where(types.PreAuthKeyACLTag{PreAuthKeyID: pak.ID}).Delete(&types.PreAuthKeyACLTag{}); result.Error != nil {
 			return result.Error
 		}
@@ -156,12 +150,15 @@ func (hsdb *HSDatabase) destroyPreAuthKey(pak types.PreAuthKey) error {
 	})
 }
 
-// MarkExpirePreAuthKey marks a PreAuthKey as expired.
 func (hsdb *HSDatabase) ExpirePreAuthKey(k *types.PreAuthKey) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
+	return hsdb.Write(func(tx *gorm.DB) error {
+		return ExpirePreAuthKey(tx, k)
+	})
+}
 
-	if err := hsdb.db.Model(&k).Update("Expiration", time.Now()).Error; err != nil {
+// MarkExpirePreAuthKey marks a PreAuthKey as expired.
+func ExpirePreAuthKey(tx *gorm.DB, k *types.PreAuthKey) error {
+	if err := tx.Model(&k).Update("Expiration", time.Now()).Error; err != nil {
 		return err
 	}
 
@@ -169,26 +166,26 @@ func (hsdb *HSDatabase) ExpirePreAuthKey(k *types.PreAuthKey) error {
 }
 
 // UsePreAuthKey marks a PreAuthKey as used.
-func (hsdb *HSDatabase) UsePreAuthKey(k *types.PreAuthKey) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
+func UsePreAuthKey(tx *gorm.DB, k *types.PreAuthKey) error {
 	k.Used = true
-	if err := hsdb.db.Save(k).Error; err != nil {
+	if err := tx.Save(k).Error; err != nil {
 		return fmt.Errorf("failed to update key used status in the database: %w", err)
 	}
 
 	return nil
 }
 
+func (hsdb *HSDatabase) ValidatePreAuthKey(k string) (*types.PreAuthKey, error) {
+	return Read(hsdb.DB, func(rx *gorm.DB) (*types.PreAuthKey, error) {
+		return ValidatePreAuthKey(rx, k)
+	})
+}
+
 // ValidatePreAuthKey does the heavy lifting for validation of the PreAuthKey coming from a node
 // If returns no error and a PreAuthKey, it can be used.
-func (hsdb *HSDatabase) ValidatePreAuthKey(k string) (*types.PreAuthKey, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
+func ValidatePreAuthKey(tx *gorm.DB, k string) (*types.PreAuthKey, error) {
 	pak := types.PreAuthKey{}
-	if result := hsdb.db.Preload("User").Preload("ACLTags").First(&pak, "key = ?", k); errors.Is(
+	if result := tx.Preload("User").Preload("ACLTags").First(&pak, "key = ?", k); errors.Is(
 		result.Error,
 		gorm.ErrRecordNotFound,
 	) {
@@ -204,7 +201,7 @@ func (hsdb *HSDatabase) ValidatePreAuthKey(k string) (*types.PreAuthKey, error) 
 	}
 
 	nodes := types.Nodes{}
-	if err := hsdb.db.
+	if err := tx.
 		Preload("AuthKey").
 		Where(&types.Node{AuthKeyID: uint(pak.ID)}).
 		Find(&nodes).Error; err != nil {
@@ -218,7 +215,7 @@ func (hsdb *HSDatabase) ValidatePreAuthKey(k string) (*types.PreAuthKey, error) 
 	return &pak, nil
 }
 
-func (hsdb *HSDatabase) generateKey() (string, error) {
+func generateKey() (string, error) {
 	size := 24
 	bytes := make([]byte, size)
 	if _, err := rand.Read(bytes); err != nil {

--- a/hscontrol/db/routes.go
+++ b/hscontrol/db/routes.go
@@ -7,23 +7,15 @@ import (
 	"github.com/juanfont/headscale/hscontrol/policy"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/rs/zerolog/log"
-	"github.com/samber/lo"
 	"gorm.io/gorm"
 	"tailscale.com/types/key"
 )
 
 var ErrRouteIsNotAvailable = errors.New("route is not available")
 
-func (hsdb *HSDatabase) GetRoutes() (types.Routes, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	return hsdb.getRoutes()
-}
-
-func (hsdb *HSDatabase) getRoutes() (types.Routes, error) {
+func GetRoutes(tx *gorm.DB) (types.Routes, error) {
 	var routes types.Routes
-	err := hsdb.db.
+	err := tx.
 		Preload("Node").
 		Preload("Node.User").
 		Find(&routes).Error
@@ -34,9 +26,9 @@ func (hsdb *HSDatabase) getRoutes() (types.Routes, error) {
 	return routes, nil
 }
 
-func (hsdb *HSDatabase) getAdvertisedAndEnabledRoutes() (types.Routes, error) {
+func getAdvertisedAndEnabledRoutes(tx *gorm.DB) (types.Routes, error) {
 	var routes types.Routes
-	err := hsdb.db.
+	err := tx.
 		Preload("Node").
 		Preload("Node.User").
 		Where("advertised = ? AND enabled = ?", true, true).
@@ -48,9 +40,9 @@ func (hsdb *HSDatabase) getAdvertisedAndEnabledRoutes() (types.Routes, error) {
 	return routes, nil
 }
 
-func (hsdb *HSDatabase) getRoutesByPrefix(pref netip.Prefix) (types.Routes, error) {
+func getRoutesByPrefix(tx *gorm.DB, pref netip.Prefix) (types.Routes, error) {
 	var routes types.Routes
-	err := hsdb.db.
+	err := tx.
 		Preload("Node").
 		Preload("Node.User").
 		Where("prefix = ?", types.IPPrefix(pref)).
@@ -62,16 +54,9 @@ func (hsdb *HSDatabase) getRoutesByPrefix(pref netip.Prefix) (types.Routes, erro
 	return routes, nil
 }
 
-func (hsdb *HSDatabase) GetNodeAdvertisedRoutes(node *types.Node) (types.Routes, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	return hsdb.getNodeAdvertisedRoutes(node)
-}
-
-func (hsdb *HSDatabase) getNodeAdvertisedRoutes(node *types.Node) (types.Routes, error) {
+func GetNodeAdvertisedRoutes(tx *gorm.DB, node *types.Node) (types.Routes, error) {
 	var routes types.Routes
-	err := hsdb.db.
+	err := tx.
 		Preload("Node").
 		Preload("Node.User").
 		Where("node_id = ? AND advertised = true", node.ID).
@@ -84,15 +69,14 @@ func (hsdb *HSDatabase) getNodeAdvertisedRoutes(node *types.Node) (types.Routes,
 }
 
 func (hsdb *HSDatabase) GetNodeRoutes(node *types.Node) (types.Routes, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	return hsdb.getNodeRoutes(node)
+	return Read(hsdb.DB, func(rx *gorm.DB) (types.Routes, error) {
+		return GetNodeRoutes(rx, node)
+	})
 }
 
-func (hsdb *HSDatabase) getNodeRoutes(node *types.Node) (types.Routes, error) {
+func GetNodeRoutes(tx *gorm.DB, node *types.Node) (types.Routes, error) {
 	var routes types.Routes
-	err := hsdb.db.
+	err := tx.
 		Preload("Node").
 		Preload("Node.User").
 		Where("node_id = ?", node.ID).
@@ -104,16 +88,9 @@ func (hsdb *HSDatabase) getNodeRoutes(node *types.Node) (types.Routes, error) {
 	return routes, nil
 }
 
-func (hsdb *HSDatabase) GetRoute(id uint64) (*types.Route, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	return hsdb.getRoute(id)
-}
-
-func (hsdb *HSDatabase) getRoute(id uint64) (*types.Route, error) {
+func GetRoute(tx *gorm.DB, id uint64) (*types.Route, error) {
 	var route types.Route
-	err := hsdb.db.
+	err := tx.
 		Preload("Node").
 		Preload("Node.User").
 		First(&route, id).Error
@@ -124,40 +101,34 @@ func (hsdb *HSDatabase) getRoute(id uint64) (*types.Route, error) {
 	return &route, nil
 }
 
-func (hsdb *HSDatabase) EnableRoute(id uint64) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
-	return hsdb.enableRoute(id)
-}
-
-func (hsdb *HSDatabase) enableRoute(id uint64) error {
-	route, err := hsdb.getRoute(id)
+func EnableRoute(tx *gorm.DB, id uint64) (*types.StateUpdate, error) {
+	route, err := GetRoute(tx, id)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Tailscale requires both IPv4 and IPv6 exit routes to
 	// be enabled at the same time, as per
 	// https://github.com/juanfont/headscale/issues/804#issuecomment-1399314002
 	if route.IsExitRoute() {
-		return hsdb.enableRoutes(
+		return enableRoutes(
+			tx,
 			&route.Node,
 			types.ExitRouteV4.String(),
 			types.ExitRouteV6.String(),
 		)
 	}
 
-	return hsdb.enableRoutes(&route.Node, netip.Prefix(route.Prefix).String())
+	return enableRoutes(tx, &route.Node, netip.Prefix(route.Prefix).String())
 }
 
-func (hsdb *HSDatabase) DisableRoute(id uint64) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
-	route, err := hsdb.getRoute(id)
+func DisableRoute(tx *gorm.DB,
+	id uint64,
+	isConnected map[key.MachinePublic]bool,
+) (*types.StateUpdate, error) {
+	route, err := GetRoute(tx, id)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var routes types.Routes
@@ -166,64 +137,79 @@ func (hsdb *HSDatabase) DisableRoute(id uint64) error {
 	// Tailscale requires both IPv4 and IPv6 exit routes to
 	// be enabled at the same time, as per
 	// https://github.com/juanfont/headscale/issues/804#issuecomment-1399314002
+	var update *types.StateUpdate
 	if !route.IsExitRoute() {
-		err = hsdb.failoverRouteWithNotify(route)
+		update, err = failoverRouteReturnUpdate(tx, isConnected, route)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		route.Enabled = false
 		route.IsPrimary = false
-		err = hsdb.db.Save(route).Error
+		err = tx.Save(route).Error
 		if err != nil {
-			return err
+			return nil, err
 		}
 	} else {
-		routes, err = hsdb.getNodeRoutes(&node)
+		routes, err = GetNodeRoutes(tx, &node)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		for i := range routes {
 			if routes[i].IsExitRoute() {
 				routes[i].Enabled = false
 				routes[i].IsPrimary = false
-				err = hsdb.db.Save(&routes[i]).Error
+				err = tx.Save(&routes[i]).Error
 				if err != nil {
-					return err
+					return nil, err
 				}
 			}
 		}
 	}
 
 	if routes == nil {
-		routes, err = hsdb.getNodeRoutes(&node)
+		routes, err = GetNodeRoutes(tx, &node)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	node.Routes = routes
 
-	stateUpdate := types.StateUpdate{
-		Type:        types.StatePeerChanged,
-		ChangeNodes: types.Nodes{&node},
-		Message:     "called from db.DisableRoute",
-	}
-	if stateUpdate.Valid() {
-		hsdb.notifier.NotifyAll(stateUpdate)
+	// If update is empty, it means that one was not created
+	// by failover (as a failover was not necessary), create
+	// one and return to the caller.
+	if update == nil {
+		update = &types.StateUpdate{
+			Type: types.StatePeerChanged,
+			ChangeNodes: types.Nodes{
+				&node,
+			},
+			Message: "called from db.DisableRoute",
+		}
 	}
 
-	return nil
+	return update, nil
 }
 
-func (hsdb *HSDatabase) DeleteRoute(id uint64) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
+func (hsdb *HSDatabase) DeleteRoute(
+	id uint64,
+	isConnected map[key.MachinePublic]bool,
+) (*types.StateUpdate, error) {
+	return Write(hsdb.DB, func(tx *gorm.DB) (*types.StateUpdate, error) {
+		return DeleteRoute(tx, id, isConnected)
+	})
+}
 
-	route, err := hsdb.getRoute(id)
+func DeleteRoute(
+	tx *gorm.DB,
+	id uint64,
+	isConnected map[key.MachinePublic]bool,
+) (*types.StateUpdate, error) {
+	route, err := GetRoute(tx, id)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var routes types.Routes
@@ -232,19 +218,20 @@ func (hsdb *HSDatabase) DeleteRoute(id uint64) error {
 	// Tailscale requires both IPv4 and IPv6 exit routes to
 	// be enabled at the same time, as per
 	// https://github.com/juanfont/headscale/issues/804#issuecomment-1399314002
+	var update *types.StateUpdate
 	if !route.IsExitRoute() {
-		err := hsdb.failoverRouteWithNotify(route)
+		update, err = failoverRouteReturnUpdate(tx, isConnected, route)
 		if err != nil {
-			return nil
+			return nil, nil
 		}
 
-		if err := hsdb.db.Unscoped().Delete(&route).Error; err != nil {
-			return err
+		if err := tx.Unscoped().Delete(&route).Error; err != nil {
+			return nil, err
 		}
 	} else {
-		routes, err := hsdb.getNodeRoutes(&node)
+		routes, err := GetNodeRoutes(tx, &node)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		routesToDelete := types.Routes{}
@@ -254,56 +241,59 @@ func (hsdb *HSDatabase) DeleteRoute(id uint64) error {
 			}
 		}
 
-		if err := hsdb.db.Unscoped().Delete(&routesToDelete).Error; err != nil {
-			return err
+		if err := tx.Unscoped().Delete(&routesToDelete).Error; err != nil {
+			return nil, err
 		}
 	}
 
+	// If update is empty, it means that one was not created
+	// by failover (as a failover was not necessary), create
+	// one and return to the caller.
 	if routes == nil {
-		routes, err = hsdb.getNodeRoutes(&node)
+		routes, err = GetNodeRoutes(tx, &node)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	node.Routes = routes
 
-	stateUpdate := types.StateUpdate{
-		Type:        types.StatePeerChanged,
-		ChangeNodes: types.Nodes{&node},
-		Message:     "called from db.DeleteRoute",
-	}
-	if stateUpdate.Valid() {
-		hsdb.notifier.NotifyAll(stateUpdate)
+	if update == nil {
+		update = &types.StateUpdate{
+			Type: types.StatePeerChanged,
+			ChangeNodes: types.Nodes{
+				&node,
+			},
+			Message: "called from db.DeleteRoute",
+		}
 	}
 
-	return nil
+	return update, nil
 }
 
-func (hsdb *HSDatabase) deleteNodeRoutes(node *types.Node) error {
-	routes, err := hsdb.getNodeRoutes(node)
+func deleteNodeRoutes(tx *gorm.DB, node *types.Node, isConnected map[key.MachinePublic]bool) error {
+	routes, err := GetNodeRoutes(tx, node)
 	if err != nil {
 		return err
 	}
 
 	for i := range routes {
-		if err := hsdb.db.Unscoped().Delete(&routes[i]).Error; err != nil {
+		if err := tx.Unscoped().Delete(&routes[i]).Error; err != nil {
 			return err
 		}
 
 		// TODO(kradalby): This is a bit too aggressive, we could probably
 		// figure out which routes needs to be failed over rather than all.
-		hsdb.failoverRouteWithNotify(&routes[i])
+		failoverRouteReturnUpdate(tx, isConnected, &routes[i])
 	}
 
 	return nil
 }
 
 // isUniquePrefix returns if there is another node providing the same route already.
-func (hsdb *HSDatabase) isUniquePrefix(route types.Route) bool {
+func isUniquePrefix(tx *gorm.DB, route types.Route) bool {
 	var count int64
-	hsdb.db.
-		Model(&types.Route{}).
+	tx.Model(&types.Route{}).
 		Where("prefix = ? AND node_id != ? AND advertised = ? AND enabled = ?",
 			route.Prefix,
 			route.NodeID,
@@ -312,9 +302,9 @@ func (hsdb *HSDatabase) isUniquePrefix(route types.Route) bool {
 	return count == 0
 }
 
-func (hsdb *HSDatabase) getPrimaryRoute(prefix netip.Prefix) (*types.Route, error) {
+func getPrimaryRoute(tx *gorm.DB, prefix netip.Prefix) (*types.Route, error) {
 	var route types.Route
-	err := hsdb.db.
+	err := tx.
 		Preload("Node").
 		Where("prefix = ? AND advertised = ? AND enabled = ? AND is_primary = ?", types.IPPrefix(prefix), true, true, true).
 		First(&route).Error
@@ -329,14 +319,17 @@ func (hsdb *HSDatabase) getPrimaryRoute(prefix netip.Prefix) (*types.Route, erro
 	return &route, nil
 }
 
+func (hsdb *HSDatabase) GetNodePrimaryRoutes(node *types.Node) (types.Routes, error) {
+	return Read(hsdb.DB, func(rx *gorm.DB) (types.Routes, error) {
+		return GetNodePrimaryRoutes(rx, node)
+	})
+}
+
 // getNodePrimaryRoutes returns the routes that are enabled and marked as primary (for subnet failover)
 // Exit nodes are not considered for this, as they are never marked as Primary.
-func (hsdb *HSDatabase) GetNodePrimaryRoutes(node *types.Node) (types.Routes, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
+func GetNodePrimaryRoutes(tx *gorm.DB, node *types.Node) (types.Routes, error) {
 	var routes types.Routes
-	err := hsdb.db.
+	err := tx.
 		Preload("Node").
 		Where("node_id = ? AND advertised = ? AND enabled = ? AND is_primary = ?", node.ID, true, true, true).
 		Find(&routes).Error
@@ -347,22 +340,21 @@ func (hsdb *HSDatabase) GetNodePrimaryRoutes(node *types.Node) (types.Routes, er
 	return routes, nil
 }
 
+func (hsdb *HSDatabase) SaveNodeRoutes(node *types.Node) (bool, error) {
+	return Write(hsdb.DB, func(tx *gorm.DB) (bool, error) {
+		return SaveNodeRoutes(tx, node)
+	})
+}
+
 // SaveNodeRoutes takes a node and updates the database with
 // the new routes.
 // It returns a bool whether an update should be sent as the
 // saved route impacts nodes.
-func (hsdb *HSDatabase) SaveNodeRoutes(node *types.Node) (bool, error) {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
-	return hsdb.saveNodeRoutes(node)
-}
-
-func (hsdb *HSDatabase) saveNodeRoutes(node *types.Node) (bool, error) {
+func SaveNodeRoutes(tx *gorm.DB, node *types.Node) (bool, error) {
 	sendUpdate := false
 
 	currentRoutes := types.Routes{}
-	err := hsdb.db.Where("node_id = ?", node.ID).Find(&currentRoutes).Error
+	err := tx.Where("node_id = ?", node.ID).Find(&currentRoutes).Error
 	if err != nil {
 		return sendUpdate, err
 	}
@@ -382,7 +374,7 @@ func (hsdb *HSDatabase) saveNodeRoutes(node *types.Node) (bool, error) {
 		if _, ok := advertisedRoutes[netip.Prefix(route.Prefix)]; ok {
 			if !route.Advertised {
 				currentRoutes[pos].Advertised = true
-				err := hsdb.db.Save(&currentRoutes[pos]).Error
+				err := tx.Save(&currentRoutes[pos]).Error
 				if err != nil {
 					return sendUpdate, err
 				}
@@ -398,7 +390,7 @@ func (hsdb *HSDatabase) saveNodeRoutes(node *types.Node) (bool, error) {
 		} else if route.Advertised {
 			currentRoutes[pos].Advertised = false
 			currentRoutes[pos].Enabled = false
-			err := hsdb.db.Save(&currentRoutes[pos]).Error
+			err := tx.Save(&currentRoutes[pos]).Error
 			if err != nil {
 				return sendUpdate, err
 			}
@@ -413,7 +405,7 @@ func (hsdb *HSDatabase) saveNodeRoutes(node *types.Node) (bool, error) {
 				Advertised: true,
 				Enabled:    false,
 			}
-			err := hsdb.db.Create(&route).Error
+			err := tx.Create(&route).Error
 			if err != nil {
 				return sendUpdate, err
 			}
@@ -425,127 +417,89 @@ func (hsdb *HSDatabase) saveNodeRoutes(node *types.Node) (bool, error) {
 
 // EnsureFailoverRouteIsAvailable takes a node and checks if the node's route
 // currently have a functioning host that exposes the network.
-func (hsdb *HSDatabase) EnsureFailoverRouteIsAvailable(node *types.Node) error {
-	nodeRoutes, err := hsdb.getNodeRoutes(node)
+func EnsureFailoverRouteIsAvailable(
+	tx *gorm.DB,
+	isConnected map[key.MachinePublic]bool,
+	node *types.Node,
+) (*types.StateUpdate, error) {
+	nodeRoutes, err := GetNodeRoutes(tx, node)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 
+	var changedNodes types.Nodes
 	for _, nodeRoute := range nodeRoutes {
-		routes, err := hsdb.getRoutesByPrefix(netip.Prefix(nodeRoute.Prefix))
+		routes, err := getRoutesByPrefix(tx, netip.Prefix(nodeRoute.Prefix))
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		for _, route := range routes {
 			if route.IsPrimary {
 				// if we have a primary route, and the node is connected
 				// nothing needs to be done.
-				if hsdb.notifier.IsConnected(route.Node.MachineKey) {
+				if isConnected[route.Node.MachineKey] {
 					continue
 				}
 
 				// if not, we need to failover the route
-				err := hsdb.failoverRouteWithNotify(&route)
+				update, err := failoverRouteReturnUpdate(tx, isConnected, &route)
 				if err != nil {
-					return err
+					return nil, err
+				}
+
+				if update != nil {
+					changedNodes = append(changedNodes, update.ChangeNodes...)
 				}
 			}
 		}
 	}
 
-	return nil
-}
-
-func (hsdb *HSDatabase) FailoverNodeRoutesWithNotify(node *types.Node) error {
-	routes, err := hsdb.getNodeRoutes(node)
-	if err != nil {
-		return nil
-	}
-
-	var changedKeys []key.MachinePublic
-
-	for _, route := range routes {
-		changed, err := hsdb.failoverRoute(&route)
-		if err != nil {
-			return err
-		}
-
-		changedKeys = append(changedKeys, changed...)
-	}
-
-	changedKeys = lo.Uniq(changedKeys)
-
-	var nodes types.Nodes
-
-	for _, key := range changedKeys {
-		node, err := hsdb.GetNodeByMachineKey(key)
-		if err != nil {
-			return err
-		}
-
-		nodes = append(nodes, node)
-	}
-
-	if nodes != nil {
-		stateUpdate := types.StateUpdate{
+	if len(changedNodes) != 0 {
+		return &types.StateUpdate{
 			Type:        types.StatePeerChanged,
-			ChangeNodes: nodes,
-			Message:     "called from db.FailoverNodeRoutesWithNotify",
-		}
-		if stateUpdate.Valid() {
-			hsdb.notifier.NotifyAll(stateUpdate)
-		}
+			ChangeNodes: changedNodes,
+			Message:     "called from db.EnsureFailoverRouteIsAvailable",
+		}, nil
 	}
 
-	return nil
+	return nil, nil
 }
 
-func (hsdb *HSDatabase) failoverRouteWithNotify(r *types.Route) error {
-	changedKeys, err := hsdb.failoverRoute(r)
+func failoverRouteReturnUpdate(
+	tx *gorm.DB,
+	isConnected map[key.MachinePublic]bool,
+	r *types.Route,
+) (*types.StateUpdate, error) {
+	changedKeys, err := failoverRoute(tx, isConnected, r)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	log.Trace().
+		Interface("isConnected", isConnected).
+		Interface("changedKeys", changedKeys).
+		Msg("building route failover")
 
 	if len(changedKeys) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	var nodes types.Nodes
-
-	log.Trace().
-		Str("hostname", r.Node.Hostname).
-		Msg("loading machines with new primary routes from db")
-
 	for _, key := range changedKeys {
-		node, err := hsdb.getNodeByMachineKey(key)
+		node, err := GetNodeByMachineKey(tx, key)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		nodes = append(nodes, node)
 	}
 
-	log.Trace().
-		Str("hostname", r.Node.Hostname).
-		Msg("notifying peers about primary route change")
-
-	if nodes != nil {
-		stateUpdate := types.StateUpdate{
-			Type:        types.StatePeerChanged,
-			ChangeNodes: nodes,
-			Message:     "called from db.failoverRouteWithNotify",
-		}
-		if stateUpdate.Valid() {
-			hsdb.notifier.NotifyAll(stateUpdate)
-		}
-	}
-
-	log.Trace().
-		Str("hostname", r.Node.Hostname).
-		Msg("notified peers about primary route change")
-
-	return nil
+	return &types.StateUpdate{
+		Type:        types.StatePeerChanged,
+		ChangeNodes: nodes,
+		Message:     "called from db.failoverRouteReturnUpdate",
+	}, nil
 }
 
 // failoverRoute takes a route that is no longer available,
@@ -556,12 +510,16 @@ func (hsdb *HSDatabase) failoverRouteWithNotify(r *types.Route) error {
 //
 // and tries to find a new route to take over its place.
 // If the given route was not primary, it returns early.
-func (hsdb *HSDatabase) failoverRoute(r *types.Route) ([]key.MachinePublic, error) {
+func failoverRoute(
+	tx *gorm.DB,
+	isConnected map[key.MachinePublic]bool,
+	r *types.Route,
+) ([]key.MachinePublic, error) {
 	if r == nil {
 		return nil, nil
 	}
 
-	// This route is not a primary route, and it isnt
+	// This route is not a primary route, and it is not
 	// being served to nodes.
 	if !r.IsPrimary {
 		return nil, nil
@@ -572,7 +530,7 @@ func (hsdb *HSDatabase) failoverRoute(r *types.Route) ([]key.MachinePublic, erro
 		return nil, nil
 	}
 
-	routes, err := hsdb.getRoutesByPrefix(netip.Prefix(r.Prefix))
+	routes, err := getRoutesByPrefix(tx, netip.Prefix(r.Prefix))
 	if err != nil {
 		return nil, err
 	}
@@ -589,14 +547,14 @@ func (hsdb *HSDatabase) failoverRoute(r *types.Route) ([]key.MachinePublic, erro
 			continue
 		}
 
-		if hsdb.notifier.IsConnected(route.Node.MachineKey) {
+		if isConnected[route.Node.MachineKey] {
 			newPrimary = &routes[idx]
 			break
 		}
 	}
 
 	// If a new route was not found/available,
-	// return with an error.
+	// return without an error.
 	// We do not want to update the database as
 	// the one currently marked as primary is the
 	// best we got.
@@ -610,7 +568,7 @@ func (hsdb *HSDatabase) failoverRoute(r *types.Route) ([]key.MachinePublic, erro
 
 	// Remove primary from the old route
 	r.IsPrimary = false
-	err = hsdb.db.Save(&r).Error
+	err = tx.Save(&r).Error
 	if err != nil {
 		log.Error().Err(err).Msg("error disabling new primary route")
 
@@ -623,7 +581,7 @@ func (hsdb *HSDatabase) failoverRoute(r *types.Route) ([]key.MachinePublic, erro
 
 	// Set primary for the new primary
 	newPrimary.IsPrimary = true
-	err = hsdb.db.Save(&newPrimary).Error
+	err = tx.Save(&newPrimary).Error
 	if err != nil {
 		log.Error().Err(err).Msg("error enabling new primary route")
 
@@ -638,25 +596,26 @@ func (hsdb *HSDatabase) failoverRoute(r *types.Route) ([]key.MachinePublic, erro
 	return []key.MachinePublic{r.Node.MachineKey, newPrimary.Node.MachineKey}, nil
 }
 
-// EnableAutoApprovedRoutes enables any routes advertised by a node that match the ACL autoApprovers policy.
 func (hsdb *HSDatabase) EnableAutoApprovedRoutes(
 	aclPolicy *policy.ACLPolicy,
 	node *types.Node,
-) error {
-	if len(aclPolicy.AutoApprovers.ExitNode) == 0 && len(aclPolicy.AutoApprovers.Routes) == 0 {
-		// No autoapprovers configured
-		return nil
-	}
+) (*types.StateUpdate, error) {
+	return Write(hsdb.DB, func(tx *gorm.DB) (*types.StateUpdate, error) {
+		return EnableAutoApprovedRoutes(tx, aclPolicy, node)
+	})
+}
 
+// EnableAutoApprovedRoutes enables any routes advertised by a node that match the ACL autoApprovers policy.
+func EnableAutoApprovedRoutes(
+	tx *gorm.DB,
+	aclPolicy *policy.ACLPolicy,
+	node *types.Node,
+) (*types.StateUpdate, error) {
 	if len(node.IPAddresses) == 0 {
-		// This node has no IPAddresses, so can't possibly match any autoApprovers ACLs
-		return nil
+		return nil, nil // This node has no IPAddresses, so can't possibly match any autoApprovers ACLs
 	}
 
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
-	routes, err := hsdb.getNodeAdvertisedRoutes(node)
+	routes, err := GetNodeAdvertisedRoutes(tx, node)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		log.Error().
 			Caller().
@@ -664,7 +623,7 @@ func (hsdb *HSDatabase) EnableAutoApprovedRoutes(
 			Str("node", node.Hostname).
 			Msg("Could not get advertised routes for node")
 
-		return err
+		return nil, err
 	}
 
 	log.Trace().Interface("routes", routes).Msg("routes for autoapproving")
@@ -685,7 +644,7 @@ func (hsdb *HSDatabase) EnableAutoApprovedRoutes(
 				Uint64("nodeId", node.ID).
 				Msg("Failed to resolve autoApprovers for advertised route")
 
-			return err
+			return nil, err
 		}
 
 		log.Trace().
@@ -706,7 +665,7 @@ func (hsdb *HSDatabase) EnableAutoApprovedRoutes(
 						Str("alias", approvedAlias).
 						Msg("Failed to expand alias when processing autoApprovers policy")
 
-					return err
+					return nil, err
 				}
 
 				// approvedIPs should contain all of node's IPs if it matches the rule, so check for first
@@ -717,17 +676,25 @@ func (hsdb *HSDatabase) EnableAutoApprovedRoutes(
 		}
 	}
 
+	update := &types.StateUpdate{
+		Type:        types.StatePeerChanged,
+		ChangeNodes: types.Nodes{},
+		Message:     "created in db.EnableAutoApprovedRoutes",
+	}
+
 	for _, approvedRoute := range approvedRoutes {
-		err := hsdb.enableRoute(uint64(approvedRoute.ID))
+		perHostUpdate, err := EnableRoute(tx, uint64(approvedRoute.ID))
 		if err != nil {
 			log.Err(err).
 				Str("approvedRoute", approvedRoute.String()).
 				Uint64("nodeId", node.ID).
 				Msg("Failed to enable approved route")
 
-			return err
+			return nil, err
 		}
+
+		update.ChangeNodes = append(update.ChangeNodes, perHostUpdate.ChangeNodes...)
 	}
 
-	return nil
+	return update, nil
 }

--- a/hscontrol/db/suite_test.go
+++ b/hscontrol/db/suite_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/juanfont/headscale/hscontrol/notifier"
 	"gopkg.in/check.v1"
 )
 
@@ -48,7 +47,6 @@ func (s *Suite) ResetDB(c *check.C) {
 		"sqlite3",
 		tmpDir+"/headscale_test.db",
 		false,
-		notifier.NewNotifier(),
 		[]netip.Prefix{
 			netip.MustParsePrefix("10.27.0.0/23"),
 		},

--- a/hscontrol/db/users.go
+++ b/hscontrol/db/users.go
@@ -15,22 +15,25 @@ var (
 	ErrUserStillHasNodes = errors.New("user not empty: node(s) found")
 )
 
+func (hsdb *HSDatabase) CreateUser(name string) (*types.User, error) {
+	return Write(hsdb.DB, func(tx *gorm.DB) (*types.User, error) {
+		return CreateUser(tx, name)
+	})
+}
+
 // CreateUser creates a new User. Returns error if could not be created
 // or another user already exists.
-func (hsdb *HSDatabase) CreateUser(name string) (*types.User, error) {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
+func CreateUser(tx *gorm.DB, name string) (*types.User, error) {
 	err := util.CheckForFQDNRules(name)
 	if err != nil {
 		return nil, err
 	}
 	user := types.User{}
-	if err := hsdb.db.Where("name = ?", name).First(&user).Error; err == nil {
+	if err := tx.Where("name = ?", name).First(&user).Error; err == nil {
 		return nil, ErrUserExists
 	}
 	user.Name = name
-	if err := hsdb.db.Create(&user).Error; err != nil {
+	if err := tx.Create(&user).Error; err != nil {
 		log.Error().
 			Str("func", "CreateUser").
 			Err(err).
@@ -42,18 +45,21 @@ func (hsdb *HSDatabase) CreateUser(name string) (*types.User, error) {
 	return &user, nil
 }
 
+func (hsdb *HSDatabase) DestroyUser(name string) error {
+	return hsdb.Write(func(tx *gorm.DB) error {
+		return DestroyUser(tx, name)
+	})
+}
+
 // DestroyUser destroys a User. Returns error if the User does
 // not exist or if there are nodes associated with it.
-func (hsdb *HSDatabase) DestroyUser(name string) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
-	user, err := hsdb.getUser(name)
+func DestroyUser(tx *gorm.DB, name string) error {
+	user, err := GetUser(tx, name)
 	if err != nil {
 		return ErrUserNotFound
 	}
 
-	nodes, err := hsdb.listNodesByUser(name)
+	nodes, err := ListNodesByUser(tx, name)
 	if err != nil {
 		return err
 	}
@@ -61,32 +67,35 @@ func (hsdb *HSDatabase) DestroyUser(name string) error {
 		return ErrUserStillHasNodes
 	}
 
-	keys, err := hsdb.listPreAuthKeys(name)
+	keys, err := ListPreAuthKeys(tx, name)
 	if err != nil {
 		return err
 	}
 	for _, key := range keys {
-		err = hsdb.destroyPreAuthKey(key)
+		err = DestroyPreAuthKey(tx, key)
 		if err != nil {
 			return err
 		}
 	}
 
-	if result := hsdb.db.Unscoped().Delete(&user); result.Error != nil {
+	if result := tx.Unscoped().Delete(&user); result.Error != nil {
 		return result.Error
 	}
 
 	return nil
 }
 
+func (hsdb *HSDatabase) RenameUser(oldName, newName string) error {
+	return hsdb.Write(func(tx *gorm.DB) error {
+		return RenameUser(tx, oldName, newName)
+	})
+}
+
 // RenameUser renames a User. Returns error if the User does
 // not exist or if another User exists with the new name.
-func (hsdb *HSDatabase) RenameUser(oldName, newName string) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
-
+func RenameUser(tx *gorm.DB, oldName, newName string) error {
 	var err error
-	oldUser, err := hsdb.getUser(oldName)
+	oldUser, err := GetUser(tx, oldName)
 	if err != nil {
 		return err
 	}
@@ -94,7 +103,7 @@ func (hsdb *HSDatabase) RenameUser(oldName, newName string) error {
 	if err != nil {
 		return err
 	}
-	_, err = hsdb.getUser(newName)
+	_, err = GetUser(tx, newName)
 	if err == nil {
 		return ErrUserExists
 	}
@@ -104,24 +113,22 @@ func (hsdb *HSDatabase) RenameUser(oldName, newName string) error {
 
 	oldUser.Name = newName
 
-	if result := hsdb.db.Save(&oldUser); result.Error != nil {
+	if result := tx.Save(&oldUser); result.Error != nil {
 		return result.Error
 	}
 
 	return nil
 }
 
-// GetUser fetches a user by name.
 func (hsdb *HSDatabase) GetUser(name string) (*types.User, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	return hsdb.getUser(name)
+	return Read(hsdb.DB, func(rx *gorm.DB) (*types.User, error) {
+		return GetUser(rx, name)
+	})
 }
 
-func (hsdb *HSDatabase) getUser(name string) (*types.User, error) {
+func GetUser(tx *gorm.DB, name string) (*types.User, error) {
 	user := types.User{}
-	if result := hsdb.db.First(&user, "name = ?", name); errors.Is(
+	if result := tx.First(&user, "name = ?", name); errors.Is(
 		result.Error,
 		gorm.ErrRecordNotFound,
 	) {
@@ -131,17 +138,16 @@ func (hsdb *HSDatabase) getUser(name string) (*types.User, error) {
 	return &user, nil
 }
 
-// ListUsers gets all the existing users.
 func (hsdb *HSDatabase) ListUsers() ([]types.User, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	return hsdb.listUsers()
+	return Read(hsdb.DB, func(rx *gorm.DB) ([]types.User, error) {
+		return ListUsers(rx)
+	})
 }
 
-func (hsdb *HSDatabase) listUsers() ([]types.User, error) {
+// ListUsers gets all the existing users.
+func ListUsers(tx *gorm.DB) ([]types.User, error) {
 	users := []types.User{}
-	if err := hsdb.db.Find(&users).Error; err != nil {
+	if err := tx.Find(&users).Error; err != nil {
 		return nil, err
 	}
 
@@ -149,46 +155,42 @@ func (hsdb *HSDatabase) listUsers() ([]types.User, error) {
 }
 
 // ListNodesByUser gets all the nodes in a given user.
-func (hsdb *HSDatabase) ListNodesByUser(name string) (types.Nodes, error) {
-	hsdb.mu.RLock()
-	defer hsdb.mu.RUnlock()
-
-	return hsdb.listNodesByUser(name)
-}
-
-func (hsdb *HSDatabase) listNodesByUser(name string) (types.Nodes, error) {
+func ListNodesByUser(tx *gorm.DB, name string) (types.Nodes, error) {
 	err := util.CheckForFQDNRules(name)
 	if err != nil {
 		return nil, err
 	}
-	user, err := hsdb.getUser(name)
+	user, err := GetUser(tx, name)
 	if err != nil {
 		return nil, err
 	}
 
 	nodes := types.Nodes{}
-	if err := hsdb.db.Preload("AuthKey").Preload("AuthKey.User").Preload("User").Where(&types.Node{UserID: user.ID}).Find(&nodes).Error; err != nil {
+	if err := tx.Preload("AuthKey").Preload("AuthKey.User").Preload("User").Where(&types.Node{UserID: user.ID}).Find(&nodes).Error; err != nil {
 		return nil, err
 	}
 
 	return nodes, nil
 }
 
-// AssignNodeToUser assigns a Node to a user.
 func (hsdb *HSDatabase) AssignNodeToUser(node *types.Node, username string) error {
-	hsdb.mu.Lock()
-	defer hsdb.mu.Unlock()
+	return hsdb.Write(func(tx *gorm.DB) error {
+		return AssignNodeToUser(tx, node, username)
+	})
+}
 
+// AssignNodeToUser assigns a Node to a user.
+func AssignNodeToUser(tx *gorm.DB, node *types.Node, username string) error {
 	err := util.CheckForFQDNRules(username)
 	if err != nil {
 		return err
 	}
-	user, err := hsdb.getUser(username)
+	user, err := GetUser(tx, username)
 	if err != nil {
 		return err
 	}
 	node.User = *user
-	if result := hsdb.db.Save(&node); result.Error != nil {
+	if result := tx.Save(&node); result.Error != nil {
 		return result.Error
 	}
 

--- a/hscontrol/db/users_test.go
+++ b/hscontrol/db/users_test.go
@@ -36,7 +36,7 @@ func (s *Suite) TestDestroyUserErrors(c *check.C) {
 	err = db.DestroyUser("test")
 	c.Assert(err, check.IsNil)
 
-	result := db.db.Preload("User").First(&pak, "key = ?", pak.Key)
+	result := db.DB.Preload("User").First(&pak, "key = ?", pak.Key)
 	// destroying a user also deletes all associated preauthkeys
 	c.Assert(result.Error, check.Equals, gorm.ErrRecordNotFound)
 
@@ -53,7 +53,7 @@ func (s *Suite) TestDestroyUserErrors(c *check.C) {
 		RegisterMethod: util.RegisterMethodAuthKey,
 		AuthKeyID:      uint(pak.ID),
 	}
-	db.db.Save(&node)
+	db.DB.Save(&node)
 
 	err = db.DestroyUser("test")
 	c.Assert(err, check.Equals, ErrUserStillHasNodes)
@@ -105,7 +105,7 @@ func (s *Suite) TestSetMachineUser(c *check.C) {
 		RegisterMethod: util.RegisterMethodAuthKey,
 		AuthKeyID:      uint(pak.ID),
 	}
-	db.db.Save(&node)
+	db.DB.Save(&node)
 	c.Assert(node.UserID, check.Equals, oldUser.ID)
 
 	err = db.AssignNodeToUser(&node, newUser.Name)

--- a/hscontrol/derp/server/derp_server.go
+++ b/hscontrol/derp/server/derp_server.go
@@ -211,7 +211,7 @@ func DERPProbeHandler(
 // The initial implementation is here https://github.com/tailscale/tailscale/pull/1406
 // They have a cache, but not clear if that is really necessary at Headscale, uh, scale.
 // An example implementation is found here https://derp.tailscale.com/bootstrap-dns
-// Coordination server is included automatically, since local DERP is using the same DNS Name in d.serverURL
+// Coordination server is included automatically, since local DERP is using the same DNS Name in d.serverURL.
 func DERPBootstrapDNSHandler(
 	derpMap *tailcfg.DERPMap,
 ) func(http.ResponseWriter, *http.Request) {

--- a/hscontrol/mapper/mapper.go
+++ b/hscontrol/mapper/mapper.go
@@ -272,6 +272,7 @@ func (m *Mapper) LiteMapResponse(
 	mapRequest tailcfg.MapRequest,
 	node *types.Node,
 	pol *policy.ACLPolicy,
+	messages ...string,
 ) ([]byte, error) {
 	resp, err := m.baseWithConfigMapResponse(node, pol, mapRequest.Version)
 	if err != nil {
@@ -290,7 +291,7 @@ func (m *Mapper) LiteMapResponse(
 	resp.PacketFilter = policy.ReduceFilterRules(node, rules)
 	resp.SSHPolicy = sshPolicy
 
-	return m.marshalMapResponse(mapRequest, resp, node, mapRequest.Compress)
+	return m.marshalMapResponse(mapRequest, resp, node, mapRequest.Compress, messages...)
 }
 
 func (m *Mapper) KeepAliveResponse(
@@ -392,9 +393,7 @@ func (m *Mapper) PeerChangedPatchResponse(
 			}
 
 			if patches, ok := m.patches[uint64(change.NodeID)]; ok {
-				patches := append(patches, p)
-
-				m.patches[uint64(change.NodeID)] = patches
+				m.patches[uint64(change.NodeID)] = append(patches, p)
 			} else {
 				m.patches[uint64(change.NodeID)] = []patch{p}
 			}
@@ -470,6 +469,8 @@ func (m *Mapper) marshalMapResponse(
 		switch {
 		case resp.Peers != nil && len(resp.Peers) > 0:
 			responseType = "full"
+		case isSelfUpdate(messages...):
+			responseType = "self"
 		case resp.Peers == nil && resp.PeersChanged == nil && resp.PeersChangedPatch == nil:
 			responseType = "lite"
 		case resp.PeersChanged != nil && len(resp.PeersChanged) > 0:
@@ -667,4 +668,14 @@ func appendPeerChanges(
 	resp.SSHPolicy = sshPolicy
 
 	return nil
+}
+
+func isSelfUpdate(messages ...string) bool {
+	for _, message := range messages {
+		if strings.Contains(message, types.SelfUpdateIdentifier) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/hscontrol/mapper/tail.go
+++ b/hscontrol/mapper/tail.go
@@ -72,7 +72,7 @@ func tailNode(
 	}
 
 	var derp string
-	if node.Hostinfo.NetInfo != nil {
+	if node.Hostinfo != nil && node.Hostinfo.NetInfo != nil {
 		derp = fmt.Sprintf("127.3.3.40:%d", node.Hostinfo.NetInfo.PreferredDERP)
 	} else {
 		derp = "127.3.3.40:0" // Zero means disconnected or unknown.

--- a/hscontrol/oidc.go
+++ b/hscontrol/oidc.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juanfont/headscale/hscontrol/util"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/oauth2"
+	"gorm.io/gorm"
 	"tailscale.com/types/key"
 )
 
@@ -492,7 +493,7 @@ func (h *Headscale) validateNodeForOIDCCallback(
 			Str("node", node.Hostname).
 			Msg("node already registered, reauthenticating")
 
-		err := h.db.NodeSetExpiry(node, expiry)
+		err := h.db.NodeSetExpiry(node.ID, expiry)
 		if err != nil {
 			util.LogErr(err, "Failed to refresh node")
 			http.Error(
@@ -534,6 +535,12 @@ func (h *Headscale) validateNodeForOIDCCallback(
 		_, err = writer.Write(content.Bytes())
 		if err != nil {
 			util.LogErr(err, "Failed to write response")
+		}
+
+		stateUpdate := types.StateUpdateExpire(node.ID, expiry)
+		if stateUpdate.Valid() {
+			ctx := types.NotifyCtx(context.Background(), "oidc-expiry", "na")
+			h.nodeNotifier.NotifyWithIgnore(ctx, stateUpdate, node.MachineKey.String())
 		}
 
 		return nil, true, nil
@@ -613,14 +620,22 @@ func (h *Headscale) registerNodeForOIDCCallback(
 	machineKey *key.MachinePublic,
 	expiry time.Time,
 ) error {
-	if _, err := h.db.RegisterNodeFromAuthCallback(
-		// TODO(kradalby): find a better way to use the cache across modules
-		h.registrationCache,
-		*machineKey,
-		user.Name,
-		&expiry,
-		util.RegisterMethodOIDC,
-	); err != nil {
+	if err := h.db.DB.Transaction(func(tx *gorm.DB) error {
+		if _, err := db.RegisterNodeFromAuthCallback(
+			// TODO(kradalby): find a better way to use the cache across modules
+			tx,
+			h.registrationCache,
+			*machineKey,
+			user.Name,
+			&expiry,
+			util.RegisterMethodOIDC,
+			h.cfg.IPPrefixes,
+		); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
 		util.LogErr(err, "could not register node")
 		writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		writer.WriteHeader(http.StatusInternalServerError)

--- a/hscontrol/poll_noise.go
+++ b/hscontrol/poll_noise.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	MinimumCapVersion tailcfg.CapabilityVersion = 56
+	MinimumCapVersion tailcfg.CapabilityVersion = 58
 )
 
 // NoisePollNetMapHandler takes care of /machine/:id/map using the Noise protocol

--- a/hscontrol/types/users.go
+++ b/hscontrol/types/users.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"strconv"
-	"time"
 
 	v1 "github.com/juanfont/headscale/gen/go/headscale/v1"
 	"github.com/juanfont/headscale/hscontrol/util"
@@ -22,12 +21,13 @@ type User struct {
 
 func (n *User) TailscaleUser() *tailcfg.User {
 	user := tailcfg.User{
-		ID:            tailcfg.UserID(n.ID),
-		LoginName:     n.Name,
-		DisplayName:   n.Name,
+		ID:          tailcfg.UserID(n.ID),
+		LoginName:   n.Name,
+		DisplayName: n.Name,
+		// TODO(kradalby): See if we can fill in Gravatar here
 		ProfilePicURL: "",
 		Logins:        []tailcfg.LoginID{},
-		Created:       time.Time{},
+		Created:       n.CreatedAt,
 	}
 
 	return &user
@@ -35,9 +35,10 @@ func (n *User) TailscaleUser() *tailcfg.User {
 
 func (n *User) TailscaleLogin() *tailcfg.Login {
 	login := tailcfg.Login{
-		ID:            tailcfg.LoginID(n.ID),
-		LoginName:     n.Name,
-		DisplayName:   n.Name,
+		ID:          tailcfg.LoginID(n.ID),
+		LoginName:   n.Name,
+		DisplayName: n.Name,
+		// TODO(kradalby): See if we can fill in Gravatar here
 		ProfilePicURL: "",
 	}
 

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -1240,7 +1240,7 @@ func TestNodeRenameCommand(t *testing.T) {
 	assert.Contains(t, listAll[4].GetGivenName(), "node-5")
 
 	for idx := 0; idx < 3; idx++ {
-		_, err := headscale.Execute(
+		res, err := headscale.Execute(
 			[]string{
 				"headscale",
 				"nodes",
@@ -1251,6 +1251,8 @@ func TestNodeRenameCommand(t *testing.T) {
 			},
 		)
 		assert.Nil(t, err)
+
+		assert.Contains(t, res, "Node renamed")
 	}
 
 	var listAllAfterRename []v1.Node

--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -56,8 +56,8 @@ var (
 		"1.44":     true,  // CapVer: 63
 		"1.42":     true,  // CapVer: 61
 		"1.40":     true,  // CapVer: 61
-		"1.38":     true,  // CapVer: 58
-		"1.36":     true,  // Oldest supported version, CapVer: 56
+		"1.38":     true,  // Oldest supported version, CapVer: 58
+		"1.36":     false, // CapVer: 56
 		"1.34":     false, // CapVer: 51
 		"1.32":     false, // CapVer: 46
 		"1.30":     false,


### PR DESCRIPTION
This commits removes the locks used to guard data integrity for the
database and replaces them with Transactions, turns out that SQL had
a way to deal with this all along.

This reduces the complexity we had with multiple locks that might stack
or recurse (database, nofitifer, mapper). All notifications and state
updates are now triggered _after_ a database change.

Signed-off-by: Kristoffer Dalby <kristoffer@dalby.cc>