### PR TITLE
chore: configure some actions to be skipped for forks

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -11,6 +11,9 @@ on:
     tags:
       # Stable release tags
       - v[0-9]+.[0-9]+.[0-9]+
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/gh-actions-updater.yaml
+++ b/.github/workflows/gh-actions-updater.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'juanfont/headscale'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   goreleaser:
+    if: github.repository == 'juanfont/headscale'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   close-issues:
+    if: github.repository == 'juanfont/headscale'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   lockfile:
+    if: github.repository == 'juanfont/headscale'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This is just a simple change. 

This will configure some actions to be skipped for forks, as the actions that are changed here depend on the main repository or the configured secrets, so it makes no sense to run them for forks. This will also remove failed cron jobs from the forks, rest of the actions that don't depend on anything are left untouched. 
