### PR TITLE
oldest client supported, not latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ after improving the test harness as part of adopting [#1460](https://github.com/
   - Adds additional configuration for PostgreSQL for setting max open, idle connection and idle connection lifetime.
 - API: Machine is now Node [#1553](https://github.com/juanfont/headscale/pull/1553)
 - Remove support for older Tailscale clients [#1611](https://github.com/juanfont/headscale/pull/1611)
-  - The latest supported client is 1.42
+  - The oldest supported client is 1.42
 - Headscale checks that _at least_ one DERP is defined at start [#1564](https://github.com/juanfont/headscale/pull/1564)
   - If no DERP is configured, the server will fail to start, this can be because it cannot load the DERPMap from file or url.
 - Embedded DERP server requires a private key [#1611](https://github.com/juanfont/headscale/pull/1611)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ buttons available in the repo.
 - Taildrop (File Sharing)
 - [Access control lists](https://tailscale.com/kb/1018/acls/)
 - [MagicDNS](https://tailscale.com/kb/1081/magicdns)
-- Support for multiple IP ranges in the tailnet
 - Dual stack (IPv4 and IPv6)
 - Routing advertising (including exit nodes)
 - Ephemeral nodes


### PR DESCRIPTION
Closes #2070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation Updates**
	- Revised the changelog to clarify client compatibility, now indicating the oldest supported client version.
	- Updated the requirement for DERP configuration at startup to prevent server issues.
	- Removed information regarding support for multiple IP ranges in the README, potentially affecting user understanding of network configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->