### PR TITLE
adding oidc desired username as option in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ after improving the test harness as part of adopting [#1460](https://github.com/
 - Restore foreign keys and add constraints [#1562](https://github.com/juanfont/headscale/pull/1562)
 - Make registration page easier to use on mobile devices
 - Make write-ahead-log default on and configurable for SQLite [#1985](https://github.com/juanfont/headscale/pull/1985)
+- Allow OIDC desired_username to be used with config bool [#1997](https://github.com/juanfont/headscale/pull/1997)
 
 ## 0.22.3 (2023-05-12)
 

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -50,6 +50,11 @@ oidc:
   # If `strip_email_domain` is set to `false` the domain part will NOT be removed resulting to the following
   # user: `first-name.last-name.example.com`
   strip_email_domain: true
+
+  # If `use_desired_username` is set to `true`, the `prefered_username` oidc field will be used for the username instead of the email
+  # If `use_desired_username` and `strip_email_domain` are both active, the same transform
+  use_desired_username: false
+
 ```
 
 ## Azure AD example

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -134,6 +134,7 @@ type OIDCConfig struct {
 	StripEmaildomain           bool
 	Expiry                     time.Duration
 	UseExpiryFromToken         bool
+	UseDesiredUsername         bool
 }
 
 type DERPConfig struct {
@@ -229,6 +230,7 @@ func LoadConfig(path string, isFile bool) error {
 
 	viper.SetDefault("oidc.scope", []string{oidc.ScopeOpenID, "profile", "email"})
 	viper.SetDefault("oidc.strip_email_domain", true)
+	viper.SetDefault("oidc.use_desired_username", false)
 	viper.SetDefault("oidc.only_start_if_oidc_is_available", true)
 	viper.SetDefault("oidc.expiry", "180d")
 	viper.SetDefault("oidc.use_expiry_from_token", false)
@@ -734,15 +736,16 @@ func GetHeadscaleConfig() (*Config, error) {
 			OnlyStartIfOIDCIsAvailable: viper.GetBool(
 				"oidc.only_start_if_oidc_is_available",
 			),
-			Issuer:           viper.GetString("oidc.issuer"),
-			ClientID:         viper.GetString("oidc.client_id"),
-			ClientSecret:     oidcClientSecret,
-			Scope:            viper.GetStringSlice("oidc.scope"),
-			ExtraParams:      viper.GetStringMapString("oidc.extra_params"),
-			AllowedDomains:   viper.GetStringSlice("oidc.allowed_domains"),
-			AllowedUsers:     viper.GetStringSlice("oidc.allowed_users"),
-			AllowedGroups:    viper.GetStringSlice("oidc.allowed_groups"),
-			StripEmaildomain: viper.GetBool("oidc.strip_email_domain"),
+			Issuer:             viper.GetString("oidc.issuer"),
+			ClientID:           viper.GetString("oidc.client_id"),
+			ClientSecret:       oidcClientSecret,
+			Scope:              viper.GetStringSlice("oidc.scope"),
+			ExtraParams:        viper.GetStringMapString("oidc.extra_params"),
+			AllowedDomains:     viper.GetStringSlice("oidc.allowed_domains"),
+			AllowedUsers:       viper.GetStringSlice("oidc.allowed_users"),
+			AllowedGroups:      viper.GetStringSlice("oidc.allowed_groups"),
+			StripEmaildomain:   viper.GetBool("oidc.strip_email_domain"),
+			UseDesiredUsername: viper.GetBool("oidc.use_desired_username"),
 			Expiry: func() time.Duration {
 				// if set to 0, we assume no expiry
 				if value := viper.GetString("oidc.expiry"); value == "0" {


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

This PR allows people to use their desired username from their oidc provider instead of their email address. this is a user-facing feature and doesn't change any underlying processes

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [x] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
