### PR TITLE
replace linter actions with nix to ensure consistent version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,17 +26,12 @@ jobs:
             integration_test/
             config-example.yaml
 
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
       - name: golangci-lint
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.51.2
-
-          # Only block PRs on new problems.
-          # If this is not enabled, we will end up having PRs
-          # blocked because new linters has appared and other
-          # parts of the code is affected.
-          only-new-issues: true
+        run: nix develop --command -- golangci-lint run .
 
   prettier-lint:
     runs-on: ubuntu-latest
@@ -61,20 +56,20 @@ jobs:
             **/*.scss
             **/*.html
 
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
       - name: Prettify code
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: creyD/prettier_action@v4.3
-        with:
-          prettier_options: >-
-            --check **/*.{ts,js,md,yaml,yml,sass,css,scss,html}
-          only_changed: false
-          dry: true
+        run: nix develop --command -- prettier --check **/*.{ts,js,md,yaml,yml,sass,css,scss,html}
 
   proto-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: bufbuild/buf-setup-action@v1.7.0
-      - uses: bufbuild/buf-lint-action@v1
-        with:
-          input: "proto"
+
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Buf lint
+        run: nix develop --command -- buf lint proto

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Prettify code
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: nix develop --command -- prettier --check **/*.{ts,js,md,yaml,yml,sass,css,scss,html}
+        run: nix develop --command -- prettier --no-error-on-unmatched-pattern --ignore-unknown --check **/*.{ts,js,md,yaml,yml,sass,css,scss,html}
 
   proto-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: golangci-lint
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: nix develop --command -- golangci-lint run .
+        run: nix develop --command -- golangci-lint run --new-from-rev=${{github.event.pull_request.base.sha}} --out-format=github-actions .
 
   prettier-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The versions have been left to rot and they start failing in random ways when we upgrade for example Go.