### PR TITLE
Only load needed part of configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ dist/
 /headscale
 config.json
 config.yaml
+config*.yaml
 derp.yaml
 *.hujson
 *.key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ after improving the test harness as part of adopting [#1460](https://github.com/
 - Add APIs for managing headscale policy. [#1792](https://github.com/juanfont/headscale/pull/1792)
 - Fix for registering nodes using preauthkeys when running on a postgres database in a non-UTC timezone. [#764](https://github.com/juanfont/headscale/issues/764)
 - Make sure integration tests cover postgres for all scenarios
+- CLI commands (all except `serve`) only requires minimal configuration, no more errors or warnings from unset settings [#2109](https://github.com/juanfont/headscale/pull/2109)
 
 ## 0.22.3 (2023-05-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ after improving the test harness as part of adopting [#1460](https://github.com/
 - Fix for registering nodes using preauthkeys when running on a postgres database in a non-UTC timezone. [#764](https://github.com/juanfont/headscale/issues/764)
 - Make sure integration tests cover postgres for all scenarios
 - CLI commands (all except `serve`) only requires minimal configuration, no more errors or warnings from unset settings [#2109](https://github.com/juanfont/headscale/pull/2109)
+- CLI results are now concistently sent to stdout and errors to stderr [#2109](https://github.com/juanfont/headscale/pull/2109)
 
 ## 0.22.3 (2023-05-12)
 

--- a/cmd/headscale/cli/api_key.go
+++ b/cmd/headscale/cli/api_key.go
@@ -67,14 +67,10 @@ var listAPIKeys = &cobra.Command{
 				fmt.Sprintf("Error getting the list of keys: %s", err),
 				output,
 			)
-
-			return
 		}
 
 		if output != "" {
 			SuccessOutput(response.GetApiKeys(), "", output)
-
-			return
 		}
 
 		tableData := pterm.TableData{
@@ -102,8 +98,6 @@ var listAPIKeys = &cobra.Command{
 				fmt.Sprintf("Failed to render pterm table: %s", err),
 				output,
 			)
-
-			return
 		}
 	},
 }
@@ -119,9 +113,6 @@ If you loose a key, create a new one and revoke (expire) the old one.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		output, _ := cmd.Flags().GetString("output")
 
-		log.Trace().
-			Msg("Preparing to create ApiKey")
-
 		request := &v1.CreateApiKeyRequest{}
 
 		durationStr, _ := cmd.Flags().GetString("expiration")
@@ -133,15 +124,9 @@ If you loose a key, create a new one and revoke (expire) the old one.`,
 				fmt.Sprintf("Could not parse duration: %s\n", err),
 				output,
 			)
-
-			return
 		}
 
 		expiration := time.Now().UTC().Add(time.Duration(duration))
-
-		log.Trace().
-			Dur("expiration", time.Duration(duration)).
-			Msg("expiration has been set")
 
 		request.Expiration = timestamppb.New(expiration)
 
@@ -156,8 +141,6 @@ If you loose a key, create a new one and revoke (expire) the old one.`,
 				fmt.Sprintf("Cannot create Api Key: %s\n", err),
 				output,
 			)
-
-			return
 		}
 
 		SuccessOutput(response.GetApiKey(), response.GetApiKey(), output)
@@ -178,8 +161,6 @@ var expireAPIKeyCmd = &cobra.Command{
 				fmt.Sprintf("Error getting prefix from CLI flag: %s", err),
 				output,
 			)
-
-			return
 		}
 
 		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
@@ -197,8 +178,6 @@ var expireAPIKeyCmd = &cobra.Command{
 				fmt.Sprintf("Cannot expire Api Key: %s\n", err),
 				output,
 			)
-
-			return
 		}
 
 		SuccessOutput(response, "Key expired", output)
@@ -219,8 +198,6 @@ var deleteAPIKeyCmd = &cobra.Command{
 				fmt.Sprintf("Error getting prefix from CLI flag: %s", err),
 				output,
 			)
