### PR TITLE
Fix command get policy works with relative policy path

### DIFF
--- a/hscontrol/grpcv1.go
+++ b/hscontrol/grpcv1.go
@@ -692,7 +692,8 @@ func (api headscaleV1APIServer) GetPolicy(
 		}, nil
 	case types.PolicyModeFile:
 		// Read the file and return the contents as-is.
-		f, err := os.Open(api.h.cfg.Policy.Path)
+		absPath := util.AbsolutePathFromConfigPath(api.h.cfg.Policy.Path)
+		f, err := os.Open(absPath)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

This PR addresses the issue where the gRPC API fails to resolve relative policy file paths, unlike the server startup behavior. The fix ensures consistent handling of relative paths across server startup, CLI commands, and gRPC API calls.
## Changes

- Modified the policy file path resolution logic in the gRPC API handler to match the server startup behavior.
- Ensured that relative paths are resolved relative to the location of the config.yaml file.

Fixes #2050