### PR TITLE
Properly render ACL in documentation

### DIFF
--- a/docs/acls.md
+++ b/docs/acls.md
@@ -57,7 +57,7 @@ To use ACLs in headscale, you must edit your config.yaml file. In there you will
 
 Here are the ACL's to implement the same permissions as above:
 
-```json
+```json5
 {
   // groups are collections of users having a common scope. A user can be in multiple groups
   // groups cannot be composed of groups


### PR DESCRIPTION
The ACL example in the documentation specifies the highlighting as JSON, but it has comments which causes GitHub to render them as errors. Comments are allowed in the JSON5 extension, however, to which this patch switches.

Here is how this looks before and after the change:

![Screenshot from 2024-06-25 09-57-51](https://github.com/juanfont/headscale/assets/1008395/0eddd677-1bee-4abc-8c8c-f816781ec3ef)


<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated code block formatting in the documentation to use `json5`, enhancing syntax flexibility for code snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->