### PR TITLE
Headscale implements a single tailnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ organisation.
 
 ## Design goal
 
-Headscale aims to implement a self-hosted, open source alternative to the Tailscale
-control server.
-Headscale's goal is to provide self-hosters and hobbyists with an open-source
-server they can use for their projects and labs.
-It implements a narrow scope, a single Tailnet, suitable for a personal use, or a small
-open-source organisation.
+Headscale aims to implement a self-hosted, open source alternative to the
+[Tailscale](https://tailscale.com/) control server. Headscale's goal is to
+provide self-hosters and hobbyists with an open-source server they can use for
+their projects and labs. It implements a narrow scope, a _single_ Tailscale
+network (tailnet), suitable for a personal use, or a small open-source
+organisation.
 
 ## Supporting Headscale
 

--- a/docs/about/faq.md
+++ b/docs/about/faq.md
@@ -2,12 +2,12 @@
 
 ## What is the design goal of headscale?
 
-Headscale aims to implement a self-hosted, open source alternative to the [Tailscale](https://tailscale.com/)
-control server.
-Headscale's goal is to provide self-hosters and hobbyists with an open-source
-server they can use for their projects and labs.
-It implements a narrow scope, a _single_ Tailnet, suitable for a personal use, or a small
-open-source organisation.
+Headscale aims to implement a self-hosted, open source alternative to the
+[Tailscale](https://tailscale.com/) control server. Headscale's goal is to
+provide self-hosters and hobbyists with an open-source server they can use for
+their projects and labs. It implements a narrow scope, a _single_ Tailscale
+network (tailnet), suitable for a personal use, or a small open-source
+organisation.
 
 ## How can I contribute?
 

--- a/docs/about/features.md
+++ b/docs/about/features.md
@@ -25,7 +25,7 @@ provides on overview of headscale's feature and compatibility with the Tailscale
     - [ ] `autogroup:member`
 * [ ] Node registration using Single-Sign-On (OpenID Connect) ([GitHub label "OIDC"](https://github.com/juanfont/headscale/labels/OIDC))
     - [x] Basic registration
-    - [ ] Update user profile from identity provider
+    - [x] Update user profile from identity provider
     - [ ] Dynamic ACL support
     - [ ] OIDC groups cannot be used in ACLs
 - [ ] [Funnel](https://tailscale.com/kb/1223/funnel) ([#1040](https://github.com/juanfont/headscale/issues/1040))

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,12 +14,12 @@ Join our [Discord server](https://discord.gg/c84AZQhmpx) for a chat and communit
 
 ## Design goal
 
-Headscale aims to implement a self-hosted, open source alternative to the Tailscale
-control server.
-Headscale's goal is to provide self-hosters and hobbyists with an open-source
-server they can use for their projects and labs.
-It implements a narrower scope, a single Tailnet, suitable for a personal use, or a small
-open-source organisation.
+Headscale aims to implement a self-hosted, open source alternative to the
+[Tailscale](https://tailscale.com/) control server. Headscale's goal is to
+provide self-hosters and hobbyists with an open-source server they can use for
+their projects and labs. It implements a narrow scope, a _single_ Tailscale
+network (tailnet), suitable for a personal use, or a small open-source
+organisation.
 
 ## Supporting headscale
 

--- a/docs/setup/install/community.md
+++ b/docs/setup/install/community.md
@@ -4,7 +4,7 @@ Several Linux distributions and community members provide packages for headscale
 the [official releases](./official.md) provided by the headscale maintainers. Such packages offer improved integration
 for their targeted operating system and usually:
 
-- setup a dedicated user account to run headscale
+- setup a dedicated local user account to run headscale
 - provide a default configuration
 - install headscale as system service
 

--- a/docs/setup/install/container.md
+++ b/docs/setup/install/container.md
@@ -89,7 +89,7 @@ not work with alternatives like [Podman](https://podman.io). The Docker image ca
     curl http://127.0.0.1:9090/metrics
     ```
 
-1.  Create a user ([tailnet](https://tailscale.com/kb/1136/tailnet/)):
+1.  Create a headscale user:
 
     ```shell
     docker exec -it headscale \

--- a/docs/setup/install/official.md
+++ b/docs/setup/install/official.md
@@ -6,8 +6,8 @@ Both are available on the [GitHub releases page](https://github.com/juanfont/hea
 ## Using packages for Debian/Ubuntu (recommended)
 
 It is recommended to use our DEB packages to install headscale on a Debian based system as those packages configure a
-user to run headscale, provide a default configuration and ship with a systemd service file. Supported distributions are
-Ubuntu 20.04 or newer, Debian 11 or newer.
+local user to run headscale, provide a default configuration and ship with a systemd service file. Supported
+distributions are Ubuntu 20.04 or newer, Debian 11 or newer.
 
 1.  Download the [latest headscale package](https://github.com/juanfont/headscale/releases/latest) for your platform (`.deb` for Ubuntu and Debian).
 
@@ -46,13 +46,13 @@ Ubuntu 20.04 or newer, Debian 11 or newer.
 
 !!! warning "Advanced"
 
-    This installation method is considered advanced as one needs to take care of the headscale user and the systemd
+    This installation method is considered advanced as one needs to take care of the local user and the systemd
     service themselves. If possible, use the [DEB packages](#using-packages-for-debianubuntu-recommended) or a
     [community package](./community.md) instead.
 
 This section describes the installation of headscale according to the [Requirements and
-assumptions](../requirements.md#assumptions). Headscale is run by a dedicated user and the service itself is managed by
-systemd.
+assumptions](../requirements.md#assumptions). Headscale is run by a dedicated local user and the service itself is
+managed by systemd.
 
 1.  Download the latest [`headscale` binary from GitHub's release page](https://github.com/juanfont/headscale/releases):
 
@@ -67,7 +67,7 @@ systemd.
     sudo chmod +x /usr/local/bin/headscale
     ```
 
-1.  Add a dedicated user to run headscale:
+1.  Add a dedicated local user to run headscale:
 
     ```shell
     sudo useradd \

--- a/docs/setup/requirements.md
+++ b/docs/setup/requirements.md
@@ -6,14 +6,14 @@ Headscale should just work as long as the following requirements are met:
   recommended.
 - Headscale is served via HTTPS on port 443[^1].
 - A reasonably modern Linux or BSD based operating system.
-- A dedicated user account to run headscale.
+- A dedicated local user account to run headscale.
 - A little bit of command line knowledge to configure and operate headscale.
 
 ## Assumptions
 
 The headscale documentation and the provided examples are written with a few assumptions in mind:
 
-- Headscale is running as system service via a dedicated user `headscale`.
+- Headscale is running as system service via a dedicated local user `headscale`.
 - The [configuration](../ref/configuration.md) is loaded from `/etc/headscale/config.yaml`.
 - SQLite is used as database.
 - The data directory for headscale (used for private keys, ACLs, SQLite database, …) is located in `/var/lib/headscale`.

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -41,13 +41,14 @@ options, run:
       headscale <COMMAND> --help
     ```
 
-## Manage users
+## Manage headscale users
 
-In headscale, a node (also known as machine or device) is always assigned to a specific user, a
-[tailnet](https://tailscale.com/kb/1136/tailnet/). Such users can be managed with the `headscale users` command. Invoke
-the built-in help for more information: `headscale users --help`.
+In headscale, a node (also known as machine or device) is always assigned to a
+headscale user. Such a headscale user may have many nodes assigned to them and
+can be managed with the `headscale users` command. Invoke the built-in help for
+more information: `headscale users --help`.
 
-### Create a user
+### Create a headscale user
 
 === "Native"
 
@@ -62,7 +63,7 @@ the built-in help for more information: `headscale users --help`.
       headscale users create <USER>
     ```
 
-### List existing users
+### List existing headscale users
 
 === "Native"
 


### PR DESCRIPTION
Separate the term "tailnet" from user and be more explicit about providing a single tailnet.

Also be more explicit about users. Refer to "headscale users" when mentioning commandline invocations and use the term "local users" when discussing unix accounts.

Fixes: #2335

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
