### PR TITLE
config-example.yaml: Remove reference to yaml for policy files

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -211,9 +211,8 @@ policy:
   # The mode can be "file" or "database" that defines
   # where the ACL policies are stored and read from.
   mode: file
-  # If the mode is set to "file", the
-  # path to a file containing ACL policies.
-  # The file can be in YAML or HuJSON format.
+  # If the mode is set to "file", the path to a
+  # HuJSON file containing ACL policies.
   path: ""
 
 ## DNS


### PR DESCRIPTION
Very minor fix to some inline documentation in `config-example.yaml`, where YAML was still mentioned in the context of ACL policy files.

https://github.com/juanfont/headscale/pull/1792 removed support for YAML formatted policy files, as also noted in `CHANGELOG.md`: https://github.com/juanfont/headscale/blob/b799245f1e0a09217dd7e5f6730df9530c67458f/CHANGELOG.md#L47-L48