### PR TITLE
move logic for validating node names

### DIFF
--- a/hscontrol/db/node.go
+++ b/hscontrol/db/node.go
@@ -90,20 +90,6 @@ func (hsdb *HSDatabase) ListEphemeralNodes() (types.Nodes, error) {
 	})
 }
 
-func listNodesByGivenName(tx *gorm.DB, givenName string) (types.Nodes, error) {
-	nodes := types.Nodes{}
-	if err := tx.
-		Preload("AuthKey").
-		Preload("AuthKey.User").
-		Preload("User").
-		Preload("Routes").
-		Where("given_name = ?", givenName).Find(&nodes).Error; err != nil {
-		return nil, err
-	}
-
-	return nodes, nil
-}
-
 func (hsdb *HSDatabase) getNode(user string, name string) (*types.Node, error) {
 	return Read(hsdb.DB, func(rx *gorm.DB) (*types.Node, error) {
 		return getNode(rx, user, name)
@@ -242,15 +228,24 @@ func SetTags(
 }
 
 // RenameNode takes a Node struct and a new GivenName for the nodes
-// and renames it.
+// and renames it. If the name is not unique, it will return an error.
 func RenameNode(tx *gorm.DB,
-	nodeID uint64, newName string,
+	nodeID types.NodeID, newName string,
 ) error {
 	err := util.CheckForFQDNRules(
 		newName,
 	)
 	if err != nil {
 		return fmt.Errorf("renaming node: %w", err)
+	}
+
+	uniq, err := isUnqiueName(tx, newName)
+	if err != nil {
+		return fmt.Errorf("checking if name is unique: %w", err)
+	}
+
+	if !uniq {
+		return fmt.Errorf("name is not unique: %s", newName)
 	}
 
 	if err := tx.Model(&types.Node{}).Where("id = ?", nodeID).Update("given_name", newName).Error; err != nil {
@@ -414,6 +409,15 @@ func RegisterNode(tx *gorm.DB, node types.Node, ipv4 *netip.Addr, ipv6 *netip.Ad
 
 	node.IPv4 = ipv4
 	node.IPv6 = ipv6
+
+	if node.GivenName == "" {
+		givenName, err := ensureUniqueGivenName(tx, node.Hostname)
+		if err != nil {
+			return nil, fmt.Errorf("failed to ensure unique given name: %w", err)
+		}
+
+		node.GivenName = givenName
+	}
 
 	if err := tx.Save(&node).Error; err != nil {
 		return nil, fmt.Errorf("failed register(save) node in the database: %w", err)
@@ -642,40 +646,32 @@ func generateGivenName(suppliedName string, randomSuffix bool) (string, error) {
 	return normalizedHostname, nil
 }
 
-func (hsdb *HSDatabase) GenerateGivenName(
-	mkey key.MachinePublic,
-	suppliedName string,
-) (string, error) {
-	return Read(hsdb.DB, func(rx *gorm.DB) (string, error) {
-		return GenerateGivenName(rx, mkey, suppliedName)
-	})
+func isUnqiueName(tx *gorm.DB, name string) (bool, error) {
+	nodes := types.Nodes{}
+	if err := tx.
+		Where("given_name = ?", name, name).Find(&nodes).Error; err != nil {
+		return false, err
+	}
+
+	return len(nodes) == 0, nil
 }
 
-func GenerateGivenName(
+func ensureUniqueGivenName(
 	tx *gorm.DB,
-	mkey key.MachinePublic,
-	suppliedName string,
+	name string,
 ) (string, error) {
-	givenName, err := generateGivenName(suppliedName, false)
+	givenName, err := generateGivenName(name, false)
 	if err != nil {
 		return "", err
 	}
 
-	// Tailscale rules (may differ) https://tailscale.com/kb/1098/machine-names/
-	nodes, err := listNodesByGivenName(tx, givenName)
+	unique, err := isUnqiueName(tx, givenName)
 	if err != nil {
 		return "", err
 	}
 
-	var nodeFound *types.Node
-	for idx, node := range nodes {
-		if node.GivenName == givenName {
-			nodeFound = nodes[idx]
-		}
-	}
-
-	if nodeFound != nil && nodeFound.MachineKey.String() != mkey.String() {
-		postfixedName, err := generateGivenName(suppliedName, true)
+	if !unique {
+		postfixedName, err := generateGivenName(name, true)
 		if err != nil {
 			return "", err
 		}

--- a/hscontrol/db/node.go
+++ b/hscontrol/db/node.go
@@ -649,7 +649,7 @@ func generateGivenName(suppliedName string, randomSuffix bool) (string, error) {
 func isUnqiueName(tx *gorm.DB, name string) (bool, error) {
 	nodes := types.Nodes{}
 	if err := tx.
-		Where("given_name = ?", name, name).Find(&nodes).Error; err != nil {
+		Where("given_name = ?", name).Find(&nodes).Error; err != nil {
 		return false, err
 	}
 

--- a/hscontrol/grpcv1.go
+++ b/hscontrol/grpcv1.go
@@ -373,7 +373,7 @@ func (api headscaleV1APIServer) RenameNode(
 	node, err := db.Write(api.h.db.DB, func(tx *gorm.DB) (*types.Node, error) {
 		err := db.RenameNode(
 			tx,
-			request.GetNodeId(),
+			types.NodeID(request.GetNodeId()),
 			request.GetNewName(),
 		)
 		if err != nil {
@@ -802,18 +802,12 @@ func (api headscaleV1APIServer) DebugCreateNode(
 		return nil, err
 	}
 
-	givenName, err := api.h.db.GenerateGivenName(mkey, request.GetName())
-	if err != nil {
-		return nil, err
-	}
-
 	nodeKey := key.NewNode()
 
 	newNode := types.Node{
 		MachineKey: mkey,
 		NodeKey:    nodeKey.Public(),
 		Hostname:   request.GetName(),
-		GivenName:  givenName,
 		User:       *user,
 
 		Expiry:   &time.Time{},


### PR DESCRIPTION
this commits moves the generation of "given names" of nodes into the registration function, and adds validation of renames to RenameNode using the same logic.

Fixes #2121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced node registration with checks for unique identifiers, improving data integrity.
	- Simplified node creation process by removing the `GivenName` field.

- **Bug Fixes**
	- Ensured that node renaming adheres to uniqueness constraints, preventing conflicts.

- **Tests**
	- Introduced new tests for renaming nodes to validate uniqueness and conflict resolution.
	- Removed outdated tests related to the generation of given names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->