### PR TITLE
Fix slow shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ after improving the test harness as part of adopting [#1460](https://github.com/
 - Make sure integration tests cover postgres for all scenarios
 - CLI commands (all except `serve`) only requires minimal configuration, no more errors or warnings from unset settings [#2109](https://github.com/juanfont/headscale/pull/2109)
 - CLI results are now concistently sent to stdout and errors to stderr [#2109](https://github.com/juanfont/headscale/pull/2109)
+- Fix issue where shutting down headscale would hang [#2113](https://github.com/juanfont/headscale/pull/2113)
 
 ## 0.22.3 (2023-05-12)
 

--- a/cmd/headscale/cli/serve.go
+++ b/cmd/headscale/cli/serve.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"errors"
+	"net/http"
+
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -22,8 +25,8 @@ var serveCmd = &cobra.Command{
 		}
 
 		err = app.Serve()
-		if err != nil {
-			log.Fatal().Caller().Err(err).Msg("Error starting server")
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatal().Caller().Err(err).Msg("Headscale ran into an error and had to shut down.")
 		}
 	},
 }

--- a/hscontrol/app.go
+++ b/hscontrol/app.go
@@ -780,9 +780,6 @@ func (h *Headscale) Serve() error {
 				expireNodeCancel()
 				h.ephemeralGC.Close()
 
-				trace("waiting for netmap stream to close")
-				h.pollNetMapStreamWG.Wait()
-
 				// Gracefully shut down servers
 				ctx, cancel := context.WithTimeout(
 					context.Background(),
@@ -797,6 +794,12 @@ func (h *Headscale) Serve() error {
 					log.Error().Err(err).Msg("Failed to shutdown http")
 				}
 
+				trace("closing node notifier")
+				h.nodeNotifier.Close()
+
+				trace("waiting for netmap stream to close")
+				h.pollNetMapStreamWG.Wait()
+
 				trace("shutting down grpc server (socket)")
 				grpcSocket.GracefulStop()
 
@@ -810,9 +813,6 @@ func (h *Headscale) Serve() error {
 					trace("shutting down tailsql")
 					tailsqlContext.Done()
 				}
-
-				trace("closing node notifier")
-				h.nodeNotifier.Close()
 
 				// Close network listeners
 				trace("closing network listeners")

--- a/hscontrol/app.go
+++ b/hscontrol/app.go
@@ -772,7 +772,7 @@ func (h *Headscale) Serve() error {
 					})
 				}
 			default:
-				trace := log.Trace().Msgf
+				info := func(msg string) { log.Info().Msg(msg) }
 				log.Info().
 					Str("signal", sig.String()).
 					Msg("Received signal to stop, shutting down gracefully")
@@ -785,50 +785,50 @@ func (h *Headscale) Serve() error {
 					context.Background(),
 					types.HTTPShutdownTimeout,
 				)
-				trace("shutting down debug http server")
+				info("shutting down debug http server")
 				if err := debugHTTPServer.Shutdown(ctx); err != nil {
-					log.Error().Err(err).Msg("Failed to shutdown prometheus http")
+					log.Error().Err(err).Msg("failed to shutdown prometheus http")
 				}
-				trace("shutting down main http server")
+				info("shutting down main http server")
 				if err := httpServer.Shutdown(ctx); err != nil {
-					log.Error().Err(err).Msg("Failed to shutdown http")
+					log.Error().Err(err).Msg("failed to shutdown http")
 				}
 
-				trace("closing node notifier")
+				info("closing node notifier")
 				h.nodeNotifier.Close()
 
-				trace("waiting for netmap stream to close")
+				info("waiting for netmap stream to close")
 				h.pollNetMapStreamWG.Wait()
 
-				trace("shutting down grpc server (socket)")
+				info("shutting down grpc server (socket)")
 				grpcSocket.GracefulStop()
 
 				if grpcServer != nil {
-					trace("shutting down grpc server (external)")
+					info("shutting down grpc server (external)")
 					grpcServer.GracefulStop()
 					grpcListener.Close()
 				}
 
 				if tailsqlContext != nil {
-					trace("shutting down tailsql")
+					info("shutting down tailsql")
 					tailsqlContext.Done()
 				}
 
 				// Close network listeners
-				trace("closing network listeners")
+				info("closing network listeners")
 				debugHTTPListener.Close()
 				httpListener.Close()
 				grpcGatewayConn.Close()
 
 				// Stop listening (and unlink the socket if unix type):
-				trace("closing socket listener")
+				info("closing socket listener")
 				socketListener.Close()
 
 				// Close db connections
-				trace("closing database connection")
+				info("closing database connection")
 				err = h.db.Close()
 				if err != nil {
-					log.Error().Err(err).Msg("Failed to close db")
+					log.Error().Err(err).Msg("failed to close db")
 				}
 
 				log.Info().


### PR DESCRIPTION
Turns out we were waiting for connections to close, without telling them to close...

Now:

- Shutdown the HTTP server, so no new client conns are accepted
- Shutdown notifier, telling all the clients to disconnect
- Wait for all polls to close

Fixes #1968

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced improved error handling for server shutdown scenarios, enhancing clarity in error reporting.
	- Added a mechanism in the Notifier to track its lifecycle, preventing operations after closure.

- **Bug Fixes**
	- Resolved an issue where shutting down the headscale application would hang, ensuring a smoother shutdown process.

- **Documentation**
	- Updated the changelog to reflect the recent fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->