### PR TITLE
fix docker tagging

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,7 +97,7 @@ kos:
       - linux/arm64
       - linux/arm/v7
     tags:
-      - latest
+      - "{{ if not .Prerelease }}latest{{ end }}"
       - "{{ .Tag }}"
       - "{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
       - "{{ .Major }}.{{ .Minor }}"
@@ -116,7 +116,7 @@ kos:
       - linux/arm64
       - linux/arm/v7
     tags:
-      - latest
+      - "{{ if not .Prerelease }}latest{{ end }}"
       - "{{ .Tag }}"
       - "{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
       - "{{ .Major }}.{{ .Minor }}"
@@ -139,7 +139,7 @@ kos:
       - linux/arm64
       - linux/arm/v7
     tags:
-      - latest
+      - "{{ if not .Prerelease }}latest-debug{{ end }}"
       - "{{ .Tag }}-debug"
       - "{{ .Major }}.{{ .Minor }}.{{ .Patch }}-debug"
       - "{{ .Major }}.{{ .Minor }}-debug"
@@ -158,7 +158,7 @@ kos:
       - linux/arm64
       - linux/arm/v7
     tags:
-      - latest
+      - "{{ if not .Prerelease }}latest-debug{{ end }}"
       - "{{ .Tag }}-debug"
       - "{{ .Major }}.{{ .Minor }}.{{ .Patch }}-debug"
       - "{{ .Major }}.{{ .Minor }}-debug"


### PR DESCRIPTION
This should fix the tags for docker for prereleases. We don't want to push to latest on prerelease.

- [ x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
