### PR TITLE
do not allow preauth keys to be deleted if assigned to node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   [#2350](https://github.com/juanfont/headscale/pull/2350)
 - Print Tailscale version instead of capability versions for outdated nodes
   [#2391](https://github.com/juanfont/headscale/pull/2391)
+- Pre auth keys belonging to a user are no longer deleted with the user
+  [#2396](https://github.com/juanfont/headscale/pull/2396)
+- Pre auth keys that are used by a node can no longer be deleted
+  [#2396](https://github.com/juanfont/headscale/pull/2396)
 
 ## 0.24.2 (2025-01-30)
 

--- a/hscontrol/db/db.go
+++ b/hscontrol/db/db.go
@@ -582,6 +582,24 @@ COMMIT;
 				},
 				Rollback: func(db *gorm.DB) error { return nil },
 			},
+			// Add back constraint so you cannot delete preauth keys that
+			// is still used by a node.
+			{
+				ID: "202501311657",
+				Migrate: func(tx *gorm.DB) error {
+					err := tx.AutoMigrate(&types.PreAuthKey{})
+					if err != nil {
+						return err
+					}
+					err = tx.AutoMigrate(&types.Node{})
+					if err != nil {
+						return err
+					}
+
+					return nil
+				},
+				Rollback: func(db *gorm.DB) error { return nil },
+			},
 		},
 	)
 

--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -77,9 +77,12 @@ type Node struct {
 
 	ForcedTags []string `gorm:"serializer:json"`
 
-	// TODO(kradalby): This seems like irrelevant information?
-	AuthKeyID *uint64     `sql:"DEFAULT:NULL"`
-	AuthKey   *PreAuthKey `gorm:"constraint:OnDelete:SET NULL;"`
+	// When a node has been created with a PreAuthKey, we need to
+	// prevent the preauthkey from being deleted before the node.
+	// The preauthkey can define "tags" of the node so we need it
+	// around.
+	AuthKeyID *uint64 `sql:"DEFAULT:NULL"`
+	AuthKey   *PreAuthKey
 
 	LastSeen *time.Time
 	Expiry   *time.Time

--- a/hscontrol/types/preauth_key.go
+++ b/hscontrol/types/preauth_key.go
@@ -14,7 +14,7 @@ type PreAuthKey struct {
 	ID        uint64 `gorm:"primary_key"`
 	Key       string
 	UserID    uint
-	User      User `gorm:"constraint:OnDelete:CASCADE;"`
+	User      User `gorm:"constraint:OnDelete:SET NULL;"`
 	Reusable  bool
 	Ephemeral bool     `gorm:"default:false"`
 	Used      bool     `gorm:"default:false"`


### PR DESCRIPTION
we need to be able to look up the tags on the key, never delete, only expire if in use. There is no API for deleting, but never know if people edit the database.