### PR TITLE
Remove use_username_in_magic_dns option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ This will also affect the way you [reference users in policies](https://github.c
 
 ### BREAKING
 
-- Remove `dns.use_username_in_magic_dns` configuration option [#2020](https://github.com/juanfont/headscale/pull/2020)
+- Remove `dns.use_username_in_magic_dns` configuration option [#2020](https://github.com/juanfont/headscale/pull/2020), [#2279](https://github.com/juanfont/headscale/pull/2279)
   - Having usernames in magic DNS is no longer possible.
 - Remove versions older than 1.56 [#2149](https://github.com/juanfont/headscale/pull/2149)
   - Clean up old code required by old versions

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -311,15 +311,6 @@ dns:
   #   # you can also put it in one line
   #   - { name: "prometheus.myvpn.example.com", type: "A", value: "100.64.0.3" }
 
-  # DEPRECATED
-  # Use the username as part of the DNS name for nodes, with this option enabled:
-  # node1.username.example.com
-  # while when this is disabled:
-  # node1.example.com
-  # This is a legacy option as Headscale has have this wrongly implemented
-  # while in upstream Tailscale, the username is not included.
-  use_username_in_magic_dns: false
-
 # Unix socket used for the CLI to connect without authentication
 # Note: for production you will want to set this to something like:
 unix_socket: /var/run/headscale/headscale.sock

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -322,14 +322,12 @@ func validateServerConfig() error {
 	depr.fatalIfNewKeyIsNotUsed("dns.nameservers.split", "dns_config.restricted_nameservers")
 	depr.fatalIfNewKeyIsNotUsed("dns.search_domains", "dns_config.domains")
 	depr.fatalIfNewKeyIsNotUsed("dns.extra_records", "dns_config.extra_records")
-	depr.warn("dns_config.use_username_in_magic_dns")
-	depr.warn("dns.use_username_in_magic_dns")
+	depr.fatal("dns.use_username_in_magic_dns")
+	depr.fatal("dns_config.use_username_in_magic_dns")
 
 	// TODO(kradalby): Reintroduce when strip_email_domain is removed
 	// after #2170 is cleaned up
 	// depr.fatal("oidc.strip_email_domain")
-	depr.fatal("dns.use_username_in_musername_in_magic_dns")
-	depr.fatal("dns_config.use_username_in_musername_in_magic_dns")
 
 	depr.Log()
 
@@ -337,7 +335,8 @@ func validateServerConfig() error {
 		// TODO(kradalby): Reintroduce when strip_email_domain is removed
 		// after #2170 is cleaned up
 		// "oidc.strip_email_domain",
-		"dns_config.use_username_in_musername_in_magic_dns",
+		"dns.use_username_in_magic_dns",
+		"dns_config.use_username_in_magic_dns",
 	} {
 		if viper.IsSet(removed) {
 			log.Fatal().

--- a/hscontrol/types/testdata/base-domain-in-server-url.yaml
+++ b/hscontrol/types/testdata/base-domain-in-server-url.yaml
@@ -13,4 +13,3 @@ server_url: "https://server.derp.no"
 dns:
   magic_dns: true
   base_domain: derp.no
-  use_username_in_magic_dns: false

--- a/hscontrol/types/testdata/base-domain-not-in-server-url.yaml
+++ b/hscontrol/types/testdata/base-domain-not-in-server-url.yaml
@@ -13,4 +13,3 @@ server_url: "https://derp.no"
 dns:
   magic_dns: true
   base_domain: clients.derp.no
-  use_username_in_magic_dns: false

--- a/hscontrol/types/testdata/dns_full.yaml
+++ b/hscontrol/types/testdata/dns_full.yaml
@@ -33,5 +33,3 @@ dns:
 
     # you can also put it in one line
     - { name: "prometheus.myvpn.example.com", type: "A", value: "100.64.0.4" }
-
-  use_username_in_magic_dns: true

--- a/hscontrol/types/testdata/dns_full_no_magic.yaml
+++ b/hscontrol/types/testdata/dns_full_no_magic.yaml
@@ -33,5 +33,3 @@ dns:
 
     # you can also put it in one line
     - { name: "prometheus.myvpn.example.com", type: "A", value: "100.64.0.4" }
-
-  use_username_in_magic_dns: true


### PR DESCRIPTION
Upgrade the use of `dns.use_username_in_magic_dns` or `dns_config.use_username_in_magic_dns` to a fatal error and remove the option from the example configuration and integration tests.

Fixes: #2219

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md