### PR TITLE
add no stalebot exception

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,4 +20,5 @@ jobs:
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1
+          exempt-issue-labels: "no-stale-bot"
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
allows us to give certain issues with `no-stale-bot`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for the stale bot, allowing issues labeled with "no-stale-bot" to be exempt from inactivity checks. This improves issue management by preventing important discussions from being automatically closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->