### PR TITLE
Handle /derp/latency-check

### DIFF
--- a/hscontrol/app.go
+++ b/hscontrol/app.go
@@ -460,6 +460,7 @@ func (h *Headscale) createRouter(grpcMux *grpcRuntime.ServeMux) *mux.Router {
 	if h.cfg.DERP.ServerEnabled {
 		router.HandleFunc("/derp", h.DERPServer.DERPHandler)
 		router.HandleFunc("/derp/probe", derpServer.DERPProbeHandler)
+		router.HandleFunc("/derp/latency-check", derpServer.DERPProbeHandler)
 		router.HandleFunc("/bootstrap-dns", derpServer.DERPBootstrapDNSHandler(h.DERPMap))
 	}
 

--- a/hscontrol/metrics.go
+++ b/hscontrol/metrics.go
@@ -78,7 +78,7 @@ func prometheusMiddleware(next http.Handler) http.Handler {
 
 		// Ignore streaming and noise sessions
 		// it has its own router further down.
-		if path == "/ts2021" || path == "/machine/map" || path == "/derp" || path == "/derp/probe" || path == "/bootstrap-dns" {
+		if path == "/ts2021" || path == "/machine/map" || path == "/derp" || path == "/derp/probe" || path == "/derp/latency-check" || path == "/bootstrap-dns" {
 			next.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
According to https://github.com/tailscale/tailscale/commit/15fc6cd96637e8a0e697ff2157c1608ada8e4a39 the routes `/derp/probe` and `/derp/latency-check` are the same and different versions of the tailscale client use one or the other endpoint.

Also handle /derp/latency-check

Fixes: #2211

---

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md