### PR TITLE
Fix crash when a prefix family was empty

### DIFF
--- a/hscontrol/db/db.go
+++ b/hscontrol/db/db.go
@@ -377,14 +377,18 @@ func NewHeadscaleDatabase(
 							}
 						}
 
-						err = tx.Model(&types.Node{}).Where("id = ?", node.ID).Update("ipv4", v4.String()).Error
-						if err != nil {
-							return fmt.Errorf("saving ip addresses to new columns: %w", err)
+						if v4 != nil {
+							err = tx.Model(&types.Node{}).Where("id = ?", node.ID).Update("ipv4", v4.String()).Error
+							if err != nil {
+								return fmt.Errorf("saving ip addresses to new columns: %w", err)
+							}
 						}
 
-						err = tx.Model(&types.Node{}).Where("id = ?", node.ID).Update("ipv6", v6.String()).Error
-						if err != nil {
-							return fmt.Errorf("saving ip addresses to new columns: %w", err)
+						if v6 != nil {
+							err = tx.Model(&types.Node{}).Where("id = ?", node.ID).Update("ipv6", v6.String()).Error
+							if err != nil {
+								return fmt.Errorf("saving ip addresses to new columns: %w", err)
+							}
 						}
 					}
 


### PR DESCRIPTION
This PR fixes a crash reported in Discord https://gist.github.com/christian-heusel/d4eb0fbe529348a86b4cfc76d516ef23.

When a family is not being used (e.g., a user did not have configured IPv6 in their prefixes) the migration would crash, as it was accessing an empty ptr.

