### PR TITLE
Return better web errors to the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   [#2396](https://github.com/juanfont/headscale/pull/2396)
 - Pre auth keys that are used by a node can no longer be deleted
   [#2396](https://github.com/juanfont/headscale/pull/2396)
+- Rehaul HTTP errors, return better status code and errors to users
+  [#2398](https://github.com/juanfont/headscale/pull/2398)
 
 ## 0.24.2 (2025-01-30)
 

--- a/hscontrol/auth_test.go
+++ b/hscontrol/auth_test.go
@@ -1,0 +1,130 @@
+package hscontrol
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/juanfont/headscale/hscontrol/types"
+)
+
+func TestCanUsePreAuthKey(t *testing.T) {
+	now := time.Now()
+	past := now.Add(-time.Hour)
+	future := now.Add(time.Hour)
+
+	tests := []struct {
+		name    string
+		pak     *types.PreAuthKey
+		wantErr bool
+		err     HTTPError
+	}{
+		{
+			name: "valid reusable key",
+			pak: &types.PreAuthKey{
+				Reusable:   true,
+				Used:       false,
+				Expiration: &future,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid non-reusable key",
+			pak: &types.PreAuthKey{
+				Reusable:   false,
+				Used:       false,
+				Expiration: &future,
+			},
+			wantErr: false,
+		},
+		{
+			name: "expired key",
+			pak: &types.PreAuthKey{
+				Reusable:   false,
+				Used:       false,
+				Expiration: &past,
+			},
+			wantErr: true,
+			err:     NewHTTPError(http.StatusUnauthorized, "authkey expired", nil),
+		},
+		{
+			name: "used non-reusable key",
+			pak: &types.PreAuthKey{
+				Reusable:   false,
+				Used:       true,
+				Expiration: &future,
+			},
+			wantErr: true,
+			err:     NewHTTPError(http.StatusUnauthorized, "authkey already used", nil),
+		},
+		{
+			name: "used reusable key",
+			pak: &types.PreAuthKey{
+				Reusable:   true,
+				Used:       true,
+				Expiration: &future,
+			},
+			wantErr: false,
+		},
+		{
+			name: "no expiration date",
+			pak: &types.PreAuthKey{
+				Reusable:   false,
+				Used:       false,
+				Expiration: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "nil preauth key",
+			pak:     nil,
+			wantErr: true,
+			err:     NewHTTPError(http.StatusUnauthorized, "invalid authkey", nil),
+		},
+		{
+			name: "expired and used key",
+			pak: &types.PreAuthKey{
+				Reusable:   false,
+				Used:       true,
+				Expiration: &past,
+			},
+			wantErr: true,
+			err:     NewHTTPError(http.StatusUnauthorized, "authkey expired", nil),
+		},
+		{
+			name: "no expiration and used key",
+			pak: &types.PreAuthKey{
+				Reusable:   false,
+				Used:       true,
+				Expiration: nil,
+			},
+			wantErr: true,
+			err:     NewHTTPError(http.StatusUnauthorized, "authkey already used", nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := canUsePreAuthKey(tt.pak)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				} else {
+					httpErr, ok := err.(HTTPError)
+					if !ok {
+						t.Errorf("expected HTTPError but got %T", err)
+					} else {
+						if diff := cmp.Diff(tt.err, httpErr); diff != "" {
+							t.Errorf("unexpected error (-want +got):\n%s", diff)
+						}
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error but got %v", err)
+				}
+			}
+		})
+	}
+}

--- a/hscontrol/db/preauth_keys_test.go
+++ b/hscontrol/db/preauth_keys_test.go
@@ -3,14 +3,14 @@ package db
 import (
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/check.v1"
 	"tailscale.com/types/ptr"
+
+	"gopkg.in/check.v1"
 )
 
 func (*Suite) TestCreatePreAuthKey(c *check.C) {
@@ -41,123 +41,6 @@ func (*Suite) TestCreatePreAuthKey(c *check.C) {
 
 	// Make sure the User association is populated
 	c.Assert((keys)[0].User.ID, check.Equals, user.ID)
-}
-
-func (*Suite) TestExpiredPreAuthKey(c *check.C) {
-	user, err := db.CreateUser(types.User{Name: "test2"})
-	c.Assert(err, check.IsNil)
-
-	now := time.Now().Add(-5 * time.Second)
-	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), true, false, &now, nil)
-	c.Assert(err, check.IsNil)
-
-	key, err := db.ValidatePreAuthKey(pak.Key)
-	c.Assert(err, check.Equals, ErrPreAuthKeyExpired)
-	c.Assert(key, check.IsNil)
-}
-
-func (*Suite) TestPreAuthKeyDoesNotExist(c *check.C) {
-	key, err := db.ValidatePreAuthKey("potatoKey")
-	c.Assert(err, check.Equals, ErrPreAuthKeyNotFound)
-	c.Assert(key, check.IsNil)
-}
-
-func (*Suite) TestValidateKeyOk(c *check.C) {
-	user, err := db.CreateUser(types.User{Name: "test3"})
-	c.Assert(err, check.IsNil)
-
-	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), true, false, nil, nil)
-	c.Assert(err, check.IsNil)
-
-	key, err := db.ValidatePreAuthKey(pak.Key)
-	c.Assert(err, check.IsNil)
-	c.Assert(key.ID, check.Equals, pak.ID)
-}
-
-func (*Suite) TestAlreadyUsedKey(c *check.C) {
-	user, err := db.CreateUser(types.User{Name: "test4"})
-	c.Assert(err, check.IsNil)
-
-	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
-	c.Assert(err, check.IsNil)
-
-	node := types.Node{
-		ID:             0,
-		Hostname:       "testest",
-		UserID:         user.ID,
-		RegisterMethod: util.RegisterMethodAuthKey,
-		AuthKeyID:      ptr.To(pak.ID),
-	}
-	trx := db.DB.Save(&node)
-	c.Assert(trx.Error, check.IsNil)
-
-	key, err := db.ValidatePreAuthKey(pak.Key)
-	c.Assert(err, check.Equals, ErrSingleUseAuthKeyHasBeenUsed)
-	c.Assert(key, check.IsNil)
-}
-
-func (*Suite) TestReusableBeingUsedKey(c *check.C) {
-	user, err := db.CreateUser(types.User{Name: "test5"})
-	c.Assert(err, check.IsNil)
-
-	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), true, false, nil, nil)
-	c.Assert(err, check.IsNil)
-
-	node := types.Node{
-		ID:             1,
-		Hostname:       "testest",
-		UserID:         user.ID,
-		RegisterMethod: util.RegisterMethodAuthKey,
-		AuthKeyID:      ptr.To(pak.ID),
-	}
-	trx := db.DB.Save(&node)
-	c.Assert(trx.Error, check.IsNil)
-
-	key, err := db.ValidatePreAuthKey(pak.Key)
-	c.Assert(err, check.IsNil)
-	c.Assert(key.ID, check.Equals, pak.ID)
-}
-
-func (*Suite) TestNotReusableNotBeingUsedKey(c *check.C) {
-	user, err := db.CreateUser(types.User{Name: "test6"})
-	c.Assert(err, check.IsNil)
-
-	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
-	c.Assert(err, check.IsNil)
-
-	key, err := db.ValidatePreAuthKey(pak.Key)
-	c.Assert(err, check.IsNil)
-	c.Assert(key.ID, check.Equals, pak.ID)
-}
-
-func (*Suite) TestExpirePreauthKey(c *check.C) {
-	user, err := db.CreateUser(types.User{Name: "test3"})
-	c.Assert(err, check.IsNil)
-
-	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), true, false, nil, nil)
-	c.Assert(err, check.IsNil)
-	c.Assert(pak.Expiration, check.IsNil)
-
-	err = db.ExpirePreAuthKey(pak)
-	c.Assert(err, check.IsNil)
-	c.Assert(pak.Expiration, check.NotNil)
-
-	key, err := db.ValidatePreAuthKey(pak.Key)
-	c.Assert(err, check.Equals, ErrPreAuthKeyExpired)
-	c.Assert(key, check.IsNil)
-}
-
-func (*Suite) TestNotReusableMarkedAsUsed(c *check.C) {
-	user, err := db.CreateUser(types.User{Name: "test6"})
-	c.Assert(err, check.IsNil)
-
-	pak, err := db.CreatePreAuthKey(types.UserID(user.ID), false, false, nil, nil)
-	c.Assert(err, check.IsNil)
-	pak.Used = true
-	db.DB.Save(&pak)
-
-	_, err = db.ValidatePreAuthKey(pak.Key)
-	c.Assert(err, check.Equals, ErrSingleUseAuthKeyHasBeenUsed)
 }
 
 func (*Suite) TestPreAuthKeyACLTags(c *check.C) {

--- a/hscontrol/grpcv1.go
+++ b/hscontrol/grpcv1.go
@@ -181,9 +181,13 @@ func (api headscaleV1APIServer) ExpirePreAuthKey(
 	request *v1.ExpirePreAuthKeyRequest,
 ) (*v1.ExpirePreAuthKeyResponse, error) {
 	err := api.h.db.Write(func(tx *gorm.DB) error {
-		preAuthKey, err := db.GetPreAuthKey(tx, request.GetUser(), request.Key)
+		preAuthKey, err := db.GetPreAuthKey(tx, request.Key)
 		if err != nil {
 			return err
+		}
+
+		if preAuthKey.User.Name != request.GetUser() {
+			return fmt.Errorf("preauth key does not belong to user")
 		}
 
 		return db.ExpirePreAuthKey(tx, preAuthKey)

--- a/hscontrol/handlers.go
+++ b/hscontrol/handlers.go
@@ -33,10 +33,33 @@ const (
 )
 
 // httpError logs an error and sends an HTTP error response with the given
-func httpError(w http.ResponseWriter, err error, userError string, code int) {
-	log.Error().Err(err).Msg(userError)
-	http.Error(w, userError, code)
+func httpError(w http.ResponseWriter, err error) {
+	var herr HTTPError
+	if errors.As(err, &herr) {
+		http.Error(w, herr.Msg, herr.Code)
+		log.Error().Err(herr.Err).Int("code", herr.Code).Msgf("user msg: %s", herr.Msg)
+	} else {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		log.Error().Err(err).Int("code", http.StatusInternalServerError).Msg("http internal server error")
+	}
 }
+
+// HTTPError represents an error that is surfaced to the user via web.
+type HTTPError struct {
+	Code int    // HTTP response code to send to client; 0 means 500
+	Msg  string // Response body to send to client
+	Err  error  // Detailed error to log on the server
+}
+
+func (e HTTPError) Error() string { return fmt.Sprintf("http error[%d]: %s, %s", e.Code, e.Msg, e.Err) }
+func (e HTTPError) Unwrap() error { return e.Err }
+
+// Error returns an HTTPError containing the given information.
+func NewHTTPError(code int, msg string, err error) HTTPError {
+	return HTTPError{Code: code, Msg: msg, Err: err}
+}
+
+var errMethodNotAllowed = NewHTTPError(http.StatusMethodNotAllowed, "method not allowed", nil)
 
 var ErrRegisterMethodCLIDoesNotSupportExpire = errors.New(
 	"machines registered with CLI does not support expire",

--- a/hscontrol/platform_config.go
+++ b/hscontrol/platform_config.go
@@ -39,19 +39,19 @@ func (h *Headscale) ApplePlatformConfig(
 	vars := mux.Vars(req)
 	platform, ok := vars["platform"]
 	if !ok {
-		httpError(writer, nil, "No platform specified", http.StatusBadRequest)
+		httpError(writer, NewHTTPError(http.StatusBadRequest, "no platform specified", nil))
 		return
 	}
 
 	id, err := uuid.NewV4()
 	if err != nil {
-		httpError(writer, nil, "Failed to create UUID", http.StatusInternalServerError)
+		httpError(writer, err)
 		return
 	}
 
 	contentID, err := uuid.NewV4()
 	if err != nil {
-		httpError(writer, nil, "Failed to create UUID", http.StatusInternalServerError)
+		httpError(writer, err)
 		return
 	}
 
@@ -65,21 +65,21 @@ func (h *Headscale) ApplePlatformConfig(
 	switch platform {
 	case "macos-standalone":
 		if err := macosStandaloneTemplate.Execute(&payload, platformConfig); err != nil {
-			httpError(writer, err, "Could not render Apple macOS template", http.StatusInternalServerError)
+			httpError(writer, err)
 			return
 		}
 	case "macos-app-store":
 		if err := macosAppStoreTemplate.Execute(&payload, platformConfig); err != nil {
-			httpError(writer, err, "Could not render Apple macOS template", http.StatusInternalServerError)
+			httpError(writer, err)
 			return
 		}
 	case "ios":
 		if err := iosTemplate.Execute(&payload, platformConfig); err != nil {
-			httpError(writer, err, "Could not render Apple iOS template", http.StatusInternalServerError)
+			httpError(writer, err)
 			return
 		}
 	default:
-		httpError(writer, err, "Invalid platform. Only ios, macos-app-store and macos-standalone are supported", http.StatusInternalServerError)
+		httpError(writer, NewHTTPError(http.StatusBadRequest, "platform must be ios, macos-app-store or macos-standalone", nil))
 		return
 	}
 
@@ -91,7 +91,7 @@ func (h *Headscale) ApplePlatformConfig(
 
 	var content bytes.Buffer
 	if err := commonTemplate.Execute(&content, config); err != nil {
-		httpError(writer, err, "Could not render platform iOS template", http.StatusInternalServerError)
+		httpError(writer, err)
 		return
 	}
 


### PR DESCRIPTION
This PR continues the work of #2384 by classifying all the web errors and sending appropriate error codes, instead of just 500 for everything.

Depends on #2374 

Fixes #2390