### PR TITLE
Harden OIDC migration and make optional

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -21,6 +21,7 @@ jobs:
           - TestPolicyUpdateWhileRunningWithCLIInDatabase
           - TestOIDCAuthenticationPingAll
           - TestOIDCExpireNodesBasedOnTokenExpiry
+          - TestOIDC024UserCreation
           - TestAuthWebFlowAuthenticationPingAll
           - TestAuthWebFlowLogoutAndRelogin
           - TestUserCommand

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,82 @@
 
 ## Next
 
+### Security fix: OIDC changes in Headscale 0.24.0
+
+_Headscale v0.23.0 and earlier_ identified OIDC users by the "username" part of their email address (when `strip_email_domain: true`, the default) or whole email address (when `strip_email_domain: false`).
+
+Depending on how Headscale and your Identity Provider (IdP) were configured, only using the `email` claim could allow a malicious user with an IdP account to take over another Headscale user's account, even when `strip_email_domain: false`.
+
+This would also cause a user to lose access to their Headscale account if they changed their email address.
+
+_Headscale v0.24.0_ now identifies OIDC users by the `iss` and `sub` claims. [These are guaranteed by the OIDC specification to be stable and unique](https://openid.net/specs/openid-connect-core-1_0.html#ClaimStability), even if a user changes email address. A well-designed IdP will typically set `sub` to an opaque identifier like a UUID or numeric ID, which has no relation to the user's name or email address.
+
+This issue _only_ affects Headscale installations which authenticate with OIDC.
+
+Headscale v0.24.0 and later will also automatically update profile fields with OIDC data on login. This means that users can change those details in your IdP, and have it populate to Headscale automatically the next time they log in. However, this may affect the way you reference users in policies.
+
+#### Migrating existing installations
+
+Headscale v0.23.0 and earlier never recorded the `iss` and `sub` fields, so all legacy (existing) OIDC accounts from _need to be migrated_ to be properly secured.
+
+Headscale v0.24.0 has an automatic migration feature, which is enabled by default (`map_legacy_users: true`). **This will be disabled by default in a future version of Headscale – any unmigrated users will get new accounts.**
+
+Headscale v0.24.0 will ignore any `email` claim if the IdP does not provide an `email_verified` claim set to `true`. [What "verified" actually means is contextually dependent](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) – Headscale uses it as a signal that the contents of the `email` claim is reasonably trustworthy.
+
+Headscale v0.23.0 and earlier never checked the `email_verified` claim. This means even if an IdP explicitly indicated to Headscale that its `email` claim was untrustworthy, Headscale would have still accepted it.
+
+##### What does automatic migration do?
+
+When automatic migration is enabled (`map_legacy_users: true`), Headscale will first match an OIDC account to a Headscale account by `iss` and `sub`, and then fall back to matching OIDC users similarly to how Headscale v0.23.0 did:
+
+- If `strip_email_domain: true` (the default): the Headscale username matches the "username" part of their email address.
+- If `strip_email_domain: false`: the Headscale username matches the _whole_ email address.
+
+On migration, Headscale will change the account's username to their `preferred_username`. **This could break any ACLs or policies which are configured to match by username.**
+
+Like with Headscale v0.23.0 and earlier, this migration only works for users who haven't changed their email address since their last Headscale login.
+
+A _successful_ automated migration should otherwise be transparent to users.
+
+Once a Headscale account has been migrated, it will be _unavailable_ to be matched by the legacy process. An OIDC login with a matching username, but _non-matching_ `iss` and `sub` will instead get a _new_ Headscale account.
+
+Because of the way OIDC works, Headscale's automated migration process can _only_ work when a user tries to log in after the update. Mass updates would require Headscale implement a protocol like SCIM, which is **extremely** complicated and not available in all identity providers.
+
+Administrators could also attempt to migrate users manually by editing the database, using their own mapping rules with known-good data sources.
+
+Legacy account migration should have no effect on new installations where all users have a recorded `sub` and `iss`.
+
+##### What happens when automatic migration is disabled?
+
+When automatic migration is disabled (`map_legacy_users: false`), Headscale will only try to match an OIDC account to a Headscale account by `iss` and `sub`.
+
+If there is no match, it will get a _new_ Headscale account – even if there was a legacy account which _could_ have matched and migrated.
+
+We recommend new Headscale users explicitly disable automatic migration – but it should otherwise have no effect if every account has a recorded `iss` and `sub`.
+
+When automatic migration is disabled, the `strip_email_domain` setting will have no effect.
+
+Special thanks to @micolous for reviewing, proposing and working with us on these changes.
+
+#### Other OIDC changes
+
+Headscale now uses [the standard OIDC claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) to populate and update user information every time they log in:
+
+| Headscale profile field | OIDC claim           | Notes / examples                                                                                          |
+| ----------------------- | -------------------- | --------------------------------------------------------------------------------------------------------- |
+| email address           | `email`              | Only used when `"email_verified": true`                                                                   |
+| display name            | `name`               | eg: `Sam Smith`                                                                                           |
+| username                | `preferred_username` | Varies depending on IdP and configuration, eg: `ssmith`, `ssmith@idp.example.com`, `\\example.com\ssmith` |
+| profile picture         | `picture`            | URL to a profile picture or avatar                                                                        |
+
+These should show up nicely in the Tailscale client.
+
+This will also affect the way you [reference users in policies](https://github.com/juanfont/headscale/pull/2205).
+
 ### BREAKING
 
 - Remove `dns.use_username_in_magic_dns` configuration option [#2020](https://github.com/juanfont/headscale/pull/2020)
   - Having usernames in magic DNS is no longer possible.
-- Redo OpenID Connect configuration [#2020](https://github.com/juanfont/headscale/pull/2020)
-  - `strip_email_domain` has been removed, domain is _always_ part of the username for OIDC.
-  - Users are now identified by `sub` claim in the ID token instead of username, allowing the username, name and email to be updated.
-  - User has been extended to store username, display name, profile picture url and email.
-    - These fields are forwarded to the client, and shows up nicely in the user switcher.
-    - These fields can be made available via the API/CLI for non-OIDC users in the future.
 - Remove versions older than 1.56 [#2149](https://github.com/juanfont/headscale/pull/2149)
   - Clean up old code required by old versions
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -364,12 +364,18 @@ unix_socket_permission: "0770"
 #   allowed_users:
 #     - alice@example.com
 #
-#   # If `strip_email_domain` is set to `true`, the domain part of the username email address will be removed.
-#   # This will transform `first-name.last-name@example.com` to the user `first-name.last-name`
-#   # If `strip_email_domain` is set to `false` the domain part will NOT be removed resulting to the following
-#   user: `first-name.last-name.example.com`
-#
-#   strip_email_domain: true
+#   # Map legacy users from pre-0.24.0 versions of headscale to the new OIDC users
+#   # by taking the username from the legacy user and matching it with the username
+#   # provided by the OIDC. This is useful when migrating from legacy users to OIDC
+#   # to force them using the unique identifier from the OIDC and to give them a
+#   # proper display name and picture if available.
+#   # Note that this will only work if the username from the legacy user is the same
+#   # and ther is a posibility for account takeover should a username have changed
+#   # with the provider.
+#   # Disabling this feature will cause all new logins to be created as new users.
+#   # Note this option will be removed in the future and should be set to false
+#   # on all new installations, or when all users have logged in with OIDC once.
+#   map_legacy_users: true
 
 # Logtail configuration
 # Logtail is Tailscales logging and auditing infrastructure, it allows the control panel

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
 
           # When updating go.mod or go.sum, a new sha will need to be calculated,
           # update this if you have a mismatch after doing a change to thos files.
-          vendorHash = "sha256-Qoqu2k4vvnbRFLmT/v8lI+HCEWqJsHFs8uZRfNmwQpo=";
+          vendorHash = "sha256-4VNiHUblvtcl9UetwiL6ZeVYb0h2e9zhYVsirhAkvOg=";
 
           subPackages = ["cmd/headscale"];
 
@@ -102,6 +102,7 @@
           ko
           yq-go
           ripgrep
+          postgresql
 
           # 'dot' is needed for pprof graphs
           # go tool pprof -http=: <source>

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	gorm.io/gorm v1.25.11
 	tailscale.com v1.75.0-pre.0.20240926101731-7d1160ddaab7
 	zgo.at/zcache/v2 v2.1.0
+	zombiezen.com/go/postgrestest v1.0.1
 )
 
 require (
@@ -134,6 +135,7 @@ require (
 	github.com/kortschak/wol v0.0.0-20200729010619-da482cc4850a // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/lib/pq v1.10.9 // indirect
 	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -311,6 +311,7 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
+github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lithammer/fuzzysearch v1.1.8 h1:/HIuJnjHuXS8bKaiTMeeDlW2/AyIWk2brx1V8LFgLN4=
@@ -731,3 +732,5 @@ tailscale.com v1.75.0-pre.0.20240926101731-7d1160ddaab7 h1:nfRWV6ECxwNvvXKtbqSVs
 tailscale.com v1.75.0-pre.0.20240926101731-7d1160ddaab7/go.mod h1:xKxYf3B3PuezFlRaMT+VhuVu8XTFUTLy+VCzLPMJVmg=
 zgo.at/zcache/v2 v2.1.0 h1:USo+ubK+R4vtjw4viGzTe/zjXyPw6R7SK/RL3epBBxs=
 zgo.at/zcache/v2 v2.1.0/go.mod h1:gyCeoLVo01QjDZynjime8xUGHHMbsLiPyUTBpDGd4Gk=
+zombiezen.com/go/postgrestest v1.0.1 h1:aXoADQAJmZDU3+xilYVut0pHhgc0sF8ZspPW9gFNwP4=
+zombiezen.com/go/postgrestest v1.0.1/go.mod h1:marlZezr+k2oSJrvXHnZUs1olHqpE9czlz8ZYkVxliQ=

--- a/hscontrol/db/db.go
+++ b/hscontrol/db/db.go
@@ -505,11 +505,11 @@ func NewHeadscaleDatabase(
 					// - A provider_identifier is unique
 					// - A user name is unique if there is no provider_identifier is not set
 					for _, idx := range []string{
-						"DROP INDEX IF EXISTS `idx_provider_identifier`",
-						"DROP INDEX IF EXISTS `idx_name_provider_identifier`",
-						"CREATE UNIQUE INDEX IF NOT EXISTS `idx_provider_identifier` ON `users` (`provider_identifier`) WHERE provider_identifier IS NOT NULL;",
-						"CREATE UNIQUE INDEX IF NOT EXISTS `idx_name_provider_identifier` ON `users` (`name`,`provider_identifier`);",
-						"CREATE UNIQUE INDEX IF NOT EXISTS `idx_name_no_provider_identifier` ON `users` (`name`) WHERE provider_identifier IS NULL;",
+						"DROP INDEX IF EXISTS idx_provider_identifier",
+						"DROP INDEX IF EXISTS idx_name_provider_identifier",
+						"CREATE UNIQUE INDEX IF NOT EXISTS idx_provider_identifier ON users (provider_identifier) WHERE provider_identifier IS NOT NULL;",
+						"CREATE UNIQUE INDEX IF NOT EXISTS idx_name_provider_identifier ON users (name,provider_identifier);",
+						"CREATE UNIQUE INDEX IF NOT EXISTS idx_name_no_provider_identifier ON users (name) WHERE provider_identifier IS NULL;",
 					} {
 						err = tx.Exec(idx).Error
 						if err != nil {

--- a/hscontrol/db/db.go
+++ b/hscontrol/db/db.go
@@ -474,7 +474,24 @@ func NewHeadscaleDatabase(
 				Rollback: func(db *gorm.DB) error { return nil },
 			},
 			{
+				// Pick up new user fields used for OIDC and to
+				// populate the user with more interesting information.
 				ID: "202407191627",
+				Migrate: func(tx *gorm.DB) error {
+					err := tx.AutoMigrate(&types.User{})
+					if err != nil {
+						return err
+					}
+
+					return nil
+				},
+				Rollback: func(db *gorm.DB) error { return nil },
+			},
+			{
+				// The unique constraint of Name has been dropped
+				// in favour of a unique together of name and
+				// provider identity.
+				ID: "202408181235",
 				Migrate: func(tx *gorm.DB) error {
 					err := tx.AutoMigrate(&types.User{})
 					if err != nil {

--- a/hscontrol/db/db_test.go
+++ b/hscontrol/db/db_test.go
@@ -271,8 +271,8 @@ func TestConstraints(t *testing.T) {
 				require.NoError(t, err)
 				_, err = CreateUser(db, "user1")
 				require.Error(t, err)
-				// assert.Contains(t, err.Error(), "UNIQUE constraint failed: users.username")
-				require.Contains(t, err.Error(), "user already exists")
+				assert.Contains(t, err.Error(), "UNIQUE constraint failed:")
+				// require.Contains(t, err.Error(), "user already exists")
 			},
 		},
 		{
@@ -295,7 +295,7 @@ func TestConstraints(t *testing.T) {
 
 				err = db.Save(&user).Error
 				require.Error(t, err)
-				require.Contains(t, err.Error(), "UNIQUE constraint failed: users.provider_identifier")
+				require.Contains(t, err.Error(), "UNIQUE constraint failed:")
 			},
 		},
 		{
@@ -318,7 +318,7 @@ func TestConstraints(t *testing.T) {
 
 				err = db.Save(&user).Error
 				require.Error(t, err)
-				require.Contains(t, err.Error(), "UNIQUE constraint failed: users.provider_identifier")
+				require.Contains(t, err.Error(), "UNIQUE constraint failed:")
 			},
 		},
 		{
@@ -328,9 +328,9 @@ func TestConstraints(t *testing.T) {
 				require.NoError(t, err)
 
 				user := types.User{
-					Name: "user1",
+					Name:               "user1",
+					ProviderIdentifier: sql.NullString{String: "http://test.com/user1", Valid: true},
 				}
-				user.ProviderIdentifier.String = "http://test.com/user1"
 
 				err = db.Save(&user).Error
 				require.NoError(t, err)
@@ -340,9 +340,9 @@ func TestConstraints(t *testing.T) {
 			name: "allow-duplicate-username-oidc-then-cli",
 			run: func(t *testing.T, db *gorm.DB) {
 				user := types.User{
-					Name: "user1",
+					Name:               "user1",
+					ProviderIdentifier: sql.NullString{String: "http://test.com/user1", Valid: true},
 				}
-				user.ProviderIdentifier.String = "http://test.com/user1"
 
 				err := db.Save(&user).Error
 				require.NoError(t, err)
@@ -360,7 +360,7 @@ func TestConstraints(t *testing.T) {
 				t.Fatalf("creating database: %s", err)
 			}
 
-			tt.run(t, db.DB)
+			tt.run(t, db.DB.Debug())
 		})
 
 	}

--- a/hscontrol/db/db_test.go
+++ b/hscontrol/db/db_test.go
@@ -121,12 +121,12 @@ func TestMigrations(t *testing.T) {
 			dbPath: "testdata/0-23-0-to-0-24-0-preauthkey-tags-table.sqlite",
 			wantFunc: func(t *testing.T, h *HSDatabase) {
 				keys, err := Read(h.DB, func(rx *gorm.DB) ([]types.PreAuthKey, error) {
-					kratest, err := ListPreAuthKeys(rx, "kratest")
+					kratest, err := ListPreAuthKeysByUser(rx, 1) // kratest
 					if err != nil {
 						return nil, err
 					}
 
-					testkra, err := ListPreAuthKeys(rx, "testkra")
+					testkra, err := ListPreAuthKeysByUser(rx, 2) // testkra
 					if err != nil {
 						return nil, err
 					}

--- a/hscontrol/db/node.go
+++ b/hscontrol/db/node.go
@@ -91,15 +91,15 @@ func (hsdb *HSDatabase) ListEphemeralNodes() (types.Nodes, error) {
 	})
 }
 
-func (hsdb *HSDatabase) getNode(user string, name string) (*types.Node, error) {
+func (hsdb *HSDatabase) getNode(uid types.UserID, name string) (*types.Node, error) {
 	return Read(hsdb.DB, func(rx *gorm.DB) (*types.Node, error) {
-		return getNode(rx, user, name)
+		return getNode(rx, uid, name)
 	})
 }
 
 // getNode finds a Node by name and user and returns the Node struct.
-func getNode(tx *gorm.DB, user string, name string) (*types.Node, error) {
-	nodes, err := ListNodesByUser(tx, user)
+func getNode(tx *gorm.DB, uid types.UserID, name string) (*types.Node, error) {
+	nodes, err := ListNodesByUser(tx, uid)
 	if err != nil {
 		return nil, err
 	}

--- a/hscontrol/db/node_test.go
+++ b/hscontrol/db/node_test.go
@@ -558,7 +558,7 @@ func TestAutoApproveRoutes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adb, err := newTestDB()
+			adb, err := newSQLiteTestDB()
 			require.NoError(t, err)
 			pol, err := policy.LoadACLPolicyFromBytes([]byte(tt.acl))
 
@@ -692,7 +692,7 @@ func generateRandomNumber(t *testing.T, max int64) int64 {
 }
 
 func TestListEphemeralNodes(t *testing.T) {
-	db, err := newTestDB()
+	db, err := newSQLiteTestDB()
 	if err != nil {
 		t.Fatalf("creating db: %s", err)
 	}
@@ -748,7 +748,7 @@ func TestListEphemeralNodes(t *testing.T) {
 }
 
 func TestRenameNode(t *testing.T) {
-	db, err := newTestDB()
+	db, err := newSQLiteTestDB()
 	if err != nil {
 		t.Fatalf("creating db: %s", err)
 	}

--- a/hscontrol/db/node_test.go
+++ b/hscontrol/db/node_test.go
@@ -30,10 +30,10 @@ func (s *Suite) TestGetNode(c *check.C) {
 	user, err := db.CreateUser("test")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
-	_, err = db.getNode("test", "testnode")
+	_, err = db.getNode(types.UserID(user.ID), "testnode")
 	c.Assert(err, check.NotNil)
 
 	nodeKey := key.NewNode()
@@ -51,7 +51,7 @@ func (s *Suite) TestGetNode(c *check.C) {
 	trx := db.DB.Save(node)
 	c.Assert(trx.Error, check.IsNil)
 
-	_, err = db.getNode("test", "testnode")
+	_, err = db.getNode(types.UserID(user.ID), "testnode")
 	c.Assert(err, check.IsNil)
 }
 
@@ -59,7 +59,7 @@ func (s *Suite) TestGetNodeByID(c *check.C) {
 	user, err := db.CreateUser("test")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
 	_, err = db.GetNodeByID(0)
@@ -88,7 +88,7 @@ func (s *Suite) TestGetNodeByAnyNodeKey(c *check.C) {
 	user, err := db.CreateUser("test")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
 	_, err = db.GetNodeByID(0)
@@ -136,7 +136,7 @@ func (s *Suite) TestHardDeleteNode(c *check.C) {
 	_, err = db.DeleteNode(&node, xsync.NewMapOf[types.NodeID, bool]())
 	c.Assert(err, check.IsNil)
 
-	_, err = db.getNode(user.Name, "testnode3")
+	_, err = db.getNode(types.UserID(user.ID), "testnode3")
 	c.Assert(err, check.NotNil)
 }
 
@@ -144,7 +144,7 @@ func (s *Suite) TestListPeers(c *check.C) {
 	user, err := db.CreateUser("test")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
 	_, err = db.GetNodeByID(0)
@@ -190,7 +190,7 @@ func (s *Suite) TestGetACLFilteredPeers(c *check.C) {
 	for _, name := range []string{"test", "admin"} {
 		user, err := db.CreateUser(name)
 		c.Assert(err, check.IsNil)
-		pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+		pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 		c.Assert(err, check.IsNil)
 		stor = append(stor, base{user, pak})
 	}
@@ -282,10 +282,10 @@ func (s *Suite) TestExpireNode(c *check.C) {
 	user, err := db.CreateUser("test")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
-	_, err = db.getNode("test", "testnode")
+	_, err = db.getNode(types.UserID(user.ID), "testnode")
 	c.Assert(err, check.NotNil)
 
 	nodeKey := key.NewNode()
@@ -303,7 +303,7 @@ func (s *Suite) TestExpireNode(c *check.C) {
 	}
 	db.DB.Save(node)
 
-	nodeFromDB, err := db.getNode("test", "testnode")
+	nodeFromDB, err := db.getNode(types.UserID(user.ID), "testnode")
 	c.Assert(err, check.IsNil)
 	c.Assert(nodeFromDB, check.NotNil)
 
@@ -313,7 +313,7 @@ func (s *Suite) TestExpireNode(c *check.C) {
 	err = db.NodeSetExpiry(nodeFromDB.ID, now)
 	c.Assert(err, check.IsNil)
 
-	nodeFromDB, err = db.getNode("test", "testnode")
+	nodeFromDB, err = db.getNode(types.UserID(user.ID), "testnode")
 	c.Assert(err, check.IsNil)
 
 	c.Assert(nodeFromDB.IsExpired(), check.Equals, true)
@@ -323,10 +323,10 @@ func (s *Suite) TestSetTags(c *check.C) {
 	user, err := db.CreateUser("test")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
-	_, err = db.getNode("test", "testnode")
+	_, err = db.getNode(types.UserID(user.ID), "testnode")
 	c.Assert(err, check.NotNil)
 
 	nodeKey := key.NewNode()
@@ -349,7 +349,7 @@ func (s *Suite) TestSetTags(c *check.C) {
 	sTags := []string{"tag:test", "tag:foo"}
 	err = db.SetTags(node.ID, sTags)
 	c.Assert(err, check.IsNil)
-	node, err = db.getNode("test", "testnode")
+	node, err = db.getNode(types.UserID(user.ID), "testnode")
 	c.Assert(err, check.IsNil)
 	c.Assert(node.ForcedTags, check.DeepEquals, sTags)
 
@@ -357,7 +357,7 @@ func (s *Suite) TestSetTags(c *check.C) {
 	eTags := []string{"tag:bar", "tag:test", "tag:unknown", "tag:test"}
 	err = db.SetTags(node.ID, eTags)
 	c.Assert(err, check.IsNil)
-	node, err = db.getNode("test", "testnode")
+	node, err = db.getNode(types.UserID(user.ID), "testnode")
 	c.Assert(err, check.IsNil)
 	c.Assert(
 		node.ForcedTags,
@@ -368,7 +368,7 @@ func (s *Suite) TestSetTags(c *check.C) {
 	// test removing tags
 	err = db.SetTags(node.ID, []string{})
 	c.Assert(err, check.IsNil)
-	node, err = db.getNode("test", "testnode")
+	node, err = db.getNode(types.UserID(user.ID), "testnode")
 	c.Assert(err, check.IsNil)
 	c.Assert(node.ForcedTags, check.DeepEquals, []string{})
 }
@@ -568,7 +568,7 @@ func TestAutoApproveRoutes(t *testing.T) {
 			user, err := adb.CreateUser("test")
 			require.NoError(t, err)
 
-			pak, err := adb.CreatePreAuthKey(user.Name, false, false, nil, nil)
+			pak, err := adb.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 			require.NoError(t, err)
 
 			nodeKey := key.NewNode()
@@ -700,10 +700,10 @@ func TestListEphemeralNodes(t *testing.T) {
 	user, err := db.CreateUser("test")
 	require.NoError(t, err)
 
-	pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 	require.NoError(t, err)
 
-	pakEph, err := db.CreatePreAuthKey(user.Name, false, true, nil, nil)
+	pakEph, err := db.CreatePreAuthKey(types.UserID(user.ID), false, true, nil, nil)
 	require.NoError(t, err)
 
 	node := types.Node{

--- a/hscontrol/db/preauth_keys.go
+++ b/hscontrol/db/preauth_keys.go
@@ -23,29 +23,27 @@ var (
 )
 
 func (hsdb *HSDatabase) CreatePreAuthKey(
-	// TODO(kradalby): Should be ID, not name
-	userName string,
+	uid types.UserID,
 	reusable bool,
 	ephemeral bool,
 	expiration *time.Time,
 	aclTags []string,
 ) (*types.PreAuthKey, error) {
 	return Write(hsdb.DB, func(tx *gorm.DB) (*types.PreAuthKey, error) {
-		return CreatePreAuthKey(tx, userName, reusable, ephemeral, expiration, aclTags)
+		return CreatePreAuthKey(tx, uid, reusable, ephemeral, expiration, aclTags)
 	})
 }
 
 // CreatePreAuthKey creates a new PreAuthKey in a user, and returns it.
 func CreatePreAuthKey(
 	tx *gorm.DB,
-	// TODO(kradalby): Should be ID, not name
-	userName string,
+	uid types.UserID,
 	reusable bool,
 	ephemeral bool,
 	expiration *time.Time,
 	aclTags []string,
 ) (*types.PreAuthKey, error) {
-	user, err := GetUserByUsername(tx, userName)
+	user, err := GetUserByID(tx, uid)
 	if err != nil {
 		return nil, err
 	}
@@ -89,15 +87,15 @@ func CreatePreAuthKey(
 	return &key, nil
 }
 
-func (hsdb *HSDatabase) ListPreAuthKeys(userName string) ([]types.PreAuthKey, error) {
+func (hsdb *HSDatabase) ListPreAuthKeys(uid types.UserID) ([]types.PreAuthKey, error) {
 	return Read(hsdb.DB, func(rx *gorm.DB) ([]types.PreAuthKey, error) {
-		return ListPreAuthKeys(rx, userName)
+		return ListPreAuthKeysByUser(rx, uid)
 	})
 }
 
-// ListPreAuthKeys returns the list of PreAuthKeys for a user.
-func ListPreAuthKeys(tx *gorm.DB, userName string) ([]types.PreAuthKey, error) {
-	user, err := GetUserByUsername(tx, userName)
+// ListPreAuthKeysByUser returns the list of PreAuthKeys for a user.
+func ListPreAuthKeysByUser(tx *gorm.DB, uid types.UserID) ([]types.PreAuthKey, error) {
+	user, err := GetUserByID(tx, uid)
 	if err != nil {
 		return nil, err
 	}

--- a/hscontrol/db/preauth_keys_test.go
+++ b/hscontrol/db/preauth_keys_test.go
@@ -11,14 +11,14 @@ import (
 )
 
 func (*Suite) TestCreatePreAuthKey(c *check.C) {
-	_, err := db.CreatePreAuthKey("bogus", true, false, nil, nil)
-
+	// ID does not exist
+	_, err := db.CreatePreAuthKey(12345, true, false, nil, nil)
 	c.Assert(err, check.NotNil)
 
 	user, err := db.CreateUser("test")
 	c.Assert(err, check.IsNil)
 
-	key, err := db.CreatePreAuthKey(user.Name, true, false, nil, nil)
+	key, err := db.CreatePreAuthKey(types.UserID(user.ID), true, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
 	// Did we get a valid key?
@@ -26,17 +26,18 @@ func (*Suite) TestCreatePreAuthKey(c *check.C) {
 	c.Assert(len(key.Key), check.Equals, 48)
 
 	// Make sure the User association is populated
-	c.Assert(key.User.Name, check.Equals, user.Name)
+	c.Assert(key.User.ID, check.Equals, user.ID)
 
-	_, err = db.ListPreAuthKeys("bogus")
+	// ID does not exist
+	_, err = db.ListPreAuthKeys(1000000)
 	c.Assert(err, check.NotNil)
 
-	keys, err := db.ListPreAuthKeys(user.Name)
+	keys, err := db.ListPreAuthKeys(types.UserID(user.ID))
 	c.Assert(err, check.IsNil)
 	c.Assert(len(keys), check.Equals, 1)
 
 	// Make sure the User association is populated
-	c.Assert((keys)[0].User.Name, check.Equals, user.Name)
+	c.Assert((keys)[0].User.ID, check.Equals, user.ID)
 }
 
 func (*Suite) TestExpiredPreAuthKey(c *check.C) {
@@ -44,7 +45,7 @@ func (*Suite) TestExpiredPreAuthKey(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	now := time.Now().Add(-5 * time.Second)
-	pak, err := db.CreatePreAuthKey(user.Name, true, false, &now, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), true, false, &now, nil)
 	c.Assert(err, check.IsNil)
 
 	key, err := db.ValidatePreAuthKey(pak.Key)
@@ -62,7 +63,7 @@ func (*Suite) TestValidateKeyOk(c *check.C) {
 	user, err := db.CreateUser("test3")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, true, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), true, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
 	key, err := db.ValidatePreAuthKey(pak.Key)
@@ -74,7 +75,7 @@ func (*Suite) TestAlreadyUsedKey(c *check.C) {
 	user, err := db.CreateUser("test4")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
 	node := types.Node{
@@ -96,7 +97,7 @@ func (*Suite) TestReusableBeingUsedKey(c *check.C) {
 	user, err := db.CreateUser("test5")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, true, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), true, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
 	node := types.Node{
@@ -118,7 +119,7 @@ func (*Suite) TestNotReusableNotBeingUsedKey(c *check.C) {
 	user, err := db.CreateUser("test6")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
 	key, err := db.ValidatePreAuthKey(pak.Key)
@@ -130,7 +131,7 @@ func (*Suite) TestExpirePreauthKey(c *check.C) {
 	user, err := db.CreateUser("test3")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, true, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), true, false, nil, nil)
 	c.Assert(err, check.IsNil)
 	c.Assert(pak.Expiration, check.IsNil)
 
@@ -147,7 +148,7 @@ func (*Suite) TestNotReusableMarkedAsUsed(c *check.C) {
 	user, err := db.CreateUser("test6")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 	c.Assert(err, check.IsNil)
 	pak.Used = true
 	db.DB.Save(&pak)
@@ -160,15 +161,15 @@ func (*Suite) TestPreAuthKeyACLTags(c *check.C) {
 	user, err := db.CreateUser("test8")
 	c.Assert(err, check.IsNil)
 
-	_, err = db.CreatePreAuthKey(user.Name, false, false, nil, []string{"badtag"})
+	_, err = db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, []string{"badtag"})
 	c.Assert(err, check.NotNil) // Confirm that malformed tags are rejected
 
 	tags := []string{"tag:test1", "tag:test2"}
 	tagsWithDuplicate := []string{"tag:test1", "tag:test2", "tag:test2"}
-	_, err = db.CreatePreAuthKey(user.Name, false, false, nil, tagsWithDuplicate)
+	_, err = db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, tagsWithDuplicate)
 	c.Assert(err, check.IsNil)
 
-	listedPaks, err := db.ListPreAuthKeys("test8")
+	listedPaks, err := db.ListPreAuthKeys(types.UserID(user.ID))
 	c.Assert(err, check.IsNil)
 	gotTags := listedPaks[0].Proto().GetAclTags()
 	sort.Sort(sort.StringSlice(gotTags))

--- a/hscontrol/db/routes.go
+++ b/hscontrol/db/routes.go
@@ -639,7 +639,7 @@ func EnableAutoApprovedRoutes(
 
 		log.Trace().
 			Str("node", node.Hostname).
-			Str("user", node.User.Name).
+			Uint("user.id", node.User.ID).
 			Strs("routeApprovers", routeApprovers).
 			Str("prefix", netip.Prefix(advertisedRoute.Prefix).String()).
 			Msg("looking up route for autoapproving")

--- a/hscontrol/db/routes_test.go
+++ b/hscontrol/db/routes_test.go
@@ -35,10 +35,10 @@ func (s *Suite) TestGetRoutes(c *check.C) {
 	user, err := db.CreateUser("test")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
-	_, err = db.getNode("test", "test_get_route_node")
+	_, err = db.getNode(types.UserID(user.ID), "test_get_route_node")
 	c.Assert(err, check.NotNil)
 
 	route, err := netip.ParsePrefix("10.0.0.0/24")
@@ -79,10 +79,10 @@ func (s *Suite) TestGetEnableRoutes(c *check.C) {
 	user, err := db.CreateUser("test")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
-	_, err = db.getNode("test", "test_enable_route_node")
+	_, err = db.getNode(types.UserID(user.ID), "test_enable_route_node")
 	c.Assert(err, check.NotNil)
 
 	route, err := netip.ParsePrefix(
@@ -153,10 +153,10 @@ func (s *Suite) TestIsUniquePrefix(c *check.C) {
 	user, err := db.CreateUser("test")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
-	_, err = db.getNode("test", "test_enable_route_node")
+	_, err = db.getNode(types.UserID(user.ID), "test_enable_route_node")
 	c.Assert(err, check.NotNil)
 
 	route, err := netip.ParsePrefix(
@@ -234,10 +234,10 @@ func (s *Suite) TestDeleteRoutes(c *check.C) {
 	user, err := db.CreateUser("test")
 	c.Assert(err, check.IsNil)
 
-	pak, err := db.CreatePreAuthKey(user.Name, false, false, nil, nil)
+	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
 	c.Assert(err, check.IsNil)
 
-	_, err = db.getNode("test", "test_enable_route_node")
+	_, err = db.getNode(types.UserID(user.ID), "test_enable_route_node")
 	c.Assert(err, check.NotNil)
 
 	prefix, err := netip.ParsePrefix(

--- a/hscontrol/db/suite_test.go
+++ b/hscontrol/db/suite_test.go
@@ -1,12 +1,17 @@
 package db
 
 import (
+	"context"
 	"log"
+	"net/url"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/juanfont/headscale/hscontrol/types"
 	"gopkg.in/check.v1"
+	"zombiezen.com/go/postgrestest"
 )
 
 func Test(t *testing.T) {
@@ -36,13 +41,15 @@ func (s *Suite) ResetDB(c *check.C) {
 	// }
 
 	var err error
-	db, err = newTestDB()
+	db, err = newSQLiteTestDB()
 	if err != nil {
 		c.Fatal(err)
 	}
 }
 
-func newTestDB() (*HSDatabase, error) {
+// TODO(kradalby): make this a t.Helper when we dont depend
+// on check test framework.
+func newSQLiteTestDB() (*HSDatabase, error) {
 	var err error
 	tmpDir, err = os.MkdirTemp("", "headscale-db-test-*")
 	if err != nil {
@@ -53,7 +60,7 @@ func newTestDB() (*HSDatabase, error) {
 
 	db, err = NewHeadscaleDatabase(
 		types.DatabaseConfig{
-			Type: "sqlite3",
+			Type: types.DatabaseSqlite,
 			Sqlite: types.SqliteConfig{
 				Path: tmpDir + "/headscale_test.db",
 			},
@@ -66,4 +73,54 @@ func newTestDB() (*HSDatabase, error) {
 	}
 
 	return db, nil
+}
+
+func newPostgresTestDB(t *testing.T) *HSDatabase {
+	t.Helper()
+
+	var err error
+	tmpDir, err = os.MkdirTemp("", "headscale-db-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log.Printf("database path: %s", tmpDir+"/headscale_test.db")
+
+	ctx := context.Background()
+	srv, err := postgrestest.Start(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(srv.Cleanup)
+
+	u, err := srv.CreateDatabase(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("created local postgres: %s", u)
+	pu, _ := url.Parse(u)
+
+	pass, _ := pu.User.Password()
+	port, _ := strconv.Atoi(pu.Port())
+
+	db, err = NewHeadscaleDatabase(
+		types.DatabaseConfig{
+			Type: types.DatabasePostgres,
+			Postgres: types.PostgresConfig{
+				Host: pu.Hostname(),
+				User: pu.User.Username(),
+				Name: strings.TrimLeft(pu.Path, "/"),
+				Pass: pass,
+				Port: port,
+				Ssl:  "disable",
+			},
+		},
+		"",
+		emptyCache(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return db
 }

--- a/hscontrol/db/users.go
+++ b/hscontrol/db/users.go
@@ -28,11 +28,9 @@ func CreateUser(tx *gorm.DB, name string) (*types.User, error) {
 	if err != nil {
 		return nil, err
 	}
-	user := types.User{}
-	if err := tx.Where("name = ?", name).First(&user).Error; err == nil {
-		return nil, ErrUserExists
+	user := types.User{
+		Name: name,
 	}
-	user.Name = name
 	if err := tx.Create(&user).Error; err != nil {
 		return nil, fmt.Errorf("creating user: %w", err)
 	}
@@ -175,6 +173,10 @@ func (hsdb *HSDatabase) GetUserByName(name string) (*types.User, error) {
 	users, err := hsdb.ListUsers(&types.User{Name: name})
 	if err != nil {
 		return nil, err
+	}
+
+	if len(users) == 0 {
+		return nil, ErrUserNotFound
 	}
 
 	if len(users) != 1 {

--- a/hscontrol/db/users.go
+++ b/hscontrol/db/users.go
@@ -40,21 +40,21 @@ func CreateUser(tx *gorm.DB, name string) (*types.User, error) {
 	return &user, nil
 }
 
-func (hsdb *HSDatabase) DestroyUser(name string) error {
+func (hsdb *HSDatabase) DestroyUser(uid types.UserID) error {
 	return hsdb.Write(func(tx *gorm.DB) error {
-		return DestroyUser(tx, name)
+		return DestroyUser(tx, uid)
 	})
 }
 
 // DestroyUser destroys a User. Returns error if the User does
 // not exist or if there are nodes associated with it.
-func DestroyUser(tx *gorm.DB, name string) error {
-	user, err := GetUserByUsername(tx, name)
+func DestroyUser(tx *gorm.DB, uid types.UserID) error {
+	user, err := GetUserByID(tx, uid)
 	if err != nil {
-		return ErrUserNotFound
+		return err
 	}
 
-	nodes, err := ListNodesByUser(tx, name)
+	nodes, err := ListNodesByUser(tx, uid)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func DestroyUser(tx *gorm.DB, name string) error {
 		return ErrUserStillHasNodes
 	}
 
-	keys, err := ListPreAuthKeys(tx, name)
+	keys, err := ListPreAuthKeysByUser(tx, uid)
 	if err != nil {
 		return err
 	}
@@ -80,17 +80,17 @@ func DestroyUser(tx *gorm.DB, name string) error {
 	return nil
 }
 
-func (hsdb *HSDatabase) RenameUser(oldName, newName string) error {
+func (hsdb *HSDatabase) RenameUser(uid types.UserID, newName string) error {
 	return hsdb.Write(func(tx *gorm.DB) error {
-		return RenameUser(tx, oldName, newName)
+		return RenameUser(tx, uid, newName)
 	})
 }
 
 // RenameUser renames a User. Returns error if the User does
 // not exist or if another User exists with the new name.
-func RenameUser(tx *gorm.DB, oldName, newName string) error {
+func RenameUser(tx *gorm.DB, uid types.UserID, newName string) error {
 	var err error
-	oldUser, err := GetUserByUsername(tx, oldName)
+	oldUser, err := GetUserByID(tx, uid)
 	if err != nil {
 		return err
 	}
@@ -98,50 +98,25 @@ func RenameUser(tx *gorm.DB, oldName, newName string) error {
 	if err != nil {
 		return err
 	}
-	_, err = GetUserByUsername(tx, newName)
-	if err == nil {
-		return ErrUserExists
-	}
-	if !errors.Is(err, ErrUserNotFound) {
-		return err
-	}
 
 	oldUser.Name = newName
 
-	if result := tx.Save(&oldUser); result.Error != nil {
-		return result.Error
+	if err := tx.Save(&oldUser).Error; err != nil {
+		return err
 	}
 
 	return nil
 }
 
-func (hsdb *HSDatabase) GetUserByName(name string) (*types.User, error) {
+func (hsdb *HSDatabase) GetUserByID(uid types.UserID) (*types.User, error) {
 	return Read(hsdb.DB, func(rx *gorm.DB) (*types.User, error) {
-		return GetUserByUsername(rx, name)
+		return GetUserByID(rx, uid)
 	})
 }
 
-func GetUserByUsername(tx *gorm.DB, name string) (*types.User, error) {
+func GetUserByID(tx *gorm.DB, uid types.UserID) (*types.User, error) {
 	user := types.User{}
-	if result := tx.First(&user, "name = ?", name); errors.Is(
-		result.Error,
-		gorm.ErrRecordNotFound,
-	) {
-		return nil, ErrUserNotFound
-	}
-
-	return &user, nil
-}
-
-func (hsdb *HSDatabase) GetUserByID(id types.UserID) (*types.User, error) {
-	return Read(hsdb.DB, func(rx *gorm.DB) (*types.User, error) {
-		return GetUserByID(rx, id)
-	})
-}
-
-func GetUserByID(tx *gorm.DB, id types.UserID) (*types.User, error) {
-	user := types.User{}
-	if result := tx.First(&user, "id = ?", id); errors.Is(
+	if result := tx.First(&user, "id = ?", uid); errors.Is(
 		result.Error,
 		gorm.ErrRecordNotFound,
 	) {
@@ -169,54 +144,65 @@ func GetUserByOIDCIdentifier(tx *gorm.DB, id string) (*types.User, error) {
 	return &user, nil
 }
 
-func (hsdb *HSDatabase) ListUsers() ([]types.User, error) {
+func (hsdb *HSDatabase) ListUsers(where ...*types.User) ([]types.User, error) {
 	return Read(hsdb.DB, func(rx *gorm.DB) ([]types.User, error) {
-		return ListUsers(rx)
+		return ListUsers(rx, where...)
 	})
 }
 
 // ListUsers gets all the existing users.
-func ListUsers(tx *gorm.DB) ([]types.User, error) {
+func ListUsers(tx *gorm.DB, where ...*types.User) ([]types.User, error) {
+	if len(where) > 1 {
+		return nil, fmt.Errorf("expect 0 or 1 where User structs, got %d", len(where))
+	}
+
+	var user *types.User
+	if len(where) == 1 {
+		user = where[0]
+	}
+
 	users := []types.User{}
-	if err := tx.Find(&users).Error; err != nil {
+	if err := tx.Where(user).Find(&users).Error; err != nil {
 		return nil, err
 	}
 
 	return users, nil
 }
 
-// ListNodesByUser gets all the nodes in a given user.
-func ListNodesByUser(tx *gorm.DB, name string) (types.Nodes, error) {
-	err := util.CheckForFQDNRules(name)
-	if err != nil {
-		return nil, err
-	}
-	user, err := GetUserByUsername(tx, name)
+// GetUserByName returns a user if the provided username is
+// unique, and otherwise an error.
+func (hsdb *HSDatabase) GetUserByName(name string) (*types.User, error) {
+	users, err := hsdb.ListUsers(&types.User{Name: name})
 	if err != nil {
 		return nil, err
 	}
 
+	if len(users) != 1 {
+		return nil, fmt.Errorf("expected exactly one user, found %d", len(users))
+	}
+
+	return &users[0], nil
+}
+
+// ListNodesByUser gets all the nodes in a given user.
+func ListNodesByUser(tx *gorm.DB, uid types.UserID) (types.Nodes, error) {
 	nodes := types.Nodes{}
-	if err := tx.Preload("AuthKey").Preload("AuthKey.User").Preload("User").Where(&types.Node{UserID: user.ID}).Find(&nodes).Error; err != nil {
+	if err := tx.Preload("AuthKey").Preload("AuthKey.User").Preload("User").Where(&types.Node{UserID: uint(uid)}).Find(&nodes).Error; err != nil {
 		return nil, err
 	}
 
 	return nodes, nil
 }
 
-func (hsdb *HSDatabase) AssignNodeToUser(node *types.Node, username string) error {
+func (hsdb *HSDatabase) AssignNodeToUser(node *types.Node, uid types.UserID) error {
 	return hsdb.Write(func(tx *gorm.DB) error {
-		return AssignNodeToUser(tx, node, username)
+		return AssignNodeToUser(tx, node, uid)
 	})
 }
 
 // AssignNodeToUser assigns a Node to a user.
-func AssignNodeToUser(tx *gorm.DB, node *types.Node, username string) error {
-	err := util.CheckForFQDNRules(username)
-	if err != nil {
-		return err
-	}
-	user, err := GetUserByUsername(tx, username)
+func AssignNodeToUser(tx *gorm.DB, node *types.Node, uid types.UserID) error {
+	user, err := GetUserByID(tx, uid)
 	if err != nil {
 		return err
 	}

--- a/hscontrol/db/users_test.go
+++ b/hscontrol/db/users_test.go
@@ -90,9 +90,10 @@ func (s *Suite) TestRenameUser(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(userTest2.Name, check.Equals, "test2")
 
+	want := "UNIQUE constraint failed"
 	err = db.RenameUser(types.UserID(userTest2.ID), "test-renamed")
-	if !strings.Contains(err.Error(), "UNIQUE constraint failed") {
-		c.Fatalf("expected failure with unique constraint, got: %s", err.Error())
+	if err == nil || !strings.Contains(err.Error(), want) {
+		c.Fatalf("expected failure with unique constraint, want: %q got: %q", want, err)
 	}
 }
 

--- a/hscontrol/oidc.go
+++ b/hscontrol/oidc.go
@@ -460,7 +460,7 @@ func (a *AuthProviderOIDC) createOrUpdateUserFromClaim(
 			// This is to prevent users that have already been migrated to the new OIDC format
 			// to be updated with the new OIDC identifier inexplicitly which might be the cause of an
 			// account takeover.
-			if user != nil && user.ProviderIdentifier != "" {
+			if user != nil && user.ProviderIdentifier.Valid {
 				log.Info().Str("username", claims.Username).Str("sub", claims.Sub).Msg("user found by username, but has provider identifier, creating new user.")
 				user = &types.User{}
 			}

--- a/hscontrol/policy/acls.go
+++ b/hscontrol/policy/acls.go
@@ -178,7 +178,12 @@ func (pol *ACLPolicy) CompileFilterRules(
 		for srcIndex, src := range acl.Sources {
 			srcs, err := pol.expandSource(src, nodes)
 			if err != nil {
-				return nil, fmt.Errorf("parsing policy, acl index: %d->%d: %w", index, srcIndex, err)
+				return nil, fmt.Errorf(
+					"parsing policy, acl index: %d->%d: %w",
+					index,
+					srcIndex,
+					err,
+				)
 			}
 			srcIPs = append(srcIPs, srcs...)
 		}
@@ -335,12 +340,21 @@ func (pol *ACLPolicy) CompileSSHPolicy(
 		case "check":
 			checkAction, err := sshCheckAction(sshACL.CheckPeriod)
 			if err != nil {
-				return nil, fmt.Errorf("parsing SSH policy, parsing check duration, index: %d: %w", index, err)
+				return nil, fmt.Errorf(
+					"parsing SSH policy, parsing check duration, index: %d: %w",
+					index,
+					err,
+				)
 			} else {
 				action = *checkAction
 			}
 		default:
-			return nil, fmt.Errorf("parsing SSH policy, unknown action %q, index: %d: %w", sshACL.Action, index, err)
+			return nil, fmt.Errorf(
+				"parsing SSH policy, unknown action %q, index: %d: %w",
+				sshACL.Action,
+				index,
+				err,
+			)
 		}
 
 		principals := make([]*tailcfg.SSHPrincipal, 0, len(sshACL.Sources))
@@ -977,10 +991,7 @@ func FilterNodesByACL(
 			continue
 		}
 
-		log.Printf("Checking if %s can access %s", node.Hostname, peer.Hostname)
-
 		if node.CanAccess(filter, nodes[index]) || peer.CanAccess(filter, node) {
-			log.Printf("CAN ACCESS %s can access %s", node.Hostname, peer.Hostname)
 			result = append(result, peer)
 		}
 	}

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -905,7 +905,10 @@ func LoadServerConfig() (*Config, error) {
 				}
 			}(),
 			UseExpiryFromToken: viper.GetBool("oidc.use_expiry_from_token"),
-			MapLegacyUsers:     viper.GetBool("oidc.map_legacy_users"),
+			// TODO(kradalby): Remove when strip_email_domain is removed
+			// after #2170 is cleaned up
+			StripEmaildomain: viper.GetBool("oidc.strip_email_domain"),
+			MapLegacyUsers:   viper.GetBool("oidc.map_legacy_users"),
 		},
 
 		LogTail:             logTailConfig,

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -163,6 +163,7 @@ type OIDCConfig struct {
 	AllowedDomains             []string
 	AllowedUsers               []string
 	AllowedGroups              []string
+	StripEmaildomain           bool
 	Expiry                     time.Duration
 	UseExpiryFromToken         bool
 	MapLegacyUsers             bool
@@ -274,6 +275,7 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("database.sqlite.write_ahead_log", true)
 
 	viper.SetDefault("oidc.scope", []string{oidc.ScopeOpenID, "profile", "email"})
+	viper.SetDefault("oidc.strip_email_domain", true)
 	viper.SetDefault("oidc.only_start_if_oidc_is_available", true)
 	viper.SetDefault("oidc.expiry", "180d")
 	viper.SetDefault("oidc.use_expiry_from_token", false)
@@ -321,14 +323,18 @@ func validateServerConfig() error {
 	depr.warn("dns_config.use_username_in_magic_dns")
 	depr.warn("dns.use_username_in_magic_dns")
 
-	depr.fatal("oidc.strip_email_domain")
+	// TODO(kradalby): Reintroduce when strip_email_domain is removed
+	// after #2170 is cleaned up
+	// depr.fatal("oidc.strip_email_domain")
 	depr.fatal("dns.use_username_in_musername_in_magic_dns")
 	depr.fatal("dns_config.use_username_in_musername_in_magic_dns")
 
 	depr.Log()
 
 	for _, removed := range []string{
-		"oidc.strip_email_domain",
+		// TODO(kradalby): Reintroduce when strip_email_domain is removed
+		// after #2170 is cleaned up
+		// "oidc.strip_email_domain",
 		"dns_config.use_username_in_musername_in_magic_dns",
 	} {
 		if viper.IsSet(removed) {

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -165,6 +165,7 @@ type OIDCConfig struct {
 	AllowedGroups              []string
 	Expiry                     time.Duration
 	UseExpiryFromToken         bool
+	MapLegacyUsers             bool
 }
 
 type DERPConfig struct {
@@ -276,6 +277,7 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("oidc.only_start_if_oidc_is_available", true)
 	viper.SetDefault("oidc.expiry", "180d")
 	viper.SetDefault("oidc.use_expiry_from_token", false)
+	viper.SetDefault("oidc.map_legacy_users", true)
 
 	viper.SetDefault("logtail.enabled", false)
 	viper.SetDefault("randomize_client_port", false)
@@ -897,6 +899,7 @@ func LoadServerConfig() (*Config, error) {
 				}
 			}(),
 			UseExpiryFromToken: viper.GetBool("oidc.use_expiry_from_token"),
+			MapLegacyUsers:     viper.GetBool("oidc.map_legacy_users"),
 		},
 
 		LogTail:             logTailConfig,

--- a/hscontrol/types/preauth_key.go
+++ b/hscontrol/types/preauth_key.go
@@ -26,7 +26,7 @@ type PreAuthKey struct {
 
 func (key *PreAuthKey) Proto() *v1.PreAuthKey {
 	protoKey := v1.PreAuthKey{
-		User:      key.User.Name,
+		User:      key.User.Username(),
 		Id:        strconv.FormatUint(key.ID, util.Base10),
 		Key:       key.Key,
 		Ephemeral: key.Ephemeral,

--- a/hscontrol/types/users.go
+++ b/hscontrol/types/users.go
@@ -3,6 +3,7 @@ package types
 import (
 	"cmp"
 	"strconv"
+	"strings"
 
 	v1 "github.com/juanfont/headscale/gen/go/headscale/v1"
 	"github.com/juanfont/headscale/hscontrol/util"
@@ -50,8 +51,14 @@ type User struct {
 // enabled with OIDC, which means that there is a domain involved which
 // should be used throughout headscale, in information returned to the
 // user and the Policy engine.
+// If the username does not contain an '@' it will be added to the end.
 func (u *User) Username() string {
-	return cmp.Or(u.Email, u.Name, u.ProviderIdentifier, strconv.FormatUint(uint64(u.ID), 10))
+	username := cmp.Or(u.Email, u.Name, u.ProviderIdentifier, strconv.FormatUint(uint64(u.ID), 10))
+	if !strings.Contains(username, "@") {
+		username = username + "@"
+	}
+
+	return username
 }
 
 // DisplayNameOrUsername returns the DisplayName if it exists, otherwise

--- a/hscontrol/types/users.go
+++ b/hscontrol/types/users.go
@@ -26,7 +26,7 @@ type User struct {
 
 	// Username for the user, is used if email is empty
 	// Should not be used, please use Username().
-	Name string `gorm:"index,uniqueIndex:idx_name_provider_identifier"`
+	Name string `gorm:"uniqueIndex:idx_name_provider_identifier,index"`
 
 	// Typically the full name of the user
 	DisplayName string

--- a/hscontrol/types/users.go
+++ b/hscontrol/types/users.go
@@ -27,7 +27,7 @@ type User struct {
 
 	// Username for the user, is used if email is empty
 	// Should not be used, please use Username().
-	Name string `gorm:"uniqueIndex:idx_name_provider_identifier;index"`
+	Name string
 
 	// Typically the full name of the user
 	DisplayName string
@@ -39,7 +39,7 @@ type User struct {
 	// Unique identifier of the user from OIDC,
 	// comes from `sub` claim in the OIDC token
 	// and is used to lookup the user.
-	ProviderIdentifier sql.NullString `gorm:"uniqueIndex:idx_name_provider_identifier;uniqueIndex:idx_provider_identifier"`
+	ProviderIdentifier sql.NullString
 
 	// Provider is the origin of the user account,
 	// same as RegistrationMethod, without authkey.

--- a/hscontrol/types/users.go
+++ b/hscontrol/types/users.go
@@ -21,7 +21,7 @@ type User struct {
 	gorm.Model
 	// The index `idx_name_provider_identifier` is to enforce uniqueness
 	// between Name and ProviderIdentifier. This ensures that
-	// you can have multiple usersnames of the same name in OIDC,
+	// you can have multiple users with the same name in OIDC,
 	// but not if you only run with CLI users.
 
 	// Username for the user, is used if email is empty
@@ -54,9 +54,9 @@ type User struct {
 // enabled with OIDC, which means that there is a domain involved which
 // should be used throughout headscale, in information returned to the
 // user and the Policy engine.
-// If the username does not contain an '@' it will be added to the end.
 func (u *User) Username() string {
 	username := cmp.Or(u.Email, u.Name, u.ProviderIdentifier, strconv.FormatUint(uint64(u.ID), 10))
+
 	// TODO(kradalby): Wire up all of this for the future
 	// if !strings.Contains(username, "@") {
 	// 	username = username + "@"

--- a/hscontrol/util/dns.go
+++ b/hscontrol/util/dns.go
@@ -182,3 +182,33 @@ func GenerateIPv6DNSRootDomain(ipPrefix netip.Prefix) []dnsname.FQDN {
 
 	return fqdns
 }
+
+// TODO(kradalby): Reintroduce when strip_email_domain is removed
+// after #2170 is cleaned up
+// DEPRECATED: DO NOT USE
+// NormalizeToFQDNRules will replace forbidden chars in user
+// it can also return an error if the user doesn't respect RFC 952 and 1123.
+func NormalizeToFQDNRules(name string, stripEmailDomain bool) (string, error) {
+
+	name = strings.ToLower(name)
+	name = strings.ReplaceAll(name, "'", "")
+	atIdx := strings.Index(name, "@")
+	if stripEmailDomain && atIdx > 0 {
+		name = name[:atIdx]
+	} else {
+		name = strings.ReplaceAll(name, "@", ".")
+	}
+	name = invalidCharsInUserRegex.ReplaceAllString(name, "-")
+
+	for _, elt := range strings.Split(name, ".") {
+		if len(elt) > LabelHostnameLength {
+			return "", fmt.Errorf(
+				"label %v is more than 63 chars: %w",
+				elt,
+				ErrInvalidUserName,
+			)
+		}
+	}
+
+	return name, nil
+}

--- a/integration/auth_oidc_test.go
+++ b/integration/auth_oidc_test.go
@@ -54,7 +54,7 @@ func TestOIDCAuthenticationPingAll(t *testing.T) {
 	scenario := AuthOIDCScenario{
 		Scenario: baseScenario,
 	}
-	defer scenario.ShutdownAssertNoPanics(t)
+	// defer scenario.ShutdownAssertNoPanics(t)
 
 	// Logins to MockOIDC is served by a queue with a strict order,
 	// if we use more than one node per user, the order of the logins

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -213,7 +213,9 @@ func TestPreAuthKeyCommand(t *testing.T) {
 			continue
 		}
 
-		assert.Equal(t, []string{"tag:test1", "tag:test2"}, listedPreAuthKeys[index].GetAclTags())
+		tags := listedPreAuthKeys[index].GetAclTags()
+		sort.Strings(tags)
+		assert.Equal(t, []string{"tag:test1", "tag:test2"}, tags)
 	}
 
 	// Test key expiry

--- a/integration/dockertestutil/execute.go
+++ b/integration/dockertestutil/execute.go
@@ -74,7 +74,7 @@ func ExecuteCommand(
 	select {
 	case res := <-resultChan:
 		if res.err != nil {
-			return stdout.String(), stderr.String(), res.err
+			return stdout.String(), stderr.String(), fmt.Errorf("command failed, stderr: %s: %w", stderr.String(), res.err)
 		}
 
 		if res.exitCode != 0 {
@@ -83,12 +83,12 @@ func ExecuteCommand(
 			// log.Println("stdout: ", stdout.String())
 			// log.Println("stderr: ", stderr.String())
 
-			return stdout.String(), stderr.String(), ErrDockertestCommandFailed
+			return stdout.String(), stderr.String(), fmt.Errorf("command failed, stderr: %s: %w", stderr.String(), ErrDockertestCommandFailed)
 		}
 
 		return stdout.String(), stderr.String(), nil
 	case <-time.After(execConfig.timeout):
 
-		return stdout.String(), stderr.String(), ErrDockertestCommandTimeout
+		return stdout.String(), stderr.String(), fmt.Errorf("command failed, stderr: %s: %w", stderr.String(), ErrDockertestCommandTimeout)
 	}
 }


### PR DESCRIPTION
This commit hardens the migration part of the OIDC from the old username based approach to the new sub based approach and makes it possible for the operator to opt out entirely.

Fixes #1990
