### PR TITLE
Spell check and updating docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,7 +366,7 @@ part of adopting [#1460](https://github.com/juanfont/headscale/pull/1460).
   [#1391](https://github.com/juanfont/headscale/pull/1391)
 - Improvements on Noise implementation
   [#1379](https://github.com/juanfont/headscale/pull/1379)
-- Replace node filter logic, ensuring nodes with access can see eachother
+- Replace node filter logic, ensuring nodes with access can see each other
   [#1381](https://github.com/juanfont/headscale/pull/1381)
 - Disable (or delete) both exit routes at the same time
   [#1428](https://github.com/juanfont/headscale/pull/1428)

--- a/docs/about/clients.md
+++ b/docs/about/clients.md
@@ -10,7 +10,7 @@ headscale.
 | OpenBSD | Yes                                                                                                   |
 | FreeBSD | Yes                                                                                                   |
 | Windows | Yes (see [docs](../usage/connect/windows.md) and `/windows` on your headscale for more information)   |
-| Android | Yes (see [docs](../usage/connect/android.md))                                                         |
+| Android | Yes (see [docs](../usage/connect/android.md) and `/android` on your headscale for more information)   |
 | macOS   | Yes (see [docs](../usage/connect/apple.md#macos) and `/apple` on your headscale for more information) |
 | iOS     | Yes (see [docs](../usage/connect/apple.md#ios) and `/apple` on your headscale for more information)   |
 | tvOS    | Yes (see [docs](../usage/connect/apple.md#tvos) and `/apple` on your headscale for more information)  |

--- a/docs/about/clients.md
+++ b/docs/about/clients.md
@@ -10,7 +10,7 @@ headscale.
 | OpenBSD | Yes                                                                                                   |
 | FreeBSD | Yes                                                                                                   |
 | Windows | Yes (see [docs](../usage/connect/windows.md) and `/windows` on your headscale for more information)   |
-| Android | Yes (see [docs](../usage/connect/android.md) and `/android` on your headscale for more information)   |
+| Android | Yes (see [docs](../usage/connect/android.md) for more information)                                    |
 | macOS   | Yes (see [docs](../usage/connect/apple.md#macos) and `/apple` on your headscale for more information) |
 | iOS     | Yes (see [docs](../usage/connect/apple.md#ios) and `/apple` on your headscale for more information)   |
 | tvOS    | Yes (see [docs](../usage/connect/apple.md#tvos) and `/apple` on your headscale for more information)  |

--- a/hscontrol/db/db.go
+++ b/hscontrol/db/db.go
@@ -103,7 +103,7 @@ func NewHeadscaleDatabase(
 
 					dbConn.Model(&types.Node{}).Where("auth_key_id = ?", 0).Update("auth_key_id", nil)
 					// If the Node table has a column for registered,
-					// find all occourences of "false" and drop them. Then
+					// find all occurrences of "false" and drop them. Then
 					// remove the column.
 					if tx.Migrator().HasColumn(&types.Node{}, "registered") {
 						log.Info().
@@ -641,7 +641,7 @@ func openDB(cfg types.DatabaseConfig) (*gorm.DB, error) {
 		}
 
 		// The pure Go SQLite library does not handle locking in
-		// the same way as the C based one and we cant use the gorm
+		// the same way as the C based one and we can't use the gorm
 		// connection pool as of 2022/02/23.
 		sqlDB, _ := db.DB()
 		sqlDB.SetMaxIdleConns(1)
@@ -704,7 +704,7 @@ func openDB(cfg types.DatabaseConfig) (*gorm.DB, error) {
 }
 
 func runMigrations(cfg types.DatabaseConfig, dbConn *gorm.DB, migrations *gormigrate.Gormigrate) error {
-	// Turn off foreign keys for the duration of the migration if using sqllite to
+	// Turn off foreign keys for the duration of the migration if using sqlite to
 	// prevent data loss due to the way the GORM migrator handles certain schema
 	// changes.
 	if cfg.Type == types.DatabaseSqlite {

--- a/hscontrol/notifier/notifier.go
+++ b/hscontrol/notifier/notifier.go
@@ -153,7 +153,7 @@ func (n *Notifier) IsConnected(nodeID types.NodeID) bool {
 }
 
 // IsLikelyConnected reports if a node is connected to headscale and has a
-// poll session open, but doesnt lock, so might be wrong.
+// poll session open, but doesn't lock, so might be wrong.
 func (n *Notifier) IsLikelyConnected(nodeID types.NodeID) bool {
 	if val, ok := n.connected.Load(nodeID); ok {
 		return val

--- a/hscontrol/notifier/notifier_test.go
+++ b/hscontrol/notifier/notifier_test.go
@@ -223,7 +223,7 @@ func TestBatcher(t *testing.T) {
 					// so do not run the worker.
 					BatchChangeDelay: time.Hour,
 
-					// Since we do not load the config, we wont get the
+					// Since we do not load the config, we won't get the
 					// default, so set it manually so we dont time out
 					// and have flakes.
 					NotifierSendTimeout: time.Second,

--- a/hscontrol/policy/acls.go
+++ b/hscontrol/policy/acls.go
@@ -61,7 +61,7 @@ func theInternet() *netipx.IPSet {
 	internetBuilder.RemovePrefix(tsaddr.TailscaleULARange())
 	internetBuilder.RemovePrefix(tsaddr.CGNATRange())
 
-	// Delete "cant find DHCP networks"
+	// Delete "can't find DHCP networks"
 	internetBuilder.RemovePrefix(netip.MustParsePrefix("fe80::/10")) // link-local
 	internetBuilder.RemovePrefix(netip.MustParsePrefix("169.254.0.0/16"))
 
@@ -251,7 +251,7 @@ func ReduceFilterRules(node *types.Node, rules []tailcfg.FilterRule) []tailcfg.F
 	DEST_LOOP:
 		for _, dest := range rule.DstPorts {
 			expanded, err := util.ParseIPSet(dest.IP, nil)
-			// Fail closed, if we cant parse it, then we should not allow
+			// Fail closed, if we can't parse it, then we should not allow
 			// access.
 			if err != nil {
 				continue DEST_LOOP
@@ -934,7 +934,7 @@ func (pol *ACLPolicy) expandIPsFromIPPrefix(
 	build.AddPrefix(prefix)
 
 	// This is suboptimal and quite expensive, but if we only add the prefix, we will miss all the relevant IPv6
-	// addresses for the hosts that belong to tailscale. This doesnt really affect stuff like subnet routers.
+	// addresses for the hosts that belong to tailscale. This doesn't really affect stuff like subnet routers.
 	for _, node := range nodes {
 		for _, ip := range node.IPs() {
 			// log.Trace().
@@ -1066,7 +1066,7 @@ func findUserFromTokenOrErr(
 	for _, user := range users {
 		if user.ProviderIdentifier.Valid && user.ProviderIdentifier.String == token {
 			// If a user is matching with a known unique field,
-			// disgard all other users and only keep the current
+			// discard all other users and only keep the current
 			// user.
 			potentialUsers = []types.User{user}
 

--- a/hscontrol/poll.go
+++ b/hscontrol/poll.go
@@ -156,7 +156,7 @@ func (m *mapSession) serve() {
 	// current configuration.
 	//
 	// If OmitPeers is true, Stream is false, and ReadOnly is false,
-	// then te server will let clients update their endpoints without
+	// then the server will let clients update their endpoints without
 	// breaking existing long-polling (Stream == true) connections.
 	// In this case, the server can omit the entire response; the client
 	// only checks the HTTP response status code.
@@ -691,7 +691,7 @@ func hostInfoChanged(old, new *tailcfg.Hostinfo) (bool, bool) {
 	}
 
 	// Services is mostly useful for discovery and not critical,
-	// except for peerapi, which is how nodes talk to eachother.
+	// except for peerapi, which is how nodes talk to each other.
 	// If peerapi was not part of the initial mapresponse, we
 	// need to make sure its sent out later as it is needed for
 	// Taildrop.

--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -105,7 +105,7 @@ func (node *Node) GivenNameHasBeenChanged() bool {
 // IsExpired returns whether the node registration has expired.
 func (node Node) IsExpired() bool {
 	// If Expiry is not set, the client has not indicated that
-	// it wants an expiry time, it is therefor considered
+	// it wants an expiry time, it is therefore considered
 	// to mean "not expired"
 	if node.Expiry == nil || node.Expiry.IsZero() {
 		return false
@@ -180,7 +180,7 @@ func (node *Node) CanAccess(filter []tailcfg.FilterRule, node2 *Node) bool {
 	src := node.IPs()
 	allowedIPs := node2.IPs()
 
-	// TODO(kradalby): Regenerate this everytime the filter change, instead of
+	// TODO(kradalby): Regenerate this every time the filter change, instead of
 	// every time we use it.
 	matchers := make([]matcher.Match, len(filter))
 	for i, rule := range filter {

--- a/hscontrol/util/dns.go
+++ b/hscontrol/util/dns.go
@@ -81,7 +81,7 @@ func CheckForFQDNRules(name string) error {
 	}
 	if invalidDNSRegex.MatchString(name) {
 		return fmt.Errorf(
-			"DNS segment should only be composed of lowercase ASCII letters numbers, hyphen and dots. %v doesn't comply with theses rules: %w",
+			"DNS segment should only be composed of lowercase ASCII letters numbers, hyphen and dots. %v doesn't comply with these rules: %w",
 			name,
 			ErrInvalidUserName,
 		)

--- a/integration/acl_test.go
+++ b/integration/acl_test.go
@@ -124,7 +124,7 @@ func TestACLHostsInNetMapTable(t *testing.T) {
 			},
 		},
 		// Test that when we have two users, which cannot see
-		// eachother, each node has only the number of pairs from
+		// each other, each node has only the number of pairs from
 		// their own user.
 		"two-isolated-users": {
 			users: map[string]int{

--- a/integration/auth_oidc_test.go
+++ b/integration/auth_oidc_test.go
@@ -230,7 +230,7 @@ func TestOIDCExpireNodesBasedOnTokenExpiry(t *testing.T) {
 
 	// This is not great, but this sadly is a time dependent test, so the
 	// safe thing to do is wait out the whole TTL time before checking if
-	// the clients have logged out. The Wait function cant do it itself
+	// the clients have logged out. The Wait function can't do it itself
 	// as it has an upper bound of 1 min.
 	time.Sleep(shortAccessTTL)
 

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -1840,7 +1840,7 @@ func TestPolicyBrokenConfigCommand(t *testing.T) {
 			{
 				// This is an unknown action, so it will return an error
 				// and the config will not be applied.
-				Action:       "acccept",
+				Action:       "accept",
 				Sources:      []string{"*"},
 				Destinations: []string{"*:*"},
 			},

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -1840,7 +1840,7 @@ func TestPolicyBrokenConfigCommand(t *testing.T) {
 			{
 				// This is an unknown action, so it will return an error
 				// and the config will not be applied.
-				Action:       "accept",
+				Action:       "unknown-action",
 				Sources:      []string{"*"},
 				Destinations: []string{"*:*"},
 			},

--- a/integration/dns_test.go
+++ b/integration/dns_test.go
@@ -349,7 +349,7 @@ func TestValidateResolvConf(t *testing.T) {
 				"HEADSCALE_DNS_BASE_DOMAIN":        "all-of.it",
 				"HEADSCALE_DNS_NAMESERVERS_GLOBAL": `8.8.8.8`,
 				"HEADSCALE_DNS_SEARCH_DOMAINS":     "test1.no test2.no",
-				// TODO(kradalby): this currently isnt working, need to fix it
+				// TODO(kradalby): this currently isn't working, need to fix it
 				// "HEADSCALE_DNS_NAMESERVERS_SPLIT": `{foo.bar.com: ["1.1.1.1"]}`,
 				// "HEADSCALE_DNS_EXTRA_RECORDS":     `[{ name: "prometheus.myvpn.example.com", type: "A", value: "100.64.0.4" }]`,
 			},

--- a/integration/dockertestutil/network.go
+++ b/integration/dockertestutil/network.go
@@ -50,7 +50,7 @@ func AddContainerToNetwork(
 		return err
 	}
 
-	// TODO(kradalby): This doesnt work reliably, but calling the exact same functions
+	// TODO(kradalby): This doesn't work reliably, but calling the exact same functions
 	// seem to work fine...
 	// if container, ok := pool.ContainerByName("/" + testContainer); ok {
 	// 	err := container.ConnectToNetwork(network)

--- a/integration/dsic/dsic.go
+++ b/integration/dsic/dsic.go
@@ -163,8 +163,8 @@ func New(
 		runOptions.WorkingDir = dsic.workdir
 	}
 
-	// dockertest isnt very good at handling containers that has already
-	// been created, this is an attempt to make sure this container isnt
+	// dockertest isn't very good at handling containers that has already
+	// been created, this is an attempt to make sure this container isn't
 	// present.
 	err = pool.RemoveContainerByName(hostname)
 	if err != nil {

--- a/integration/hsic/config.go
+++ b/integration/hsic/config.go
@@ -33,7 +33,7 @@ func DefaultConfigEnv() map[string]string {
 		"HEADSCALE_DERP_AUTO_UPDATE_ENABLED":          "false",
 		"HEADSCALE_DERP_UPDATE_FREQUENCY":             "1m",
 
-		// a bunch of tests (ACL/Policy) rely on predicable IP alloc,
+		// a bunch of tests (ACL/Policy) rely on predictable IP alloc,
 		// so ensure the sequential alloc is used by default.
 		"HEADSCALE_PREFIXES_ALLOCATION": string(types.IPAllocationStrategySequential),
 	}

--- a/integration/hsic/hsic.go
+++ b/integration/hsic/hsic.go
@@ -381,8 +381,8 @@ func New(
 		}
 	}
 
-	// dockertest isnt very good at handling containers that has already
-	// been created, this is an attempt to make sure this container isnt
+	// dockertest isn't very good at handling containers that has already
+	// been created, this is an attempt to make sure this container isn't
 	// present.
 	err = pool.RemoveContainerByName(hsic.hostname)
 	if err != nil {

--- a/integration/ssh_test.go
+++ b/integration/ssh_test.go
@@ -31,7 +31,7 @@ var retry = func(times int, sleepInterval time.Duration,
 		}
 
 		// If we get a permission denied error, we can fail immediately
-		// since that is something we wont recover from by retrying.
+		// since that is something we won't recover from by retrying.
 		if err != nil && strings.Contains(stderr, "Permission denied (tailscale)") {
 			return result, stderr, err
 		}

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -263,8 +263,8 @@ func New(
 		tailscaleOptions.WorkingDir = tsic.workdir
 	}
 
-	// dockertest isnt very good at handling containers that has already
-	// been created, this is an attempt to make sure this container isnt
+	// dockertest isn't very good at handling containers that has already
+	// been created, this is an attempt to make sure this container isn't
 	// present.
 	err = pool.RemoveContainerByName(hostname)
 	if err != nil {

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -264,7 +264,7 @@ func assertValidStatus(t *testing.T, client TailscaleClient) {
 
 	assert.Truef(t, status.Self.InNetworkMap, "%q is not in network map", client.Hostname())
 
-	// This isnt really relevant for Self as it wont be in its own socket/wireguard.
+	// This isn't really relevant for Self as it won't be in its own socket/wireguard.
 	// assert.Truef(t, status.Self.InMagicSock, "%q is not tracked by magicsock", client.Hostname())
 	// assert.Truef(t, status.Self.InEngine, "%q is not in in wireguard engine", client.Hostname())
 


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [ ] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [~] added integration tests
- [X] updated documentation if needed
- [X] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

I noticed a slight inconsistency in the public docs (the `/windows` and `/apple` pages were referenced but not `/android`) and I figured while I was making this PR that I might as well do a quick spell check across the codebase. Most everything was updating spelling in comments. 

There is one actual code change in an integration test (`/integration/cli_test.go`) that had a string that had a typo in it. That is probably the only thing that could use a pair of eyes from an actual codebase developer to make sure that doesn't break anything. 

Thanks!