### PR TITLE
fix(1996): Implement register method enum converter

### DIFF
--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -373,8 +373,7 @@ func (node *Node) Proto() *v1.Node {
 		User:        node.User.Proto(),
 		ForcedTags:  node.ForcedTags,
 
-		// TODO(kradalby): Implement register method enum converter
-		// RegisterMethod: ,
+		RegisterMethod: node.RegisterMethodToV1Enum(),
 
 		CreatedAt: timestamppb.New(node.CreatedAt),
 	}
@@ -487,6 +486,19 @@ func (node *Node) PeerChangeFromMapRequest(req tailcfg.MapRequest) tailcfg.PeerC
 	ret.LastSeen = &now
 
 	return ret
+}
+
+func (node *Node) RegisterMethodToV1Enum() v1.RegisterMethod {
+	switch node.RegisterMethod {
+	case "authkey":
+		return v1.RegisterMethod_REGISTER_METHOD_AUTH_KEY
+	case "oidc":
+		return v1.RegisterMethod_REGISTER_METHOD_OIDC
+	case "cli":
+		return v1.RegisterMethod_REGISTER_METHOD_CLI
+	default:
+		return v1.RegisterMethod_REGISTER_METHOD_UNSPECIFIED
+	}
 }
 
 // ApplyPeerChange takes a PeerChange struct and updates the node.

--- a/hscontrol/types/node_test.go
+++ b/hscontrol/types/node_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	v1 "github.com/juanfont/headscale/gen/go/headscale/v1"
 	"github.com/juanfont/headscale/hscontrol/util"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
@@ -536,6 +537,56 @@ func TestApplyPeerChange(t *testing.T) {
 
 			if diff := cmp.Diff(tt.want, tt.nodeBefore, util.Comparers...); diff != "" {
 				t.Errorf("Patch unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNodeRegisterMethodToV1Enum(t *testing.T) {
+	tests := []struct {
+		name string
+		node Node
+		want v1.RegisterMethod
+	}{
+		{
+			name: "authkey",
+			node: Node{
+				ID:             1,
+				RegisterMethod: util.RegisterMethodAuthKey,
+			},
+			want: v1.RegisterMethod_REGISTER_METHOD_AUTH_KEY,
+		},
+		{
+			name: "oidc",
+			node: Node{
+				ID:             1,
+				RegisterMethod: util.RegisterMethodOIDC,
+			},
+			want: v1.RegisterMethod_REGISTER_METHOD_OIDC,
+		},
+		{
+			name: "cli",
+			node: Node{
+				ID:             1,
+				RegisterMethod: util.RegisterMethodCLI,
+			},
+			want: v1.RegisterMethod_REGISTER_METHOD_CLI,
+		},
+		{
+			name: "unknown",
+			node: Node{
+				ID: 0,
+			},
+			want: v1.RegisterMethod_REGISTER_METHOD_UNSPECIFIED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.node.RegisterMethodToV1Enum()
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("RegisterMethodToV1Enum() unexpected result (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Added a new function `RegisterMethodToV1Enum()` to Node, converting the internal register method string to the corresponding V1 Enum value. Included corresponding unit test in `node_test.go` to ensure correct conversion for various register methods.

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
