### PR TITLE
Move flags after the command

### DIFF
--- a/docs/running-headscale-container.md
+++ b/docs/running-headscale-container.md
@@ -117,7 +117,7 @@ To register a machine when running `headscale` in a container, take the headscal
 
 ```shell
 docker exec headscale \
-  headscale --user myfirstuser nodes register --key <YOUR_MACHINE_KEY>
+  headscale nodes register --user myfirstuser --key <YOUR_MACHINE_KEY>
 ```
 
 ### Register machine using a pre authenticated key
@@ -126,7 +126,7 @@ Generate a key using the command line:
 
 ```shell
 docker exec headscale \
-  headscale --user myfirstuser preauthkeys create --reusable --expiration 24h
+  headscale preauthkeys create --user myfirstuser --reusable --expiration 24h
 ```
 
 This will return a pre-authenticated key that can be used to connect a node to `headscale` during the `tailscale` command:

--- a/docs/running-headscale-linux-manual.md
+++ b/docs/running-headscale-linux-manual.md
@@ -92,7 +92,7 @@ tailscale up --login-server YOUR_HEADSCALE_URL
 Register the machine:
 
 ```shell
-headscale --user myfirstuser nodes register --key <YOUR_MACHINE_KEY>
+headscale nodes register --user myfirstuser --key <YOUR_MACHINE_KEY>
 ```
 
 ### Register machine using a pre authenticated key
@@ -100,7 +100,7 @@ headscale --user myfirstuser nodes register --key <YOUR_MACHINE_KEY>
 Generate a key using the command line:
 
 ```shell
-headscale --user myfirstuser preauthkeys create --reusable --expiration 24h
+headscale preauthkeys create --user myfirstuser --reusable --expiration 24h
 ```
 
 This will return a pre-authenticated key that can be used to connect a node to `headscale` during the `tailscale` command:

--- a/docs/running-headscale-linux.md
+++ b/docs/running-headscale-linux.md
@@ -78,7 +78,7 @@ tailscale up --login-server <YOUR_HEADSCALE_URL>
 Register the machine:
 
 ```shell
-headscale --user myfirstuser nodes register --key <YOUR_MACHINE_KEY>
+headscale nodes register --user myfirstuser --key <YOUR_MACHINE_KEY>
 ```
 
 ### Register machine using a pre authenticated key
@@ -86,7 +86,7 @@ headscale --user myfirstuser nodes register --key <YOUR_MACHINE_KEY>
 Generate a key using the command line:
 
 ```shell
-headscale --user myfirstuser preauthkeys create --reusable --expiration 24h
+headscale preauthkeys create --user myfirstuser --reusable --expiration 24h
 ```
 
 This will return a pre-authenticated key that is used to

--- a/docs/running-headscale-openbsd.md
+++ b/docs/running-headscale-openbsd.md
@@ -129,7 +129,7 @@ tailscale up --login-server YOUR_HEADSCALE_URL
 Register the machine:
 
 ```shell
-headscale --user myfirstuser nodes register --key <YOUR_MACHINE_KEY>
+headscale nodes register --user myfirstuser --key <YOUR_MACHINE_KEY>
 ```
 
 ### Register machine using a pre authenticated key
@@ -137,7 +137,7 @@ headscale --user myfirstuser nodes register --key <YOUR_MACHINE_KEY>
 Generate a key using the command line:
 
 ```shell
-headscale --user myfirstuser preauthkeys create --reusable --expiration 24h
+headscale preauthkeys create --user myfirstuser --reusable --expiration 24h
 ```
 
 This will return a pre-authenticated key that can be used to connect a node to `headscale` during the `tailscale` command:

--- a/docs/running-headscale-sealos.md
+++ b/docs/running-headscale-sealos.md
@@ -41,7 +41,7 @@ tailscale up --login-server YOUR_HEADSCALE_URL
 To register a machine when running headscale in [Sealos](https://sealos.io), click on 'Terminal' button on the right side of the headscale application's detail page to access the Terminal of the headscale application, then take the headscale command:
 
 ```bash
-headscale --user myfirstuser nodes register --key <YOUR_MACHINE_KEY>
+headscale nodes register --user myfirstuser --key <YOUR_MACHINE_KEY>
 ```
 
 ### Register machine using a pre authenticated key
@@ -49,7 +49,7 @@ headscale --user myfirstuser nodes register --key <YOUR_MACHINE_KEY>
 click on 'Terminal' button on the right side of the headscale application's detail page to access the Terminal of the headscale application, then generate a key using the command line:
 
 ```bash
-headscale --user myfirstuser preauthkeys create --reusable --expiration 24h
+headscale preauthkeys create --user myfirstuser --reusable --expiration 24h
 ```
 
 This will return a pre-authenticated key that can be used to connect a node to `headscale` during the `tailscale` command:


### PR DESCRIPTION
The built-in help also shows flags to given after the command. Align documentation examples accordingly.

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Simplified command syntax for registering machines and creating pre-authenticated keys in the `headscale` documentation, enhancing clarity and usability.
	- Removed redundant `headscale` prefix in command examples, aligning with common command-line conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->