### PR TITLE
low priority PR - Update OpenBSD installation docs for 2024

### DIFF
--- a/docs/running-headscale-openbsd.md
+++ b/docs/running-headscale-openbsd.md
@@ -9,19 +9,17 @@
 
 ## Goal
 
-This documentation has the goal of showing a user how-to install and run `headscale` on OpenBSD 7.1.
+This documentation has the goal of showing a user how-to install and run `headscale` on OpenBSD.
 In additional to the "get up and running section", there is an optional [rc.d section](#running-headscale-in-the-background-with-rcd)
 describing how to make `headscale` run properly in a server environment.
 
 ## Install `headscale`
 
-1. Install from ports (not recommended)
+1. Install from ports
 
-    !!! info
+    You can install headscale from ports by running `pkg_add headscale`.
 
-        As of OpenBSD 7.2, there's a headscale in ports collection, however, it's severely outdated(v0.12.4). You can install it via `pkg_add headscale`.
-
-1. Install from source on OpenBSD 7.2
+1. Install from source
 
     ```shell
     # Install prerequistes


### PR DESCRIPTION
OpenBSD packages a reasonably up to date version of headscale now (0.22.1), if that's actually too old then feel free to just close this

7.1/7.2 are no longer supported so remove references to them