### PR TITLE
Downgrade update sent to debug

### DIFF
--- a/hscontrol/poll.go
+++ b/hscontrol/poll.go
@@ -507,7 +507,7 @@ func (h *Headscale) handlePoll(
 				}
 				log.Trace().Str("node", node.Hostname).TimeDiff("timeSpent", time.Now(), startWrite).Str("mkey", node.MachineKey.String()).Int("type", int(update.Type)).Msg("finished writing mapresp to node")
 
-				log.Info().
+				log.Debug().
 					Caller().
 					Bool("readOnly", mapRequest.ReadOnly).
 					Bool("omitPeers", mapRequest.OmitPeers).


### PR DESCRIPTION
This seems to be logged once every 15 to 20 seconds for each machine and belonging to background activities, so it should belong to debug logging level or even trace

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
