### PR TITLE
Docs: Update ACLs on file formats

### DIFF
--- a/docs/acls.md
+++ b/docs/acls.md
@@ -43,8 +43,7 @@ servers.
 Note: Users will be created automatically when users authenticate with the
 Headscale server.
 
-ACLs could be written either on [huJSON](https://github.com/tailscale/hujson)
-or YAML. Check the [test ACLs](../tests/acls) for further information.
+ACLs have to be written in [huJSON](https://github.com/tailscale/hujson). Check the [test ACLs](../tests/acls) for further information.
 
 When registering the servers we will need to add the flag
 `--advertise-tags=tag:<tag1>,tag:<tag2>`, and the user that is


### PR DESCRIPTION
Updated docs on ACLs according to the comment on [YAML deprecation](https://github.com/juanfont/headscale/issues/2024#issuecomment-2272976178)

By the way, the 'tests' link is broken and I couldn't find the files this link should mention. Any clues?

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Access Control Lists (ACLs) documentation to specify that only huJSON format is accepted, removing the previous YAML option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->