### PR TITLE
make acl_policy_path fatal if policy.path is not set

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -224,8 +224,8 @@ policy:
 # - https://tailscale.com/kb/1081/magicdns/
 # - https://tailscale.com/blog/2021-09-private-dns-with-magicdns/
 #
-# Please not that for the DNS configuration to have any effect,
-# clients must have the `--accept-ds=true` option enabled. This is the
+# Please note that for the DNS configuration to have any effect,
+# clients must have the `--accept-dns=true` option enabled. This is the
 # default for the Tailscale client. This option is enabled by default
 # in the Tailscale client.
 #

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -292,7 +292,7 @@ func LoadConfig(path string, isFile bool) error {
 	// https://github.com/spf13/viper/issues/560
 
 	// Alias the old ACL Policy path with the new configuration option.
-	depr.warnWithAlias("policy.path", "acl_policy_path")
+	depr.fatalIfNewKeyIsNotUsed("policy.path", "acl_policy_path")
 
 	// Move dns_config -> dns
 	depr.warn("dns_config.override_local_dns")

--- a/hscontrol/types/config_test.go
+++ b/hscontrol/types/config_test.go
@@ -161,6 +161,25 @@ func TestReadConfig(t *testing.T) {
 			},
 			wantErr: "",
 		},
+		{
+			name:       "policy-path-is-loaded",
+			configPath: "testdata/policy-path-is-loaded.yaml",
+			setup: func(t *testing.T) (any, error) {
+				cfg, err := GetHeadscaleConfig()
+				if err != nil {
+					return nil, err
+				}
+
+				return map[string]string{
+					"policy.mode": string(cfg.Policy.Mode),
+					"policy.path": cfg.Policy.Path,
+				}, err
+			},
+			want: map[string]string{
+				"policy.mode": "file",
+				"policy.path": "/etc/policy.hujson",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/hscontrol/types/testdata/policy-path-is-loaded.yaml
+++ b/hscontrol/types/testdata/policy-path-is-loaded.yaml
@@ -1,0 +1,18 @@
+noise:
+  private_key_path: "private_key.pem"
+
+prefixes:
+  v6: fd7a:115c:a1e0::/48
+  v4: 100.64.0.0/10
+
+database:
+  type: sqlite3
+
+server_url: "https://derp.no"
+
+acl_policy_path: "/etc/acl_policy.yaml"
+policy:
+  type: file
+  path: "/etc/policy.hujson"
+
+dns.magic_dns: false

--- a/integration/hsic/config.go
+++ b/integration/hsic/config.go
@@ -13,7 +13,7 @@ noise:
 func DefaultConfigEnv() map[string]string {
 	return map[string]string{
 		"HEADSCALE_LOG_LEVEL":                         "trace",
-		"HEADSCALE_ACL_POLICY_PATH":                   "",
+		"HEADSCALE_POLICY_PATH":                       "",
 		"HEADSCALE_DATABASE_TYPE":                     "sqlite",
 		"HEADSCALE_DATABASE_SQLITE_PATH":              "/tmp/integration_test_db.sqlite3",
 		"HEADSCALE_EPHEMERAL_NODE_INACTIVITY_TIMEOUT": "30m",

--- a/integration/hsic/hsic.go
+++ b/integration/hsic/hsic.go
@@ -82,7 +82,7 @@ type Option = func(c *HeadscaleInContainer)
 func WithACLPolicy(acl *policy.ACLPolicy) Option {
 	return func(hsic *HeadscaleInContainer) {
 		// TODO(kradalby): Move somewhere appropriate
-		hsic.env["HEADSCALE_ACL_POLICY_PATH"] = aclPolicyPath
+		hsic.env["HEADSCALE_POLICY_PATH"] = aclPolicyPath
 
 		hsic.aclPolicy = acl
 	}


### PR DESCRIPTION
this commit changes and streamlines the dns_config into a new
key, dns. It removes a combination of outdates and incompatible
configuration options that made it easy to confuse what headscale
could and could not do, or what to expect from ones configuration.

It has to go in after #2034 with a rebase as it contains that commit because of 
some helpers used there.

Fixes #2024

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration file to manage network policies and database settings, enhancing overall system capabilities.
	- Updated DNS settings in the configuration to improve clarity and accuracy.
  
- **Bug Fixes**
	- Corrected typographical errors in the configuration documentation, improving user understanding.

- **Tests**
	- Added a new test case to ensure proper loading of configuration files and validation of policy settings.

- **Chores**
	- Renamed ACL policy path key for better clarity and consistency in configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->