### PR TITLE
feat: Create headscale user and group as system user/groups

### DIFF
--- a/docs/packaging/postinstall.sh
+++ b/docs/packaging/postinstall.sh
@@ -31,13 +31,13 @@ ensure_headscale_path() {
 
 create_headscale_user() {
 	printf "PostInstall: Adding headscale user %s\n" "$HEADSCALE_USER"
-	useradd -s "$HEADSCALE_SHELL" -d "$HEADSCALE_HOME_DIR" -c "headscale default user" "$HEADSCALE_USER"
+	useradd -r -s "$HEADSCALE_SHELL" -d "$HEADSCALE_HOME_DIR" -c "headscale default user" "$HEADSCALE_USER"
 }
 
 create_headscale_group() {
 	if command -V systemctl >/dev/null 2>&1; then
 		printf "PostInstall: Adding headscale group %s\n" "$HEADSCALE_GROUP"
-		groupadd "$HEADSCALE_GROUP"
+		groupadd -r "$HEADSCALE_GROUP"
 
 		printf "PostInstall: Adding headscale user %s to group %s\n" "$HEADSCALE_USER" "$HEADSCALE_GROUP"
 		usermod -a -G "$HEADSCALE_GROUP" "$HEADSCALE_USER"
@@ -45,7 +45,7 @@ create_headscale_group() {
 
 	if [ "$ID" = "alpine" ]; then
 		printf "PostInstall: Adding headscale group %s\n" "$HEADSCALE_GROUP"
-		addgroup "$HEADSCALE_GROUP"
+		addgroup -S "$HEADSCALE_GROUP"
 
 		printf "PostInstall: Adding headscale user %s to group %s\n" "$HEADSCALE_USER" "$HEADSCALE_GROUP"
 		addgroup "$HEADSCALE_USER" "$HEADSCALE_GROUP"


### PR DESCRIPTION
When creating the headscale user and group, create both as system groups rather than creating them as 'user' groups.

FIXES #2278

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
