### PR TITLE
chore: fix some comments

### DIFF
--- a/hscontrol/mapper/mapper.go
+++ b/hscontrol/mapper/mapper.go
@@ -227,7 +227,7 @@ func (m *Mapper) FullMapResponse(
 	return m.marshalMapResponse(mapRequest, resp, node, mapRequest.Compress, messages...)
 }
 
-// ReadOnlyResponse returns a MapResponse for the given node.
+// ReadOnlyMapResponse returns a MapResponse for the given node.
 // Lite means that the peers has been omitted, this is intended
 // to be used to answer MapRequests with OmitPeers set to true.
 func (m *Mapper) ReadOnlyMapResponse(
@@ -552,7 +552,7 @@ func appendPeerChanges(
 	}
 
 	// If there are filter rules present, see if there are any nodes that cannot
-	// access eachother at all and remove them from the peers.
+	// access each-other at all and remove them from the peers.
 	if len(packetFilter) > 0 {
 		changed = policy.FilterNodesByACL(node, changed, packetFilter)
 	}
@@ -596,7 +596,7 @@ func appendPeerChanges(
 	} else {
 		// This is a hack to avoid sending an empty list of packet filters.
 		// Since tailcfg.PacketFilter has omitempty, any empty PacketFilter will
-		// be omitted, causing the client to consider it unchange, keeping the
+		// be omitted, causing the client to consider it unchanged, keeping the
 		// previous packet filter. Worst case, this can cause a node that previously
 		// has access to a node to _not_ loose access if an empty (allow none) is sent.
 		reduced := policy.ReduceFilterRules(node, packetFilter)


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->


fix some comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Renamed `ReadOnlyResponse` to `ReadOnlyMapResponse` to improve clarity and alignment with its purpose.

- **Bug Fixes**
	- Minor corrections in comments for improved readability, including textual adjustments for accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->