### PR TITLE
Add support for service reload and sync service file

### DIFF
--- a/docs/packaging/headscale.systemd.service
+++ b/docs/packaging/headscale.systemd.service
@@ -9,6 +9,7 @@ Type=simple
 User=headscale
 Group=headscale
 ExecStart=/usr/bin/headscale serve
+ExecReload=/usr/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5
 

--- a/docs/running-headscale-linux-manual.md
+++ b/docs/running-headscale-linux-manual.md
@@ -111,40 +111,12 @@ tailscale up --login-server <YOUR_HEADSCALE_URL> --authkey <YOUR_AUTH_KEY>
 
 ## Running `headscale` in the background with SystemD
 
-:warning: **Deprecated**: This part is very outdated and you should use the [pre-packaged Headscale for this](./running-headscale-linux.md)
-
 This section demonstrates how to run `headscale` as a service in the background with [SystemD](https://www.freedesktop.org/wiki/Software/systemd/).
 This should work on most modern Linux distributions.
 
-1. Create a SystemD service configuration at `/etc/systemd/system/headscale.service` containing:
-
-    ```systemd
-    [Unit]
-    Description=headscale controller
-    After=syslog.target
-    After=network.target
-
-    [Service]
-    Type=simple
-    User=headscale
-    Group=headscale
-    ExecStart=/usr/local/bin/headscale serve
-    Restart=always
-    RestartSec=5
-
-    # Optional security enhancements
-    NoNewPrivileges=yes
-    PrivateTmp=yes
-    ProtectSystem=strict
-    ProtectHome=yes
-    WorkingDirectory=/var/lib/headscale
-    ReadWritePaths=/var/lib/headscale /var/run/headscale
-    AmbientCapabilities=CAP_NET_BIND_SERVICE
-    RuntimeDirectory=headscale
-
-    [Install]
-    WantedBy=multi-user.target
-    ```
+1. Copy [headscale's systemd service file](./packaging/headscale.systemd.service) to
+   `/etc/systemd/system/headscale.service` and adjust it to suit your local setup. The following parameters likely need
+   to be modified: `ExecStart`, `WorkingDirectory`, `ReadWritePaths`.
 
     Note that when running as the headscale user ensure that, either you add your current user to the headscale group:
 

--- a/docs/running-headscale-linux-manual.md
+++ b/docs/running-headscale-linux-manual.md
@@ -111,7 +111,7 @@ tailscale up --login-server <YOUR_HEADSCALE_URL> --authkey <YOUR_AUTH_KEY>
 
 ## Running `headscale` in the background with systemd
 
-This section demonstrates how to run `headscale` as a service in the background with [systemd](https://www.freedesktop.org/wiki/Software/systemd/).
+This section demonstrates how to run `headscale` as a service in the background with [systemd](https://systemd.io/).
 This should work on most modern Linux distributions.
 
 1. Copy [headscale's systemd service file](./packaging/headscale.systemd.service) to

--- a/docs/running-headscale-linux-manual.md
+++ b/docs/running-headscale-linux-manual.md
@@ -8,7 +8,7 @@
 ## Goal
 
 This documentation has the goal of showing a user how-to set up and run `headscale` on Linux.
-In additional to the "get up and running section", there is an optional [SystemD section](#running-headscale-in-the-background-with-systemd)
+In additional to the "get up and running section", there is an optional [systemd section](#running-headscale-in-the-background-with-systemd)
 describing how to make `headscale` run properly in a server environment.
 
 ## Configure and run `headscale`
@@ -66,7 +66,7 @@ describing how to make `headscale` run properly in a server environment.
     To continue the tutorial, open a new terminal and let it run in the background.
     Alternatively use terminal emulators like [tmux](https://github.com/tmux/tmux) or [screen](https://www.gnu.org/software/screen/).
 
-    To run `headscale` in the background, please follow the steps in the [SystemD section](#running-headscale-in-the-background-with-systemd) before continuing.
+    To run `headscale` in the background, please follow the steps in the [systemd section](#running-headscale-in-the-background-with-systemd) before continuing.
 
 1. Verify `headscale` is running:
   Verify `headscale` is available:
@@ -109,9 +109,9 @@ This will return a pre-authenticated key that can be used to connect a node to `
 tailscale up --login-server <YOUR_HEADSCALE_URL> --authkey <YOUR_AUTH_KEY>
 ```
 
-## Running `headscale` in the background with SystemD
+## Running `headscale` in the background with systemd
 
-This section demonstrates how to run `headscale` as a service in the background with [SystemD](https://www.freedesktop.org/wiki/Software/systemd/).
+This section demonstrates how to run `headscale` as a service in the background with [systemd](https://www.freedesktop.org/wiki/Software/systemd/).
 This should work on most modern Linux distributions.
 
 1. Copy [headscale's systemd service file](./packaging/headscale.systemd.service) to
@@ -136,7 +136,7 @@ This should work on most modern Linux distributions.
     unix_socket: /var/run/headscale/headscale.sock
     ```
 
-1. Reload SystemD to load the new configuration file:
+1. Reload systemd to load the new configuration file:
 
     ```shell
     systemctl daemon-reload

--- a/docs/running-headscale-linux.md
+++ b/docs/running-headscale-linux.md
@@ -8,7 +8,7 @@
 
 Get Headscale up and running.
 
-This includes running Headscale with SystemD.
+This includes running Headscale with systemd.
 
 ## Migrating from manual install
 

--- a/integration/dns_test.go
+++ b/integration/dns_test.go
@@ -86,7 +86,7 @@ func TestResolveMagicDNS(t *testing.T) {
 // All the containers are based on Alpine, meaning Tailscale
 // will overwrite the resolv.conf file.
 // On other platform, Tailscale will integrate with a dns manager
-// if available (like Systemd-Resolved).
+// if available (like systemd-resolved).
 func TestValidateResolvConf(t *testing.T) {
 	IntegrationSkip(t)
 


### PR DESCRIPTION
* Copy the systemd.service file to the manual linux docs and adjust the path to the headscale binary to match with the previous documentation blocks. Unfortunately, there seems to be no easy way to include a file in mkdocs.
* Remove a redundant "deprecation" block. The beginning of the documentation already states that.
* Add `ExecReload` to the systemd.service file.

Fixes #2016

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced service management with the addition of the `ExecReload` directive for graceful configuration reloads.

- **Documentation**
	- Streamlined instructions for running `headscale` on Linux, encouraging the use of pre-packaged service files.
	- Corrected references from "SystemD" to "systemd" for consistency and accuracy in documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->