### PR TITLE
Defaults to deny all rather than accept all if no acl policy defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ after improving the test harness as part of adopting [#1460](https://github.com/
   - `/var/lib/headscale` and `/var/run/headscale` is no longer created automatically, see [container docs](./docs/running-headscale-container.md)
 - Prefixes are now defined per v4 and v6 range. [#1756](https://github.com/juanfont/headscale/pull/1756)
   - `ip_prefixes` option is now `prefixes.v4` and `prefixes.v6`
+- If no acl policy defined now defaults to deny all rather than allow all for device visibility and ability to communicate on any protocol. [#1814](https://github.com/juanfont/headscale/pull/1814)
 
 ### Changes
 

--- a/hscontrol/policy/acls.go
+++ b/hscontrol/policy/acls.go
@@ -30,6 +30,13 @@ var (
 	ErrWildcardIsNeeded  = errors.New("wildcard as port is required for the protocol")
 )
 
+var FilterDenyAll = []tailcfg.FilterRule{
+	{
+		SrcIPs:  []string{},
+		SrcBits: nil,
+	},
+}
+
 const (
 	portRangeBegin     = 0
 	portRangeEnd       = 65535
@@ -119,9 +126,10 @@ func GenerateFilterAndSSHRules(
 	node *types.Node,
 	peers types.Nodes,
 ) ([]tailcfg.FilterRule, *tailcfg.SSHPolicy, error) {
-	// If there is no policy defined, we default to allow all
+	// If there is no policy defined, we default to deny all
 	if policy == nil {
-		return tailcfg.FilterAllowAll, &tailcfg.SSHPolicy{}, nil
+		log.Warn().Msg("Default deny all ACL rules being applied")
+		return FilterDenyAll, &tailcfg.SSHPolicy{}, nil
 	}
 
 	rules, err := policy.generateFilterRules(node, peers)


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

Fixes #1814.