### PR TITLE
Don't overwrite previously filled dnsConfig.Domains

### DIFF
--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -587,7 +587,7 @@ func GetDNSConfig() (*tailcfg.DNSConfig, string) {
 		}
 
 		if !viper.GetBool("dns_config.use_username_in_magic_dns") {
-			dnsConfig.Domains = []string{baseDomain}
+			dnsConfig.Domains = append(dnsConfig.Domains, baseDomain)
 		} else {
 			log.Warn().Msg("DNS: Usernames in DNS has been deprecated, this option will be remove in future versions")
 			log.Warn().Msg("DNS: see 0.23.0 changelog for more information.")


### PR DESCRIPTION
Before we threw away the value from https://github.com/juanfont/headscale/blob/8b3af45091b07169699c7879f3e050e312e42cf1/hscontrol/types/config.go#L561

I am not sure if this was more correct. If so, we should drop the domains code in the loop.

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
