### PR TITLE
feat: support client verify for derp

### DIFF
--- a/hscontrol/app.go
+++ b/hscontrol/app.go
@@ -484,6 +484,8 @@ func (h *Headscale) createRouter(grpcMux *grpcRuntime.ServeMux) *mux.Router {
 	router.HandleFunc("/swagger/v1/openapiv2.json", headscale.SwaggerAPIv1).
 		Methods(http.MethodGet)
 
+	router.HandleFunc("/verify", h.VerifyHandler).Methods(http.MethodPost)
+
 	if h.cfg.DERP.ServerEnabled {
 		router.HandleFunc("/derp", h.DERPServer.DERPHandler)
 		router.HandleFunc("/derp/probe", derpServer.DERPProbeHandler)

--- a/hscontrol/tailsql.go
+++ b/hscontrol/tailsql.go
@@ -92,7 +92,7 @@ func runTailSQLService(ctx context.Context, logf logger.Logf, stateDir, dbPath s
 	mux := tsql.NewMux()
 	tsweb.Debugger(mux)
 	go http.Serve(lst, mux)
-	logf("ailSQL started")
+	logf("TailSQL started")
 	<-ctx.Done()
 	logf("TailSQL shutting down...")
 	return tsNode.Close()

--- a/integration/README.md
+++ b/integration/README.md
@@ -11,10 +11,10 @@ Tests are located in files ending with `_test.go` and the framework are located 
 
 ## Running integration tests locally
 
-The easiest way to run tests locally is to use `[act](INSERT LINK)`, a local GitHub Actions runner:
+The easiest way to run tests locally is to use [act](https://github.com/nektos/act), a local GitHub Actions runner:
 
 ```
-act pull_request -W .github/workflows/test-integration-v2-TestPingAllByIP.yaml
+act pull_request -W .github/workflows/test-integration.yaml
 ```
 
 Alternatively, the `docker run` command in each GitHub workflow file can be used.


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [x] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

I have initially implemented the verification function. Derp can verify whether the client is in the node list of headscale by specifying the `--verify-client-url` parameter to `/verify` in headscale.

I know there is still a lot of work to be done, such as comments, testing, documentation, etc. I am also willing to participate in the subsequent work.

Fixes #1953 

