### PR TITLE
add shutdown that asserts if headscale had panics

### DIFF
--- a/integration/acl_test.go
+++ b/integration/acl_test.go
@@ -276,7 +276,7 @@ func TestACLHostsInNetMapTable(t *testing.T) {
 				hsic.WithACLPolicy(&testCase.policy),
 			)
 			assertNoErr(t, err)
-			defer scenario.Shutdown()
+			defer scenario.ShutdownAssertNoPanics(t)
 
 			allClients, err := scenario.ListTailscaleClients()
 			assertNoErr(t, err)
@@ -316,7 +316,7 @@ func TestACLAllowUser80Dst(t *testing.T) {
 		},
 		1,
 	)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	user1Clients, err := scenario.ListTailscaleClients("user1")
 	assertNoErr(t, err)
@@ -373,7 +373,7 @@ func TestACLDenyAllPort80(t *testing.T) {
 		},
 		4,
 	)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	allClients, err := scenario.ListTailscaleClients()
 	assertNoErr(t, err)
@@ -417,7 +417,7 @@ func TestACLAllowUserDst(t *testing.T) {
 		},
 		2,
 	)
-	// defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	user1Clients, err := scenario.ListTailscaleClients("user1")
 	assertNoErr(t, err)
@@ -473,7 +473,7 @@ func TestACLAllowStarDst(t *testing.T) {
 		},
 		2,
 	)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	user1Clients, err := scenario.ListTailscaleClients("user1")
 	assertNoErr(t, err)
@@ -534,7 +534,7 @@ func TestACLNamedHostsCanReachBySubnet(t *testing.T) {
 		},
 		3,
 	)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	user1Clients, err := scenario.ListTailscaleClients("user1")
 	assertNoErr(t, err)
@@ -672,7 +672,7 @@ func TestACLNamedHostsCanReach(t *testing.T) {
 				&testCase.policy,
 				2,
 			)
-			defer scenario.Shutdown()
+			defer scenario.ShutdownAssertNoPanics(t)
 
 			// Since user/users dont matter here, we basically expect that some clients
 			// will be assigned these ips and that we can pick them up for our own use.
