### PR TITLE
Get integration test netmap from watch-ipn command

### DIFF
--- a/hscontrol/poll.go
+++ b/hscontrol/poll.go
@@ -202,15 +202,9 @@ func (h *Headscale) handlePoll(
 			return
 		}
 
-		// TODO(kradalby): Figure out why patch changes does
-		// not show up in output from `tailscale debug netmap`.
-		// stateUpdate := types.StateUpdate{
-		// 	Type:          types.StatePeerChangedPatch,
-		// 	ChangePatches: []*tailcfg.PeerChange{&change},
-		// }
 		stateUpdate := types.StateUpdate{
-			Type:        types.StatePeerChanged,
-			ChangeNodes: types.Nodes{node},
+			Type:          types.StatePeerChangedPatch,
+			ChangePatches: []*tailcfg.PeerChange{&change},
 		}
 		if stateUpdate.Valid() {
 			ctx := types.NotifyCtx(context.Background(), "poll-nodeupdate-peers-patch", node.Hostname)

--- a/hscontrol/util/util.go
+++ b/hscontrol/util/util.go
@@ -1,0 +1,14 @@
+package util
+
+import "tailscale.com/util/cmpver"
+
+func TailscaleVersionNewerOrEqual(minimum, toCheck string) bool {
+	if cmpver.Compare(minimum, toCheck) <= 0 ||
+		toCheck == "unstable" ||
+		toCheck == "head" {
+
+		return true
+	}
+
+	return false
+}

--- a/hscontrol/util/util.go
+++ b/hscontrol/util/util.go
@@ -6,7 +6,6 @@ func TailscaleVersionNewerOrEqual(minimum, toCheck string) bool {
 	if cmpver.Compare(minimum, toCheck) <= 0 ||
 		toCheck == "unstable" ||
 		toCheck == "head" {
-
 		return true
 	}
 

--- a/hscontrol/util/util_test.go
+++ b/hscontrol/util/util_test.go
@@ -1,0 +1,95 @@
+package util
+
+import "testing"
+
+func TestTailscaleVersionNewerOrEqual(t *testing.T) {
+	type args struct {
+		minimum string
+		toCheck string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "is-equal",
+			args: args{
+				minimum: "1.56",
+				toCheck: "1.56",
+			},
+			want: true,
+		},
+		{
+			name: "is-newer-head",
+			args: args{
+				minimum: "1.56",
+				toCheck: "head",
+			},
+			want: true,
+		},
+		{
+			name: "is-newer-unstable",
+			args: args{
+				minimum: "1.56",
+				toCheck: "unstable",
+			},
+			want: true,
+		},
+		{
+			name: "is-newer-patch",
+			args: args{
+				minimum: "1.56.1",
+				toCheck: "1.56.1",
+			},
+			want: true,
+		},
+		{
+			name: "is-older-patch-same-minor",
+			args: args{
+				minimum: "1.56.1",
+				toCheck: "1.56.0",
+			},
+			want: false,
+		},
+		{
+			name: "is-older-unstable",
+			args: args{
+				minimum: "1.56",
+				toCheck: "1.55",
+			},
+			want: false,
+		},
+		{
+			name: "is-older-one-stable",
+			args: args{
+				minimum: "1.56",
+				toCheck: "1.54",
+			},
+			want: false,
+		},
+		{
+			name: "is-older-five-stable",
+			args: args{
+				minimum: "1.56",
+				toCheck: "1.46",
+			},
+			want: false,
+		},
+		{
+			name: "is-older-patch",
+			args: args{
+				minimum: "1.56",
+				toCheck: "1.48.1",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TailscaleVersionNewerOrEqual(tt.args.minimum, tt.args.toCheck); got != tt.want {
+				t.Errorf("TailscaleVersionNewerThan() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/integration/embedded_derp_test.go
+++ b/integration/embedded_derp_test.go
@@ -70,8 +70,6 @@ func TestDERPServerScenario(t *testing.T) {
 	err = scenario.WaitForTailscaleSync()
 	assertNoErrSync(t, err)
 
-	assertClientsState(t, allClients)
-
 	allHostnames, err := scenario.ListTailscaleClientsFQDNs()
 	assertNoErrListFQDN(t, err)
 

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -3,12 +3,12 @@ package integration
 import (
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/juanfont/headscale/integration/tsic"
 	"github.com/stretchr/testify/assert"
-	"tailscale.com/util/cmpver"
 )
 
 const (
@@ -127,11 +127,21 @@ func pingDerpAllHelper(t *testing.T, clients []TailscaleClient, addrs []string) 
 func assertClientsState(t *testing.T, clients []TailscaleClient) {
 	t.Helper()
 
+	var wg sync.WaitGroup
+
 	for _, client := range clients {
-		assertValidStatus(t, client)
-		assertValidNetmap(t, client)
-		assertValidNetcheck(t, client)
+		wg.Add(1)
+		c := client // Avoid loop pointer
+		go func() {
+			defer wg.Done()
+			assertValidStatus(t, c)
+			assertValidNetcheck(t, c)
+			assertValidNetmap(t, c)
+		}()
 	}
+
+	t.Logf("waiting for client state checks to finish")
+	wg.Wait()
 }
 
 // assertValidNetmap asserts that the netmap of a client has all
@@ -144,11 +154,13 @@ func assertClientsState(t *testing.T, clients []TailscaleClient) {
 func assertValidNetmap(t *testing.T, client TailscaleClient) {
 	t.Helper()
 
-	if cmpver.Compare("1.56.1", client.Version()) <= 0 ||
-		!strings.Contains(client.Hostname(), "unstable") ||
-		!strings.Contains(client.Hostname(), "head") {
-		return
-	}
+	// if !util.TailscaleVersionNewerOrEqual("1.56", client.Version()) {
+	// 	t.Logf("%q has version %q, skipping netmap check...", client.Hostname(), client.Version())
+
+	// 	return
+	// }
+
+	t.Logf("Checking netmap of %q", client.Hostname())
 
 	netmap, err := client.Netmap()
 	if err != nil {
@@ -177,11 +189,10 @@ func assertValidNetmap(t *testing.T, client TailscaleClient) {
 			assert.LessOrEqualf(t, 3, peer.Hostinfo().Services().Len(), "peer (%s) of %q does not have enough services, got: %v", peer.ComputedName(), client.Hostname(), peer.Hostinfo().Services())
 
 			// Netinfo is not always set
-			assert.Truef(t, hi.NetInfo().Valid(), "peer (%s) of %q does not have NetInfo", peer.ComputedName(), client.Hostname())
+			// assert.Truef(t, hi.NetInfo().Valid(), "peer (%s) of %q does not have NetInfo", peer.ComputedName(), client.Hostname())
 			if ni := hi.NetInfo(); ni.Valid() {
 				assert.NotEqualf(t, 0, ni.PreferredDERP(), "peer (%s) has no home DERP in %q's netmap, got: %s", peer.ComputedName(), client.Hostname(), peer.Hostinfo().NetInfo().PreferredDERP())
 			}
-
 		}
 
 		assert.NotEmptyf(t, peer.Endpoints(), "peer (%s) of %q does not have any endpoints", peer.ComputedName(), client.Hostname())


### PR DESCRIPTION
This version uses `tailscale debug watch-ipn` as
it is available in all supported versions, and it
does not seem to have any weird side effect when using
Patch updates (empty values).

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>