### PR TITLE
validate policy against nodes, error if not valid

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -37,6 +37,7 @@ jobs:
           - TestNodeRenameCommand
           - TestNodeMoveCommand
           - TestPolicyCommand
+          - TestPolicyBrokenConfigCommand
           - TestResolveMagicDNS
           - TestValidateResolvConf
           - TestDERPServerScenario

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -1683,7 +1683,7 @@ func TestPolicyBrokenConfigCommand(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	// defer scenario.Shutdown()
+	defer scenario.Shutdown()
 
 	spec := map[string]int{
 		"policy-user": 1,

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -1676,3 +1676,77 @@ func TestPolicyCommand(t *testing.T) {
 	assert.Len(t, output.ACLs, 1)
 	assert.Equal(t, output.TagOwners["tag:exists"], []string{"policy-user"})
 }
+
+func TestPolicyBrokenConfigCommand(t *testing.T) {
+	IntegrationSkip(t)
+	t.Parallel()
+
+	scenario, err := NewScenario(dockertestMaxWait())
+	assertNoErr(t, err)
+	// defer scenario.Shutdown()
+
+	spec := map[string]int{
+		"policy-user": 1,
+	}
+
+	err = scenario.CreateHeadscaleEnv(
+		spec,
+		[]tsic.Option{},
+		hsic.WithTestName("clins"),
+		hsic.WithConfigEnv(map[string]string{
+			"HEADSCALE_POLICY_MODE": "database",
+		}),
+	)
+	assertNoErr(t, err)
+
+	headscale, err := scenario.Headscale()
+	assertNoErr(t, err)
+
+	p := policy.ACLPolicy{
+		ACLs: []policy.ACL{
+			{
+				// This is an unknown action, so it will return an error
+				// and the config will not be applied.
+				Action:       "acccept",
+				Sources:      []string{"*"},
+				Destinations: []string{"*:*"},
+			},
+		},
+		TagOwners: map[string][]string{
+			"tag:exists": {"policy-user"},
+		},
+	}
+
+	pBytes, _ := json.Marshal(p)
+
+	policyFilePath := "/etc/headscale/policy.json"
+
+	err = headscale.WriteFile(policyFilePath, pBytes)
+	assertNoErr(t, err)
+
+	// No policy is present at this time.
+	// Add a new policy from a file.
+	_, err = headscale.Execute(
+		[]string{
+			"headscale",
+			"policy",
+			"set",
+			"-f",
+			policyFilePath,
+		},
+	)
+	assert.ErrorContains(t, err, "verifying policy rules: invalid action")
+
+	// The new policy was invalid, the old one should still be in place, which
+	// is none.
+	_, err = headscale.Execute(
+		[]string{
+			"headscale",
+			"policy",
+			"get",
+			"--output",
+			"json",
+		},
+	)
+	assert.ErrorContains(t, err, "acl policy not found")
+}

--- a/integration/dockertestutil/execute.go
+++ b/integration/dockertestutil/execute.go
@@ -62,7 +62,7 @@ func ExecuteCommand(
 		exitCode, err := resource.Exec(
 			cmd,
 			dockertest.ExecOptions{
-				Env:    append(env, "HEADSCALE_LOG_LEVEL=disabled"),
+				Env:    append(env, "HEADSCALE_LOG_LEVEL=info"),
 				StdOut: &stdout,
 				StdErr: &stderr,
 			},

--- a/integration/hsic/hsic.go
+++ b/integration/hsic/hsic.go
@@ -551,7 +551,7 @@ func (t *HeadscaleInContainer) Execute(
 			log.Printf("command stdout: %s\n", stdout)
 		}
 
-		return "", err
+		return stdout, fmt.Errorf("executing command in docker: %w, stderr: %s", err, stderr)
 	}
 
 	return stdout, nil


### PR DESCRIPTION
this commit aims to improve the feedback of "runtime" policy errors which would only manifest when the rules are compiled to filter rules with nodes.

this change will in;

file-based mode load the nodes from the db and try to compile the rules on start up and return an error if they would not work as intended.

database-based mode prevent a new ACL being written to the database if it does not compile with the current set of node.

Fixes #2073
Fixes #2044


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for Access Control List (ACL) policies to prevent runtime errors from invalid configurations.
	- Improved error reporting with additional context when setting policies, aiding in better issue traceability.

- **Bug Fixes**
	- Resolved potential issues related to policy application by ensuring policies are validated against the current database state.
	- Added tests to validate error handling for invalid policy configurations, ensuring system integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->