### PR TITLE
Update tls.md to mention using the full cert chain

### DIFF
--- a/docs/ref/tls.md
+++ b/docs/ref/tls.md
@@ -9,6 +9,8 @@ tls_cert_path: ""
 tls_key_path: ""
 ```
 
+The certificate should contain the full chain, else some clients, like the Tailscale Android client, will reject it.
+
 ## Let's Encrypt / ACME
 
 To get a certificate automatically via [Let's Encrypt](https://letsencrypt.org/), set `tls_letsencrypt_hostname` to the desired certificate hostname. This name must resolve to the IP address(es) headscale is reachable on (i.e., it must correspond to the `server_url` configuration parameter). The certificate and Let's Encrypt account credentials will be stored in the directory configured in `tls_letsencrypt_cache_dir`. If the path is relative, it will be interpreted as relative to the directory the configuration file was read from.


### PR DESCRIPTION
- [X] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [X] updated documentation if needed
- [ ] updated CHANGELOG.md

The Tailscale Android client fails silently if the full certificate chain is not provided.