-
-			return
 		}
 
 		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
@@ -238,8 +215,6 @@ var deleteAPIKeyCmd = &cobra.Command{
 				fmt.Sprintf("Cannot delete Api Key: %s\n", err),
 				output,
 			)
-
-			return
 		}
 
 		SuccessOutput(response, "Key deleted", output)

--- a/cmd/headscale/cli/api_key.go
+++ b/cmd/headscale/cli/api_key.go
@@ -54,7 +54,7 @@ var listAPIKeys = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		output, _ := cmd.Flags().GetString("output")
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -145,7 +145,7 @@ If you loose a key, create a new one and revoke (expire) the old one.`,
 
 		request.Expiration = timestamppb.New(expiration)
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -182,7 +182,7 @@ var expireAPIKeyCmd = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -223,7 +223,7 @@ var deleteAPIKeyCmd = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 

--- a/cmd/headscale/cli/configtest.go
+++ b/cmd/headscale/cli/configtest.go
@@ -14,7 +14,7 @@ var configTestCmd = &cobra.Command{
 	Short: "Test the configuration.",
 	Long:  "Run a test of the configuration and exit.",
 	Run: func(cmd *cobra.Command, args []string) {
-		_, err := getHeadscaleApp()
+		_, err := newHeadscaleServerWithConfig()
 		if err != nil {
 			log.Fatal().Caller().Err(err).Msg("Error initializing")
 		}

--- a/cmd/headscale/cli/debug.go
+++ b/cmd/headscale/cli/debug.go
@@ -64,8 +64,6 @@ var createNodeCmd = &cobra.Command{
 		user, err := cmd.Flags().GetString("user")
 		if err != nil {
 			ErrorOutput(err, fmt.Sprintf("Error getting user: %s", err), output)
-
-			return
 		}
 
 		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
@@ -79,8 +77,6 @@ var createNodeCmd = &cobra.Command{
 				fmt.Sprintf("Error getting node from flag: %s", err),
 				output,
 			)
-
-			return
 		}
 
 		machineKey, err := cmd.Flags().GetString("key")
@@ -90,8 +86,6 @@ var createNodeCmd = &cobra.Command{
 				fmt.Sprintf("Error getting key from flag: %s", err),
 				output,
 			)
-
-			return
 		}
 
 		var mkey key.MachinePublic
@@ -102,8 +96,6 @@ var createNodeCmd = &cobra.Command{
 				fmt.Sprintf("Failed to parse machine key from flag: %s", err),
 				output,
 			)
-
-			return
 		}
 
 		routes, err := cmd.Flags().GetStringSlice("route")
@@ -113,8 +105,6 @@ var createNodeCmd = &cobra.Command{
 				fmt.Sprintf("Error getting routes from flag: %s", err),
 				output,
 			)
-
-			return
 		}
 
 		request := &v1.DebugCreateNodeRequest{
@@ -131,8 +121,6 @@ var createNodeCmd = &cobra.Command{
 				fmt.Sprintf("Cannot create node: %s", status.Convert(err).Message()),
 				output,
 			)
-
-			return
 		}
 
 		SuccessOutput(response.GetNode(), "Node created", output)

--- a/cmd/headscale/cli/debug.go
+++ b/cmd/headscale/cli/debug.go
@@ -68,7 +68,7 @@ var createNodeCmd = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 

--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -116,8 +116,6 @@ var registerNodeCmd = &cobra.Command{
 		user, err := cmd.Flags().GetString("user")
 		if err != nil {
 			ErrorOutput(err, fmt.Sprintf("Error getting user: %s", err), output)
-
-			return
 		}
 
 		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
@@ -131,8 +129,6 @@ var registerNodeCmd = &cobra.Command{
 				fmt.Sprintf("Error getting node key from flag: %s", err),
 				output,
 			)
-
-			return
 		}
 
 		request := &v1.RegisterNodeRequest{
@@ -150,8 +146,6 @@ var registerNodeCmd = &cobra.Command{
 				),
 				output,
 			)
-
-			return
 		}
 
 		SuccessOutput(
@@ -169,14 +163,10 @@ var listNodesCmd = &cobra.Command{
 		user, err := cmd.Flags().GetString("user")
 		if err != nil {
 			ErrorOutput(err, fmt.Sprintf("Error getting user: %s", err), output)
-
-			return
 		}
 		showTags, err := cmd.Flags().GetBool("tags")
 		if err != nil {
 			ErrorOutput(err, fmt.Sprintf("Error getting tags flag: %s", err), output)
-
-			return
 		}
 
 		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
@@ -194,21 +184,15 @@ var listNodesCmd = &cobra.Command{
 				fmt.Sprintf("Cannot get nodes: %s", status.Convert(err).Message()),
 				output,
 			)
-
-			return
 		}
 
 		if output != "" {
 			SuccessOutput(response.GetNodes(), "", output)
-
-			return
 		}
 
 		tableData, err := nodesToPtables(user, showTags, response.GetNodes())
 		if err != nil {
 			ErrorOutput(err, fmt.Sprintf("Error converting to table: %s", err), output)
-
-			return
 		}
 
 		err = pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
@@ -218,8 +202,6 @@ var listNodesCmd = &cobra.Command{
 				fmt.Sprintf("Failed to render pterm table: %s", err),
 				output,
 			)
-
-			return
 		}
 	},
 }

--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -120,7 +120,7 @@ var registerNodeCmd = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -179,7 +179,7 @@ var listNodesCmd = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -243,7 +243,7 @@ var expireNodeCmd = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -286,7 +286,7 @@ var renameNodeCmd = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -335,7 +335,7 @@ var deleteNodeCmd = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -435,7 +435,7 @@ var moveNodeCmd = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -508,7 +508,7 @@ be assigned to nodes.`,
 			return
 		}
 		if confirm {
-			ctx, client, conn, cancel := getHeadscaleCLIClient()
+			ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 			defer cancel()
 			defer conn.Close()
 
@@ -681,7 +681,7 @@ var tagCmd = &cobra.Command{
 	Aliases: []string{"tags", "t"},
 	Run: func(cmd *cobra.Command, args []string) {
 		output, _ := cmd.Flags().GetString("output")
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 

--- a/cmd/headscale/cli/policy.go
+++ b/cmd/headscale/cli/policy.go
@@ -30,7 +30,7 @@ var getPolicy = &cobra.Command{
 	Short:   "Print the current ACL Policy",
 	Aliases: []string{"show", "view", "fetch"},
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -75,7 +75,7 @@ var setPolicy = &cobra.Command{
 
 		request := &v1.SetPolicyRequest{Policy: string(policyBytes)}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 

--- a/cmd/headscale/cli/preauthkeys.go
+++ b/cmd/headscale/cli/preauthkeys.go
@@ -64,7 +64,7 @@ var listPreAuthKeys = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -192,7 +192,7 @@ var createPreAuthKeyCmd = &cobra.Command{
 
 		request.Expiration = timestamppb.New(expiration)
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -231,7 +231,7 @@ var expirePreAuthKeyCmd = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 

--- a/cmd/headscale/cli/preauthkeys.go
+++ b/cmd/headscale/cli/preauthkeys.go
@@ -60,8 +60,6 @@ var listPreAuthKeys = &cobra.Command{
 		user, err := cmd.Flags().GetString("user")
 		if err != nil {
 			ErrorOutput(err, fmt.Sprintf("Error getting user: %s", err), output)
-
-			return
 		}
 
 		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
@@ -85,8 +83,6 @@ var listPreAuthKeys = &cobra.Command{
 
 		if output != "" {
 			SuccessOutput(response.GetPreAuthKeys(), "", output)
-
-			return
 		}
 
 		tableData := pterm.TableData{
@@ -134,8 +130,6 @@ var listPreAuthKeys = &cobra.Command{
 				fmt.Sprintf("Failed to render pterm table: %s", err),
 				output,
 			)
-
-			return
 		}
 	},
 }
@@ -150,19 +144,11 @@ var createPreAuthKeyCmd = &cobra.Command{
 		user, err := cmd.Flags().GetString("user")
 		if err != nil {
 			ErrorOutput(err, fmt.Sprintf("Error getting user: %s", err), output)
-
-			return
 		}
 
 		reusable, _ := cmd.Flags().GetBool("reusable")
 		ephemeral, _ := cmd.Flags().GetBool("ephemeral")
 		tags, _ := cmd.Flags().GetStringSlice("tags")
-
-		log.Trace().
-			Bool("reusable", reusable).
-			Bool("ephemeral", ephemeral).
-			Str("user", user).
-			Msg("Preparing to create preauthkey")
 
 		request := &v1.CreatePreAuthKeyRequest{
 			User:      user,
@@ -180,8 +166,6 @@ var createPreAuthKeyCmd = &cobra.Command{
 				fmt.Sprintf("Could not parse duration: %s\n", err),
 				output,
 			)
-
-			return
 		}
 
 		expiration := time.Now().UTC().Add(time.Duration(duration))
@@ -203,8 +187,6 @@ var createPreAuthKeyCmd = &cobra.Command{
 				fmt.Sprintf("Cannot create Pre Auth Key: %s\n", err),
 				output,
 			)
-
-			return
 		}
 
 		SuccessOutput(response.GetPreAuthKey(), response.GetPreAuthKey().GetKey(), output)
@@ -227,8 +209,6 @@ var expirePreAuthKeyCmd = &cobra.Command{
 		user, err := cmd.Flags().GetString("user")
 		if err != nil {
 			ErrorOutput(err, fmt.Sprintf("Error getting user: %s", err), output)
-
-			return
 		}
 
 		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
@@ -247,8 +227,6 @@ var expirePreAuthKeyCmd = &cobra.Command{
 				fmt.Sprintf("Cannot expire Pre Auth Key: %s\n", err),
 				output,
 			)
-
-			return
 		}
 
 		SuccessOutput(response, "Key expired", output)

--- a/cmd/headscale/cli/root.go
+++ b/cmd/headscale/cli/root.go
@@ -58,11 +58,10 @@ func initConfig() {
 		zerolog.SetGlobalLevel(zerolog.Disabled)
 	}
 
-	logFormat := viper.GetString("log.format")
-
-	if logFormat == types.JSONLogFormat {
-		log.Logger = log.Output(os.Stdout)
-	}
+	// logFormat := viper.GetString("log.format")
+	// if logFormat == types.JSONLogFormat {
+	// 	log.Logger = log.Output(os.Stdout)
+	// }
 
 	disableUpdateCheck := viper.GetBool("disable_check_updates")
 	if !disableUpdateCheck && !machineOutput {

--- a/cmd/headscale/cli/root.go
+++ b/cmd/headscale/cli/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/tcnksm/go-latest"
 )
 
@@ -49,11 +50,6 @@ func initConfig() {
 		}
 	}
 
-	cfg, err := types.GetHeadscaleConfig()
-	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to read headscale configuration")
-	}
-
 	machineOutput := HasMachineOutputFlag()
 
 	// If the user has requested a "node" readable format,
@@ -62,11 +58,14 @@ func initConfig() {
 		zerolog.SetGlobalLevel(zerolog.Disabled)
 	}
 
-	if cfg.Log.Format == types.JSONLogFormat {
+	logFormat := viper.GetString("log.format")
+
+	if logFormat == types.JSONLogFormat {
 		log.Logger = log.Output(os.Stdout)
 	}
 
-	if !cfg.DisableUpdateCheck && !machineOutput {
+	disableUpdateCheck := viper.GetBool("disable_check_updates")
+	if !disableUpdateCheck && !machineOutput {
 		if (runtime.GOOS == "linux" || runtime.GOOS == "darwin") &&
 			Version != "dev" {
 			githubTag := &latest.GithubTag{

--- a/cmd/headscale/cli/routes.go
+++ b/cmd/headscale/cli/routes.go
@@ -68,7 +68,7 @@ var listRoutesCmd = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -154,7 +154,7 @@ var enableRouteCmd = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -197,7 +197,7 @@ var disableRouteCmd = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -240,7 +240,7 @@ var deleteRouteCmd = &cobra.Command{
 			return
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 

--- a/cmd/headscale/cli/routes.go
+++ b/cmd/headscale/cli/routes.go
@@ -64,8 +64,6 @@ var listRoutesCmd = &cobra.Command{
 				fmt.Sprintf("Error getting machine id from flag: %s", err),
 				output,
 			)
-
-			return
 		}
 
 		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
@@ -82,14 +80,10 @@ var listRoutesCmd = &cobra.Command{
 					fmt.Sprintf("Cannot get nodes: %s", status.Convert(err).Message()),
 					output,
 				)
-
-				return
 			}
 
 			if output != "" {
 				SuccessOutput(response.GetRoutes(), "", output)
-
-				return
 			}
 
 			routes = response.GetRoutes()
@@ -103,14 +97,10 @@ var listRoutesCmd = &cobra.Command{
 					fmt.Sprintf("Cannot get routes for node %d: %s", machineID, status.Convert(err).Message()),
 					output,
 				)
-
-				return
 			}
 
 			if output != "" {
 				SuccessOutput(response.GetRoutes(), "", output)
-
-				return
 			}
 
 			routes = response.GetRoutes()
@@ -119,8 +109,6 @@ var listRoutesCmd = &cobra.Command{
 		tableData := routesToPtables(routes)
 		if err != nil {
 			ErrorOutput(err, fmt.Sprintf("Error converting to table: %s", err), output)
-
-			return
 		}
 
 		err = pterm.DefaultTable.WithHasHeader().WithData(tableData).Render()
@@ -130,8 +118,6 @@ var listRoutesCmd = &cobra.Command{
 				fmt.Sprintf("Failed to render pterm table: %s", err),
 				output,
 			)
-
-			return
 		}
 	},
 }
@@ -150,8 +136,6 @@ var enableRouteCmd = &cobra.Command{
 				fmt.Sprintf("Error getting machine id from flag: %s", err),
 				output,
 			)
-
-			return
 		}
 
 		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
@@ -167,14 +151,10 @@ var enableRouteCmd = &cobra.Command{
 				fmt.Sprintf("Cannot enable route %d: %s", routeID, status.Convert(err).Message()),
 				output,
 			)
-
-			return
 		}
 
 		if output != "" {
 			SuccessOutput(response, "", output)
-
-			return
 		}
 	},
 }
@@ -193,8 +173,6 @@ var disableRouteCmd = &cobra.Command{
 				fmt.Sprintf("Error getting machine id from flag: %s", err),
 				output,
 			)
-
-			return
 		}
 
 		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
