### PR TITLE
Remove deprecated linters from golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,19 +12,13 @@ linters:
   disable:
     - depguard
 
-    - exhaustivestruct
     - revive
     - lll
-    - interfacer
-    - scopelint
-    - maligned
-    - golint
     - gofmt
     - gochecknoglobals
     - gochecknoinits
     - gocognit
     - funlen
-    - exhaustivestruct
     - tagliatelle
     - godox
     - ireturn
@@ -33,13 +27,6 @@ linters:
     - nolintlint
     - musttag # causes issues with imported libs
     - depguard
-
-    # deprecated
-    - structcheck # replaced by unused
-    - ifshort # deprecated by the owner
-    - varcheck # replaced by unused
-    - nosnakecase # replaced by revive
-    - deadcode # replaced by unused
 
     # We should strive to enable these:
     - wrapcheck


### PR DESCRIPTION
When running lints, golangci-lint complained about removed linters (which were already disabled).
This removes the relevant warnings.

Would you be interested in follow up PRs to address the existing warnings? (Ultimately enabling golangci-lint in the CI I guess?)
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
