### PR TITLE
Exclude irrelevant files from mkdocs rendering

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,13 @@ theme:
   favicon: assets/favicon.png
   logo: ./logo/headscale3-dots.svg
 
+# Excludes
+exclude_docs: |
+  /packaging/README.md
+  /packaging/postinstall.sh
+  /packaging/postremove.sh
+  /requirements.txt
+
 # Plugins
 plugins:
   - search:


### PR DESCRIPTION
Files are otherwise copied as-is to the `site/` directory and get published along with the documentation.

Ref: https://www.mkdocs.org/user-guide/configuration/#exclude_docs

---

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `exclude_docs` configuration in the documentation settings to omit specific files from the generated documentation, enhancing clarity and focus on relevant content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->