### PR TITLE
Make write-ahead-log default and configurable for sqlite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ after improving the test harness as part of adopting [#1460](https://github.com/
 - Add `autogroup:internet` to Policy [#1917](https://github.com/juanfont/headscale/pull/1917)
 - Restore foreign keys and add constraints [#1562](https://github.com/juanfont/headscale/pull/1562)
 - Make registration page easier to use on mobile devices
+- Make write-ahead-log default on and configurable for SQLite [#1985](https://github.com/juanfont/headscale/pull/1985)
 
 ## 0.22.3 (2023-05-12)
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -144,6 +144,10 @@ database:
   sqlite:
     path: /var/lib/headscale/db.sqlite
 
+    # Enable WAL mode for SQLite. This is recommended for production environments.
+    # https://www.sqlite.org/wal.html
+    write_ahead_log: true
+
   # # Postgres config
   # postgres:
   #   # If using a Unix socket to connect to Postgres, set the socket path in the 'host' field and leave 'port' blank.

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -81,7 +81,8 @@ type Config struct {
 }
 
 type SqliteConfig struct {
-	Path string
+	Path          string
+	WriteAheadLog bool
 }
 
 type PostgresConfig struct {
@@ -221,6 +222,8 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("database.postgres.max_open_conns", 10)
 	viper.SetDefault("database.postgres.max_idle_conns", 10)
 	viper.SetDefault("database.postgres.conn_max_idle_time_secs", 3600)
+
+	viper.SetDefault("database.sqlite.write_ahead_log", true)
 
 	viper.SetDefault("oidc.scope", []string{oidc.ScopeOpenID, "profile", "email"})
 	viper.SetDefault("oidc.strip_email_domain", true)
@@ -443,6 +446,7 @@ func GetDatabaseConfig() DatabaseConfig {
 			Path: util.AbsolutePathFromConfigPath(
 				viper.GetString("database.sqlite.path"),
 			),
+			WriteAheadLog: viper.GetBool("database.sqlite.write_ahead_log"),
 		},
 		Postgres: PostgresConfig{
 			Host:               viper.GetString("database.postgres.host"),


### PR DESCRIPTION
this commit makes headscale correctly enable write-ahead-log for sqlite and adds an option to turn it on and off.

WAL is enabled by default and should make sqlite perform a lot better, even further eliminating the need to use postgres.

It also adds a couple of other useful defaults.

Note, this PR removes WAL from the sqlite connection string, as that did not have any effect with the sqlite driver we use.

Fixes #1983