@@ -210,14 +188,10 @@ var disableRouteCmd = &cobra.Command{
 				fmt.Sprintf("Cannot disable route %d: %s", routeID, status.Convert(err).Message()),
 				output,
 			)
-
-			return
 		}
 
 		if output != "" {
 			SuccessOutput(response, "", output)
-
-			return
 		}
 	},
 }
@@ -236,8 +210,6 @@ var deleteRouteCmd = &cobra.Command{
 				fmt.Sprintf("Error getting machine id from flag: %s", err),
 				output,
 			)
-
-			return
 		}
 
 		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
@@ -253,14 +225,10 @@ var deleteRouteCmd = &cobra.Command{
 				fmt.Sprintf("Cannot delete route %d: %s", routeID, status.Convert(err).Message()),
 				output,
 			)
-
-			return
 		}
 
 		if output != "" {
 			SuccessOutput(response, "", output)
-
-			return
 		}
 	},
 }

--- a/cmd/headscale/cli/serve.go
+++ b/cmd/headscale/cli/serve.go
@@ -16,7 +16,7 @@ var serveCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		app, err := getHeadscaleApp()
+		app, err := newHeadscaleServerWithConfig()
 		if err != nil {
 			log.Fatal().Caller().Err(err).Msg("Error initializing")
 		}

