### PR TITLE
Issue 2045, Feature Request

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -25,9 +25,9 @@ body:
       description: Are you willing to contribute to the implementation of this feature?
       options:
         - label: I can write the design doc for this feature
-          required: true
+          required: false
         - label: I can contribute this feature
-          required: true
+          required: false
   - type: textarea
     attributes:
       label: How can it be implemented?


### PR DESCRIPTION
Requiring someone to write a design doc/contribute to the feature shouldn't be a requirement for raising a feature request as users may lack the skills required to do this.


<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the feature request template to make certain fields optional, streamlining the submission process for contributors.
	- Maintained the textarea for implementation ideas, allowing users to provide input without mandatory requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->