### PR TITLE
make stream shutdown if self-node has been removed

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -52,6 +52,7 @@ jobs:
           - TestExpireNode
           - TestNodeOnlineStatus
           - TestPingAllByIPManyUpDown
+          - Test2118DeletingOnlineNodePanics
           - TestEnablingRoutes
           - TestHASubnetRouterFailover
           - TestEnableDisableAutoApprovedRoute

--- a/hscontrol/poll.go
+++ b/hscontrol/poll.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -270,6 +271,12 @@ func (m *mapSession) serveLongPoll() {
 		case update, ok := <-m.ch:
 			if !ok {
 				m.tracef("update channel closed, streaming session is likely being replaced")
+				return
+			}
+
+			// If the node has been removed from headscale, close the stream
+			if slices.Contains(update.Removed, m.node.ID) {
+				m.tracef("node removed, closing stream")
 				return
 			}
 

--- a/integration/control.go
+++ b/integration/control.go
@@ -6,8 +6,8 @@ import (
 )
 
 type ControlServer interface {
-	Shutdown() error
-	SaveLog(string) error
+	Shutdown() (string, string, error)
+	SaveLog(string) (string, string, error)
 	SaveProfile(string) error
 	Execute(command []string) (string, error)
 	WriteFile(path string, content []byte) error

--- a/integration/dockertestutil/logs.go
+++ b/integration/dockertestutil/logs.go
@@ -17,10 +17,10 @@ func SaveLog(
 	pool *dockertest.Pool,
 	resource *dockertest.Resource,
 	basePath string,
-) error {
+) (string, string, error) {
 	err := os.MkdirAll(basePath, os.ModePerm)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 
 	var stdout bytes.Buffer
@@ -41,28 +41,30 @@ func SaveLog(
 		},
 	)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 
 	log.Printf("Saving logs for %s to %s\n", resource.Container.Name, basePath)
 
+	stdoutPath := path.Join(basePath, resource.Container.Name+".stdout.log")
 	err = os.WriteFile(
-		path.Join(basePath, resource.Container.Name+".stdout.log"),
+		stdoutPath,
 		stdout.Bytes(),
 		filePerm,
 	)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 
+	stderrPath := path.Join(basePath, resource.Container.Name+".stderr.log")
 	err = os.WriteFile(
-		path.Join(basePath, resource.Container.Name+".stderr.log"),
+		stderrPath,
 		stderr.Bytes(),
 		filePerm,
 	)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 
-	return nil
+	return stdoutPath, stderrPath, nil
 }

--- a/integration/hsic/hsic.go
+++ b/integration/hsic/hsic.go
@@ -398,8 +398,8 @@ func (t *HeadscaleInContainer) hasTLS() bool {
 }
 
 // Shutdown stops and cleans up the Headscale container.
-func (t *HeadscaleInContainer) Shutdown() error {
-	err := t.SaveLog("/tmp/control")
+func (t *HeadscaleInContainer) Shutdown() (string, string, error) {
+	stdoutPath, stderrPath, err := t.SaveLog("/tmp/control")
 	if err != nil {
 		log.Printf(
 			"Failed to save log from control: %s",
@@ -458,12 +458,12 @@ func (t *HeadscaleInContainer) Shutdown() error {
 		t.pool.Purge(t.pgContainer)
 	}
 
-	return t.pool.Purge(t.container)
+	return stdoutPath, stderrPath, t.pool.Purge(t.container)
 }
 
 // SaveLog saves the current stdout log of the container to a path
 // on the host system.
-func (t *HeadscaleInContainer) SaveLog(path string) error {
+func (t *HeadscaleInContainer) SaveLog(path string) (string, string, error) {
 	return dockertestutil.SaveLog(t.pool, t.container, path)
 }
 

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -998,7 +998,9 @@ func (t *TailscaleInContainer) WriteFile(path string, data []byte) error {
 // SaveLog saves the current stdout log of the container to a path
 // on the host system.
 func (t *TailscaleInContainer) SaveLog(path string) error {
-	return dockertestutil.SaveLog(t.pool, t.container, path)
+	// TODO(kradalby): Assert if tailscale logs contains panics.
+	_, _, err := dockertestutil.SaveLog(t.pool, t.container, path)
+	return err
 }
 
 // ReadFile reads a file from the Tailscale container.


### PR DESCRIPTION
Currently we will read the node from database, and since it is
deleted, the id might be set to nil. Keep the node around and
just shutdown, so it is cleanly removed from notifier.

Fixes https://github.com/juanfont/headscale/issues/2118

Also adds the ability to check integration test headscale for panics 
and a test case producing the error, which is then fixed.

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new test case to validate the deletion of an online node, enhancing system robustness.
	- Enhanced logging capabilities during shutdown processes, providing paths to log files for better diagnostics.

- **Bug Fixes**
	- Improved error handling and logging during node removal and shutdown operations to prevent system panics.

- **Documentation**
	- Added comments to indicate future enhancements regarding panic log assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->