--- a/cmd/headscale/cli/users.go
+++ b/cmd/headscale/cli/users.go
@@ -44,7 +44,7 @@ var createUserCmd = &cobra.Command{
 
 		userName := args[0]
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -91,7 +91,7 @@ var destroyUserCmd = &cobra.Command{
 			Name: userName,
 		}
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -151,7 +151,7 @@ var listUsersCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		output, _ := cmd.Flags().GetString("output")
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 
@@ -213,7 +213,7 @@ var renameUserCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		output, _ := cmd.Flags().GetString("output")
 
-		ctx, client, conn, cancel := getHeadscaleCLIClient()
+		ctx, client, conn, cancel := newHeadscaleCLIWithConfig()
 		defer cancel()
 		defer conn.Close()
 

--- a/cmd/headscale/cli/users.go
+++ b/cmd/headscale/cli/users.go
@@ -63,8 +63,6 @@ var createUserCmd = &cobra.Command{
 				),
 				output,
 			)
-
-			return
 		}
 
 		SuccessOutput(response.GetUser(), "User created", output)
@@ -102,8 +100,6 @@ var destroyUserCmd = &cobra.Command{
 				fmt.Sprintf("Error: %s", status.Convert(err).Message()),
 				output,
 			)
-
-			return
 		}
 
 		confirm := false
