### PR TITLE
handle register auth errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
   - View of config, policy, filter, ssh policy per node, connected nodes and
     DERPmap
 
+## 0.25.1 (2025-02-18)
+
+### Changes
+
+- Fix issue where registration errors are sent correctly
+  [#2435](https://github.com/juanfont/headscale/pull/2435)
+
 ## 0.25.0 (2025-02-11)
 
 ### BREAKING


### PR DESCRIPTION
This commit handles register auth errors as the
Tailscale clients expect. It returns the error as
part of a tailcfg.RegisterResponse and not as a
http error.

In addition it fixes a nil pointer panic triggered by not handling the errors as part of this chain.

Fixes #2434