@@ -1021,7 +1021,7 @@ func TestPolicyUpdateWhileRunningWithCLIInDatabase(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": 1,

--- a/integration/auth_oidc_test.go
+++ b/integration/auth_oidc_test.go
@@ -48,7 +48,7 @@ func TestOIDCAuthenticationPingAll(t *testing.T) {
 	scenario := AuthOIDCScenario{
 		Scenario: baseScenario,
 	}
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": len(MustTestVersions),
@@ -108,7 +108,7 @@ func TestOIDCExpireNodesBasedOnTokenExpiry(t *testing.T) {
 	scenario := AuthOIDCScenario{
 		Scenario: baseScenario,
 	}
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": 3,

--- a/integration/auth_web_flow_test.go
+++ b/integration/auth_web_flow_test.go
@@ -34,7 +34,7 @@ func TestAuthWebFlowAuthenticationPingAll(t *testing.T) {
 	scenario := AuthWebFlowScenario{
 		Scenario: baseScenario,
 	}
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": len(MustTestVersions),
@@ -73,7 +73,7 @@ func TestAuthWebFlowLogoutAndRelogin(t *testing.T) {
 	scenario := AuthWebFlowScenario{
 		Scenario: baseScenario,
 	}
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": len(MustTestVersions),

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -35,7 +35,7 @@ func TestUserCommand(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": 0,
@@ -115,7 +115,7 @@ func TestPreAuthKeyCommand(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		user: 0,
@@ -257,7 +257,7 @@ func TestPreAuthKeyCommandWithoutExpiry(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		user: 0,
@@ -320,7 +320,7 @@ func TestPreAuthKeyCommandReusableEphemeral(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		user: 0,
@@ -398,7 +398,7 @@ func TestPreAuthKeyCorrectUserLoggedInCommand(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		user1: 1,
@@ -492,7 +492,7 @@ func TestApiKeyCommand(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": 0,
@@ -660,7 +660,7 @@ func TestNodeTagCommand(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": 0,
@@ -785,7 +785,7 @@ func TestNodeAdvertiseTagNoACLCommand(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": 1,
@@ -835,7 +835,7 @@ func TestNodeAdvertiseTagWithACLCommand(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": 1,
@@ -898,7 +898,7 @@ func TestNodeCommand(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"node-user":  0,
@@ -1139,7 +1139,7 @@ func TestNodeExpireCommand(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"node-expire-user": 0,
@@ -1266,7 +1266,7 @@ func TestNodeRenameCommand(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"node-rename-command": 0,
@@ -1432,7 +1432,7 @@ func TestNodeMoveCommand(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"old-user": 0,
@@ -1593,7 +1593,7 @@ func TestPolicyCommand(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"policy-user": 0,
@@ -1673,7 +1673,7 @@ func TestPolicyBrokenConfigCommand(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"policy-user": 1,

--- a/integration/dns_test.go
+++ b/integration/dns_test.go
@@ -17,7 +17,7 @@ func TestResolveMagicDNS(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"magicdns1": len(MustTestVersions),
@@ -208,7 +208,7 @@ func TestValidateResolvConf(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			scenario, err := NewScenario(dockertestMaxWait())
 			assertNoErr(t, err)
-			defer scenario.Shutdown()
+			defer scenario.ShutdownAssertNoPanics(t)
 
 			spec := map[string]int{
 				"resolvconf1": 3,

--- a/integration/embedded_derp_test.go
+++ b/integration/embedded_derp_test.go
@@ -32,7 +32,7 @@ func TestDERPServerScenario(t *testing.T) {
 		Scenario:     baseScenario,
 		tsicNetworks: map[string]*dockertest.Network{},
 	}
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": len(MustTestVersions),

--- a/integration/general_test.go
+++ b/integration/general_test.go
@@ -27,7 +27,7 @@ func TestPingAllByIP(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	// TODO(kradalby): it does not look like the user thing works, only second
 	// get created? maybe only when many?
@@ -71,7 +71,7 @@ func TestPingAllByIPPublicDERP(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": len(MustTestVersions),
@@ -109,7 +109,7 @@ func TestAuthKeyLogoutAndRelogin(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": len(MustTestVersions),
@@ -228,7 +228,7 @@ func testEphemeralWithOptions(t *testing.T, opts ...hsic.Option) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": len(MustTestVersions),
@@ -313,7 +313,7 @@ func TestEphemeral2006DeletedTooQuickly(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": len(MustTestVersions),
@@ -427,7 +427,7 @@ func TestPingAllByHostname(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user3": len(MustTestVersions),
@@ -476,7 +476,7 @@ func TestTaildrop(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"taildrop": len(MustTestVersions),
@@ -637,7 +637,7 @@ func TestExpireNode(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": len(MustTestVersions),
@@ -763,7 +763,7 @@ func TestNodeOnlineStatus(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		"user1": len(MustTestVersions),
@@ -878,7 +878,7 @@ func TestPingAllByIPManyUpDown(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	// TODO(kradalby): it does not look like the user thing works, only second
 	// get created? maybe only when many?

--- a/integration/route_test.go
+++ b/integration/route_test.go
@@ -32,7 +32,7 @@ func TestEnablingRoutes(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErrf(t, "failed to create scenario: %s", err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		user: 3,
@@ -254,7 +254,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErrf(t, "failed to create scenario: %s", err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		user: 3,
@@ -826,7 +826,7 @@ func TestEnableDisableAutoApprovedRoute(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErrf(t, "failed to create scenario: %s", err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		user: 1,
@@ -968,7 +968,7 @@ func TestAutoApprovedSubRoute2068(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErrf(t, "failed to create scenario: %s", err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		user: 1,
@@ -1059,7 +1059,7 @@ func TestSubnetRouteACL(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErrf(t, "failed to create scenario: %s", err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	spec := map[string]int{
 		user: 2,

--- a/integration/scenario_test.go
+++ b/integration/scenario_test.go
@@ -35,7 +35,7 @@ func TestHeadscale(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	t.Run("start-headscale", func(t *testing.T) {
 		headscale, err := scenario.Headscale()
@@ -80,7 +80,7 @@ func TestCreateTailscale(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	scenario.users[user] = &User{
 		Clients: make(map[string]TailscaleClient),
@@ -116,7 +116,7 @@ func TestTailscaleNodesJoiningHeadcale(t *testing.T) {
 
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	t.Run("start-headscale", func(t *testing.T) {
 		headscale, err := scenario.Headscale()

--- a/integration/ssh_test.go
+++ b/integration/ssh_test.go
@@ -111,7 +111,7 @@ func TestSSHOneUserToAll(t *testing.T) {
 		},
 		len(MustTestVersions),
 	)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	allClients, err := scenario.ListTailscaleClients()
 	assertNoErrListClients(t, err)
@@ -176,7 +176,7 @@ func TestSSHMultipleUsersAllToAll(t *testing.T) {
 		},
 		len(MustTestVersions),
 	)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	nsOneClients, err := scenario.ListTailscaleClients("user1")
 	assertNoErrListClients(t, err)
@@ -222,7 +222,7 @@ func TestSSHNoSSHConfigured(t *testing.T) {
 		},
 		len(MustTestVersions),
 	)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	allClients, err := scenario.ListTailscaleClients()
 	assertNoErrListClients(t, err)
@@ -271,7 +271,7 @@ func TestSSHIsBlockedInACL(t *testing.T) {
 		},
 		len(MustTestVersions),
 	)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	allClients, err := scenario.ListTailscaleClients()
 	assertNoErrListClients(t, err)
@@ -327,7 +327,7 @@ func TestSSHUserOnlyIsolation(t *testing.T) {
 		},
 		len(MustTestVersions),
 	)
-	defer scenario.Shutdown()
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	ssh1Clients, err := scenario.ListTailscaleClients("user1")
 	assertNoErrListClients(t, err)


### PR DESCRIPTION
Depends on #2125 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling during test shutdown processes to ensure no panics occur, improving test robustness across multiple test files.
  
- **Chores**
	- Standardised the shutdown mechanism in tests by replacing `scenario.Shutdown()` with `scenario.ShutdownAssertNoPanics(t)` for better error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->