### PR TITLE
Make registration screen easier to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ after improving the test harness as part of adopting [#1460](https://github.com/
 - Log available update as warning [#1877](https://github.com/juanfont/headscale/pull/1877)
 - Add `autogroup:internet` to Policy [#1917](https://github.com/juanfont/headscale/pull/1917)
 - Restore foreign keys and add constraints [#1562](https://github.com/juanfont/headscale/pull/1562)
+- Make registration page easier to use on mobile devices
 
 ## 0.22.3 (2023-05-12)
 

--- a/hscontrol/handlers.go
+++ b/hscontrol/handlers.go
@@ -143,6 +143,18 @@ var registerWebAPITemplate = template.Must(
 <html>
 	<head>
 		<title>Registration - Headscale</title>
+		<meta name=viewport content="width=device-width, initial-scale=1">
+		<style>
+			body {
+				font-family: sans;
+			}
+			code {
+				display: block;
+				padding: 20px;
+				border: 1px solid #bbb;
+				background-color: #eee;
+			}
+		</style>
 	</head>
 	<body>
 		<h1>headscale</h1>
@@ -150,7 +162,7 @@ var registerWebAPITemplate = template.Must(
 		<p>
 			Run the command below in the headscale server to add this machine to your network:
 		</p>
-		<pre><code>headscale nodes register --user USERNAME --key {{.Key}}</code></pre>
+		<code>headscale nodes register --user USERNAME --key {{.Key}}</code>
 	</body>
 </html>
 `))


### PR DESCRIPTION
This patch adds a simply styles to the registration screen.

This should be particular helpful on mobile devices since this makes the user interface responsive and means that you don't have to deal with a tiny font size.

This is how this looks like on a mobile device before and after:
![Screenshot from 2024-06-14 00-45-13](https://github.com/juanfont/headscale/assets/1008395/fece98c2-f059-47c7-95b6-280285a0ab44)


<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

I hope it's fine that I didn't open an issue for this first since it's just a small thing.

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
