### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/cmd/headscale/cli/mockoidc.go
+++ b/cmd/headscale/cli/mockoidc.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -68,7 +69,7 @@ func mockOIDC() error {
 
 	userStr := os.Getenv("MOCKOIDC_USERS")
 	if userStr == "" {
-		return fmt.Errorf("MOCKOIDC_USERS not defined")
+		return errors.New("MOCKOIDC_USERS not defined")
 	}
 
 	var users []mockoidc.MockUser


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters