### PR TITLE
Integrate GORM Logger with Zerolog and Add Configuration Options for Logging and Performance

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -140,6 +140,23 @@ ephemeral_node_inactivity_timeout: 30m
 database:
   type: sqlite
 
+  # Enable debug mode. Set log.level to "debug".
+  debug: false
+
+  # GORM configuration settings.
+  gorm:
+    # Enable prepared statements.
+    prepare_stmt: true
+
+    # Enable parameterized queries.
+    parameterized_queries: true
+
+    # Skip logging "record not found" errors.
+    skip_err_record_not_found: true
+
+    # Threshold for slow queries in milliseconds.
+    slow_threshold: 1000
+
   # SQLite config
   sqlite:
     path: /var/lib/headscale/db.sqlite

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -140,7 +140,7 @@ ephemeral_node_inactivity_timeout: 30m
 database:
   type: sqlite
 
-  # Enable debug mode. Set log.level to "debug".
+  # Enable debug mode. This setting requires the log.level to be set to "debug" or "trace".
   debug: false
 
   # GORM configuration settings.

--- a/hscontrol/db/db.go
+++ b/hscontrol/db/db.go
@@ -426,7 +426,7 @@ func openDB(cfg types.DatabaseConfig) (*gorm.DB, error) {
 	// TODO(kradalby): Integrate this with zerolog
 	var dbLogger logger.Interface
 	if cfg.Debug {
-		dbLogger = util.NewDBLogWrapper(&log.Logger, cfg.SlowThreshold, cfg.SkipErrRecordNotFound, cfg.ParameterizedQueries)
+		dbLogger = util.NewDBLogWrapper(&log.Logger, cfg.Gorm.SlowThreshold, cfg.Gorm.SkipErrRecordNotFound, cfg.Gorm.ParameterizedQueries)
 	} else {
 		dbLogger = logger.Default.LogMode(logger.Silent)
 	}
@@ -447,7 +447,7 @@ func openDB(cfg types.DatabaseConfig) (*gorm.DB, error) {
 		db, err := gorm.Open(
 			sqlite.Open(cfg.Sqlite.Path),
 			&gorm.Config{
-				PrepareStmt: cfg.PrepareStmt,
+				PrepareStmt: cfg.Gorm.PrepareStmt,
 				Logger:      dbLogger,
 			},
 		)

--- a/hscontrol/db/db.go
+++ b/hscontrol/db/db.go
@@ -426,7 +426,7 @@ func openDB(cfg types.DatabaseConfig) (*gorm.DB, error) {
 	// TODO(kradalby): Integrate this with zerolog
 	var dbLogger logger.Interface
 	if cfg.Debug {
-		dbLogger = logger.Default
+		dbLogger = util.NewDBLogWrapper(&log.Logger, cfg.SlowThreshold, cfg.SkipErrRecordNotFound, cfg.ParameterizedQueries)
 	} else {
 		dbLogger = logger.Default.LogMode(logger.Silent)
 	}
@@ -447,7 +447,8 @@ func openDB(cfg types.DatabaseConfig) (*gorm.DB, error) {
 		db, err := gorm.Open(
 			sqlite.Open(cfg.Sqlite.Path),
 			&gorm.Config{
-				Logger: dbLogger,
+				PrepareStmt: cfg.PrepareStmt,
+				Logger:      dbLogger,
 			},
 		)
 

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -110,6 +110,12 @@ type DatabaseConfig struct {
 	Type  string
 	Debug bool
 
+	// Type sets the gorm configuration
+	SlowThreshold         time.Duration
+	SkipErrRecordNotFound bool
+	ParameterizedQueries  bool
+	PrepareStmt           bool
+
 	Sqlite   SqliteConfig
 	Postgres PostgresConfig
 }
@@ -450,6 +456,11 @@ func GetDatabaseConfig() DatabaseConfig {
 
 	type_ := viper.GetString("database.type")
 
+	skipErrRecordNotFound := viper.GetBool("database.gorm.skip_err_record_not_found")
+	slowThreshold := viper.GetDuration("database.gorm.slow_threshold") * time.Millisecond
+	parameterizedQueries := viper.GetBool("database.gorm.parameterized_queries")
+	prepareStmt := viper.GetBool("database.gorm.prepare_stmt")
+
 	switch type_ {
 	case DatabaseSqlite, DatabasePostgres:
 		break
@@ -461,8 +472,12 @@ func GetDatabaseConfig() DatabaseConfig {
 	}
 
 	return DatabaseConfig{
-		Type:  type_,
-		Debug: debug,
+		Type:                  type_,
+		Debug:                 debug,
+		SkipErrRecordNotFound: skipErrRecordNotFound,
+		SlowThreshold:         slowThreshold,
+		ParameterizedQueries:  parameterizedQueries,
+		PrepareStmt:           prepareStmt,
 		Sqlite: SqliteConfig{
 			Path: util.AbsolutePathFromConfigPath(
 				viper.GetString("database.sqlite.path"),

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -105,16 +105,21 @@ type PostgresConfig struct {
 	ConnMaxIdleTimeSecs int
 }
 
+type GormConfig struct {
+	Debug                 bool
+	SlowThreshold         time.Duration
+	SkipErrRecordNotFound bool
+	ParameterizedQueries  bool
+	PrepareStmt           bool
+}
+
 type DatabaseConfig struct {
 	// Type sets the database type, either "sqlite3" or "postgres"
 	Type  string
 	Debug bool
 
 	// Type sets the gorm configuration
-	SlowThreshold         time.Duration
-	SkipErrRecordNotFound bool
-	ParameterizedQueries  bool
-	PrepareStmt           bool
+	Gorm GormConfig
 
 	Sqlite   SqliteConfig
 	Postgres PostgresConfig
@@ -472,12 +477,15 @@ func GetDatabaseConfig() DatabaseConfig {
 	}
 
 	return DatabaseConfig{
-		Type:                  type_,
-		Debug:                 debug,
-		SkipErrRecordNotFound: skipErrRecordNotFound,
-		SlowThreshold:         slowThreshold,
-		ParameterizedQueries:  parameterizedQueries,
-		PrepareStmt:           prepareStmt,
+		Type:  type_,
+		Debug: debug,
+		Gorm: GormConfig{
+			Debug:                 debug,
+			SkipErrRecordNotFound: skipErrRecordNotFound,
+			SlowThreshold:         slowThreshold,
+			ParameterizedQueries:  parameterizedQueries,
+			PrepareStmt:           prepareStmt,
+		},
 		Sqlite: SqliteConfig{
 			Path: util.AbsolutePathFromConfigPath(
 				viper.GetString("database.sqlite.path"),

--- a/hscontrol/util/log.go
+++ b/hscontrol/util/log.go
@@ -1,7 +1,14 @@
 package util
 
 import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+	gormLogger "gorm.io/gorm/logger"
 	"tailscale.com/types/logger"
 )
 
@@ -13,4 +20,72 @@ func TSLogfWrapper() logger.Logf {
 	return func(format string, args ...any) {
 		log.Debug().Caller().Msgf(format, args...)
 	}
+}
+
+type DBLogWrapper struct {
+	Logger                *zerolog.Logger
+	Level                 zerolog.Level
+	Event                 *zerolog.Event
+	SlowThreshold         time.Duration
+	SkipErrRecordNotFound bool
+	ParameterizedQueries  bool
+}
+
+func NewDBLogWrapper(origin *zerolog.Logger, slowThreshold time.Duration, skipErrRecordNotFound bool, parameterizedQueries bool) *DBLogWrapper {
+	l := &DBLogWrapper{
+		Logger:                origin,
+		Level:                 origin.GetLevel(),
+		SlowThreshold:         slowThreshold,
+		SkipErrRecordNotFound: skipErrRecordNotFound,
+		ParameterizedQueries:  parameterizedQueries,
+	}
+
+	return l
+}
+
+type DBLogWrapperOption func(*DBLogWrapper)
+
+func (l *DBLogWrapper) LogMode(gormLogger.LogLevel) gormLogger.Interface {
+	return l
+}
+
+func (l *DBLogWrapper) Info(ctx context.Context, msg string, data ...interface{}) {
+	l.Logger.Info().Msgf(msg, data...)
+}
+
+func (l *DBLogWrapper) Warn(ctx context.Context, msg string, data ...interface{}) {
+	l.Logger.Warn().Msgf(msg, data...)
+}
+
+func (l *DBLogWrapper) Error(ctx context.Context, msg string, data ...interface{}) {
+	l.Logger.Error().Msgf(msg, data...)
+}
+
+func (l *DBLogWrapper) Trace(ctx context.Context, begin time.Time, fc func() (sql string, rowsAffected int64), err error) {
+	elapsed := time.Since(begin)
+	sql, rowsAffected := fc()
+	fields := map[string]interface{}{
+		"duration":     elapsed,
+		"sql":          sql,
+		"rowsAffected": rowsAffected,
+	}
+
+	if err != nil && !(errors.Is(err, gorm.ErrRecordNotFound) && l.SkipErrRecordNotFound) {
+		l.Logger.Error().Err(err).Fields(fields).Msgf("")
+		return
+	}
+
+	if l.SlowThreshold != 0 && elapsed > l.SlowThreshold {
+		l.Logger.Warn().Fields(fields).Msgf("")
+		return
+	}
+
+	l.Logger.Debug().Fields(fields).Msgf("")
+}
+
+func (l *DBLogWrapper) ParamsFilter(ctx context.Context, sql string, params ...interface{}) (string, []interface{}) {
+	if l.ParameterizedQueries {
+		return sql, nil
+	}
+	return sql, params
 }


### PR DESCRIPTION


<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

This PR integrates the GORM logger with zerolog to detect database-related bottlenecks. With this integration, the log level now follows the level set in zerolog (e.g., debug.level), ensuring consistent and detailed logging for database operations.

To activate database debugging, make sure to set `log.level` to `debug` and `database.debug` to `true`.

Additionally, custom configuration options for GORM have been added. Example configurations can be found in config-example.yaml. The available options include:

## Options:
### config-example.yaml
```
database:
...
  # Enable debug mode. Set log.level to "debug".
  debug: false

  # GORM configuration settings.
  gorm:
    # Enable prepared statements.
    prepare_stmt: true

    # Enable parameterized queries.
    parameterized_queries: true

    # Skip logging "record not found" errors.
    skip_err_record_not_found: true

    # Threshold for slow queries in milliseconds.
    slow_threshold: 1000
```
### 1. Log Options:
- SlowThreshold (ms): Sets the duration threshold for logging slow queries.
- ParameterizedQueries (bool): Provides the option to enable query caching. This option is enabled by default in Postgres.
- SkipErrRecordNotFound (bool): Controls whether to skip logging "record not found" errors.
### 2. Statement Preparation Option:
- PrepareStmt (bool): Specifies whether SQL statements should be prepared.

These options support existing GORM settings and allow for flexible configuration tailored to different environments and needs.

## Summary of Changes
- Integrated GORM logger with zerolog.
- Added custom GORM configuration options.

## Example
- log.level: debug, database.debug: true, database.gorm.parameterized_queries: true
![image](https://github.com/user-attachments/assets/9ab62ea0-4811-4d7c-be05-d1900579b91b)
-  log.level: debug, database.gorm.debug: true, database.gorm.parameterized_queries: false
![image](https://github.com/user-attachments/assets/b6adb731-9863-4c52-adf9-0f176406113b)
- log.level: debug, database.gorm.debug: true, database.gorm.parameterized_queries: false, database.gorm.slow_threshold
![image](https://github.com/user-attachments/assets/b72957f5-abd0-4bae-a6a4-428d635cc17f)

## Reference
- [Statement preparation option](https://gorm.io/docs/performance.html)
- [Log option](https://gorm.io/docs/logger.html)