### PR TITLE
Allow to remove forced tags of a node

### DIFF
--- a/hscontrol/db/node.go
+++ b/hscontrol/db/node.go
@@ -206,6 +206,11 @@ func SetTags(
 	tags []string,
 ) error {
 	if len(tags) == 0 {
+		// if no tags are provided, we remove all forced tags
+		if err := tx.Model(&types.Node{}).Where("id = ?", nodeID).Update("forced_tags", types.StringList{}).Error; err != nil {
+			return fmt.Errorf("failed to remove tags for node in the database: %w", err)
+		}
+
 		return nil
 	}
 

--- a/hscontrol/db/node_test.go
+++ b/hscontrol/db/node_test.go
@@ -386,6 +386,13 @@ func (s *Suite) TestSetTags(c *check.C) {
 		check.DeepEquals,
 		types.StringList([]string{"tag:bar", "tag:test", "tag:unknown"}),
 	)
+
+	// test removing tags
+	err = db.SetTags(node.ID, []string{})
+	c.Assert(err, check.IsNil)
+	node, err = db.getNode("test", "testnode")
+	c.Assert(err, check.IsNil)
+	c.Assert(node.ForcedTags, check.DeepEquals, types.StringList([]string{}))
 }
 
 func TestHeadscale_generateGivenName(t *testing.T) {


### PR DESCRIPTION
This PR fixes #1849, by allowing to set an empty list of tags from CLI or API.