### PR TITLE
Remove references to tests/acls from the documentation

### DIFF
--- a/docs/acls.md
+++ b/docs/acls.md
@@ -3,7 +3,7 @@ Headscale implements the same policy ACLs as Tailscale.com, adapted to the self-
 For instance, instead of referring to users when defining groups you must
 use users (which are the equivalent to user/logins in Tailscale.com).
 
-Please check https://tailscale.com/kb/1018/acls/, and `./tests/acls/` in this repo for working examples.
+Please check https://tailscale.com/kb/1018/acls/ for further information.
 
 When using ACL's the User borders are no longer applied. All machines
 whichever the User have the ability to communicate with other hosts as
@@ -43,7 +43,7 @@ servers.
 Note: Users will be created automatically when users authenticate with the
 Headscale server.
 
-ACLs have to be written in [huJSON](https://github.com/tailscale/hujson). Check the [test ACLs](../tests/acls) for further information.
+ACLs have to be written in [huJSON](https://github.com/tailscale/hujson).
 
 When registering the servers we will need to add the flag
 `--advertise-tags=tag:<tag1>,tag:<tag2>`, and the user that is


### PR DESCRIPTION
The ACL test files got removed with 2d365c8c9c34c095fbe7c2ab7f32b4fb3a511ec2

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity and conciseness of the ACLs documentation by removing redundant phrases and simplifying instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->