### PR TITLE
Do not access node ID when node is not found

### DIFF
--- a/hscontrol/noise.go
+++ b/hscontrol/noise.go
@@ -226,7 +226,6 @@ func (ns *noiseServer) NoisePollNetMapHandler(
 	if err != nil {
 		log.Error().
 			Str("handler", "NoisePollNetMap").
-			Uint64("node.id", node.ID.Uint64()).
 			Msgf("Failed to fetch node from the database with node key: %s", mapRequest.NodeKey.String())
 		http.Error(writer, "Internal error", http.StatusInternalServerError)
 


### PR DESCRIPTION
This PR fixes #1883 

Basically do not access in node if we failed to find it.