### PR TITLE
build docker images on PR

### DIFF
--- a/.github/workflows/build-docker-pr.yml
+++ b/.github/workflows/build-docker-pr.yml
@@ -1,0 +1,71 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Get changed files
+        id: changed-files
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            files:
+              - '*.nix'
+              - 'go.*'
+              - '**/*.go'
+              - 'integration_test/'
+              - 'config-example.yaml'
+      - uses: DeterminateSystems/nix-installer-action@main
+        if: steps.changed-files.outputs.files == 'true'
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+        if: steps.changed-files.outputs.files == 'true'
+
+      - name: Run build
+        id: build
+        if: steps.changed-files.outputs.files == 'true'
+        run: |
+          nix build |& tee build-result
+          BUILD_STATUS="${PIPESTATUS[0]}"
+
+          OLD_HASH=$(cat build-result | grep specified: | awk -F ':' '{print $2}' | sed 's/ //g')
+          NEW_HASH=$(cat build-result | grep got: | awk -F ':' '{print $2}' | sed 's/ //g')
+
+          echo "OLD_HASH=$OLD_HASH" >> $GITHUB_OUTPUT
+          echo "NEW_HASH=$NEW_HASH" >> $GITHUB_OUTPUT
+
+          exit $BUILD_STATUS
+
+      - name: Nix gosum diverging
+        uses: actions/github-script@v6
+        if: failure() && steps.build.outcome == 'failure'
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.pulls.createReviewComment({
+              pull_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Nix build failed with wrong gosum, please update "vendorSha256" (${{ steps.build.outputs.OLD_HASH }}) for the "headscale" package in flake.nix with the new SHA: ${{ steps.build.outputs.NEW_HASH }}'
+            })
+
+      - uses: actions/upload-artifact@v4
+        if: steps.changed-files.outputs.files == 'true'
+        with:
+          name: headscale-linux
+          path: result/bin/headscale

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
-name: Build
+name: Build Docker images for PRs
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -36,36 +33,22 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
         if: steps.changed-files.outputs.files == 'true'
 
-      - name: Run build
+      - uses: actions/github-script@v6
+        id: get_pr_data
+        with:
+          script: |
+            return (
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                commit_sha: context.sha,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              })
+            ).data[0];
+
+      - name: Run ko build
         id: build
         if: steps.changed-files.outputs.files == 'true'
+        env:
+          KO_DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/headscale
         run: |
-          nix build |& tee build-result
-          BUILD_STATUS="${PIPESTATUS[0]}"
-
-          OLD_HASH=$(cat build-result | grep specified: | awk -F ':' '{print $2}' | sed 's/ //g')
-          NEW_HASH=$(cat build-result | grep got: | awk -F ':' '{print $2}' | sed 's/ //g')
-
-          echo "OLD_HASH=$OLD_HASH" >> $GITHUB_OUTPUT
-          echo "NEW_HASH=$NEW_HASH" >> $GITHUB_OUTPUT
-
-          exit $BUILD_STATUS
-
-      - name: Nix gosum diverging
-        uses: actions/github-script@v6
-        if: failure() && steps.build.outcome == 'failure'
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.rest.pulls.createReviewComment({
-              pull_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Nix build failed with wrong gosum, please update "vendorSha256" (${{ steps.build.outputs.OLD_HASH }}) for the "headscale" package in flake.nix with the new SHA: ${{ steps.build.outputs.NEW_HASH }}'
-            })
-
-      - uses: actions/upload-artifact@v4
-        if: steps.changed-files.outputs.files == 'true'
-        with:
-          name: headscale-linux
-          path: result/bin/headscale
+          ko build --tags=pr-${{ fromJson(steps.get_pr_data.outputs.result).number }},${{ github.sha }} ./cmd/headscale

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
+    permissions: write-all
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,9 @@ jobs:
               })
             ).data[0];
 
+      - name: Issue number
+        run: echo '${{steps.get_pr_data.outputs.result}}'
+
       - name: Run ko build
         id: build
         if: steps.changed-files.outputs.files == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -34,7 +36,7 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
         if: steps.changed-files.outputs.files == 'true'
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         id: get_pr_data
         with:
           script: |
@@ -46,8 +48,11 @@ jobs:
               })
             ).data[0];
 
-      - name: Issue number
-        run: echo '${{steps.get_pr_data.outputs.result}}'
+      - name: Pull Request data
+        run: |
+          echo '${{ fromJson(steps.get_pr_data.outputs.result).number }}'
+          echo '${{ fromJson(steps.get_pr_data.outputs.result).title }}'
+          echo '${{steps.get_pr_data.outputs.result}}'
 
       - name: Run ko build
         id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,28 +34,28 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
         if: steps.changed-files.outputs.files == 'true'
 
-      - uses: actions/github-script@v7
-        id: get_pr_data
-        with:
-          script: |
-            return (
-              await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                commit_sha: context.sha,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              })
-            ).data[0];
+      # - uses: actions/github-script@v7
+      #   id: get_pr_data
+      #   with:
+      #     script: |
+      #       return (
+      #         await github.rest.repos.listPullRequestsAssociatedWithCommit({
+      #           commit_sha: context.sha,
+      #           owner: context.repo.owner,
+      #           repo: context.repo.repo,
+      #         })
+      #       ).data[0];
 
