### PR TITLE
remove multistep build, build go last, allowing cached build layers (for debug image)

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -2,30 +2,23 @@
 # and are in no way endorsed by Headscale's maintainers as an
 # official nor supported release or distribution.
 
-FROM docker.io/golang:1.22-bookworm AS build
+FROM docker.io/golang:1.22-bookworm
 ARG VERSION=dev
 ENV GOPATH /go
 WORKDIR /go/src/headscale
-
-COPY go.mod go.sum /go/src/headscale/
-RUN go mod download
-
-COPY . .
-
-RUN CGO_ENABLED=0 GOOS=linux go install -ldflags="-s -w -X github.com/juanfont/headscale/cmd/headscale/cli.Version=$VERSION" -a ./cmd/headscale
-RUN test -e /go/bin/headscale
-
-# Debug image
-FROM docker.io/golang:1.22-bookworm
-
-COPY --from=build /go/bin/headscale /bin/headscale
-ENV TZ UTC
 
 RUN apt-get update \
   && apt-get install --no-install-recommends --yes less jq \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean
 RUN mkdir -p /var/run/headscale
+
+COPY go.mod go.sum /go/src/headscale/
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go install -ldflags="-s -w -X github.com/juanfont/headscale/cmd/headscale/cli.Version=$VERSION" -a ./cmd/headscale && test -e /go/bin/headscale
 
 # Need to reset the entrypoint or everything will run as a busybox script
 ENTRYPOINT []


### PR DESCRIPTION
Makes sure everything is installed first, then build go stuff.

Main purpose is to make us able to rebuild the container offline since we mostly have the first apt layers cached, but since we did go first, it would always invalidate.