### PR TITLE
Use dns: as config key

### DIFF
--- a/docs/dns-records.md
+++ b/docs/dns-records.md
@@ -19,7 +19,7 @@ An example use case is to serve apps on the same host via a reverse proxy like N
 1. Change the `config.yaml` to contain the desired records like so:
 
     ```yaml
-    dns_config:
+    dns:
       ...
       extra_records:
         - name: "prometheus.myvpn.example.com"


### PR DESCRIPTION
0.23 uses `dns:` while older versions use `dns_config:`.

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the DNS records documentation to reflect a simplified configuration key, changing `dns_config` to `dns`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->