### PR TITLE
Remove routes without a node_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 - Fix issue where email and username being equal fails to match in Policy
   [#2388](https://github.com/juanfont/headscale/pull/2388)
+- Delete invalid routes before adding a NOT NULL constraint on node_id
+  [#2386](https://github.com/juanfont/headscale/pull/2386)
 
 ## 0.24.1 (2025-01-23)
 

--- a/hscontrol/db/db.go
+++ b/hscontrol/db/db.go
@@ -565,6 +565,14 @@ COMMIT;
 						}
 					}
 
+					// Remove any invalid routes without a node_id.
+					if tx.Migrator().HasTable(&types.Route{}) {
+						err := tx.Exec("delete from routes where node_id is null").Error
+						if err != nil {
+							return err
+						}
+					}
+
 					err := tx.AutoMigrate(&types.Route{})
 					if err != nil {
 						return err


### PR DESCRIPTION
The routes table has a NOT NULL constraint on node_id.

Fixes: #2376

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
