### PR TITLE
feat: Support SSH session recording configuration

### DIFF
--- a/hscontrol/policy/acls.go
+++ b/hscontrol/policy/acls.go
@@ -356,6 +356,9 @@ func (pol *ACLPolicy) generateSSHRules(
 				recs = append(recs, netip.AddrPortFrom(rec.Addr(), 80))
 			}
 		}
+		if len(recs) > 0 {
+			action.Message = "# This session is being recorded.\n"
+		}
 		action.Recorders = recs
 
 		if sshACL.EnforceRecorder {

--- a/hscontrol/policy/acls_test.go
+++ b/hscontrol/policy/acls_test.go
@@ -2956,7 +2956,11 @@ func TestSSHRules(t *testing.T) {
 					SSHUsers: map[string]string{
 						"autogroup:nonroot": "=",
 					},
-					Action: &tailcfg.SSHAction{Accept: true, AllowLocalPortForwarding: true},
+					Action: &tailcfg.SSHAction{
+						Accept:                   true,
+						AllowLocalPortForwarding: true,
+						Recorders:                []netip.AddrPort{},
+					},
 				},
 				{
 					SSHUsers: map[string]string{
@@ -2967,7 +2971,11 @@ func TestSSHRules(t *testing.T) {
 							Any: true,
 						},
 					},
-					Action: &tailcfg.SSHAction{Accept: true, AllowLocalPortForwarding: true},
+					Action: &tailcfg.SSHAction{
+						Accept:                   true,
+						AllowLocalPortForwarding: true,
+						Recorders:                []netip.AddrPort{},
+					},
 				},
 				{
 					Principals: []*tailcfg.SSHPrincipal{
@@ -2978,7 +2986,11 @@ func TestSSHRules(t *testing.T) {
 					SSHUsers: map[string]string{
 						"autogroup:nonroot": "=",
 					},
-					Action: &tailcfg.SSHAction{Accept: true, AllowLocalPortForwarding: true},
+					Action: &tailcfg.SSHAction{
+						Accept:                   true,
+						AllowLocalPortForwarding: true,
+						Recorders:                []netip.AddrPort{},
+					},
 				},
 				{
 					SSHUsers: map[string]string{
@@ -2989,7 +3001,11 @@ func TestSSHRules(t *testing.T) {
 							Any: true,
 						},
 					},
-					Action: &tailcfg.SSHAction{Accept: true, AllowLocalPortForwarding: true},
+					Action: &tailcfg.SSHAction{
+						Accept:                   true,
+						AllowLocalPortForwarding: true,
+						Recorders:                []netip.AddrPort{},
+					},
 				},
 			},
 		},

--- a/hscontrol/policy/acls_types.go
+++ b/hscontrol/policy/acls_types.go
@@ -53,11 +53,13 @@ type AutoApprovers struct {
 
 // SSH controls who can ssh into which machines.
 type SSH struct {
-	Action       string   `json:"action"                yaml:"action"`
-	Sources      []string `json:"src"                   yaml:"src"`
-	Destinations []string `json:"dst"                   yaml:"dst"`
-	Users        []string `json:"users"                 yaml:"users"`
-	CheckPeriod  string   `json:"checkPeriod,omitempty" yaml:"checkPeriod,omitempty"`
+	Action          string   `json:"action"                    yaml:"action"`
+	Sources         []string `json:"src"                       yaml:"src"`
+	Destinations    []string `json:"dst"                       yaml:"dst"`
+	Users           []string `json:"users"                     yaml:"users"`
+	CheckPeriod     string   `json:"checkPeriod,omitempty"     yaml:"checkPeriod,omitempty"`
+	Recorder        []string `json:"recorder,omitempty"        yaml:"recorder,omitempty"`
+	EnforceRecorder bool     `json:"enforceRecorder,omitempty" yaml:"enforceRecorder,omitempty"`
 }
 
 // UnmarshalJSON allows to parse the Hosts directly into netip objects.


### PR DESCRIPTION
- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

This PR makes the necessary backend changes to support [SSH session recording](https://tailscale.com/kb/1246/tailscale-ssh-session-recording). This consists of handling the `recorder` and `enforceRecorder` fields[^1] of the `ssh` ACL rules. Providing a compatible recorder is not part of this PR.

Resolves #1793

[^1]: https://tailscale.com/kb/1246/tailscale-ssh-session-recording#turn-on-session-recording-in-acls