@@ -134,8 +130,6 @@ var destroyUserCmd = &cobra.Command{
 					),
 					output,
 				)
-
-				return
 			}
 			SuccessOutput(response, "User destroyed", output)
 		} else {
@@ -164,14 +158,10 @@ var listUsersCmd = &cobra.Command{
 				fmt.Sprintf("Cannot get users: %s", status.Convert(err).Message()),
 				output,
 			)
-
-			return
 		}
 
 		if output != "" {
 			SuccessOutput(response.GetUsers(), "", output)
-
-			return
 		}
 
 		tableData := pterm.TableData{{"ID", "Name", "Created"}}
@@ -192,8 +182,6 @@ var listUsersCmd = &cobra.Command{
 				fmt.Sprintf("Failed to render pterm table: %s", err),
 				output,
 			)
-
-			return
 		}
 	},
 }
@@ -232,8 +220,6 @@ var renameUserCmd = &cobra.Command{
 				),
 				output,
 			)
-
-			return
 		}
 
 		SuccessOutput(response.GetUser(), "User renamed", output)

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -23,8 +23,8 @@ const (
 	SocketWritePermissions  = 0o666
 )
 
-func getHeadscaleApp() (*hscontrol.Headscale, error) {
-	cfg, err := types.GetHeadscaleConfig()
+func newHeadscaleServerWithConfig() (*hscontrol.Headscale, error) {
+	cfg, err := types.LoadServerConfig()
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to load configuration while creating headscale instance: %w",
@@ -40,8 +40,8 @@ func getHeadscaleApp() (*hscontrol.Headscale, error) {
 	return app, nil
 }
 
-func getHeadscaleCLIClient() (context.Context, v1.HeadscaleServiceClient, *grpc.ClientConn, context.CancelFunc) {
-	cfg, err := types.GetHeadscaleConfig()
+func newHeadscaleCLIWithConfig() (context.Context, v1.HeadscaleServiceClient, *grpc.ClientConn, context.CancelFunc) {
+	cfg, err := types.LoadCLIConfig()
 	if err != nil {
 		log.Fatal().
 			Err(err).

--- a/cmd/headscale/cli/utils.go
+++ b/cmd/headscale/cli/utils.go
@@ -130,7 +130,7 @@ func newHeadscaleCLIWithConfig() (context.Context, v1.HeadscaleServiceClient, *g
 	return ctx, client, conn, cancel
 }
 
-func SuccessOutput(result interface{}, override string, outputFormat string) {
+func output(result interface{}, override string, outputFormat string) string {
 	var jsonBytes []byte
 	var err error
 	switch outputFormat {
@@ -151,21 +151,26 @@ func SuccessOutput(result interface{}, override string, outputFormat string) {
 		}
 	default:
 		// nolint
-		fmt.Println(override)
-
-		return
+		return override
 	}
 
-	// nolint
-	fmt.Println(string(jsonBytes))
+	return string(jsonBytes)
 }
 
+// SuccessOutput prints the result to stdout and exits with status code 0.
+func SuccessOutput(result interface{}, override string, outputFormat string) {
+	fmt.Println(output(result, override, outputFormat))
+	os.Exit(0)
+}
+
+// ErrorOutput prints an error message to stderr and exits with status code 1.
 func ErrorOutput(errResult error, override string, outputFormat string) {
 	type errOutput struct {
 		Error string `json:"error"`
 	}
 
-	SuccessOutput(errOutput{errResult.Error()}, override, outputFormat)
+	fmt.Fprintf(os.Stderr, "%s\n", output(errOutput{errResult.Error()}, override, outputFormat))
+	os.Exit(1)
 }
 
 func HasMachineOutputFlag() bool {

--- a/cmd/headscale/headscale_test.go
+++ b/cmd/headscale/headscale_test.go
@@ -4,7 +4,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/juanfont/headscale/hscontrol/types"
@@ -112,61 +111,4 @@ func (*Suite) TestConfigLoading(c *check.C) {
 	)
 	c.Assert(viper.GetBool("logtail.enabled"), check.Equals, false)
 	c.Assert(viper.GetBool("randomize_client_port"), check.Equals, false)
-}
-
-func writeConfig(c *check.C, tmpDir string, configYaml []byte) {
-	// Populate a custom config file
-	configFile := filepath.Join(tmpDir, "config.yaml")
-	err := os.WriteFile(configFile, configYaml, 0o600)
-	if err != nil {
-		c.Fatalf("Couldn't write file %s", configFile)
-	}
-}
-
-func (*Suite) TestTLSConfigValidation(c *check.C) {
-	tmpDir, err := os.MkdirTemp("", "headscale")
-	if err != nil {
-		c.Fatal(err)
-	}
-	// defer os.RemoveAll(tmpDir)
-	configYaml := []byte(`---
-tls_letsencrypt_hostname: example.com
-tls_letsencrypt_challenge_type: ""
-tls_cert_path: abc.pem
-noise:
-  private_key_path: noise_private.key`)
-	writeConfig(c, tmpDir, configYaml)
-
-	// Check configuration validation errors (1)
-	err = types.LoadConfig(tmpDir, false)
-	c.Assert(err, check.NotNil)
-	// check.Matches can not handle multiline strings
-	tmp := strings.ReplaceAll(err.Error(), "\n", "***")
-	c.Assert(
-		tmp,
-		check.Matches,
-		".*Fatal config error: set either tls_letsencrypt_hostname or tls_cert_path/tls_key_path, not both.*",
-	)
-	c.Assert(
-		tmp,
-		check.Matches,
-		".*Fatal config error: the only supported values for tls_letsencrypt_challenge_type are.*",
-	)
-	c.Assert(
-		tmp,
-		check.Matches,
-		".*Fatal config error: server_url must start with https:// or http://.*",
-	)
-
-	// Check configuration validation errors (2)
-	configYaml = []byte(`---
-noise:
-  private_key_path: noise_private.key
-server_url: http://127.0.0.1:8080
-tls_letsencrypt_hostname: example.com
-tls_letsencrypt_challenge_type: TLS-ALPN-01
-`)
-	writeConfig(c, tmpDir, configYaml)
-	err = types.LoadConfig(tmpDir, false)
-	c.Assert(err, check.IsNil)
 }

--- a/hscontrol/grpcv1.go
+++ b/hscontrol/grpcv1.go
@@ -684,7 +684,7 @@ func (api headscaleV1APIServer) GetPolicy(
 	case types.PolicyModeDB:
 		p, err := api.h.db.GetPolicy()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("loading ACL from database: %w", err)
 		}
 
 		return &v1.GetPolicyResponse{
@@ -696,20 +696,20 @@ func (api headscaleV1APIServer) GetPolicy(
 		absPath := util.AbsolutePathFromConfigPath(api.h.cfg.Policy.Path)
 		f, err := os.Open(absPath)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("reading policy from path %q: %w", absPath, err)
 		}
 
 		defer f.Close()
 
 		b, err := io.ReadAll(f)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("reading policy from file: %w", err)
 		}
 
 		return &v1.GetPolicyResponse{Policy: string(b)}, nil
 	}
 
-	return nil, nil
+	return nil, fmt.Errorf("no supported policy mode found in configuration, policy.mode: %q", api.h.cfg.Policy.Mode)
 }
 
 func (api headscaleV1APIServer) SetPolicy(

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -733,7 +733,8 @@ func prefixV6() (*netip.Prefix, error) {
 // of Headscale to connect to a Headscale server.
 func LoadCLIConfig() (*Config, error) {
 	return &Config{
-		UnixSocket: viper.GetString("unix_socket"),
+		DisableUpdateCheck: viper.GetBool("disable_check_updates"),
+		UnixSocket:         viper.GetString("unix_socket"),
 		CLI: CLIConfig{
 			Address:  viper.GetString("cli.address"),
 			APIKey:   viper.GetString("cli.api_key"),
@@ -821,7 +822,7 @@ func LoadServerConfig() (*Config, error) {
 		MetricsAddr:        viper.GetString("metrics_listen_addr"),
 		GRPCAddr:           viper.GetString("grpc_listen_addr"),
 		GRPCAllowInsecure:  viper.GetBool("grpc_allow_insecure"),
-		DisableUpdateCheck: viper.GetBool("disable_check_updates"),
+		DisableUpdateCheck: false,
 
 		PrefixV4:     prefix4,
 		PrefixV6:     prefix6,


### PR DESCRIPTION
Currently all configuration was loaded and validated regardless of what
the CLI was doing, if you did a `nodes ls` or `serve` the whole thing would
be loaded and validated which caused a machine that were doing only CLI
stuff to need the full config, or at least a bunch that would throw errors.

This commit cleans up and splits this so that only the subset needed for
running the CLI (unix socket or remote gRPC) is required when running
all commands except for `serve`.

When `serve` is ran, the normal chain with validations and loading of the
whole config is ran.

This means that deprecation warnings for the server config will only be shown
in the server log.

This should be a nice quality of life improvements for users running headscale 
as a remote CLI, split config or Nix users with the module updates for 0.23.0 (https://github.com/NixOS/nixpkgs/pull/340054).

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced command-line interface (CLI) functionality, requiring minimal configuration for all commands except `serve`.
	- Improved configuration management with a streamlined approach using the `viper` package.

- **Bug Fixes**
	- Adjusted client initialization methods across multiple commands to enhance flexibility and reduce errors.

- **Documentation**
	- Updated CHANGELOG.md to reflect significant improvements and changes in functionality.

- **Tests**
	- Introduced new tests for TLS configuration validation to ensure compliance with expected settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->