### PR TITLE
Include ca-certificates in Dockerfile.debug

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -8,7 +8,7 @@ ENV GOPATH /go
 WORKDIR /go/src/headscale
 
 RUN apt-get update \
-  && apt-get install --no-install-recommends --yes less jq \
+  && apt-get install --no-install-recommends --yes less jq ca-certificates \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean
 RUN mkdir -p /var/run/headscale


### PR DESCRIPTION
Should fix #1868 but I'm not sure about the goreleaser thing...