### PR TITLE
Login with OIDC after having been logged out

### DIFF
--- a/hscontrol/auth.go
+++ b/hscontrol/auth.go
@@ -199,6 +199,19 @@ func (h *Headscale) handleRegister(
 			return
 		}
 
+		// When logged out and reauthenticating with OIDC, the OldNodeKey is not passed, but the NodeKey has changed
+		if node.NodeKey.String() != registerRequest.NodeKey.String() &&
+			registerRequest.OldNodeKey.IsZero() && !node.IsExpired() {
+			h.handleNodeKeyRefresh(
+				writer,
+				registerRequest,
+				*node,
+				machineKey,
+			)
+
+			return
+		}
+
 		if registerRequest.Followup != "" {
 			select {
 			case <-req.Context().Done():


### PR DESCRIPTION
<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
Fixes https://github.com/juanfont/headscale/issues/1675
Fixes https://github.com/juanfont/headscale/issues/1705

These issues started in the v0.23.0 alpha. 
When reauthenticating using oidc, no OldNodeKey is set by the client, the NodeKey set by the client is different from the one headscale has set, but the NodeKey does not get updated to the new one.

 A better fix might be to update the nodekey in the RegisterOIDC stack, but my attempts there did not work.