### PR TITLE
Add assert func for verifying status, netmap and netcheck

### DIFF
--- a/.github/workflows/test-integration-v2-TestPingAllByIPPublicDERP.yaml
+++ b/.github/workflows/test-integration-v2-TestPingAllByIPPublicDERP.yaml
@@ -1,0 +1,67 @@
+# DO NOT EDIT, generated with cmd/gh-action-integration-generator/main.go
+# To regenerate, run "go generate" in cmd/gh-action-integration-generator/
+
+name: Integration Test v2 - TestPingAllByIPPublicDERP
+
+on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  TestPingAllByIPPublicDERP:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: satackey/action-docker-layer-caching@main
+        continue-on-error: true
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v34
+        with:
+          files: |
+            *.nix
+            go.*
+            **/*.go
+            integration_test/
+            config-example.yaml
+
+      - name: Run TestPingAllByIPPublicDERP
+        uses: Wandalen/wretry.action@master
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          attempt_limit: 5
+          command: |
+            nix develop --command -- docker run \
+              --tty --rm \
+              --volume ~/.cache/hs-integration-go:/go \
+              --name headscale-test-suite \
+              --volume $PWD:$PWD -w $PWD/integration \
+              --volume /var/run/docker.sock:/var/run/docker.sock \
+              --volume $PWD/control_logs:/tmp/control \
+              golang:1 \
+                go run gotest.tools/gotestsum@latest -- ./... \
+                  -failfast \
+                  -timeout 120m \
+                  -parallel 1 \
+                  -run "^TestPingAllByIPPublicDERP$"
+
+      - uses: actions/upload-artifact@v3
+        if: always() && steps.changed-files.outputs.any_changed == 'true'
+        with:
+          name: logs
+          path: "control_logs/*.log"
+
+      - uses: actions/upload-artifact@v3
+        if: always() && steps.changed-files.outputs.any_changed == 'true'
+        with:
+          name: pprof
+          path: "control_logs/*.pprof.tar"

--- a/hscontrol/poll.go
+++ b/hscontrol/poll.go
@@ -201,9 +201,15 @@ func (h *Headscale) handlePoll(
 			return
 		}
 
+		// TODO(kradalby): Figure out why patch changes does
+		// not show up in output from `tailscale debug netmap`.
+		// stateUpdate := types.StateUpdate{
+		// 	Type:          types.StatePeerChangedPatch,
+		// 	ChangePatches: []*tailcfg.PeerChange{&change},
+		// }
 		stateUpdate := types.StateUpdate{
-			Type:          types.StatePeerChangedPatch,
-			ChangePatches: []*tailcfg.PeerChange{&change},
+			Type:        types.StatePeerChanged,
+			ChangeNodes: types.Nodes{node},
 		}
 		if stateUpdate.Valid() {
 			ctx := types.NotifyCtx(context.Background(), "poll-nodeupdate-peers-patch", node.Hostname)

--- a/hscontrol/util/test.go
+++ b/hscontrol/util/test.go
@@ -15,6 +15,10 @@ var IPComparer = cmp.Comparer(func(x, y netip.Addr) bool {
 	return x.Compare(y) == 0
 })
 
+var AddrPortComparer = cmp.Comparer(func(x, y netip.AddrPort) bool {
+	return x == y
+})
+
 var MkeyComparer = cmp.Comparer(func(x, y key.MachinePublic) bool {
 	return x.String() == y.String()
 })
@@ -28,5 +32,5 @@ var DkeyComparer = cmp.Comparer(func(x, y key.DiscoPublic) bool {
 })
 
 var Comparers []cmp.Option = []cmp.Option{
-	IPComparer, PrefixComparer, MkeyComparer, NkeyComparer, DkeyComparer,
+	IPComparer, PrefixComparer, AddrPortComparer, MkeyComparer, NkeyComparer, DkeyComparer,
 }

--- a/integration/auth_oidc_test.go
+++ b/integration/auth_oidc_test.go
@@ -83,6 +83,8 @@ func TestOIDCAuthenticationPingAll(t *testing.T) {
 	err = scenario.WaitForTailscaleSync()
 	assertNoErrSync(t, err)
 
+	assertClientsState(t, allClients)
+
 	allAddrs := lo.Map(allIps, func(x netip.Addr, index int) string {
 		return x.String()
 	})
@@ -139,6 +141,8 @@ func TestOIDCExpireNodesBasedOnTokenExpiry(t *testing.T) {
 
 	err = scenario.WaitForTailscaleSync()
 	assertNoErrSync(t, err)
+
+	assertClientsState(t, allClients)
 
 	allAddrs := lo.Map(allIps, func(x netip.Addr, index int) string {
 		return x.String()

--- a/integration/auth_web_flow_test.go
+++ b/integration/auth_web_flow_test.go
@@ -53,6 +53,8 @@ func TestAuthWebFlowAuthenticationPingAll(t *testing.T) {
 	err = scenario.WaitForTailscaleSync()
 	assertNoErrSync(t, err)
 
+	assertClientsState(t, allClients)
+
 	allAddrs := lo.Map(allIps, func(x netip.Addr, index int) string {
 		return x.String()
 	})
@@ -89,6 +91,8 @@ func TestAuthWebFlowLogoutAndRelogin(t *testing.T) {
 
 	err = scenario.WaitForTailscaleSync()
 	assertNoErrSync(t, err)
+
+	assertClientsState(t, allClients)
 
 	allAddrs := lo.Map(allIps, func(x netip.Addr, index int) string {
 		return x.String()

--- a/integration/embedded_derp_test.go
+++ b/integration/embedded_derp_test.go
@@ -33,20 +33,23 @@ func TestDERPServerScenario(t *testing.T) {
 	defer scenario.Shutdown()
 
 	spec := map[string]int{
-		"user1": len(MustTestVersions),
+		"user1": 10,
+		// "user1": len(MustTestVersions),
 	}
 
-	headscaleConfig := map[string]string{}
-	headscaleConfig["HEADSCALE_DERP_URLS"] = ""
-	headscaleConfig["HEADSCALE_DERP_SERVER_ENABLED"] = "true"
-	headscaleConfig["HEADSCALE_DERP_SERVER_REGION_ID"] = "999"
-	headscaleConfig["HEADSCALE_DERP_SERVER_REGION_CODE"] = "headscale"
-	headscaleConfig["HEADSCALE_DERP_SERVER_REGION_NAME"] = "Headscale Embedded DERP"
-	headscaleConfig["HEADSCALE_DERP_SERVER_STUN_LISTEN_ADDR"] = "0.0.0.0:3478"
-	headscaleConfig["HEADSCALE_DERP_SERVER_PRIVATE_KEY_PATH"] = "/tmp/derp.key"
-	// Envknob for enabling DERP debug logs
-	headscaleConfig["DERP_DEBUG_LOGS"] = "true"
-	headscaleConfig["DERP_PROBER_DEBUG_LOGS"] = "true"
+	headscaleConfig := map[string]string{
+		"HEADSCALE_DERP_URLS":                    "",
+		"HEADSCALE_DERP_SERVER_ENABLED":          "true",
+		"HEADSCALE_DERP_SERVER_REGION_ID":        "999",
+		"HEADSCALE_DERP_SERVER_REGION_CODE":      "headscale",
+		"HEADSCALE_DERP_SERVER_REGION_NAME":      "Headscale Embedded DERP",
+		"HEADSCALE_DERP_SERVER_STUN_LISTEN_ADDR": "0.0.0.0:3478",
+		"HEADSCALE_DERP_SERVER_PRIVATE_KEY_PATH": "/tmp/derp.key",
+
+		// Envknob for enabling DERP debug logs
+		"DERP_DEBUG_LOGS":        "true",
+		"DERP_PROBER_DEBUG_LOGS": "true",
+	}
 
 	err = scenario.CreateHeadscaleEnv(
 		spec,

--- a/integration/embedded_derp_test.go
+++ b/integration/embedded_derp_test.go
@@ -70,6 +70,8 @@ func TestDERPServerScenario(t *testing.T) {
 	err = scenario.WaitForTailscaleSync()
 	assertNoErrSync(t, err)
 
+	assertClientsState(t, allClients)
+
 	allHostnames, err := scenario.ListTailscaleClientsFQDNs()
 	assertNoErrListFQDN(t, err)
 

--- a/integration/general_test.go
+++ b/integration/general_test.go
@@ -65,7 +65,43 @@ func TestPingAllByIP(t *testing.T) {
 	err = scenario.WaitForTailscaleSync()
 	assertNoErrSync(t, err)
 
-	// time.Sleep(2 * time.Minute)
+	assertClientsState(t, allClients)
+
+	allAddrs := lo.Map(allIps, func(x netip.Addr, index int) string {
+		return x.String()
+	})
+
+	success := pingAllHelper(t, allClients, allAddrs)
+	t.Logf("%d successful pings out of %d", success, len(allClients)*len(allIps))
+}
+
+func TestPingAllByIPPublicDERP(t *testing.T) {
+	IntegrationSkip(t)
+	t.Parallel()
+
+	scenario, err := NewScenario()
+	assertNoErr(t, err)
+	defer scenario.Shutdown()
+
+	spec := map[string]int{
+		"user1": len(MustTestVersions),
+		"user2": len(MustTestVersions),
+	}
+
+	err = scenario.CreateHeadscaleEnv(spec,
+		[]tsic.Option{},
+		hsic.WithTestName("pingallbyippubderp"),
+	)
+	assertNoErrHeadscaleEnv(t, err)
+
+	allClients, err := scenario.ListTailscaleClients()
+	assertNoErrListClients(t, err)
+
+	allIps, err := scenario.ListTailscaleClientsIPs()
+	assertNoErrListClientIPs(t, err)
+
+	err = scenario.WaitForTailscaleSync()
+	assertNoErrSync(t, err)
 
 	assertClientsState(t, allClients)
 

--- a/integration/tailscale.go
+++ b/integration/tailscale.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juanfont/headscale/integration/dockertestutil"
 	"github.com/juanfont/headscale/integration/tsic"
 	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/net/netcheck"
 	"tailscale.com/types/netmap"
 )
 
@@ -28,6 +29,7 @@ type TailscaleClient interface {
 	FQDN() (string, error)
 	Status() (*ipnstate.Status, error)
 	Netmap() (*netmap.NetworkMap, error)
+	Netcheck() (*netcheck.Report, error)
 	WaitForNeedsLogin() error
 	WaitForRunning() error
 	WaitForPeers(expected int) error

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -685,9 +685,9 @@ func (t *TailscaleInContainer) WaitForPeers(expected int) error {
 					return fmt.Errorf("[%s] peer count correct, but %s does not have a Hostname", t.hostname, peer.HostName)
 				}
 
-				// if peer.Relay == "" {
-				// 	return fmt.Errorf("[%s] peer count correct, but %s does not have a DERP", t.hostname, peer.HostName)
-				// }
+				if peer.Relay == "" {
+					return fmt.Errorf("[%s] peer count correct, but %s does not have a DERP", t.hostname, peer.HostName)
+				}
 			}
 		}
 

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juanfont/headscale/integration/tsic"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -83,7 +84,7 @@ func pingAllHelper(t *testing.T, clients []TailscaleClient, addrs []string, opts
 		for _, addr := range addrs {
 			err := client.Ping(addr, opts...)
 			if err != nil {
-				t.Fatalf("failed to ping %s from %s: %s", addr, client.Hostname(), err)
+				t.Errorf("failed to ping %s from %s: %s", addr, client.Hostname(), err)
 			} else {
 				success++
 			}
@@ -120,6 +121,138 @@ func pingDerpAllHelper(t *testing.T, clients []TailscaleClient, addrs []string) 
 	return success
 }
 
+// assertClientsState validates the status and netmap of a list of
+// clients for the general case of all to all connectivity.
+func assertClientsState(t *testing.T, clients []TailscaleClient) {
+	t.Helper()
+
+	for _, client := range clients {
+		assertValidStatus(t, client)
+		assertValidNetmap(t, client)
+		assertValidNetcheck(t, client)
+	}
+}
+
+// assertValidNetmap asserts that the netmap of a client has all
+// the minimum required fields set to a known working config for
+// the general case. Fields are checked on self, then all peers.
+// This test is not suitable for ACL/partial connection tests.
+// This test can only be run on clients from 1.56.1. It will
+// automatically pass all clients below that and is safe to call
+// for all versions.
+func assertValidNetmap(t *testing.T, client TailscaleClient) {
+	t.Helper()
+
+	// TODO(kradalby): Add check for over 1.56.1
+	if !strings.Contains(client.Hostname(), "head") && !strings.Contains(client.Hostname(), "unstable") {
+		return
+	}
+
+	netmap, err := client.Netmap()
+	if err != nil {
+		t.Fatalf("getting netmap for %q: %s", client.Hostname(), err)
+	}
+
+	assert.Truef(t, netmap.SelfNode.Hostinfo().Valid(), "%q does not have Hostinfo", client.Hostname())
+	if hi := netmap.SelfNode.Hostinfo(); hi.Valid() {
+		assert.LessOrEqual(t, 1, netmap.SelfNode.Hostinfo().Services().Len(), "%q does not have enough services, got: %v", client.Hostname(), netmap.SelfNode.Hostinfo().Services())
+	}
+
+	assert.NotEmptyf(t, netmap.SelfNode.AllowedIPs(), "%q does not have any allowed IPs", client.Hostname())
+	assert.NotEmptyf(t, netmap.SelfNode.Addresses(), "%q does not have any addresses", client.Hostname())
+
+	assert.Truef(t, *netmap.SelfNode.Online(), "%q is not online", client.Hostname())
+
+	assert.Falsef(t, netmap.SelfNode.Key().IsZero(), "%q does not have a valid NodeKey", client.Hostname())
+	assert.Falsef(t, netmap.SelfNode.Machine().IsZero(), "%q does not have a valid MachineKey", client.Hostname())
+	assert.Falsef(t, netmap.SelfNode.DiscoKey().IsZero(), "%q does not have a valid DiscoKey", client.Hostname())
+
+	for _, peer := range netmap.Peers {
+		assert.NotEqualf(t, "127.3.3.40:0", peer.DERP(), "peer (%s) has no home DERP in %q's netmap, got: %s", peer.ComputedName(), client.Hostname(), peer.DERP())
+
+		assert.Truef(t, peer.Hostinfo().Valid(), "peer (%s) of %q does not have Hostinfo", peer.ComputedName(), client.Hostname())
+		if hi := peer.Hostinfo(); hi.Valid() {
+			assert.LessOrEqualf(t, 3, peer.Hostinfo().Services().Len(), "peer (%s) of %q does not have enough services, got: %v", peer.ComputedName(), client.Hostname(), peer.Hostinfo().Services())
+
+			// Netinfo is not always set
+			// assert.Truef(t, hi.NetInfo().Valid(), "peer (%s) of %q does not have NetInfo", peer.ComputedName(), client.Hostname())
+			if ni := hi.NetInfo(); ni.Valid() {
+				assert.NotEqualf(t, 0, ni.PreferredDERP(), "peer (%s) has no home DERP in %q's netmap, got: %s", peer.ComputedName(), client.Hostname(), peer.Hostinfo().NetInfo().PreferredDERP())
+			}
+
+		}
+
+		assert.NotEmptyf(t, peer.Endpoints(), "peer (%s) of %q does not have any endpoints", peer.ComputedName(), client.Hostname())
+		assert.NotEmptyf(t, peer.AllowedIPs(), "peer (%s) of %q does not have any allowed IPs", peer.ComputedName(), client.Hostname())
+		assert.NotEmptyf(t, peer.Addresses(), "peer (%s) of %q does not have any addresses", peer.ComputedName(), client.Hostname())
+
+		assert.Truef(t, *peer.Online(), "peer (%s) of %q is not online", peer.ComputedName(), client.Hostname())
+
+		assert.Falsef(t, peer.Key().IsZero(), "peer (%s) of %q does not have a valid NodeKey", peer.ComputedName(), client.Hostname())
+		assert.Falsef(t, peer.Machine().IsZero(), "peer (%s) of %q does not have a valid MachineKey", peer.ComputedName(), client.Hostname())
+		assert.Falsef(t, peer.DiscoKey().IsZero(), "peer (%s) of %q does not have a valid DiscoKey", peer.ComputedName(), client.Hostname())
+	}
+}
+
+// assertValidStatus asserts that the status of a client has all
+// the minimum required fields set to a known working config for
+// the general case. Fields are checked on self, then all peers.
+// This test is not suitable for ACL/partial connection tests.
+func assertValidStatus(t *testing.T, client TailscaleClient) {
+	t.Helper()
+	status, err := client.Status()
+	if err != nil {
+		t.Fatalf("getting status for %q: %s", client.Hostname(), err)
+	}
+
+	assert.NotEmptyf(t, status.Self.HostName, "%q does not have HostName set, likely missing Hostinfo", client.Hostname())
+	assert.NotEmptyf(t, status.Self.OS, "%q does not have OS set, likely missing Hostinfo", client.Hostname())
+	assert.NotEmptyf(t, status.Self.Relay, "%q does not have a relay, likely missing Hostinfo/Netinfo", client.Hostname())
+
+	assert.NotEmptyf(t, status.Self.TailscaleIPs, "%q does not have Tailscale IPs", client.Hostname())
+	assert.NotEmptyf(t, status.Self.AllowedIPs, "%q does not have any allowed IPs", client.Hostname())
+	assert.NotEmptyf(t, status.Self.Addrs, "%q does not have any endpoints", client.Hostname())
+
+	assert.Truef(t, status.Self.Online, "%q is not online", client.Hostname())
+
+	assert.Truef(t, status.Self.InNetworkMap, "%q is not in network map", client.Hostname())
+
+	// This isnt really relevant for Self as it wont be in its own socket/wireguard.
+	// assert.Truef(t, status.Self.InMagicSock, "%q is not tracked by magicsock", client.Hostname())
+	// assert.Truef(t, status.Self.InEngine, "%q is not in in wireguard engine", client.Hostname())
+
+	for _, peer := range status.Peer {
+		assert.NotEmptyf(t, peer.HostName, "peer (%s) of %q does not have HostName set, likely missing Hostinfo", peer.DNSName, client.Hostname())
+		assert.NotEmptyf(t, peer.OS, "peer (%s) of %q does not have OS set, likely missing Hostinfo", peer.DNSName, client.Hostname())
+		assert.NotEmptyf(t, peer.Relay, "peer (%s) of %q does not have a relay, likely missing Hostinfo/Netinfo", peer.DNSName, client.Hostname())
+
+		assert.NotEmptyf(t, peer.TailscaleIPs, "peer (%s) of %q does not have Tailscale IPs", peer.DNSName, client.Hostname())
+		assert.NotEmptyf(t, peer.AllowedIPs, "peer (%s) of %q does not have any allowed IPs", peer.DNSName, client.Hostname())
+
+		// Addrs does not seem to appear in the status from peers.
+		// assert.NotEmptyf(t, peer.Addrs, "peer (%s) of %q does not have any endpoints", peer.DNSName, client.Hostname())
+
+		assert.Truef(t, peer.Online, "peer (%s) of %q is not online", peer.DNSName, client.Hostname())
+
+		assert.Truef(t, peer.InNetworkMap, "peer (%s) of %q is not in network map", peer.DNSName, client.Hostname())
+		assert.Truef(t, peer.InMagicSock, "peer (%s) of %q is not tracked by magicsock", peer.DNSName, client.Hostname())
+
+		// TODO(kradalby): InEngine is only true when a proper tunnel is set up,
+		// there might be some interesting stuff to test here in the future.
+		// assert.Truef(t, peer.InEngine, "peer (%s) of %q is not in wireguard engine", peer.DNSName, client.Hostname())
+	}
+}
+
+func assertValidNetcheck(t *testing.T, client TailscaleClient) {
+	t.Helper()
+	report, err := client.Netcheck()
+	if err != nil {
+		t.Fatalf("getting status for %q: %s", client.Hostname(), err)
+	}
+
+	assert.NotEqualf(t, 0, report.PreferredDERP, "%q does not have a DERP relay", client.Hostname())
+}
+
 func isSelfClient(client TailscaleClient, addr string) bool {
 	if addr == client.Hostname() {
 		return true
@@ -152,7 +285,7 @@ func isCI() bool {
 }
 
 func dockertestMaxWait() time.Duration {
-	wait := 60 * time.Second //nolint
+	wait := 120 * time.Second //nolint
 
 	if isCI() {
 		wait = 300 * time.Second //nolint


### PR DESCRIPTION
This PR adds three new integration test assert methods which will do the following for the "general" case:

`assertValidNetmap`: in clients which support `tailscale debug netmap` it will dump the netmap and verify that it is in a known "good" state, this includes checking for endpoints, derp relays, ips, online status and more.

`assertValidStatus`: check the output of the `tailscale status` command, checking derp relay, hostname, os, peer ips, network map status and magic sock status

`assertValidNetcheck`: checks that the client has a valid DERP server using output from `tailscale netcheck`.

The "general" case is any all to all communication, it does not account for things like nodes with ACLs and similar.

This also splits "PingAllByAll" into two, one version which use internal DERP for better use offline or dodgy internet, and one with public DERP.

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>