### PR TITLE
Ephemeral keys can now be reusable and non-reusable

### DIFF
--- a/cmd/headscale/cli/preauthkeys.go
+++ b/cmd/headscale/cli/preauthkeys.go
@@ -107,13 +107,6 @@ var listPreAuthKeys = &cobra.Command{
 				expiration = ColourTime(key.GetExpiration().AsTime())
 			}
 
-			var reusable string
-			if key.GetEphemeral() {
-				reusable = "N/A"
-			} else {
-				reusable = fmt.Sprintf("%v", key.GetReusable())
-			}
-
 			aclTags := ""
 
 			for _, tag := range key.GetAclTags() {
@@ -125,7 +118,7 @@ var listPreAuthKeys = &cobra.Command{
 			tableData = append(tableData, []string{
 				key.GetId(),
 				key.GetKey(),
-				reusable,
+				strconv.FormatBool(key.GetReusable()),
 				strconv.FormatBool(key.GetEphemeral()),
 				strconv.FormatBool(key.GetUsed()),
 				expiration,

--- a/hscontrol/db/preauth_keys.go
+++ b/hscontrol/db/preauth_keys.go
@@ -196,7 +196,7 @@ func ValidatePreAuthKey(tx *gorm.DB, k string) (*types.PreAuthKey, error) {
 		return nil, ErrPreAuthKeyExpired
 	}
 
-	if pak.Reusable || pak.Ephemeral { // we don't need to check if has been used before
+	if pak.Reusable { // we don't need to check if has been used before
 		return &pak, nil
 	}
 


### PR DESCRIPTION
In Tailscale SaaS, ephemeral keys can be single-user or reusable. Until now, our ephemerals were only reusable. 

This PR makes us adhere to the .com behaviour. Fixes the issue reported in #1712.