### PR TITLE
Add contributing document

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ If you find mistakes in the documentation, please submit a fix to the documentat
 
 <!-- Please tick if the following things apply. You… -->
 
-- [ ] read the [CONTRIBUTING guidelines](README.md#contributing)
+- [ ] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
 - [ ] raised a GitHub issue or discussed it on the projects chat beforehand
 - [ ] added unit tests
 - [ ] added integration tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+Headscale is "Open Source, acknowledged contribution", this means that any contribution will have to be discussed with the Maintainers before being submitted.
+This model has been chosen to reduce the risk of burnout by limiting the maintenance overhead of reviewing and validating third-party code.
+
+## Why do we have this model?
+
+Headscale has a small maintainer team that tries to balance working on the project, fixing bugs and reviewing contributions.
+
+When we work on issues ourselves, we develop first hand knowledge of the code and it makes it possible for us to maintain and own the code as the project develops.
+
+When code is contributed to the project, it is typically a positive thing. People enjoy and engage with our project, but it also comes with some challenges; we have to understand the code, we have to understand the feature, we might have to become familiar with external libraries or services that this new feature integrates with and it needs to be reviewed from a security perspective. And that is only when it comes to reviewing it. After the code has been merged, the feature has to be maintained, meaning that changes to external parts need to be updated, and kept working.
+
+The review and the day-1 maintenance adds a significant burden on them maintainers. Often we hope that the contributor of the feature will help out, but we found that most of the time, they disappear when they have their new feature added.
+
+This means that when someone contributes, we are mostly happy about it, but we do have to run it through a series of checks to establish if we actually can maintain this feature.
+
+## What do we require?
+
+A general description is provided here and an explicit list is provided in our pull request template.
+
+All new features have to start with a design document that has to be discussed in the issue tracker (not discord) with a use case for the feature, how it can be implemented, who will implement it and what the plan for maintaining it is.
+
+All features have to be end to end tested (integration tests) and have good unit test coverage to ensure that they work as expected, and work as expected over time. If the change cannot be tested, a strong case for why this is not possible needs to be presented.
+
+The contributor must help maintain the feature over time, if a feature is found to be left unmaintained, we will have to remove it.
+
+## Bug fixes
+
+Headscale is open to code contributions for bug fixes without discussion.
+
+## Documentation
+
+If you find mistakes in the documentation, please submit a fix to the documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,9 @@ Headscale has a small maintainer team that tries to balance working on the proje
 
 When we work on issues ourselves, we develop first hand knowledge of the code and it makes it possible for us to maintain and own the code as the project develops.
 
-Code contributions are seen as a positive thing. People enjoy and engage with our project, but it also comes with some challenges; we have to understand the code, we have to understand the feature, we might have to become familiar with external libraries or services and we think about security implications. All those steps are required during reviewing process.  After the code has been merged, the feature has to be maintained. Any changes reliant on external services must be updated and expanded accordingly. .
+Code contributions are seen as a positive thing. People enjoy and engage with our project, but it also comes with some challenges; we have to understand the code, we have to understand the feature, we might have to become familiar with external libraries or services and we think about security implications. All those steps are required during the reviewing process. After the code has been merged, the feature has to be maintained. Any changes reliant on external services must be updated and expanded accordingly. 
 
-The review and the day-1 maintenance adds a significant burden on the maintainers. Often we hope that the contributor will help out, but we found that most of the time, they disappear after their new feature was added.
+The review and day-1 maintenance adds a significant burden on the maintainers. Often we hope that the contributor will help out, but we found that most of the time, they disappear after their new feature was added.
 
 This means that when someone contributes, we are mostly happy about it, but we do have to run it through a series of checks to establish if we actually can maintain this feature.
 
@@ -23,7 +23,7 @@ All new features have to start out with a design document, which should be discu
 
 All features have to be end-to-end tested (integration tests) and have good unit test coverage to ensure that they work as expected. This will also ensure that the feature continues to work as expected over time. If a change cannot be tested, a strong case for why this is not possible needs to be presented.
 
-The contributor must help maintain the feature over time, if a feature is found to be left unmaintained, we will have to remove it.
+The contributor should help to maintain the feature over time. In case the feature is not maintained probably, the maintainers reserve themselves the right to remove features they redeem as unmaintainable. This should help to improve the quality of the software and keep it in a maintainable state.
 
 ## Bug fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ When we work on issues ourselves, we develop first hand knowledge of the code an
 
 When code is contributed to the project, it is typically a positive thing. People enjoy and engage with our project, but it also comes with some challenges; we have to understand the code, we have to understand the feature, we might have to become familiar with external libraries or services that this new feature integrates with and it needs to be reviewed from a security perspective. And that is only when it comes to reviewing it. After the code has been merged, the feature has to be maintained, meaning that changes to external parts need to be updated, and kept working.
 
-The review and the day-1 maintenance adds a significant burden on them maintainers. Often we hope that the contributor of the feature will help out, but we found that most of the time, they disappear when they have their new feature added.
+The review and the day-1 maintenance adds a significant burden on the maintainers. Often we hope that the contributor will help out, but we found that most of the time, they disappear after their new feature was added.
 
 This means that when someone contributes, we are mostly happy about it, but we do have to run it through a series of checks to establish if we actually can maintain this feature.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Headscale is "Open Source, acknowledged contribution", this means that any contribution will have to be discussed with the Maintainers before being submitted.
+Headscale is "Open Source, acknowledged contribution", this means that any contribution will have to be discussed with the maintainers before being added to the project.
 This model has been chosen to reduce the risk of burnout by limiting the maintenance overhead of reviewing and validating third-party code.
 
 ## Why do we have this model?
@@ -9,7 +9,7 @@ Headscale has a small maintainer team that tries to balance working on the proje
 
 When we work on issues ourselves, we develop first hand knowledge of the code and it makes it possible for us to maintain and own the code as the project develops.
 
-When code is contributed to the project, it is typically a positive thing. People enjoy and engage with our project, but it also comes with some challenges; we have to understand the code, we have to understand the feature, we might have to become familiar with external libraries or services that this new feature integrates with and it needs to be reviewed from a security perspective. And that is only when it comes to reviewing it. After the code has been merged, the feature has to be maintained, meaning that changes to external parts need to be updated, and kept working.
+Code contributions are seen as a positive thing. People enjoy and engage with our project, but it also comes with some challenges; we have to understand the code, we have to understand the feature, we might have to become familiar with external libraries or services and we think about security implications. All those steps are required during reviewing process.  After the code has been merged, the feature has to be maintained. Any changes reliant on external services must be updated and expanded accordingly. .
 
 The review and the day-1 maintenance adds a significant burden on the maintainers. Often we hope that the contributor will help out, but we found that most of the time, they disappear after their new feature was added.
 
@@ -21,7 +21,7 @@ A general description is provided here and an explicit list is provided in our p
 
 All new features have to start out with a design document, which should be discussed on the issue tracker (not discord). It should include a use case for the feature, how it can be implemented, who will implement it and a plan for maintaining it.
 
-All features have to be end to end tested (integration tests) and have good unit test coverage to ensure that they work as expected, and work as expected over time. If the change cannot be tested, a strong case for why this is not possible needs to be presented.
+All features have to be end-to-end tested (integration tests) and have good unit test coverage to ensure that they work as expected. This will also ensure that the feature continues to work as expected over time. If a change cannot be tested, a strong case for why this is not possible needs to be presented.
 
 The contributor must help maintain the feature over time, if a feature is found to be left unmaintained, we will have to remove it.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ This means that when someone contributes, we are mostly happy about it, but we d
 
 A general description is provided here and an explicit list is provided in our pull request template.
 
-All new features have to start with a design document that has to be discussed in the issue tracker (not discord) with a use case for the feature, how it can be implemented, who will implement it and what the plan for maintaining it is.
+All new features have to start out with a design document, which should be discussed on the issue tracker (not discord). It should include a use case for the feature, how it can be implemented, who will implement it and a plan for maintaining it.
 
 All features have to be end to end tested (integration tests) and have good unit test coverage to ensure that they work as expected, and work as expected over time. If the change cannot be tested, a strong case for why this is not possible needs to be presented.
 

--- a/README.md
+++ b/README.md
@@ -92,15 +92,7 @@ Please have a look at the [`documentation`](https://headscale.net/).
 
 ## Contributing
 
-Headscale is "Open Source, acknowledged contribution", this means that any
-contribution will have to be discussed with the Maintainers before being submitted.
-
-This model has been chosen to reduce the risk of burnout by limiting the
-maintenance overhead of reviewing and validating third-party code.
-
-Headscale is open to code contributions for bug fixes without discussion.
-
-If you find mistakes in the documentation, please submit a fix to the documentation.
+Please read the [CONTRIBUTING.md](./CONTRIBUTING.md) file.
 
 ### Requirements
 


### PR DESCRIPTION
This PR adds a `CONTRIBUTING.md` document, detailing headscale's contribution policy.

The document is open for discussion with the community, and we welcome suggestions and adjustments.

Our objective is to have a sustainable project that serves the community, and does not burn out its maintainer.