### PR TITLE
fix search domains and remove username from magicdns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ after improving the test harness as part of adopting [#1460](https://github.com/
 - Prefixes are now defined per v4 and v6 range. [#1756](https://github.com/juanfont/headscale/pull/1756)
   - `ip_prefixes` option is now `prefixes.v4` and `prefixes.v6`
   - `prefixes.allocation` can be set to assign IPs at `sequential` or `random`. [#1869](https://github.com/juanfont/headscale/pull/1869)
+- MagicDNS domains no longer contain usernames []()
+  - This is in preperation to fix Headscales implementation of tags which currently does not correctly remove the link between a tagged device and a user. As tagged devices will not have a user, this will require a change to the DNS generation, removing the username, see [#1369](https://github.com/juanfont/headscale/issues/1369) for more information.
+  - `use_username_in_magic_dns` can be used to turn this behaviour on again, but note that this option _will be removed_ when tags are fixed.
+  - This option brings Headscales behaviour in line with Tailscale.
 
 ### Changes
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -261,6 +261,15 @@ dns_config:
   # Only works if there is at least a nameserver defined.
   magic_dns: true
 
+  # DEPRECATED
+  # Use the username as part of the DNS name for nodes, with this option enabled:
+  # node1.username.example.com
+  # while when this is disabled:
+  # node1.example.com
+  # This is a legacy option as Headscale has have this wrongly implemented
+  # while in upstream Tailscale, the username is not included.
+  use_username_in_magic_dns: false
+
   # Defines the base domain to create the hostnames for MagicDNS.
   # `base_domain` must be a FQDNs, without the trailing dot.
   # The FQDN of the hosts will be

--- a/hscontrol/mapper/mapper_test.go
+++ b/hscontrol/mapper/mapper_test.go
@@ -127,7 +127,10 @@ func TestDNSConfigMapResponse(t *testing.T) {
 			}
 
 			got := generateDNSConfig(
-				&dnsConfigOrig,
+				&types.Config{
+					DNSConfig:             &dnsConfigOrig,
+					DNSUserNameInMagicDNS: true,
+				},
 				baseDomain,
 				nodeInShared1,
 				peersOfNodeInShared1,
@@ -187,9 +190,9 @@ func Test_fullMapResponse(t *testing.T) {
 		UserID:     0,
 		User:       types.User{Name: "mini"},
 		ForcedTags: []string{},
-		AuthKey:     &types.PreAuthKey{},
-		LastSeen:    &lastSeen,
-		Expiry:      &expire,
+		AuthKey:    &types.PreAuthKey{},
+		LastSeen:   &lastSeen,
+		Expiry:     &expire,
 		Hostinfo:   &tailcfg.Hostinfo{},
 		Routes: []types.Route{
 			{

--- a/hscontrol/mapper/tail.go
+++ b/hscontrol/mapper/tail.go
@@ -77,7 +77,7 @@ func tailNode(
 		keyExpiry = time.Time{}
 	}
 
-	hostname, err := node.GetFQDN(cfg.DNSConfig, cfg.BaseDomain)
+	hostname, err := node.GetFQDN(cfg, cfg.BaseDomain)
 	if err != nil {
 		return nil, fmt.Errorf("tailNode, failed to create FQDN: %s", err)
 	}

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -536,16 +536,6 @@ func GetDNSConfig() (*tailcfg.DNSConfig, string) {
 			dnsConfig.Domains = domains
 		}
 
-		if viper.IsSet("dns_config.domains") {
-			domains := viper.GetStringSlice("dns_config.domains")
-			if len(dnsConfig.Resolvers) > 0 {
-				dnsConfig.Domains = domains
-			} else if domains != nil {
-				log.Warn().
-					Msg("Warning: dns_config.domains is set, but no nameservers are configured. Ignoring domains.")
-			}
-		}
-
 		if viper.IsSet("dns_config.extra_records") {
 			var extraRecords []tailcfg.DNSRecord
 
@@ -571,8 +561,11 @@ func GetDNSConfig() (*tailcfg.DNSConfig, string) {
 			baseDomain = "headscale.net" // does not really matter when MagicDNS is not enabled
 		}
 
-		log.Trace().Interface("dns_config", dnsConfig).Msg("DNS configuration loaded")
+		if domains := viper.GetStringSlice("dns_config.domains"); len(domains) > 0 {
+			dnsConfig.Domains = append(dnsConfig.Domains, domains...)
+		}
 
+		log.Trace().Interface("dns_config", dnsConfig).Msg("DNS configuration loaded")
 		return dnsConfig, baseDomain
 	}
 


### PR DESCRIPTION
This commit fixes an issue where search domains was ignored
if the user has not configured any external resolvers. Based
on tailscale's documentation, there is no mention of this
behaviour as far as I can see:
https://tailscale.com/kb/1054/dns#search-domains

In addition, it does add the missing base domain to the
search domain.

and

This commit removes the username from magicDNS names.
This is in preparation of fixing tags, which currently is
not correctly disassociated from users when added. With the
current behaviour, fixing tagged devices would break the
MagicDNS behaviour.

This brings headscale to use the same behaviour of tailscale.

Fixes #1963
Updates #1369