### PR TITLE
Remove unused node check interval

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -137,12 +137,6 @@ disable_check_updates: false
 # Time before an inactive ephemeral node is deleted?
 ephemeral_node_inactivity_timeout: 30m
 
-# Period to check for node updates within the tailnet. A value too low will severely affect
-# CPU consumption of Headscale. A value too high (over 60s) will cause problems
-# for the nodes, as they won't get updates or keep alive messages frequently enough.
-# In case of doubts, do not touch the default 10s.
-node_update_check_interval: 10s
-
 database:
   type: sqlite
 

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -46,7 +46,6 @@ type Config struct {
 	GRPCAddr                       string
 	GRPCAllowInsecure              bool
 	EphemeralNodeInactivityTimeout time.Duration
-	NodeUpdateCheckInterval        time.Duration
 	PrefixV4                       *netip.Prefix
 	PrefixV6                       *netip.Prefix
 	IPAllocation                   IPAllocationStrategy
@@ -233,8 +232,6 @@ func LoadConfig(path string, isFile bool) error {
 
 	viper.SetDefault("ephemeral_node_inactivity_timeout", "120s")
 
-	viper.SetDefault("node_update_check_interval", "10s")
-
 	viper.SetDefault("tuning.batch_change_delay", "800ms")
 	viper.SetDefault("tuning.node_mapsession_buffered_chan_size", 30)
 
@@ -287,15 +284,6 @@ func LoadConfig(path string, isFile bool) error {
 			"Fatal config error: ephemeral_node_inactivity_timeout (%s) is set too low, must be more than %s",
 			viper.GetString("ephemeral_node_inactivity_timeout"),
 			minInactivityTimeout,
-		)
-	}
-
-	maxNodeUpdateCheckInterval, _ := time.ParseDuration("60s")
-	if viper.GetDuration("node_update_check_interval") > maxNodeUpdateCheckInterval {
-		errorText += fmt.Sprintf(
-			"Fatal config error: node_update_check_interval (%s) is set too high, must be less than %s",
-			viper.GetString("node_update_check_interval"),
-			maxNodeUpdateCheckInterval,
 		)
 	}
 
@@ -712,10 +700,6 @@ func GetHeadscaleConfig() (*Config, error) {
 
 		EphemeralNodeInactivityTimeout: viper.GetDuration(
 			"ephemeral_node_inactivity_timeout",
-		),
-
-		NodeUpdateCheckInterval: viper.GetDuration(
-			"node_update_check_interval",
 		),
 
 		Database: GetDatabaseConfig(),

--- a/integration/hsic/config.go
+++ b/integration/hsic/config.go
@@ -73,7 +73,6 @@ database:
   type: sqlite3
   sqlite.path: /tmp/integration_test_db.sqlite3
 ephemeral_node_inactivity_timeout: 30m
-node_update_check_interval: 10s
 prefixes:
   v6: fd7a:115c:a1e0::/48
   v4: 100.64.0.0/10
@@ -116,7 +115,6 @@ func DefaultConfigEnv() map[string]string {
 		"HEADSCALE_DATABASE_TYPE":                     "sqlite",
 		"HEADSCALE_DATABASE_SQLITE_PATH":              "/tmp/integration_test_db.sqlite3",
 		"HEADSCALE_EPHEMERAL_NODE_INACTIVITY_TIMEOUT": "30m",
-		"HEADSCALE_NODE_UPDATE_CHECK_INTERVAL":        "10s",
 		"HEADSCALE_PREFIXES_V4":                       "100.64.0.0/10",
 		"HEADSCALE_PREFIXES_V6":                       "fd7a:115c:a1e0::/48",
 		"HEADSCALE_DNS_CONFIG_BASE_DOMAIN":            "headscale.net",


### PR DESCRIPTION
This PR removes a now unused config parameter.

The param has been deprecated since the rework of the mapper.