### PR TITLE
chore: updated windows client docs

### DIFF
--- a/docs/windows-client.md
+++ b/docs/windows-client.md
@@ -4,36 +4,21 @@
 
 This documentation has the goal of showing how a user can use the official Windows [Tailscale](https://tailscale.com) client with `headscale`.
 
-## Add registry keys
-
-To make the Windows client behave as expected and to run well with `headscale`, two registry keys **must** be set:
-
-- `HKLM:\SOFTWARE\Tailscale IPN\UnattendedMode` must be set to `always` as a `string` type, to allow Tailscale to run properly in the background
-- `HKLM:\SOFTWARE\Tailscale IPN\LoginURL` must be set to `<YOUR HEADSCALE URL>` as a `string` type, to ensure Tailscale contacts the correct control server.
-
-You can set these using the Windows Registry Editor:
-
-![windows-registry](./images/windows-registry.png)
-
-Or via the following Powershell commands (right click Powershell icon and select "Run as administrator"):
-
-```
-New-Item -Path "HKLM:\SOFTWARE\Tailscale IPN"
-New-ItemProperty -Path 'HKLM:\Software\Tailscale IPN' -Name UnattendedMode -PropertyType String -Value always
-New-ItemProperty -Path 'HKLM:\Software\Tailscale IPN' -Name LoginURL -PropertyType String -Value https://YOUR-HEADSCALE-URL
-```
-
-The Tailscale Windows client has been observed to reset its configuration on logout/reboot and these two keys [resolves that issue](https://github.com/tailscale/tailscale/issues/2798).
-
-For a guide on how to edit registry keys, [check out Computer Hope](https://www.computerhope.com/issues/ch001348.htm).
-
 ## Installation
 
 Download the [Official Windows Client](https://tailscale.com/download/windows) and install it.
 
-When the installation has finished, start Tailscale and log in (you might have to click the icon in the system tray).
+When the installation has finished, close the tailscale application in the windows tray. (Richt click > Exit)
 
-The log in should open a browser Window and direct you to your `headscale` instance.
+## Login to Headscale server
+
+Open Command Prompt or Powershell and type in the following:
+
+```
+tailscale up --accept-routes --login-server https://<your-headscale-server>
+```
+
+Follow the instructions shown in your opened browser.
 
 ## Troubleshooting
 


### PR DESCRIPTION
I have updated the windows client documentation, the current docs don't working anymore with the latest tailscale client. The new description is working fine and is less complex.

- [ ] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [X] updated documentation if needed
- [ ] updated CHANGELOG.md