### PR TITLE
Fix data race issues in EphemeralGarbageCollector tests

### DIFF
--- a/hscontrol/db/node_test.go
+++ b/hscontrol/db/node_test.go
@@ -605,7 +605,7 @@ func TestEphemeralGarbageCollectorOrder(t *testing.T) {
 	e := NewEphemeralGarbageCollector(func(ni types.NodeID) {
 		mu.Lock()
 		got = append(got, ni)
-		mu.Unlock()
+		defer mu.Unlock()
 	})
 	go e.Start()
 

--- a/hscontrol/db/node_test.go
+++ b/hscontrol/db/node_test.go
@@ -600,9 +600,12 @@ func (s *Suite) TestAutoApproveRoutes(c *check.C) {
 func TestEphemeralGarbageCollectorOrder(t *testing.T) {
 	want := []types.NodeID{1, 3}
 	got := []types.NodeID{}
+	var mu sync.Mutex
 
 	e := NewEphemeralGarbageCollector(func(ni types.NodeID) {
+		mu.Lock()
 		got = append(got, ni)
+		mu.Unlock()
 	})
 	go e.Start()
 
@@ -616,6 +619,9 @@ func TestEphemeralGarbageCollectorOrder(t *testing.T) {
 	time.Sleep(6 * time.Second)
 
 	e.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("wrong nodes deleted, unexpected result (-want +got):\n%s", diff)
@@ -644,6 +650,10 @@ func TestEphemeralGarbageCollectorLoads(t *testing.T) {
 	time.Sleep(10 * time.Second)
 
 	e.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+
 	if len(got) != want {
 		t.Errorf("expected %d, got %d", want, len(got))
 	}

--- a/hscontrol/db/node_test.go
+++ b/hscontrol/db/node_test.go
@@ -604,8 +604,8 @@ func TestEphemeralGarbageCollectorOrder(t *testing.T) {
 
 	e := NewEphemeralGarbageCollector(func(ni types.NodeID) {
 		mu.Lock()
-		got = append(got, ni)
 		defer mu.Unlock()
+		got = append(got, ni)
 	})
 	go e.Start()
 
@@ -635,8 +635,8 @@ func TestEphemeralGarbageCollectorLoads(t *testing.T) {
 	want := 1000
 
 	e := NewEphemeralGarbageCollector(func(ni types.NodeID) {
-		defer mu.Unlock()
 		mu.Lock()
+		defer mu.Unlock()
 
 		time.Sleep(time.Duration(generateRandomNumber(t, 3)) * time.Millisecond)
 		got = append(got, ni)


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

- This PR addresses data race issues detected by the `-race` flag during `gotestsum -- -short -coverprofile=coverage.out ./...` execution for the `EphemeralGarbageCollector` tests. 

The changes include:
- Added necessary synchronization with mutex locks to prevent concurrent access issues.
- Ensured that shared data structures are properly protected during test execution.

## Log
- gotestsum -- -race -coverprofile=coverage.out ./...
```
=== Failed
=== FAIL: hscontrol/db TestEphemeralGarbageCollectorOrder (6.00s)
==================
WARNING: DATA RACE
Read at 0x00c00057e198 by goroutine 276:
  github.com/juanfont/headscale/hscontrol/db.TestEphemeralGarbageCollectorOrder()
      /Users/dongjunna/headscale/hscontrol/db/node_test.go:620 +0x414
  testing.tRunner()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:1742 +0x40

Previous write at 0x00c00057e198 by goroutine 293:
  github.com/juanfont/headscale/hscontrol/db.TestEphemeralGarbageCollectorOrder.func1()
      /Users/dongjunna/headscale/hscontrol/db/node_test.go:605 +0xa4
  github.com/juanfont/headscale/hscontrol/db.(*EphemeralGarbageCollector).Start.gowrap1()
      /Users/dongjunna/headscale/hscontrol/db/node.go:792 +0x44

Goroutine 276 (running) created at:
  testing.(*T).Run()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:1742 +0x5e4
  testing.runTests.func1()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:2161 +0x80
  testing.tRunner()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:1689 +0x180
  testing.runTests()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:2159 +0x6e0
  testing.(*M).Run()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:2027 +0xb74
  main.main()
      _testmain.go:101 +0x2b4

Goroutine 293 (finished) created at:
  github.com/juanfont/headscale/hscontrol/db.(*EphemeralGarbageCollector).Start()
      /Users/dongjunna/headscale/hscontrol/db/node.go:792 +0x94
  github.com/juanfont/headscale/hscontrol/db.TestEphemeralGarbageCollectorOrder.gowrap1()
      /Users/dongjunna/headscale/hscontrol/db/node_test.go:607 +0x34
==================
==================
WARNING: DATA RACE
Read at 0x00c000010f38 by goroutine 276:
  reflect.Value.Uint()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/reflect/value.go:2753 +0xa80
  github.com/google/go-cmp/cmp.(*state).compareAny()
      /Users/dongjunna/go/pkg/mod/github.com/google/go-cmp@v0.6.0/cmp/compare.go:277 +0x894
  github.com/google/go-cmp/cmp.(*state).statelessCompare()
      /Users/dongjunna/go/pkg/mod/github.com/google/go-cmp@v0.6.0/cmp/compare.go:232 +0xbc
  github.com/google/go-cmp/cmp.(*state).compareSlice.func2()
      /Users/dongjunna/go/pkg/mod/github.com/google/go-cmp@v0.6.0/cmp/compare.go:480 +0xdc
  github.com/google/go-cmp/cmp/internal/diff.Difference()
      /Users/dongjunna/go/pkg/mod/github.com/google/go-cmp@v0.6.0/cmp/internal/diff/diff.go:286 +0x4b8
  github.com/google/go-cmp/cmp.(*state).compareSlice()
      /Users/dongjunna/go/pkg/mod/github.com/google/go-cmp@v0.6.0/cmp/compare.go:479 +0xad0
  github.com/google/go-cmp/cmp.(*state).compareAny()
      /Users/dongjunna/go/pkg/mod/github.com/google/go-cmp@v0.6.0/cmp/compare.go:291 +0xf70
  github.com/google/go-cmp/cmp.Diff()
      /Users/dongjunna/go/pkg/mod/github.com/google/go-cmp@v0.6.0/cmp/compare.go:122 +0x94
  github.com/juanfont/headscale/hscontrol/db.TestEphemeralGarbageCollectorOrder()
      /Users/dongjunna/headscale/hscontrol/db/node_test.go:620 +0x458
  testing.tRunner()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:1742 +0x40

Previous write at 0x00c000010f38 by goroutine 293:
  github.com/juanfont/headscale/hscontrol/db.TestEphemeralGarbageCollectorOrder.func1()
      /Users/dongjunna/headscale/hscontrol/db/node_test.go:605 +0x8c
  github.com/juanfont/headscale/hscontrol/db.(*EphemeralGarbageCollector).Start.gowrap1()
      /Users/dongjunna/headscale/hscontrol/db/node.go:792 +0x44

Goroutine 276 (running) created at:
  testing.(*T).Run()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:1742 +0x5e4
  testing.runTests.func1()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:2161 +0x80
  testing.tRunner()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:1689 +0x180
  testing.runTests()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:2159 +0x6e0
  testing.(*M).Run()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:2027 +0xb74
  main.main()
      _testmain.go:101 +0x2b4

Goroutine 293 (finished) created at:
  github.com/juanfont/headscale/hscontrol/db.(*EphemeralGarbageCollector).Start()
      /Users/dongjunna/headscale/hscontrol/db/node.go:792 +0x94
  github.com/juanfont/headscale/hscontrol/db.TestEphemeralGarbageCollectorOrder.gowrap1()
      /Users/dongjunna/headscale/hscontrol/db/node_test.go:607 +0x34
==================
    testing.go:1398: race detected during execution of test

=== FAIL: hscontrol/db TestEphemeralGarbageCollectorLoads (10.01s)
==================
WARNING: DATA RACE
Read at 0x00c00057e2a0 by goroutine 294:
  github.com/juanfont/headscale/hscontrol/db.TestEphemeralGarbageCollectorLoads()
      /Users/dongjunna/headscale/hscontrol/db/node_test.go:647 +0x48c
  testing.tRunner()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:1742 +0x40

Previous write at 0x00c00057e2a0 by goroutine 4873:
  github.com/juanfont/headscale/hscontrol/db.TestEphemeralGarbageCollectorLoads.func1()
      /Users/dongjunna/headscale/hscontrol/db/node_test.go:636 +0x11c
  github.com/juanfont/headscale/hscontrol/db.(*EphemeralGarbageCollector).Start.gowrap1()
      /Users/dongjunna/headscale/hscontrol/db/node.go:792 +0x44

Goroutine 294 (running) created at:
  testing.(*T).Run()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:1742 +0x5e4
  testing.runTests.func1()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:2161 +0x80
  testing.tRunner()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:1689 +0x180
  testing.runTests()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:2159 +0x6e0
  testing.(*M).Run()
      /nix/store/05saqcgidraqmn4z82prsp7rbj9hjmwm-go-1.22.5/share/go/src/testing/testing.go:2027 +0xb74
  main.main()
      _testmain.go:101 +0x2b4

Goroutine 4873 (finished) created at:
  github.com/juanfont/headscale/hscontrol/db.(*EphemeralGarbageCollector).Start()
      /Users/dongjunna/headscale/hscontrol/db/node.go:792 +0x94
  github.com/juanfont/headscale/hscontrol/db.TestEphemeralGarbageCollectorLoads.gowrap1()
      /Users/dongjunna/headscale/hscontrol/db/node_test.go:638 +0x34
==================
    testing.go:1398: race detected during execution of test
```