### PR TITLE
Correct macOS GUI connect guide because there's no ALT key on a mac

### DIFF
--- a/docs/usage/connect/apple.md
+++ b/docs/usage/connect/apple.md
@@ -43,7 +43,7 @@ tailscale login --login-server <YOUR_HEADSCALE_URL>
 
 #### GUI
 
-- ALT + Click the Tailscale icon in the menu and hover over the Debug menu
+- Option + Click the Tailscale icon in the menu and hover over the Debug menu
 - Under `Custom Login Server`, select `Add Account...`
 - Enter the URL of your headscale instance (e.g `https://headscale.example.com`) and press `Add Account`
 - Follow the login procedure in the browser

--- a/hscontrol/templates/apple.go
+++ b/hscontrol/templates/apple.go
@@ -93,7 +93,7 @@ func Apple(url string) *elem.Element {
 				elem.Li(
 					nil,
 					elem.Text(
-						"ALT + Click the Tailscale icon in the menu and hover over the Debug menu",
+						"Option + Click the Tailscale icon in the menu and hover over the Debug menu",
 					),
 				),
 				elem.Li(nil,


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [ ] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
