### PR TITLE
Fix 764

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -45,6 +45,7 @@ jobs:
           - TestPingAllByIPPublicDERP
           - TestAuthKeyLogoutAndRelogin
           - TestEphemeral
+          - TestEphemeralInAlternateTimezone
           - TestEphemeral2006DeletedTooQuickly
           - TestPingAllByHostname
           - TestTaildrop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ after improving the test harness as part of adopting [#1460](https://github.com/
 - Make registration page easier to use on mobile devices
 - Make write-ahead-log default on and configurable for SQLite [#1985](https://github.com/juanfont/headscale/pull/1985)
 - Add APIs for managing headscale policy. [#1792](https://github.com/juanfont/headscale/pull/1792)
+- Fix for registering nodes using preauthkeys when running on a postgres database in a non-UTC timezone. [#764](https://github.com/juanfont/headscale/issues/764)
+- Make sure integration tests cover postgres for all scenarios
 
 ## 0.22.3 (2023-05-12)
 

--- a/hscontrol/mapper/tail.go
+++ b/hscontrol/mapper/tail.go
@@ -93,7 +93,7 @@ func tailNode(
 		User: tailcfg.UserID(node.UserID),
 
 		Key:       node.NodeKey,
-		KeyExpiry: keyExpiry,
+		KeyExpiry: keyExpiry.UTC(),
 
 		Machine:    node.MachineKey,
 		DiscoKey:   node.DiscoKey,
@@ -102,7 +102,7 @@ func tailNode(
 		Endpoints:  node.Endpoints,
 		DERP:       derp,
 		Hostinfo:   node.Hostinfo.View(),
-		Created:    node.CreatedAt,
+		Created:    node.CreatedAt.UTC(),
 
 		Online: node.IsOnline,
 

--- a/hscontrol/mapper/tail_test.go
+++ b/hscontrol/mapper/tail_test.go
@@ -1,6 +1,7 @@
 package mapper
 
 import (
+	"encoding/json"
 	"net/netip"
 	"testing"
 	"time"
@@ -202,6 +203,73 @@ func TestTailNode(t *testing.T) {
 			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("tailNode() unexpected result (-want +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+func TestNodeExpiry(t *testing.T) {
+	tp := func(t time.Time) *time.Time {
+		return &t
+	}
+	tests := []struct {
+		name         string
+		exp          *time.Time
+		wantTime     time.Time
+		wantTimeZero bool
+	}{
+		{
+			name:         "no-expiry",
+			exp:          nil,
+			wantTimeZero: true,
+		},
+		{
+			name:         "zero-expiry",
+			exp:          &time.Time{},
+			wantTimeZero: true,
+		},
+		{
+			name:         "localtime",
+			exp:          tp(time.Time{}.Local()),
+			wantTimeZero: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &types.Node{
+				GivenName: "test",
+				Expiry:    tt.exp,
+			}
+			tn, err := tailNode(
+				node,
+				0,
+				&policy.ACLPolicy{},
+				&types.Config{},
+			)
+
+			if err != nil {
+				t.Fatalf("nodeExpiry() error = %v", err)
+			}
+
+			// Round trip the node through JSON to ensure the time is serialized correctly
+			seri, err := json.Marshal(tn)
+			if err != nil {
+				t.Fatalf("nodeExpiry() error = %v", err)
+			}
+			var deseri tailcfg.Node
+			err = json.Unmarshal(seri, &deseri)
+			if err != nil {
+				t.Fatalf("nodeExpiry() error = %v", err)
+			}
+
+			if tt.wantTimeZero {
+				if !deseri.KeyExpiry.IsZero() {
+					t.Errorf("nodeExpiry() = %v, want zero", deseri.KeyExpiry)
+				}
+			} else if deseri.KeyExpiry != tt.wantTime {
+				t.Errorf("nodeExpiry() = %v, want %v", deseri.KeyExpiry, tt.wantTime)
+			}
+
 		})
 	}
 }

--- a/hscontrol/mapper/tail_test.go
+++ b/hscontrol/mapper/tail_test.go
@@ -246,7 +246,6 @@ func TestNodeExpiry(t *testing.T) {
 				&policy.ACLPolicy{},
 				&types.Config{},
 			)
-
 			if err != nil {
 				t.Fatalf("nodeExpiry() error = %v", err)
 			}
@@ -269,7 +268,6 @@ func TestNodeExpiry(t *testing.T) {
 			} else if deseri.KeyExpiry != tt.wantTime {
 				t.Errorf("nodeExpiry() = %v, want %v", deseri.KeyExpiry, tt.wantTime)
 			}
-
 		})
 	}
 }

--- a/integration/general_test.go
+++ b/integration/general_test.go
@@ -215,6 +215,14 @@ func TestAuthKeyLogoutAndRelogin(t *testing.T) {
 }
 
 func TestEphemeral(t *testing.T) {
+	testEphemeralWithOptions(t, hsic.WithTestName("ephemeral"))
+}
+
+func TestEphemeralInAlternateTimezone(t *testing.T) {
+	testEphemeralWithOptions(t, hsic.WithTestName("ephemeral-tz"), hsic.WithTimezone("America/Los_Angeles"))
+}
+
+func testEphemeralWithOptions(t *testing.T, opts ...hsic.Option) {
 	IntegrationSkip(t)
 	t.Parallel()
 
@@ -227,7 +235,7 @@ func TestEphemeral(t *testing.T) {
 		"user2": len(MustTestVersions),
 	}
 
-	headscale, err := scenario.Headscale(hsic.WithTestName("ephemeral"))
+	headscale, err := scenario.Headscale(opts...)
 	assertNoErrHeadscaleEnv(t, err)
 
 	for userName, clientCount := range spec {

--- a/integration/hsic/hsic.go
+++ b/integration/hsic/hsic.go
@@ -211,6 +211,12 @@ func WithTuning(batchTimeout time.Duration, mapSessionChanSize int) Option {
 	}
 }
 
+func WithTimezone(timezone string) Option {
+	return func(hsic *HeadscaleInContainer) {
+		hsic.env["TZ"] = timezone
+	}
+}
+
 // New returns a new HeadscaleInContainer instance.
 func New(
 	pool *dockertest.Pool,

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -26,6 +26,7 @@ run_tests() {
 			--volume "$PWD:$PWD" -w "$PWD"/integration \
 			--volume /var/run/docker.sock:/var/run/docker.sock \
 			--volume "$PWD"/control_logs:/tmp/control \
+			-e "HEADSCALE_INTEGRATION_POSTGRES" \
 			golang:1 \
 			go test ./... \
 			-failfast \

--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -249,6 +249,10 @@ func (s *Scenario) Headscale(opts ...hsic.Option) (ControlServer, error) {
 		return headscale, nil
 	}
 
+	if usePostgresForTest {
+		opts = append(opts, hsic.WithPostgres())
+	}
+
 	headscale, err := hsic.New(s.pool, s.network, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create headscale container: %w", err)
@@ -465,10 +469,6 @@ func (s *Scenario) CreateHeadscaleEnv(
 	tsOpts []tsic.Option,
 	opts ...hsic.Option,
 ) error {
-	if usePostgresForTest {
-		opts = append(opts, hsic.WithPostgres())
-	}
-
 	headscale, err := s.Headscale(opts...)
 	if err != nil {
 		return err


### PR DESCRIPTION
When a zero time value is loaded from JSON or a DB in a way that assigns it the local timezone, it does not roudtrip in JSON as a value for which IsZero returns true. This causes KeyExpiry to be treated as a far past value instead of a nilish value.

See https://github.com/golang/go/issues/57040

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
Fixes #764 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new test cases to enhance testing for time-sensitive operations and PostgreSQL interactions.
	- Added a function to allow users to specify timezones for container configurations.
	- Enhanced test configurability with new options for flexible testing scenarios.
  
- **Bug Fixes**
	- Resolved issues related to node registration in non-UTC timezones for PostgreSQL databases.

- **Documentation**
	- Updated CHANGELOG to reflect recent updates and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->