### PR TITLE
fix: Preauth key list reusable column

### DIFF
--- a/cmd/headscale/cli/preauthkeys.go
+++ b/cmd/headscale/cli/preauthkeys.go
@@ -107,13 +107,6 @@ var listPreAuthKeys = &cobra.Command{
 				expiration = ColourTime(key.GetExpiration().AsTime())
 			}
 
-			var reusable string
-			if key.GetEphemeral() {
-				reusable = "N/A"
-			} else {
-				reusable = fmt.Sprintf("%v", key.GetReusable())
-			}
-
 			aclTags := ""
 
 			for _, tag := range key.GetAclTags() {
@@ -125,7 +118,7 @@ var listPreAuthKeys = &cobra.Command{
 			tableData = append(tableData, []string{
 				key.GetId(),
 				key.GetKey(),
-				reusable,
+				fmt.Sprintf("%v", key.GetReusable()),
 				strconv.FormatBool(key.GetEphemeral()),
 				strconv.FormatBool(key.GetUsed()),
 				expiration,


### PR DESCRIPTION
## Overview

Fixes https://github.com/juanfont/headscale/issues/1712

The preauthkeys Reusable column is incorrectly showing N/A rather than true when a key is reusable. Not quite sure what the original intention was, but this makes it more clear.

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.mm
