### PR TITLE
Update headscale user creation settings in .deb

### DIFF
--- a/docs/packaging/postinstall.sh
+++ b/docs/packaging/postinstall.sh
@@ -6,7 +6,7 @@
 HEADSCALE_EXE="/usr/bin/headscale"
 BSD_HIER=""
 HEADSCALE_RUN_DIR="/var/run/headscale"
-HEAD_SCALE_HOME_DIR="/var/lib/headscale"
+HEADSCALE_HOME_DIR="/var/lib/headscale"
 HEADSCALE_USER="headscale"
 HEADSCALE_GROUP="headscale"
 HEADSCALE_SHELL="/usr/sbin/nologin"

--- a/docs/packaging/postinstall.sh
+++ b/docs/packaging/postinstall.sh
@@ -6,8 +6,10 @@
 HEADSCALE_EXE="/usr/bin/headscale"
 BSD_HIER=""
 HEADSCALE_RUN_DIR="/var/run/headscale"
+HEAD_SCALE_HOME_DIR="/var/lib/headscale"
 HEADSCALE_USER="headscale"
 HEADSCALE_GROUP="headscale"
+HEADSCALE_SHELL="/usr/sbin/nologin"
 
 ensure_sudo() {
 	if [ "$(id -u)" = "0" ]; then
@@ -29,7 +31,7 @@ ensure_headscale_path() {
 
 create_headscale_user() {
 	printf "PostInstall: Adding headscale user %s\n" "$HEADSCALE_USER"
-	useradd -s /usr/sbin/nologin -d /var/lib/headscale -c "headscale default user" headscale
+	useradd -s "$HEADSCALE_SHELL" -d "$HEADSCALE_HOME_DIR" -c "headscale default user" "$HEADSCALE_USER"
 }
 
 create_headscale_group() {

--- a/docs/packaging/postinstall.sh
+++ b/docs/packaging/postinstall.sh
@@ -29,7 +29,7 @@ ensure_headscale_path() {
 
 create_headscale_user() {
 	printf "PostInstall: Adding headscale user %s\n" "$HEADSCALE_USER"
-	useradd -s /bin/sh -c "headscale default user" headscale
+	useradd -s /usr/sbin/nologin -d /var/lib/headscale -c "headscale default user" headscale
 }
 
 create_headscale_group() {


### PR DESCRIPTION
Update the headscale user settings to:
- shell = /usr/sbin/nologin
- home-dir = /var/lib/headscale

This syncs the .deb installation behavior with the current Linux docs: https://github.com/juanfont/headscale/blob/fe68f503289db6cb1c2a568b8ae02a45ac632dd6/docs/running-headscale-linux-manual.md?plain=1#L39-L45

Fixes juanfont/headscale#2133

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced security by modifying user creation parameters, preventing interactive logins for the headscale user.
  - Specified a dedicated home directory for the headscale user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->