### PR TITLE
[docs] Add Ouroboros to community web ui list

### DIFF
--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -5,11 +5,12 @@
     This page contains community contributions. The projects listed here are not
     maintained by the Headscale authors and are written by community members.
 
-| Name            | Repository Link                                         | Description                                                                 | Status |
-| --------------- | ------------------------------------------------------- | --------------------------------------------------------------------------- | ------ |
-| headscale-webui | [Github](https://github.com/ifargle/headscale-webui)    | A simple Headscale web UI for small-scale deployments.                      | Alpha  |
-| headscale-ui    | [Github](https://github.com/gurucomputing/headscale-ui) | A web frontend for the headscale Tailscale-compatible coordination server   | Alpha  |
-| HeadscaleUi     | [GitHub](https://github.com/simcu/headscale-ui)         | A static headscale admin ui, no backend enviroment required                 | Alpha  |
-| headscale-admin | [Github](https://github.com/GoodiesHQ/headscale-admin)  | Headscale-Admin is meant to be a simple, modern web interface for Headscale | Beta   |
+| Name            | Repository Link                                         | Description                                                                         | Status |
+| --------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------- | ------ |
+| headscale-webui | [Github](https://github.com/ifargle/headscale-webui)    | A simple Headscale web UI for small-scale deployments.                              | Alpha  |
+| headscale-ui    | [Github](https://github.com/gurucomputing/headscale-ui) | A web frontend for the headscale Tailscale-compatible coordination server           | Alpha  |
+| HeadscaleUi     | [GitHub](https://github.com/simcu/headscale-ui)         | A static headscale admin ui, no backend enviroment required                         | Alpha  |
+| headscale-admin | [Github](https://github.com/GoodiesHQ/headscale-admin)  | Headscale-Admin is meant to be a simple, modern web interface for Headscale         | Beta   |
+| ouroboros       | [Github](https://github.com/yellowsink/ouroboros)       | Ouroboros is designed for users to manage their own devices, rather than for admins | Stable |
 
 You can ask for support on our dedicated [Discord channel](https://discord.com/channels/896711691637780480/1105842846386356294).


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

Hi! I have developed a UI for Headscale which I have running in production on my server currently.
It is designed for multi-user tailnets, to allow users to manage their nodes entirely on their own, without providing any sysadmin features.
It offers management (rename, delete, logout, exit node, routes) of nodes, and intercepts the /register endpoint (if using a correctly configured reverse proxy), to allow users to add their own nodes.

Users must authenticate through Github OAuth2 and the list of allowed users are predefined up-front by the admin.

![image](https://github.com/user-attachments/assets/b0455891-fedb-47e9-b096-f7d801331936)

![image](https://github.com/user-attachments/assets/c19efd93-e05b-4a81-af37-2afb6a1f29eb)
