### PR TITLE
[DOCS] Make linux installation instructions more clear

### DIFF
--- a/docs/running-headscale-linux.md
+++ b/docs/running-headscale-linux.md
@@ -32,7 +32,7 @@ configuration (`/etc/headscale/config.yaml`).
 1. Install Headscale:
 
     ```shell
-    sudo dpkg -i headscale.deb
+    sudo apt install ./headscale.deb
     ```
 
 1. Enable Headscale service, this will start Headscale at boot:

--- a/docs/running-headscale-linux.md
+++ b/docs/running-headscale-linux.md
@@ -20,17 +20,19 @@ configuration (`/etc/headscale/config.yaml`).
 
 ## Installation
 
-1. Download the latest Headscale package for your platform (`.deb` for Ubuntu and Debian) from [Headscale's releases page](https://github.com/juanfont/headscale/releases):
+1. Download the [latest Headscale package](https://github.com/juanfont/headscale/releases/latest) for your platform (`.deb` for Ubuntu and Debian).
 
     ```shell
+    HEADSCALE_VERSION="" # See above URL for latest version, e.g. "X.Y.Z" (NOTE: do not add the "v" prefix!)
+    HEADSCALE_ARCH="" # Your system architecture, e.g. "amd64"
     wget --output-document=headscale.deb \
-      https://github.com/juanfont/headscale/releases/download/v<HEADSCALE VERSION>/headscale_<HEADSCALE VERSION>_linux_<ARCH>.deb
+      "https://github.com/juanfont/headscale/releases/download/v${HEADSCALE_VERSION}/headscale_${HEADSCALE_VERSION}_linux_${HEADSCALE_ARCH}.deb"
     ```
 
 1. Install Headscale:
 
     ```shell
-    sudo apt install headscale.deb
+    sudo dpkg -i headscale.deb
     ```
 
 1. Enable Headscale service, this will start Headscale at boot:


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->


---


Made some small changes to the docs to make linux easier to install, notably because "sudo apt install headscale.deb" doesn't seem to be a valid apt command. You have to reference with leading dot to prevent it from seeing as package name.

Also I changed the link to the github `/latest` release since presumably we don't want people who are just getting started installing alpha versions (which appear first in GitHub)
