### PR TITLE
feat: derpmap field in config

### DIFF
--- a/hscontrol/derp/derp.go
+++ b/hscontrol/derp/derp.go
@@ -82,6 +82,9 @@ func mergeDERPMaps(derpMaps []*tailcfg.DERPMap) *tailcfg.DERPMap {
 
 func GetDERPMap(cfg types.DERPConfig) *tailcfg.DERPMap {
 	var derpMaps []*tailcfg.DERPMap
+	if cfg.DERPMap != nil {
+		derpMaps = append(derpMaps, cfg.DERPMap)
+	}
 
 	for _, path := range cfg.Paths {
 		log.Debug().

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -179,6 +179,7 @@ type DERPConfig struct {
 	STUNAddr                           string
 	URLs                               []url.URL
 	Paths                              []string
+	DERPMap                            *tailcfg.DERPMap
 	AutoUpdate                         bool
 	UpdateFrequency                    time.Duration
 	IPv4                               string


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

Currently DERP map can be set only from URLs or local yaml config paths. This PR adds a simple and optional `DERPMap` config field which allows setting initial DERP map which is useful when using headscale programatically. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration capabilities with the addition of a `DERPMap` field in the DERP configuration.
	- Improved logic in the DERP map retrieval process to prevent runtime errors by excluding nil values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->