### PR TITLE
Prepare notify channel before sending first update

### DIFF
--- a/hscontrol/grpcv1.go
+++ b/hscontrol/grpcv1.go
@@ -200,16 +200,6 @@ func (api headscaleV1APIServer) RegisterNode(
 		return nil, err
 	}
 
-	stateUpdate := types.StateUpdate{
-		Type:        types.StatePeerChanged,
-		ChangeNodes: types.Nodes{node},
-		Message:     "called from api.RegisterNode",
-	}
-	if stateUpdate.Valid() {
-		ctx := types.NotifyCtx(ctx, "cli-registernode", node.Hostname)
-		api.h.nodeNotifier.NotifyWithIgnore(ctx, stateUpdate, node.MachineKey.String())
-	}
-
 	return &v1.RegisterNodeResponse{Node: node.Proto()}, nil
 }
 


### PR DESCRIPTION
This tries to solve a timing issue where nodes might send updates between the first full map and the channel for getting updates being opened which means they might not get endpoints or derp updates from peers.

In addition, it removes the notifier in the registration stages, with the reasoning that its better to announce when the nodes contacts the poller as it is "more ready" and not missing things like hostinfo.

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>