### PR TITLE
remove versions older than 1.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Remove versions older than 1.56 [#2149](https://github.com/juanfont/headscale/pull/2149)
+  - Clean up old code required by old versions
 - Improved compatibilty of built-in DERP server with clients connecting over WebSocket.
 - Allow nodes to use SSH agent forwarding [#2145](https://github.com/juanfont/headscale/pull/2145)
 

--- a/hscontrol/mapper/mapper_test.go
+++ b/hscontrol/mapper/mapper_test.go
@@ -244,11 +244,11 @@ func Test_fullMapResponse(t *testing.T) {
 		PrimaryRoutes:     []netip.Prefix{netip.MustParsePrefix("192.168.0.0/24")},
 		LastSeen:          &lastSeen,
 		MachineAuthorized: true,
-		Capabilities: []tailcfg.NodeCapability{
-			tailcfg.CapabilityFileSharing,
-			tailcfg.CapabilityAdmin,
-			tailcfg.CapabilitySSH,
-			tailcfg.NodeAttrDisableUPnP,
+
+		CapMap: tailcfg.NodeCapMap{
+			tailcfg.CapabilityFileSharing: []tailcfg.RawMessage{},
+			tailcfg.CapabilityAdmin:       []tailcfg.RawMessage{},
+			tailcfg.CapabilitySSH:         []tailcfg.RawMessage{},
 		},
 	}
 
@@ -299,11 +299,11 @@ func Test_fullMapResponse(t *testing.T) {
 		PrimaryRoutes:     []netip.Prefix{},
 		LastSeen:          &lastSeen,
 		MachineAuthorized: true,
-		Capabilities: []tailcfg.NodeCapability{
-			tailcfg.CapabilityFileSharing,
-			tailcfg.CapabilityAdmin,
-			tailcfg.CapabilitySSH,
-			tailcfg.NodeAttrDisableUPnP,
+
+		CapMap: tailcfg.NodeCapMap{
+			tailcfg.CapabilityFileSharing: []tailcfg.RawMessage{},
+			tailcfg.CapabilityAdmin:       []tailcfg.RawMessage{},
+			tailcfg.CapabilitySSH:         []tailcfg.RawMessage{},
 		},
 	}
 

--- a/hscontrol/mapper/tail.go
+++ b/hscontrol/mapper/tail.go
@@ -114,32 +114,14 @@ func tailNode(
 		Expired:           node.IsExpired(),
 	}
 
-	//   - 74: 2023-09-18: Client understands NodeCapMap
-	if capVer >= 74 {
-		tNode.CapMap = tailcfg.NodeCapMap{
-			tailcfg.CapabilityFileSharing: []tailcfg.RawMessage{},
-			tailcfg.CapabilityAdmin:       []tailcfg.RawMessage{},
-			tailcfg.CapabilitySSH:         []tailcfg.RawMessage{},
-		}
-
-		if cfg.RandomizeClientPort {
-			tNode.CapMap[tailcfg.NodeAttrRandomizeClientPort] = []tailcfg.RawMessage{}
-		}
-	} else {
-		tNode.Capabilities = []tailcfg.NodeCapability{
-			tailcfg.CapabilityFileSharing,
-			tailcfg.CapabilityAdmin,
-			tailcfg.CapabilitySSH,
-		}
-
-		if cfg.RandomizeClientPort {
-			tNode.Capabilities = append(tNode.Capabilities, tailcfg.NodeAttrRandomizeClientPort)
-		}
+	tNode.CapMap = tailcfg.NodeCapMap{
+		tailcfg.CapabilityFileSharing: []tailcfg.RawMessage{},
+		tailcfg.CapabilityAdmin:       []tailcfg.RawMessage{},
+		tailcfg.CapabilitySSH:         []tailcfg.RawMessage{},
 	}
 
-	//   - 72: 2023-08-23: TS-2023-006 UPnP issue fixed; UPnP can now be used again
-	if capVer < 72 {
-		tNode.Capabilities = append(tNode.Capabilities, tailcfg.NodeAttrDisableUPnP)
+	if cfg.RandomizeClientPort {
+		tNode.CapMap[tailcfg.NodeAttrRandomizeClientPort] = []tailcfg.RawMessage{}
 	}
 
 	if node.IsOnline == nil || !*node.IsOnline {

--- a/hscontrol/mapper/tail_test.go
+++ b/hscontrol/mapper/tail_test.go
@@ -72,9 +72,11 @@ func TestTailNode(t *testing.T) {
 				Tags:              []string{},
 				PrimaryRoutes:     []netip.Prefix{},
 				MachineAuthorized: true,
-				Capabilities: []tailcfg.NodeCapability{
-					"https://tailscale.com/cap/file-sharing", "https://tailscale.com/cap/is-admin",
-					"https://tailscale.com/cap/ssh", "debug-disable-upnp",
+
+				CapMap: tailcfg.NodeCapMap{
+					tailcfg.CapabilityFileSharing: []tailcfg.RawMessage{},
+					tailcfg.CapabilityAdmin:       []tailcfg.RawMessage{},
+					tailcfg.CapabilitySSH:         []tailcfg.RawMessage{},
 				},
 			},
 			wantErr: false,
@@ -166,11 +168,10 @@ func TestTailNode(t *testing.T) {
 				LastSeen:          &lastSeen,
 				MachineAuthorized: true,
 
-				Capabilities: []tailcfg.NodeCapability{
-					tailcfg.CapabilityFileSharing,
-					tailcfg.CapabilityAdmin,
-					tailcfg.CapabilitySSH,
-					tailcfg.NodeAttrDisableUPnP,
+				CapMap: tailcfg.NodeCapMap{
+					tailcfg.CapabilityFileSharing: []tailcfg.RawMessage{},
+					tailcfg.CapabilityAdmin:       []tailcfg.RawMessage{},
+					tailcfg.CapabilitySSH:         []tailcfg.RawMessage{},
 				},
 			},
 			wantErr: false,

--- a/hscontrol/metrics.go
+++ b/hscontrol/metrics.go
@@ -37,11 +37,6 @@ var (
 		Name:      "mapresponse_updates_received_total",
 		Help:      "total count of mapresponse updates received on update channel",
 	}, []string{"type"})
-	mapResponseWriteUpdatesInStream = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: prometheusNamespace,
-		Name:      "mapresponse_write_updates_in_stream_total",
-		Help:      "total count of writes that occurred in a stream session, pre-68 nodes",
-	}, []string{"status"})
 	mapResponseEndpointUpdates = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: prometheusNamespace,
 		Name:      "mapresponse_endpoint_updates_total",

--- a/hscontrol/noise.go
+++ b/hscontrol/noise.go
@@ -166,7 +166,7 @@ func (ns *noiseServer) earlyNoise(protocolVersion int, writer io.Writer) error {
 }
 
 const (
-	MinimumCapVersion tailcfg.CapabilityVersion = 61
+	MinimumCapVersion tailcfg.CapabilityVersion = 82
 )
 
 // NoisePollNetMapHandler takes care of /machine/:id/map using the Noise protocol
@@ -182,15 +182,6 @@ func (ns *noiseServer) NoisePollNetMapHandler(
 	writer http.ResponseWriter,
 	req *http.Request,
 ) {
-	log.Trace().
-		Str("handler", "NoisePollNetMap").
-		Msg("PollNetMapHandler called")
-
-	log.Trace().
-		Any("headers", req.Header).
-		Caller().
-		Msg("Headers")
-
 	body, _ := io.ReadAll(req.Body)
 
 	mapRequest := tailcfg.MapRequest{}
@@ -203,6 +194,14 @@ func (ns *noiseServer) NoisePollNetMapHandler(
 
 		return
 	}
+
+	log.Trace().
+		Caller().
+		Str("handler", "NoisePollNetMap").
+		Any("headers", req.Header).
+		Str("node", mapRequest.Hostinfo.Hostname).
+		Int("capver", int(mapRequest.Version)).
+		Msg("PollNetMapHandler called")
 
 	// Reject unsupported versions
 	if mapRequest.Version < MinimumCapVersion {

--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -53,21 +53,23 @@ var (
 	tailscaleVersions2021 = map[string]bool{
 		"head":     true,
 		"unstable": true,
-		"1.70":     true,  // CapVer: not checked
-		"1.68":     true,  // CapVer: not checked
-		"1.66":     true,  // CapVer: not checked
-		"1.64":     true,  // CapVer: not checked
-		"1.62":     true,  // CapVer: not checked
-		"1.60":     true,  // CapVer: not checked
-		"1.58":     true,  // CapVer: not checked
-		"1.56":     true,  // CapVer: 82
-		"1.54":     true,  // CapVer: 79
-		"1.52":     true,  // CapVer: 79
-		"1.50":     true,  // CapVer: 74
-		"1.48":     true,  // CapVer: 68
-		"1.46":     true,  // CapVer: 65
+		"1.74":     true,  // CapVer: 106
+		"1.72":     true,  // CapVer: 104
+		"1.70":     true,  // CapVer: 102
+		"1.68":     true,  // CapVer: 97
+		"1.66":     true,  // CapVer: 95
+		"1.64":     true,  // CapVer: 90
+		"1.62":     true,  // CapVer: 88
+		"1.60":     true,  // CapVer: 87
+		"1.58":     true,  // CapVer: 85
+		"1.56":     true,  // Oldest supported version, CapVer: 82
+		"1.54":     false, // CapVer: 79
+		"1.52":     false, // CapVer: 79
+		"1.50":     false, // CapVer: 74
+		"1.48":     false, // CapVer: 68
+		"1.46":     false, // CapVer: 65
 		"1.44":     false, // CapVer: 63
-		"1.42":     false, // Oldest supported version, CapVer: 61
+		"1.42":     false, // CapVer: 61
 		"1.40":     false, // CapVer: 61
 		"1.38":     false, // CapVer: 58
 		"1.36":     false, // CapVer: 56


### PR DESCRIPTION
From 0.23.0, headscale has a goal of supporting the 10 latest versions of tailscale, this PR removes versions older than 1.56.

This allows us to remove a bunch of code, some duplicate! 🎉 

Signed-off-by: Kristoffer Dalby <kristoffer@tailscale.com>