### PR TITLE
Initialize log config earlier to prevent trace messages being printed early on

### DIFF
--- a/cmd/headscale/cli/root.go
+++ b/cmd/headscale/cli/root.go
@@ -56,8 +56,6 @@ func initConfig() {
 
 	machineOutput := HasMachineOutputFlag()
 
-	zerolog.SetGlobalLevel(cfg.Log.Level)
-
 	// If the user has requested a "node" readable format,
 	// then disable login so the output remains valid.
 	if machineOutput {

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -640,6 +640,9 @@ func GetHeadscaleConfig() (*Config, error) {
 		}, nil
 	}
 
+  logConfig := GetLogConfig()
+	zerolog.SetGlobalLevel(logConfig.Level)
+
 	prefix4, err := PrefixV4()
 	if err != nil {
 		return nil, err
@@ -667,7 +670,7 @@ func GetHeadscaleConfig() (*Config, error) {
 
 	dnsConfig, baseDomain := GetDNSConfig()
 	derpConfig := GetDERPConfig()
-	logConfig := GetLogTailConfig()
+	logTailConfig := GetLogTailConfig()
 	randomizeClientPort := viper.GetBool("randomize_client_port")
 
 	oidcClientSecret := viper.GetString("oidc.client_secret")
@@ -749,7 +752,7 @@ func GetHeadscaleConfig() (*Config, error) {
 			UseExpiryFromToken: viper.GetBool("oidc.use_expiry_from_token"),
 		},
 
-		LogTail:             logConfig,
+		LogTail:             logTailConfig,
 		RandomizeClientPort: randomizeClientPort,
 
 		ACL: GetACLConfig(),
@@ -761,7 +764,7 @@ func GetHeadscaleConfig() (*Config, error) {
 			Insecure: viper.GetBool("cli.insecure"),
 		},
 
-		Log: GetLogConfig(),
+		Log: logConfig,
 
 		// TODO(kradalby): Document these settings when more stable
 		Tuning: Tuning{


### PR DESCRIPTION
like TRC DNS configuration loaded dns_config={....}

Closes #1576

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
