### PR TITLE
rework docker tags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,13 +97,17 @@ kos:
       - linux/arm64
       - linux/arm/v7
     tags:
-      - latest
-      - "{{ .Tag }}"
-      - "{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
-      - "{{ .Major }}.{{ .Minor }}"
-      - "{{ .Major }}"
-      - "sha-{{ .ShortCommit }}"
+      - "{{ if not .Prerelease }}latest{{ end }}"
+      - "{{ if not .Prerelease }}{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "{{ if not .Prerelease }}{{ .Major }}.{{ .Minor }}"
+      - "{{ if not .Prerelease }}{{ .Major }}"
+      - "{{ if not .Prerelease }}v{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "{{ if not .Prerelease }}v{{ .Major }}.{{ .Minor }}"
+      - "{{ if not .Prerelease }}v{{ .Major }}"
       - "{{ if not .Prerelease }}stable{{ else }}unstable{{ end }}"
+      - "{{ .Tag }}"
+      - '{{ trimprefix .Tag "v" }}'
+      - "sha-{{ .ShortCommit }}"
 
   - id: dockerhub
     build: headscale
@@ -116,14 +120,17 @@ kos:
       - linux/arm64
       - linux/arm/v7
     tags:
-      - latest
-      - "{{ .Tag }}"
-      - "{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
-      - "{{ .Major }}.{{ .Minor }}"
-      - "{{ .Major }}"
-      - "sha-{{ .ShortCommit }}"
-      - "{{ if not .Prerelease }}stable{{ end }}"
+      - "{{ if not .Prerelease }}latest{{ end }}"
+      - "{{ if not .Prerelease }}{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "{{ if not .Prerelease }}{{ .Major }}.{{ .Minor }}"
+      - "{{ if not .Prerelease }}{{ .Major }}"
+      - "{{ if not .Prerelease }}v{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "{{ if not .Prerelease }}v{{ .Major }}.{{ .Minor }}"
+      - "{{ if not .Prerelease }}v{{ .Major }}"
       - "{{ if not .Prerelease }}stable{{ else }}unstable{{ end }}"
+      - "{{ .Tag }}"
+      - '{{ trimprefix .Tag "v" }}'
+      - "sha-{{ .ShortCommit }}"
 
   - id: ghcr-debug
     repository: ghcr.io/juanfont/headscale
@@ -139,13 +146,17 @@ kos:
       - linux/arm64
       - linux/arm/v7
     tags:
-      - latest
-      - "{{ .Tag }}-debug"
-      - "{{ .Major }}.{{ .Minor }}.{{ .Patch }}-debug"
-      - "{{ .Major }}.{{ .Minor }}-debug"
-      - "{{ .Major }}-debug"
-      - "sha-{{ .ShortCommit }}-debug"
+      - "{{ if not .Prerelease }}latest{{ end }}-debug"
+      - "{{ if not .Prerelease }}{{ .Major }}.{{ .Minor }}.{{ .Patch }}-debug"
+      - "{{ if not .Prerelease }}{{ .Major }}.{{ .Minor }}-debug"
+      - "{{ if not .Prerelease }}{{ .Major }}-debug"
+      - "{{ if not .Prerelease }}v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-debug"
+      - "{{ if not .Prerelease }}v{{ .Major }}.{{ .Minor }}-debug"
+      - "{{ if not .Prerelease }}v{{ .Major }}-debug"
       - "{{ if not .Prerelease }}stable{{ else }}unstable{{ end }}-debug"
+      - "{{ .Tag }}-debug"
+      - '{{ trimprefix .Tag "v" }}-debug'
+      - "sha-{{ .ShortCommit }}-debug"
 
   - id: dockerhub-debug
     build: headscale
@@ -158,13 +169,17 @@ kos:
       - linux/arm64
       - linux/arm/v7
     tags:
-      - latest
-      - "{{ .Tag }}-debug"
-      - "{{ .Major }}.{{ .Minor }}.{{ .Patch }}-debug"
-      - "{{ .Major }}.{{ .Minor }}-debug"
-      - "{{ .Major }}-debug"
-      - "sha-{{ .ShortCommit }}-debug"
+      - "{{ if not .Prerelease }}latest{{ end }}-debug"
+      - "{{ if not .Prerelease }}{{ .Major }}.{{ .Minor }}.{{ .Patch }}-debug"
+      - "{{ if not .Prerelease }}{{ .Major }}.{{ .Minor }}-debug"
+      - "{{ if not .Prerelease }}{{ .Major }}-debug"
+      - "{{ if not .Prerelease }}v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-debug"
+      - "{{ if not .Prerelease }}v{{ .Major }}.{{ .Minor }}-debug"
+      - "{{ if not .Prerelease }}v{{ .Major }}-debug"
       - "{{ if not .Prerelease }}stable{{ else }}unstable{{ end }}-debug"
+      - "{{ .Tag }}-debug"
+      - '{{ trimprefix .Tag "v" }}-debug'
+      - "sha-{{ .ShortCommit }}-debug"
 
 checksum:
   name_template: "checksums.txt"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ after improving the test harness as part of adopting [#1460](https://github.com/
   - If no DERP is configured, the server will fail to start, this can be because it cannot load the DERPMap from file or url.
 - Embedded DERP server requires a private key [#1611](https://github.com/juanfont/headscale/pull/1611)
   - Add a filepath entry to [`derp.server.private_key_path`](https://github.com/juanfont/headscale/blob/b35993981297e18393706b2c963d6db882bba6aa/config-example.yaml#L95)
+- Docker images are now built with goreleaser (ko) [#1716](https://github.com/juanfont/headscale/pull/1716) [#1763](https://github.com/juanfont/headscale/pull/1763)
+  - Entrypoint of container image has changed from shell to headscale, require change from `headscale serve` to `serve`
 
 ### Changes
 


### PR DESCRIPTION
This commit tries to align the new docker tags with the old schema

A prerelease will end up with the following tags:

- unstable
- v0.23.0-alpha3
- 0.23.0-alpha3
- sha-1234adsfg

A release will end up with:

- latest
- stable
- v0.23.0
- v0.23
- v0
- 0.23.0
- 0.23
- 0
- sha-1234adsfg

All of the builds will also have a `-debug` version.

I think this addresses the feedback from discord and https://github.com/juanfont/headscale/issues/1561#issuecomment-1946243866.
