### PR TITLE
Split MagicDNS base domain and org domain

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -12,6 +12,10 @@
 #
 server_url: http://127.0.0.1:8080
 
+# Tailnet organization base domain
+# Used to differentiate multiple tailnets in GUIs.
+base_domain: example.com
+
 # Address to listen to / bind to on the server
 #
 # For production:

--- a/hscontrol/mapper/tail.go
+++ b/hscontrol/mapper/tail.go
@@ -76,7 +76,7 @@ func tailNode(
 		keyExpiry = time.Time{}
 	}
 
-	hostname, err := node.GetFQDN(cfg.BaseDomain)
+	hostname, err := node.GetFQDN(cfg.DNSConfig.BaseDomain)
 	if err != nil {
 		return nil, fmt.Errorf("tailNode, failed to create FQDN: %s", err)
 	}

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -62,9 +62,12 @@ type Config struct {
 	PrefixV6                       *netip.Prefix
 	IPAllocation                   IPAllocationStrategy
 	NoisePrivateKeyPath            string
-	BaseDomain                     string
-	Log                            LogConfig
-	DisableUpdateCheck             bool
+	// This is the organization base domain and used to differentiate between tailnets in GUIs.
+	// Tailscale calls this Organization Name in their dashboard.
+	// This is not used for DNS resolution.
+	BaseDomain         string
+	Log                LogConfig
+	DisableUpdateCheck bool
 
 	Database DatabaseConfig
 
@@ -884,6 +887,12 @@ func LoadServerConfig() (*Config, error) {
 		}
 	}
 
+	orgBaseDomain := viper.GetString("base_domain")
+	// Fallback to the dns base domain if no base_domain is configured
+	if orgBaseDomain == "" {
+		orgBaseDomain = dnsConfig.BaseDomain
+	}
+
 	return &Config{
 		ServerURL:          serverURL,
 		Addr:               viper.GetString("listen_addr"),
@@ -899,7 +908,7 @@ func LoadServerConfig() (*Config, error) {
 		NoisePrivateKeyPath: util.AbsolutePathFromConfigPath(
 			viper.GetString("noise.private_key_path"),
 		),
-		BaseDomain: dnsConfig.BaseDomain,
+		BaseDomain: orgBaseDomain,
 
 		DERP: derpConfig,
 


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

This fixes #2318 by making cfg.BaseDomain configurable in the config and using cfg.DNSConfig.BaseDomain for creating fqdns.
A fallback is implemented for backwards support.

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
