### PR TITLE
Use a more direct and less error-prone return value

### DIFF
--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -589,7 +589,7 @@ func (t *TailscaleInContainer) Netmap() (*netmap.NetworkMap, error) {
 		return nil, fmt.Errorf("saving netmap to /tmp/control: %w", err)
 	}
 
-	return &nm, err
+	return &nm, nil
 }
 
 // Netmap returns the current Netmap (netmap.NetworkMap) of the Tailscale instance.


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->


Since err != nil has been judged before, nil is returned directly here, which is more obvious, readable and less error-prone.