-      - name: Pull Request data
-        run: |
-          echo '${{steps.get_pr_data.outputs.result}}'
+      # - name: Pull Request data
+      #   run: |
+      #     echo '${{steps.get_pr_data.outputs.result}}'
 
       - name: Run ko build
         id: build
         if: steps.changed-files.outputs.files == 'true'
         env:
           KO_DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/headscale
-          TAG_PR_NAME: pr-${{ fromJson(steps.get_pr_data.outputs.result).number }}
+          # TAG_PR_NAME: pr-${{ fromJson(steps.get_pr_data.outputs.result).number }}
           TAG_SHA: ${{ github.sha }}
         run: |
-          nix develop --command -- ko build --tags=$TAG_SHA,$TAG_PR_NAME ./cmd/headscale
+          nix develop --command -- ko build --tags=$TAG_SHA ./cmd/headscale

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,5 +51,7 @@ jobs:
         if: steps.changed-files.outputs.files == 'true'
         env:
           KO_DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/headscale
+          TAG_PR_NAME: pr-${{ fromJson(steps.get_pr_data.outputs.result).number }}
+          TAG_SHA: ${{ github.sha }}
         run: |
-          ko build --tags=pr-${{ fromJson(steps.get_pr_data.outputs.result).number }},${{ github.sha }} ./cmd/headscale
+          ko build --tags=$TAG_PR_NAME,$TAG_SHA ./cmd/headscale

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
               - '**/*.go'
               - 'integration_test/'
               - 'config-example.yaml'
+              - '.ko.yaml'
       - uses: DeterminateSystems/nix-installer-action@main
         if: steps.changed-files.outputs.files == 'true'
       - uses: DeterminateSystems/magic-nix-cache-action@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,5 +60,4 @@ jobs:
           # TAG_PR_NAME: pr-${{ fromJson(steps.get_pr_data.outputs.result).number }}
           TAG_SHA: ${{ github.sha }}
         run: |
-          echo $TAG_PR_NAME
-          ko build --tags=$TAG_SHA ./cmd/headscale
+          nix develop --command -- ko build --tags=$TAG_SHA ./cmd/headscale

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
               })
-            ).data[0];
+            ).data;
 
       - name: Pull Request data
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         if: steps.changed-files.outputs.files == 'true'
         env:
           KO_DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/headscale
-          TAG_PR_NAME: pr-${{ fromJson(steps.get_pr_data.outputs.result).number }}
+          # TAG_PR_NAME: pr-${{ fromJson(steps.get_pr_data.outputs.result).number }}
           TAG_SHA: ${{ github.sha }}
         run: |
           echo $TAG_PR_NAME

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,4 +54,5 @@ jobs:
           TAG_PR_NAME: pr-${{ fromJson(steps.get_pr_data.outputs.result).number }}
           TAG_SHA: ${{ github.sha }}
         run: |
-          ko build --tags=$TAG_PR_NAME,$TAG_SHA ./cmd/headscale
+          echo $TAG_PR_NAME
+          ko build --tags=$TAG_SHA ./cmd/headscale

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
               })
-            ).data;
+            ).data[0];
 
       - name: Pull Request data
         run: |
@@ -55,7 +55,7 @@ jobs:
         if: steps.changed-files.outputs.files == 'true'
         env:
           KO_DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/headscale
-          # TAG_PR_NAME: pr-${{ fromJson(steps.get_pr_data.outputs.result).number }}
+          TAG_PR_NAME: pr-${{ fromJson(steps.get_pr_data.outputs.result).number }}
           TAG_SHA: ${{ github.sha }}
         run: |
-          nix develop --command -- ko build --tags=$TAG_SHA ./cmd/headscale
+          nix develop --command -- ko build --tags=$TAG_SHA,$TAG_PR_NAME ./cmd/headscale

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,6 @@ jobs:
 
       - name: Pull Request data
         run: |
-          echo '${{ fromJson(steps.get_pr_data.outputs.result).number }}'
-          echo '${{ fromJson(steps.get_pr_data.outputs.result).title }}'
           echo '${{steps.get_pr_data.outputs.result}}'
 
       - name: Run ko build

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,8 +27,6 @@ builds:
       - -mod=readonly
     ldflags:
       - -s -w -X github.com/juanfont/headscale/cmd/headscale/cli.Version=v{{.Version}}
-    tags:
-      - ts2019
 
 archives:
   - id: golang-cross

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,16 @@
+defaultBaseImage: gcr.io/distroless/base-debian12:debug
+defaultPlatforms:
+  - linux/arm64
+  - linux/arm/v7
+  - linux/amd64
+  - linux/386
+
+builds:
+  - id: headscale
+    main: ./cmd/headscale
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -s -w -X github.com/juanfont/headscale/cmd/headscale/cli.Version=v{{.Git.ShortCommit}}


### PR DESCRIPTION
Sometimes we want people to test features in PRs and not everyone is used to using git, build go and docker.

This commit builds docker containers and pushes them to GHCR (not dockerhub) for testing on pushes to branches that has open pull requests to main using Ko.
This is configured to mimic the debug images produced by goreleaser.