### PR TITLE
Multi network integration tests

### DIFF
--- a/.github/workflows/test-integration-policyv2.yaml
+++ b/.github/workflows/test-integration-policyv2.yaml
@@ -71,6 +71,7 @@ jobs:
           - TestSubnetRouteACL
           - TestEnablingExitRoutes
           - TestSubnetRouterMultiNetwork
+          - TestSubnetRouterMultiNetworkExitNode
           - TestHeadscale
           - TestTailscaleNodesJoiningHeadcale
           - TestSSHOneUserToAll

--- a/.github/workflows/test-integration-policyv2.yaml
+++ b/.github/workflows/test-integration-policyv2.yaml
@@ -70,6 +70,7 @@ jobs:
           - TestAutoApprovedSubRoute2068
           - TestSubnetRouteACL
           - TestEnablingExitRoutes
+          - TestSubnetRouterMultiNetwork
           - TestHeadscale
           - TestTailscaleNodesJoiningHeadcale
           - TestSSHOneUserToAll

--- a/.github/workflows/test-integration-policyv2.yaml
+++ b/.github/workflows/test-integration-policyv2.yaml
@@ -71,7 +71,6 @@ jobs:
           - TestSubnetRouteACL
           - TestEnablingExitRoutes
           - TestHeadscale
-          - TestCreateTailscale
           - TestTailscaleNodesJoiningHeadcale
           - TestSSHOneUserToAll
           - TestSSHMultipleUsersAllToAll

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -71,6 +71,7 @@ jobs:
           - TestSubnetRouteACL
           - TestEnablingExitRoutes
           - TestSubnetRouterMultiNetwork
+          - TestSubnetRouterMultiNetworkExitNode
           - TestHeadscale
           - TestTailscaleNodesJoiningHeadcale
           - TestSSHOneUserToAll

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -70,6 +70,7 @@ jobs:
           - TestAutoApprovedSubRoute2068
           - TestSubnetRouteACL
           - TestEnablingExitRoutes
+          - TestSubnetRouterMultiNetwork
           - TestHeadscale
           - TestTailscaleNodesJoiningHeadcale
           - TestSSHOneUserToAll

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -71,7 +71,6 @@ jobs:
           - TestSubnetRouteACL
           - TestEnablingExitRoutes
           - TestHeadscale
-          - TestCreateTailscale
           - TestTailscaleNodesJoiningHeadcale
           - TestSSHOneUserToAll
           - TestSSHMultipleUsersAllToAll

--- a/hscontrol/mapper/mapper_test.go
+++ b/hscontrol/mapper/mapper_test.go
@@ -165,9 +165,10 @@ func Test_fullMapResponse(t *testing.T) {
 		),
 		Addresses: []netip.Prefix{netip.MustParsePrefix("100.64.0.1/32")},
 		AllowedIPs: []netip.Prefix{
-			netip.MustParsePrefix("100.64.0.1/32"),
 			tsaddr.AllIPv4(),
 			netip.MustParsePrefix("192.168.0.0/24"),
+			netip.MustParsePrefix("100.64.0.1/32"),
+			tsaddr.AllIPv6(),
 		},
 		PrimaryRoutes: []netip.Prefix{
 			netip.MustParsePrefix("192.168.0.0/24"),

--- a/hscontrol/mapper/mapper_test.go
+++ b/hscontrol/mapper/mapper_test.go
@@ -169,6 +169,9 @@ func Test_fullMapResponse(t *testing.T) {
 			tsaddr.AllIPv4(),
 			netip.MustParsePrefix("192.168.0.0/24"),
 		},
+		PrimaryRoutes: []netip.Prefix{
+			netip.MustParsePrefix("192.168.0.0/24"),
+		},
 		HomeDERP:         0,
 		LegacyDERPString: "127.3.3.40:0",
 		Hostinfo: hiview(tailcfg.Hostinfo{

--- a/hscontrol/mapper/tail.go
+++ b/hscontrol/mapper/tail.go
@@ -5,6 +5,8 @@ import (
 	"net/netip"
 	"time"
 
+	"slices"
+
 	"github.com/juanfont/headscale/hscontrol/policy"
 	"github.com/juanfont/headscale/hscontrol/routes"
 	"github.com/juanfont/headscale/hscontrol/types"
@@ -49,9 +51,8 @@ func tailNode(
 ) (*tailcfg.Node, error) {
 	addrs := node.Prefixes()
 
-	allowedIPs := append(
-		[]netip.Prefix{},
-		addrs...) // we append the node own IP, as it is required by the clients
+	// we append the node own IP, as it is required by the clients
+	allowedIPs := slices.Clone(node.Prefixes())
 
 	for _, route := range node.SubnetRoutes() {
 		allowedIPs = append(allowedIPs, netip.Prefix(route))

--- a/hscontrol/mapper/tail.go
+++ b/hscontrol/mapper/tail.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juanfont/headscale/hscontrol/routes"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/samber/lo"
+	"tailscale.com/net/tsaddr"
 	"tailscale.com/tailcfg"
 )
 
@@ -79,6 +80,10 @@ func tailNode(
 		}
 	}
 	tags = lo.Uniq(append(tags, node.ForcedTags...))
+
+	allowed := append(node.Prefixes(), primary.PrimaryRoutes(node.ID)...)
+	allowed = append(allowed, node.ExitRoutes()...)
+	tsaddr.SortPrefixes(allowed)
 
 	tNode := tailcfg.Node{
 		ID:       tailcfg.NodeID(node.ID), // this is the actual ID

--- a/hscontrol/mapper/tail.go
+++ b/hscontrol/mapper/tail.go
@@ -2,10 +2,7 @@ package mapper
 
 import (
 	"fmt"
-	"net/netip"
 	"time"
-
-	"slices"
 
 	"github.com/juanfont/headscale/hscontrol/policy"
 	"github.com/juanfont/headscale/hscontrol/routes"
@@ -50,13 +47,6 @@ func tailNode(
 	cfg *types.Config,
 ) (*tailcfg.Node, error) {
 	addrs := node.Prefixes()
-
-	// we append the node own IP, as it is required by the clients
-	allowedIPs := slices.Clone(node.Prefixes())
-
-	for _, route := range node.SubnetRoutes() {
-		allowedIPs = append(allowedIPs, netip.Prefix(route))
-	}
 
 	var derp int
 
@@ -105,7 +95,7 @@ func tailNode(
 		DiscoKey:         node.DiscoKey,
 		Addresses:        addrs,
 		PrimaryRoutes:    primary.PrimaryRoutes(node.ID),
-		AllowedIPs:       allowedIPs,
+		AllowedIPs:       allowed,
 		Endpoints:        node.Endpoints,
 		HomeDERP:         derp,
 		LegacyDERPString: legacyDERP,

--- a/hscontrol/mapper/tail_test.go
+++ b/hscontrol/mapper/tail_test.go
@@ -137,9 +137,10 @@ func TestTailNode(t *testing.T) {
 				),
 				Addresses: []netip.Prefix{netip.MustParsePrefix("100.64.0.1/32")},
 				AllowedIPs: []netip.Prefix{
-					netip.MustParsePrefix("100.64.0.1/32"),
 					tsaddr.AllIPv4(),
 					netip.MustParsePrefix("192.168.0.0/24"),
+					netip.MustParsePrefix("100.64.0.1/32"),
+					tsaddr.AllIPv6(),
 				},
 				PrimaryRoutes: []netip.Prefix{
 					netip.MustParsePrefix("192.168.0.0/24"),

--- a/hscontrol/mapper/tail_test.go
+++ b/hscontrol/mapper/tail_test.go
@@ -67,8 +67,6 @@ func TestTailNode(t *testing.T) {
 			want: &tailcfg.Node{
 				Name:              "empty",
 				StableID:          "0",
-				Addresses:         []netip.Prefix{},
-				AllowedIPs:        []netip.Prefix{},
 				HomeDERP:          0,
 				LegacyDERPString:  "127.3.3.40:0",
 				Hostinfo:          hiview(tailcfg.Hostinfo{}),
@@ -143,6 +141,9 @@ func TestTailNode(t *testing.T) {
 					tsaddr.AllIPv4(),
 					netip.MustParsePrefix("192.168.0.0/24"),
 				},
+				PrimaryRoutes: []netip.Prefix{
+					netip.MustParsePrefix("192.168.0.0/24"),
+				},
 				HomeDERP:         0,
 				LegacyDERPString: "127.3.3.40:0",
 				Hostinfo: hiview(tailcfg.Hostinfo{
@@ -155,10 +156,6 @@ func TestTailNode(t *testing.T) {
 				Created: created,
 
 				Tags: []string{},
-
-				PrimaryRoutes: []netip.Prefix{
-					netip.MustParsePrefix("192.168.0.0/24"),
-				},
 
 				LastSeen:          &lastSeen,
 				MachineAuthorized: true,

--- a/hscontrol/routes/primary.go
+++ b/hscontrol/routes/primary.go
@@ -102,12 +102,16 @@ func (pr *PrimaryRoutes) updatePrimaryLocked() bool {
 	return changed
 }
 
-func (pr *PrimaryRoutes) SetRoutes(node types.NodeID, prefix ...netip.Prefix) bool {
+// SetRoutes sets the routes for a given Node ID and recalculates the primary routes
+// of the headscale.
+// It returns true if there was a change in primary routes.
+// All exit routes are ignored as they are not used in primary route context.
+func (pr *PrimaryRoutes) SetRoutes(node types.NodeID, prefixes ...netip.Prefix) bool {
 	pr.mu.Lock()
 	defer pr.mu.Unlock()
 
 	// If no routes are being set, remove the node from the routes map.
-	if len(prefix) == 0 {
+	if len(prefixes) == 0 {
 		if _, ok := pr.routes[node]; ok {
 			delete(pr.routes, node)
 			return pr.updatePrimaryLocked()

--- a/hscontrol/routes/primary.go
+++ b/hscontrol/routes/primary.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/util"
 	xmaps "golang.org/x/exp/maps"
+	"tailscale.com/net/tsaddr"
 	"tailscale.com/util/set"
 )
 
@@ -152,6 +153,7 @@ func (pr *PrimaryRoutes) PrimaryRoutes(id types.NodeID) []netip.Prefix {
 		}
 	}
 
+	tsaddr.SortPrefixes(routes)
 	return routes
 }
 

--- a/hscontrol/routes/primary_test.go
+++ b/hscontrol/routes/primary_test.go
@@ -366,7 +366,6 @@ func TestPrimaryRoutes(t *testing.T) {
 			},
 			expectedPrimaries: map[netip.Prefix]types.NodeID{
 				mp("192.168.1.0/24"): 1,
-				mp("0.0.0.0/0"):      1,
 			},
 			expectedIsPrimary: map[types.NodeID]bool{
 				1: true,
@@ -387,6 +386,26 @@ func TestPrimaryRoutes(t *testing.T) {
 				return pr.SetRoutes(1)
 			},
 			expectedRoutes: nil,
+			expectedChange: false,
+		},
+		{
+			name: "exit-nodes",
+			operations: func(pr *PrimaryRoutes) bool {
+				pr.SetRoutes(1, mp("10.0.0.0/16"), mp("0.0.0.0/0"), mp("::/0"))
+				pr.SetRoutes(3, mp("0.0.0.0/0"), mp("::/0"))
+				return pr.SetRoutes(2, mp("0.0.0.0/0"), mp("::/0"))
+			},
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {
+					mp("10.0.0.0/16"): {},
+				},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("10.0.0.0/16"): 1,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				1: true,
+			},
 			expectedChange: false,
 		},
 		{

--- a/hscontrol/routes/primary_test.go
+++ b/hscontrol/routes/primary_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/util"
+	"tailscale.com/util/set"
 )
 
 // mp is a helper function that wraps netip.MustParsePrefix.
@@ -17,20 +19,34 @@ func mp(prefix string) netip.Prefix {
 
 func TestPrimaryRoutes(t *testing.T) {
 	tests := []struct {
-		name           string
-		operations     func(pr *PrimaryRoutes) bool
-		nodeID         types.NodeID
-		expectedRoutes []netip.Prefix
-		expectedChange bool
+		name              string
+		operations        func(pr *PrimaryRoutes) bool
+		expectedRoutes    map[types.NodeID]set.Set[netip.Prefix]
+		expectedPrimaries map[netip.Prefix]types.NodeID
+		expectedIsPrimary map[types.NodeID]bool
+		expectedChange    bool
+
+		// primaries is a map of prefixes to the node that is the primary for that prefix.
+		primaries map[netip.Prefix]types.NodeID
+		isPrimary map[types.NodeID]bool
 	}{
 		{
 			name: "single-node-registers-single-route",
 			operations: func(pr *PrimaryRoutes) bool {
 				return pr.SetRoutes(1, mp("192.168.1.0/24"))
 			},
-			nodeID:         1,
-			expectedRoutes: nil,
-			expectedChange: false,
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {
+					mp("192.168.1.0/24"): {},
+				},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 1,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				1: true,
+			},
+			expectedChange: true,
 		},
 		{
 			name: "multiple-nodes-register-different-routes",
@@ -38,19 +54,45 @@ func TestPrimaryRoutes(t *testing.T) {
 				pr.SetRoutes(1, mp("192.168.1.0/24"))
 				return pr.SetRoutes(2, mp("192.168.2.0/24"))
 			},
-			nodeID:         1,
-			expectedRoutes: nil,
-			expectedChange: false,
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {
+					mp("192.168.1.0/24"): {},
+				},
+				2: {
+					mp("192.168.2.0/24"): {},
+				},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 1,
+				mp("192.168.2.0/24"): 2,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				1: true,
+				2: true,
+			},
+			expectedChange: true,
 		},
 		{
 			name: "multiple-nodes-register-overlapping-routes",
 			operations: func(pr *PrimaryRoutes) bool {
-				pr.SetRoutes(1, mp("192.168.1.0/24"))        // false
-				return pr.SetRoutes(2, mp("192.168.1.0/24")) // true
+				pr.SetRoutes(1, mp("192.168.1.0/24"))        // true
+				return pr.SetRoutes(2, mp("192.168.1.0/24")) // false
 			},
-			nodeID:         1,
-			expectedRoutes: []netip.Prefix{mp("192.168.1.0/24")},
-			expectedChange: true,
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {
+					mp("192.168.1.0/24"): {},
+				},
+				2: {
+					mp("192.168.1.0/24"): {},
+				},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 1,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				1: true,
+			},
+			expectedChange: false,
 		},
 		{
 			name: "node-deregisters-a-route",
@@ -58,9 +100,10 @@ func TestPrimaryRoutes(t *testing.T) {
 				pr.SetRoutes(1, mp("192.168.1.0/24"))
 				return pr.SetRoutes(1) // Deregister by setting no routes
 			},
-			nodeID:         1,
-			expectedRoutes: nil,
-			expectedChange: false,
+			expectedRoutes:    nil,
+			expectedPrimaries: nil,
+			expectedIsPrimary: nil,
+			expectedChange:    true,
 		},
 		{
 			name: "node-deregisters-one-of-multiple-routes",
@@ -68,9 +111,18 @@ func TestPrimaryRoutes(t *testing.T) {
 				pr.SetRoutes(1, mp("192.168.1.0/24"), mp("192.168.2.0/24"))
 				return pr.SetRoutes(1, mp("192.168.2.0/24")) // Deregister one route by setting the remaining route
 			},
-			nodeID:         1,
-			expectedRoutes: nil,
-			expectedChange: false,
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {
+					mp("192.168.2.0/24"): {},
+				},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.2.0/24"): 1,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				1: true,
+			},
+			expectedChange: true,
 		},
 		{
 			name: "node-registers-and-deregisters-routes-in-sequence",
@@ -80,18 +132,23 @@ func TestPrimaryRoutes(t *testing.T) {
 				pr.SetRoutes(1) // Deregister by setting no routes
 				return pr.SetRoutes(1, mp("192.168.3.0/24"))
 			},
-			nodeID:         1,
-			expectedRoutes: nil,
-			expectedChange: false,
-		},
-		{
-			name: "no-change-in-primary-routes",
-			operations: func(pr *PrimaryRoutes) bool {
-				return pr.SetRoutes(1, mp("192.168.1.0/24"))
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {
+					mp("192.168.3.0/24"): {},
+				},
+				2: {
+					mp("192.168.2.0/24"): {},
+				},
 			},
-			nodeID:         1,
-			expectedRoutes: nil,
-			expectedChange: false,
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.2.0/24"): 2,
+				mp("192.168.3.0/24"): 1,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				1: true,
+				2: true,
+			},
+			expectedChange: true,
 		},
 		{
 			name: "multiple-nodes-register-same-route",
@@ -100,21 +157,24 @@ func TestPrimaryRoutes(t *testing.T) {
 				pr.SetRoutes(2, mp("192.168.1.0/24"))        // true
 				return pr.SetRoutes(3, mp("192.168.1.0/24")) // false
 			},
-			nodeID:         1,
-			expectedRoutes: []netip.Prefix{mp("192.168.1.0/24")},
-			expectedChange: false,
-		},
-		{
-			name: "register-multiple-routes-shift-primary-check-old-primary",
-			operations: func(pr *PrimaryRoutes) bool {
-				pr.SetRoutes(1, mp("192.168.1.0/24")) // false
-				pr.SetRoutes(2, mp("192.168.1.0/24")) // true, 1 primary
-				pr.SetRoutes(3, mp("192.168.1.0/24")) // false, 1 primary
-				return pr.SetRoutes(1)                // true, 2 primary
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {
+					mp("192.168.1.0/24"): {},
+				},
+				2: {
+					mp("192.168.1.0/24"): {},
+				},
+				3: {
+					mp("192.168.1.0/24"): {},
+				},
 			},
-			nodeID:         1,
-			expectedRoutes: nil,
-			expectedChange: true,
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 1,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				1: true,
+			},
+			expectedChange: false,
 		},
 		{
 			name: "register-multiple-routes-shift-primary-check-primary",
@@ -124,20 +184,20 @@ func TestPrimaryRoutes(t *testing.T) {
 				pr.SetRoutes(3, mp("192.168.1.0/24")) // false, 1 primary
 				return pr.SetRoutes(1)                // true, 2 primary
 			},
-			nodeID:         2,
-			expectedRoutes: []netip.Prefix{mp("192.168.1.0/24")},
-			expectedChange: true,
-		},
-		{
-			name: "register-multiple-routes-shift-primary-check-non-primary",
-			operations: func(pr *PrimaryRoutes) bool {
-				pr.SetRoutes(1, mp("192.168.1.0/24")) // false
-				pr.SetRoutes(2, mp("192.168.1.0/24")) // true, 1 primary
-				pr.SetRoutes(3, mp("192.168.1.0/24")) // false, 1 primary
-				return pr.SetRoutes(1)                // true, 2 primary
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				2: {
+					mp("192.168.1.0/24"): {},
+				},
+				3: {
+					mp("192.168.1.0/24"): {},
+				},
 			},
-			nodeID:         3,
-			expectedRoutes: nil,
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 2,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				2: true,
+			},
 			expectedChange: true,
 		},
 		{
@@ -150,8 +210,17 @@ func TestPrimaryRoutes(t *testing.T) {
 
 				return pr.SetRoutes(2) // true, no primary
 			},
-			nodeID:         2,
-			expectedRoutes: nil,
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				3: {
+					mp("192.168.1.0/24"): {},
+				},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 3,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				3: true,
+			},
 			expectedChange: true,
 		},
 		{
@@ -165,9 +234,7 @@ func TestPrimaryRoutes(t *testing.T) {
 
 				return pr.SetRoutes(3) // false, no primary
 			},
-			nodeID:         2,
-			expectedRoutes: nil,
-			expectedChange: false,
+			expectedChange: true,
 		},
 		{
 			name: "primary-route-map-is-cleared-up",
@@ -179,8 +246,17 @@ func TestPrimaryRoutes(t *testing.T) {
 
 				return pr.SetRoutes(2) // true, no primary
 			},
-			nodeID:         2,
-			expectedRoutes: nil,
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				3: {
+					mp("192.168.1.0/24"): {},
+				},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 3,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				3: true,
+			},
 			expectedChange: true,
 		},
 		{
@@ -193,8 +269,23 @@ func TestPrimaryRoutes(t *testing.T) {
 
 				return pr.SetRoutes(1, mp("192.168.1.0/24")) // false, 2 primary
 			},
-			nodeID:         2,
-			expectedRoutes: []netip.Prefix{mp("192.168.1.0/24")},
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {
+					mp("192.168.1.0/24"): {},
+				},
+				2: {
+					mp("192.168.1.0/24"): {},
+				},
+				3: {
+					mp("192.168.1.0/24"): {},
+				},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 2,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				2: true,
+			},
 			expectedChange: false,
 		},
 		{
@@ -207,8 +298,23 @@ func TestPrimaryRoutes(t *testing.T) {
 
 				return pr.SetRoutes(1, mp("192.168.1.0/24")) // false, 2 primary
 			},
-			nodeID:         1,
-			expectedRoutes: nil,
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {
+					mp("192.168.1.0/24"): {},
+				},
+				2: {
+					mp("192.168.1.0/24"): {},
+				},
+				3: {
+					mp("192.168.1.0/24"): {},
+				},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 2,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				2: true,
+			},
 			expectedChange: false,
 		},
 		{
@@ -218,15 +324,30 @@ func TestPrimaryRoutes(t *testing.T) {
 				pr.SetRoutes(2, mp("192.168.1.0/24")) // true, 1 primary
 				pr.SetRoutes(3, mp("192.168.1.0/24")) // false, 1 primary
 				pr.SetRoutes(1)                       // true, 2 primary
-				pr.SetRoutes(2)                       // true, no primary
-				pr.SetRoutes(1, mp("192.168.1.0/24")) // true, 1 primary
-				pr.SetRoutes(2, mp("192.168.1.0/24")) // true, 1 primary
-				pr.SetRoutes(1)                       // true, 2 primary
+				pr.SetRoutes(2)                       // true, 3 primary
+				pr.SetRoutes(1, mp("192.168.1.0/24")) // true, 3 primary
+				pr.SetRoutes(2, mp("192.168.1.0/24")) // true, 3 primary
+				pr.SetRoutes(1)                       // true, 3 primary
 
-				return pr.SetRoutes(1, mp("192.168.1.0/24")) // false, 2 primary
+				return pr.SetRoutes(1, mp("192.168.1.0/24")) // false, 3 primary
 			},
-			nodeID:         2,
-			expectedRoutes: []netip.Prefix{mp("192.168.1.0/24")},
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {
+					mp("192.168.1.0/24"): {},
+				},
+				2: {
+					mp("192.168.1.0/24"): {},
+				},
+				3: {
+					mp("192.168.1.0/24"): {},
+				},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 3,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				3: true,
+			},
 			expectedChange: false,
 		},
 		{
@@ -235,16 +356,28 @@ func TestPrimaryRoutes(t *testing.T) {
 				pr.SetRoutes(1, mp("0.0.0.0/0"), mp("192.168.1.0/24"))
 				return pr.SetRoutes(2, mp("192.168.1.0/24"))
 			},
-			nodeID:         1,
-			expectedRoutes: []netip.Prefix{mp("192.168.1.0/24")},
-			expectedChange: true,
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {
+					mp("192.168.1.0/24"): {},
+				},
+				2: {
+					mp("192.168.1.0/24"): {},
+				},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 1,
+				mp("0.0.0.0/0"):      1,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				1: true,
+			},
+			expectedChange: false,
 		},
 		{
 			name: "deregister-non-existent-route",
 			operations: func(pr *PrimaryRoutes) bool {
 				return pr.SetRoutes(1) // Deregister by setting no routes
 			},
-			nodeID:         1,
 			expectedRoutes: nil,
 			expectedChange: false,
 		},
@@ -253,16 +386,6 @@ func TestPrimaryRoutes(t *testing.T) {
 			operations: func(pr *PrimaryRoutes) bool {
 				return pr.SetRoutes(1)
 			},
-			nodeID:         1,
-			expectedRoutes: nil,
-			expectedChange: false,
-		},
-		{
-			name: "deregister-empty-prefix-list",
-			operations: func(pr *PrimaryRoutes) bool {
-				return pr.SetRoutes(1)
-			},
-			nodeID:         1,
 			expectedRoutes: nil,
 			expectedChange: false,
 		},
@@ -284,19 +407,23 @@ func TestPrimaryRoutes(t *testing.T) {
 
 				return change1 || change2
 			},
-			nodeID:         1,
-			expectedRoutes: nil,
-			expectedChange: false,
-		},
-		{
-			name: "no-routes-registered",
-			operations: func(pr *PrimaryRoutes) bool {
-				// No operations
-				return false
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {
+					mp("192.168.1.0/24"): {},
+				},
+				2: {
+					mp("192.168.2.0/24"): {},
+				},
 			},
-			nodeID:         1,
-			expectedRoutes: nil,
-			expectedChange: false,
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 1,
+				mp("192.168.2.0/24"): 2,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				1: true,
+				2: true,
+			},
+			expectedChange: true,
 		},
 	}
 
@@ -307,9 +434,15 @@ func TestPrimaryRoutes(t *testing.T) {
 			if change != tt.expectedChange {
 				t.Errorf("change = %v, want %v", change, tt.expectedChange)
 			}
-			routes := pr.PrimaryRoutes(tt.nodeID)
-			if diff := cmp.Diff(tt.expectedRoutes, routes, util.Comparers...); diff != "" {
-				t.Errorf("PrimaryRoutes() mismatch (-want +got):\n%s", diff)
+			comps := append(util.Comparers, cmpopts.EquateEmpty())
+			if diff := cmp.Diff(tt.expectedRoutes, pr.routes, comps...); diff != "" {
+				t.Errorf("routes mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.expectedPrimaries, pr.primaries, comps...); diff != "" {
+				t.Errorf("primaries mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.expectedIsPrimary, pr.isPrimary, comps...); diff != "" {
+				t.Errorf("isPrimary mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juanfont/headscale/hscontrol/util"
 	"go4.org/netipx"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"tailscale.com/net/tsaddr"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 )
@@ -220,6 +221,19 @@ func (node *Node) Prefixes() []netip.Prefix {
 	}
 
 	return addrs
+}
+
+// ExitRoutes returns a list of both exit routes if the
+// node has any exit routes enabled.
+// If none are enabled, it will return nil.
+func (node *Node) ExitRoutes() []netip.Prefix {
+	for _, route := range node.SubnetRoutes() {
+		if tsaddr.IsExitRoute(route) {
+			return tsaddr.ExitRoutes()
+		}
+	}
+
+	return nil
 }
 
 func (node *Node) IPsAsString() []string {

--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -213,7 +213,7 @@ func (node *Node) RequestTags() []string {
 }
 
 func (node *Node) Prefixes() []netip.Prefix {
-	addrs := []netip.Prefix{}
+	var addrs []netip.Prefix
 	for _, nodeAddress := range node.IPs() {
 		ip := netip.PrefixFrom(nodeAddress, nodeAddress.BitLen())
 		addrs = append(addrs, ip)

--- a/hscontrol/util/string.go
+++ b/hscontrol/util/string.go
@@ -57,6 +57,15 @@ func GenerateRandomStringDNSSafe(size int) (string, error) {
 	return str[:size], nil
 }
 
+func MustGenerateRandomStringDNSSafe(size int) string {
+	hash, err := GenerateRandomStringDNSSafe(size)
+	if err != nil {
+		panic(err)
+	}
+
+	return hash
+}
+
 func TailNodesToString(nodes []*tailcfg.Node) string {
 	temp := make([]string, len(nodes))
 

--- a/hscontrol/util/util.go
+++ b/hscontrol/util/util.go
@@ -3,8 +3,12 @@ package util
 import (
 	"errors"
 	"fmt"
+	"net/netip"
 	"net/url"
+	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"tailscale.com/util/cmpver"
 )
@@ -45,4 +49,127 @@ func ParseLoginURLFromCLILogin(output string) (*url.URL, error) {
 	}
 
 	return loginURL, nil
+}
+
+type TraceroutePath struct {
+  // Hop is the current jump in the total traceroute.
+  Hop int
+
+  // Hostname is the resolved hostname or IP address identifying the jump
+  Hostname string
+
+  // IP is the IP address of the jump
+  IP netip.Addr
+
+  // Latencies is a list of the latencies for this jump
+  Latencies []time.Duration
+}
+
+type Traceroute struct {
+  // Hostname is the resolved hostname or IP address identifying the target
+  Hostname string
+
+  // IP is the IP address of the target
+  IP netip.Addr
+
+  // Route is the path taken to reach the target if successful. The list is ordered by the path taken.
+  Route []TraceroutePath
+
+  // Success indicates if the traceroute was successful.
+  Success bool
+
+  // Err contains an error if  the traceroute was not successful.
+  Err error
+}
+
+// ParseTraceroute parses the output of the traceroute command and returns a Traceroute struct
+func ParseTraceroute(output string) (Traceroute, error) {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) < 1 {
+		return Traceroute{}, errors.New("empty traceroute output")
+	}
+
+	// Parse the header line
+	headerRegex := regexp.MustCompile(`traceroute to ([^ ]+) \(([^)]+)\)`)
+	headerMatches := headerRegex.FindStringSubmatch(lines[0])
+	if len(headerMatches) != 3 {
+		return Traceroute{}, fmt.Errorf("parsing traceroute header: %s", lines[0])
+	}
+
+	hostname := headerMatches[1]
+	ipStr := headerMatches[2]
+	ip, err := netip.ParseAddr(ipStr)
+	if err != nil {
+		return Traceroute{}, fmt.Errorf("parsing IP address %s: %w", ipStr, err)
+	}
+
+	result := Traceroute{
+		Hostname: hostname,
+		IP:       ip,
+		Route:    []TraceroutePath{},
+		Success:  false,
+	}
+
+	// Parse each hop line
+	hopRegex := regexp.MustCompile(`^\s*(\d+)\s+(?:([^ ]+) \(([^)]+)\)|(\*))(?:\s+(\d+\.\d+) ms)?(?:\s+(\d+\.\d+) ms)?(?:\s+(\d+\.\d+) ms)?`)
+
+	for i := 1; i < len(lines); i++ {
+		matches := hopRegex.FindStringSubmatch(lines[i])
+		if len(matches) == 0 {
+			continue
+		}
+
+		hop, err := strconv.Atoi(matches[1])
+		if err != nil {
+			return Traceroute{}, fmt.Errorf("parsing hop number: %w", err)
+		}
+
+		var hopHostname string
+		var hopIP netip.Addr
+		var latencies []time.Duration
+
+		// Handle hostname and IP
+		if matches[2] != "" && matches[3] != "" {
+			hopHostname = matches[2]
+			hopIP, err = netip.ParseAddr(matches[3])
+			if err != nil {
+				return Traceroute{}, fmt.Errorf("parsing hop IP address %s: %w", matches[3], err)
+			}
+		} else if matches[4] == "*" {
+			hopHostname = "*"
+			// No IP for timeouts
+		}
+
+		// Parse latencies
+		for j := 5; j <= 7; j++ {
+			if matches[j] != "" {
+				ms, err := strconv.ParseFloat(matches[j], 64)
+				if err != nil {
+					return Traceroute{}, fmt.Errorf("parsing latency: %w", err)
+				}
+				latencies = append(latencies, time.Duration(ms*float64(time.Millisecond)))
+			}
+		}
+
+		path := TraceroutePath{
+			Hop:       hop,
+			Hostname:  hopHostname,
+			IP:        hopIP,
+			Latencies: latencies,
+		}
+
+		result.Route = append(result.Route, path)
+
+		// Check if we've reached the target
+		if hopIP == ip {
+			result.Success = true
+		}
+	}
+
+	// If we didn't reach the target, it's unsuccessful
+	if !result.Success {
+		result.Err = errors.New("traceroute did not reach target")
+	}
+
+	return result, nil
 }

--- a/hscontrol/util/util_test.go
+++ b/hscontrol/util/util_test.go
@@ -1,6 +1,13 @@
 package util
 
-import "testing"
+import (
+	"errors"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
 
 func TestTailscaleVersionNewerOrEqual(t *testing.T) {
 	type args struct {
@@ -174,6 +181,189 @@ Success.`,
 				if gotURL.String() != tt.wantURL {
 					t.Errorf("ParseLoginURLFromCLILogin() = %v, want %v", gotURL, tt.wantURL)
 				}
+			}
+		})
+	}
+}
+
+func TestParseTraceroute(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Traceroute
+		wantErr bool
+	}{
+		{
+			name: "simple successful traceroute",
+			input: `traceroute to 172.24.0.3 (172.24.0.3), 30 hops max, 46 byte packets
+ 1  ts-head-hk0urr.headscale.net (100.64.0.1)  1.135 ms  0.922 ms  0.619 ms
+ 2  172.24.0.3 (172.24.0.3)  0.593 ms  0.549 ms  0.522 ms`,
+			want: Traceroute{
+				Hostname: "172.24.0.3",
+				IP:       netip.MustParseAddr("172.24.0.3"),
+				Route: []TraceroutePath{
+					{
+						Hop:      1,
+						Hostname: "ts-head-hk0urr.headscale.net",
+						IP:       netip.MustParseAddr("100.64.0.1"),
+						Latencies: []time.Duration{
+							1135 * time.Microsecond,
+							922 * time.Microsecond,
+							619 * time.Microsecond,
+						},
+					},
+					{
+						Hop:      2,
+						Hostname: "172.24.0.3",
+						IP:       netip.MustParseAddr("172.24.0.3"),
+						Latencies: []time.Duration{
+							593 * time.Microsecond,
+							549 * time.Microsecond,
+							522 * time.Microsecond,
+						},
+					},
+				},
+				Success: true,
+				Err:     nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "traceroute with timeouts",
+			input: `traceroute to 8.8.8.8 (8.8.8.8), 30 hops max, 60 byte packets
+ 1  router.local (192.168.1.1)  1.234 ms  1.123 ms  1.121 ms
+ 2  * * *
+ 3  isp-gateway.net (10.0.0.1)  15.678 ms  14.789 ms  15.432 ms
+ 4  8.8.8.8 (8.8.8.8)  20.123 ms  19.876 ms  20.345 ms`,
+			want: Traceroute{
+				Hostname: "8.8.8.8",
+				IP:       netip.MustParseAddr("8.8.8.8"),
+				Route: []TraceroutePath{
+					{
+						Hop:      1,
+						Hostname: "router.local",
+						IP:       netip.MustParseAddr("192.168.1.1"),
+						Latencies: []time.Duration{
+							1234 * time.Microsecond,
+							1123 * time.Microsecond,
+							1121 * time.Microsecond,
+						},
+					},
+					{
+						Hop:      2,
+						Hostname: "*",
+					},
+					{
+						Hop:      3,
+						Hostname: "isp-gateway.net",
+						IP:       netip.MustParseAddr("10.0.0.1"),
+						Latencies: []time.Duration{
+							15678 * time.Microsecond,
+							14789 * time.Microsecond,
+							15432 * time.Microsecond,
+						},
+					},
+					{
+						Hop:      4,
+						Hostname: "8.8.8.8",
+						IP:       netip.MustParseAddr("8.8.8.8"),
+						Latencies: []time.Duration{
+							20123 * time.Microsecond,
+							19876 * time.Microsecond,
+							20345 * time.Microsecond,
+						},
+					},
+				},
+				Success: true,
+				Err:     nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "unsuccessful traceroute",
+			input: `traceroute to 10.0.0.99 (10.0.0.99), 5 hops max, 60 byte packets
+ 1  router.local (192.168.1.1)  1.234 ms  1.123 ms  1.121 ms
+ 2  * * *
+ 3  * * *
+ 4  * * *
+ 5  * * *`,
+			want: Traceroute{
+				Hostname: "10.0.0.99",
+				IP:       netip.MustParseAddr("10.0.0.99"),
+				Route: []TraceroutePath{
+					{
+						Hop:      1,
+						Hostname: "router.local",
+						IP:       netip.MustParseAddr("192.168.1.1"),
+						Latencies: []time.Duration{
+							1234 * time.Microsecond,
+							1123 * time.Microsecond,
+							1121 * time.Microsecond,
+						},
+					},
+					{
+						Hop:      2,
+						Hostname: "*",
+					},
+					{
+						Hop:      3,
+						Hostname: "*",
+					},
+					{
+						Hop:      4,
+						Hostname: "*",
+					},
+					{
+						Hop:      5,
+						Hostname: "*",
+					},
+				},
+				Success: false,
+				Err:     errors.New("traceroute did not reach target"),
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty input",
+			input:   "",
+			want:    Traceroute{},
+			wantErr: true,
+		},
+		{
+			name:    "invalid header",
+			input:   "not a valid traceroute output",
+			want:    Traceroute{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTraceroute(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseTraceroute() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			// Special handling for error field since it can't be directly compared with cmp.Diff
+			gotErr := got.Err
+			wantErr := tt.want.Err
+			got.Err = nil
+			tt.want.Err = nil
+
+			if diff := cmp.Diff(tt.want, got, IPComparer); diff != "" {
+				t.Errorf("ParseTraceroute() mismatch (-want +got):\n%s", diff)
+			}
+
+			// Now check error field separately
+			if (gotErr == nil) != (wantErr == nil) {
+				t.Errorf("Error field: got %v, want %v", gotErr, wantErr)
+			} else if gotErr != nil && wantErr != nil && gotErr.Error() != wantErr.Error() {
+				t.Errorf("Error message: got %q, want %q", gotErr.Error(), wantErr.Error())
 			}
 		})
 	}

--- a/integration/acl_test.go
+++ b/integration/acl_test.go
@@ -57,9 +57,9 @@ func aclScenario(
 	scenario, err := NewScenario(dockertestMaxWait())
 	require.NoError(t, err)
 
-	spec := map[string]int{
-		"user1": clientsPerUser,
-		"user2": clientsPerUser,
+	spec := ScenarioSpec{
+		NodesPerUser: clientsPerUser,
+		Users:        []string{"user1", "user2"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec,
@@ -96,22 +96,24 @@ func aclScenario(
 func TestACLHostsInNetMapTable(t *testing.T) {
 	IntegrationSkip(t)
 
+	spec := ScenarioSpec{
+		NodesPerUser: 2,
+		Users:        []string{"user1", "user2"},
+	}
+
 	// NOTE: All want cases currently checks the
 	// total count of expected peers, this would
 	// typically be the client count of the users
 	// they can access minus one (them self).
 	tests := map[string]struct {
-		users  map[string]int
+		users  ScenarioSpec
 		policy policyv1.ACLPolicy
 		want   map[string]int
 	}{
 		// Test that when we have no ACL, each client netmap has
 		// the amount of peers of the total amount of clients
 		"base-acls": {
-			users: map[string]int{
-				"user1": 2,
-				"user2": 2,
-			},
+			users: spec,
 			policy: policyv1.ACLPolicy{
 				ACLs: []policyv1.ACL{
 					{
@@ -129,10 +131,7 @@ func TestACLHostsInNetMapTable(t *testing.T) {
 		// each other, each node has only the number of pairs from
 		// their own user.
 		"two-isolated-users": {
-			users: map[string]int{
-				"user1": 2,
-				"user2": 2,
-			},
+			users: spec,
 			policy: policyv1.ACLPolicy{
 				ACLs: []policyv1.ACL{
 					{
@@ -155,10 +154,7 @@ func TestACLHostsInNetMapTable(t *testing.T) {
 		// are restricted to a single port, nodes are still present
 		// in the netmap.
 		"two-restricted-present-in-netmap": {
-			users: map[string]int{
-				"user1": 2,
-				"user2": 2,
-			},
+			users: spec,
 			policy: policyv1.ACLPolicy{
 				ACLs: []policyv1.ACL{
 					{
@@ -192,10 +188,7 @@ func TestACLHostsInNetMapTable(t *testing.T) {
 		// of peers. This will still result in all the peers as we
 		// need them present on the other side for the "return path".
 		"two-ns-one-isolated": {
-			users: map[string]int{
-				"user1": 2,
-				"user2": 2,
-			},
+			users: spec,
 			policy: policyv1.ACLPolicy{
 				ACLs: []policyv1.ACL{
 					{
@@ -220,10 +213,7 @@ func TestACLHostsInNetMapTable(t *testing.T) {
 			},
 		},
 		"very-large-destination-prefix-1372": {
-			users: map[string]int{
-				"user1": 2,
-				"user2": 2,
-			},
+			users: spec,
 			policy: policyv1.ACLPolicy{
 				ACLs: []policyv1.ACL{
 					{
@@ -248,10 +238,7 @@ func TestACLHostsInNetMapTable(t *testing.T) {
 			},
 		},
 		"ipv6-acls-1470": {
-			users: map[string]int{
-				"user1": 2,
-				"user2": 2,
-			},
+			users: spec,
 			policy: policyv1.ACLPolicy{
 				ACLs: []policyv1.ACL{
 					{
@@ -1026,9 +1013,9 @@ func TestPolicyUpdateWhileRunningWithCLIInDatabase(t *testing.T) {
 	require.NoError(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"user1": 1,
-		"user2": 1,
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{"user1", "user2"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec,

--- a/integration/acl_test.go
+++ b/integration/acl_test.go
@@ -931,6 +931,7 @@ func TestACLDevice1CanAccessDevice2(t *testing.T) {
 	for name, testCase := range tests {
 		t.Run(name, func(t *testing.T) {
 			scenario := aclScenario(t, &testCase.policy, 1)
+			defer scenario.ShutdownAssertNoPanics(t)
 
 			test1ip := netip.MustParseAddr("100.64.0.1")
 			test1ip6 := netip.MustParseAddr("fd7a:115c:a1e0::1")

--- a/integration/acl_test.go
+++ b/integration/acl_test.go
@@ -54,15 +54,16 @@ func aclScenario(
 	clientsPerUser int,
 ) *Scenario {
 	t.Helper()
-	scenario, err := NewScenario(dockertestMaxWait())
-	require.NoError(t, err)
 
 	spec := ScenarioSpec{
 		NodesPerUser: clientsPerUser,
 		Users:        []string{"user1", "user2"},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec,
+	scenario, err := NewScenario(spec)
+	require.NoError(t, err)
+
+	err = scenario.CreateHeadscaleEnv(
 		[]tsic.Option{
 			// Alpine containers dont have ip6tables set up, which causes
 			// tailscaled to stop configuring the wgengine, causing it
@@ -256,12 +257,11 @@ func TestACLHostsInNetMapTable(t *testing.T) {
 
 	for name, testCase := range tests {
 		t.Run(name, func(t *testing.T) {
-			scenario, err := NewScenario(dockertestMaxWait())
+			caseSpec := testCase.users
+			scenario, err := NewScenario(caseSpec)
 			require.NoError(t, err)
 
-			spec := testCase.users
-
-			err = scenario.CreateHeadscaleEnv(spec,
+			err = scenario.CreateHeadscaleEnv(
 				[]tsic.Option{},
 				hsic.WithACLPolicy(&testCase.policy),
 			)
@@ -1009,16 +1009,16 @@ func TestPolicyUpdateWhileRunningWithCLIInDatabase(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	require.NoError(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		NodesPerUser: 1,
 		Users:        []string{"user1", "user2"},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec,
+	scenario, err := NewScenario(spec)
+	require.NoError(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv(
 		[]tsic.Option{
 			// Alpine containers dont have ip6tables set up, which causes
 			// tailscaled to stop configuring the wgengine, causing it

--- a/integration/auth_key_test.go
+++ b/integration/auth_key_test.go
@@ -23,9 +23,9 @@ func TestAuthKeyLogoutAndReloginSameUser(t *testing.T) {
 			assertNoErr(t, err)
 			defer scenario.ShutdownAssertNoPanics(t)
 
-			spec := map[string]int{
-				"user1": len(MustTestVersions),
-				"user2": len(MustTestVersions),
+			spec := ScenarioSpec{
+				NodesPerUser: len(MustTestVersions),
+				Users:        []string{"user1", "user2"},
 			}
 
 			opts := []hsic.Option{hsic.WithTestName("pingallbyip")}
@@ -84,7 +84,7 @@ func TestAuthKeyLogoutAndReloginSameUser(t *testing.T) {
 				time.Sleep(5 * time.Minute)
 			}
 
-			for userName := range spec {
+			for _, userName := range spec.Users {
 				key, err := scenario.CreatePreAuthKey(userName, true, false)
 				if err != nil {
 					t.Fatalf("failed to create pre-auth key for user %s: %s", userName, err)
@@ -156,9 +156,9 @@ func TestAuthKeyLogoutAndReloginNewUser(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"user1": len(MustTestVersions),
-		"user2": len(MustTestVersions),
+	spec := ScenarioSpec{
+		NodesPerUser: len(MustTestVersions),
+		Users:        []string{"user1", "user2"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{},
@@ -203,7 +203,7 @@ func TestAuthKeyLogoutAndReloginNewUser(t *testing.T) {
 
 	// Log in all clients as user1, iterating over the spec only returns the
 	// clients, not the usernames.
-	for userName := range spec {
+	for _, userName := range spec.Users {
 		err = scenario.RunTailscaleUp(userName, headscale.GetEndpoint(), key.GetKey())
 		if err != nil {
 			t.Fatalf("failed to run tailscale up for user %s: %s", userName, err)
@@ -239,9 +239,9 @@ func TestAuthKeyLogoutAndReloginSameUserExpiredKey(t *testing.T) {
 			assertNoErr(t, err)
 			defer scenario.ShutdownAssertNoPanics(t)
 
-			spec := map[string]int{
-				"user1": len(MustTestVersions),
-				"user2": len(MustTestVersions),
+			spec := ScenarioSpec{
+				NodesPerUser: len(MustTestVersions),
+				Users:        []string{"user1", "user2"},
 			}
 
 			opts := []hsic.Option{hsic.WithTestName("pingallbyip")}
@@ -300,7 +300,7 @@ func TestAuthKeyLogoutAndReloginSameUserExpiredKey(t *testing.T) {
 				time.Sleep(5 * time.Minute)
 			}
 
-			for userName := range spec {
+			for _, userName := range spec.Users {
 				key, err := scenario.CreatePreAuthKey(userName, true, false)
 				if err != nil {
 					t.Fatalf("failed to create pre-auth key for user %s: %s", userName, err)

--- a/integration/auth_key_test.go
+++ b/integration/auth_key_test.go
@@ -19,14 +19,14 @@ func TestAuthKeyLogoutAndReloginSameUser(t *testing.T) {
 
 	for _, https := range []bool{true, false} {
 		t.Run(fmt.Sprintf("with-https-%t", https), func(t *testing.T) {
-			scenario, err := NewScenario(dockertestMaxWait())
-			assertNoErr(t, err)
-			defer scenario.ShutdownAssertNoPanics(t)
-
 			spec := ScenarioSpec{
 				NodesPerUser: len(MustTestVersions),
 				Users:        []string{"user1", "user2"},
 			}
+
+			scenario, err := NewScenario(spec)
+			assertNoErr(t, err)
+			defer scenario.ShutdownAssertNoPanics(t)
 
 			opts := []hsic.Option{hsic.WithTestName("pingallbyip")}
 			if https {
@@ -35,7 +35,7 @@ func TestAuthKeyLogoutAndReloginSameUser(t *testing.T) {
 				}...)
 			}
 
-			err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, opts...)
+			err = scenario.CreateHeadscaleEnv([]tsic.Option{}, opts...)
 			assertNoErrHeadscaleEnv(t, err)
 
 			allClients, err := scenario.ListTailscaleClients()
@@ -152,16 +152,16 @@ func TestAuthKeyLogoutAndReloginNewUser(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		NodesPerUser: len(MustTestVersions),
 		Users:        []string{"user1", "user2"},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{},
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{},
 		hsic.WithTestName("keyrelognewuser"),
 		hsic.WithTLS(),
 	)
@@ -235,14 +235,14 @@ func TestAuthKeyLogoutAndReloginSameUserExpiredKey(t *testing.T) {
 
 	for _, https := range []bool{true, false} {
 		t.Run(fmt.Sprintf("with-https-%t", https), func(t *testing.T) {
-			scenario, err := NewScenario(dockertestMaxWait())
-			assertNoErr(t, err)
-			defer scenario.ShutdownAssertNoPanics(t)
-
 			spec := ScenarioSpec{
 				NodesPerUser: len(MustTestVersions),
 				Users:        []string{"user1", "user2"},
 			}
+
+			scenario, err := NewScenario(spec)
+			assertNoErr(t, err)
+			defer scenario.ShutdownAssertNoPanics(t)
 
 			opts := []hsic.Option{hsic.WithTestName("pingallbyip")}
 			if https {
@@ -251,7 +251,7 @@ func TestAuthKeyLogoutAndReloginSameUserExpiredKey(t *testing.T) {
 				}...)
 			}
 
-			err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, opts...)
+			err = scenario.CreateHeadscaleEnv([]tsic.Option{}, opts...)
 			assertNoErrHeadscaleEnv(t, err)
 
 			allClients, err := scenario.ListTailscaleClients()

--- a/integration/auth_oidc_test.go
+++ b/integration/auth_oidc_test.go
@@ -743,7 +743,7 @@ func (s *AuthOIDCScenario) runMockOIDC(accessTTL time.Duration, users []mockoidc
 		PortBindings: map[docker.Port][]docker.PortBinding{
 			docker.Port(portNotation): {{HostPort: strconv.Itoa(port)}},
 		},
-		Networks: []*dockertest.Network{s.Scenario.network},
+		Networks: s.Scenario.networks,
 		Env: []string{
 			fmt.Sprintf("MOCKOIDC_ADDR=%s", hostname),
 			fmt.Sprintf("MOCKOIDC_PORT=%d", port),
@@ -774,7 +774,7 @@ func (s *AuthOIDCScenario) runMockOIDC(accessTTL time.Duration, users []mockoidc
 	}
 
 	log.Println("Waiting for headscale mock oidc to be ready for tests")
-	hostEndpoint := fmt.Sprintf("%s:%d", s.mockOIDC.GetIPInNetwork(s.network), port)
+	hostEndpoint := fmt.Sprintf("%s:%d", hostname, port)
 
 	if err := s.pool.Retry(func() error {
 		oidcConfigURL := fmt.Sprintf("http://%s/oidc/.well-known/openid-configuration", hostEndpoint)
@@ -803,7 +803,7 @@ func (s *AuthOIDCScenario) runMockOIDC(accessTTL time.Duration, users []mockoidc
 	return &types.OIDCConfig{
 		Issuer: fmt.Sprintf(
 			"http://%s/oidc",
-			net.JoinHostPort(s.mockOIDC.GetIPInNetwork(s.network), strconv.Itoa(port)),
+			net.JoinHostPort(hostname, strconv.Itoa(port)),
 		),
 		ClientID:                   "superclient",
 		ClientSecret:               "supersecret",

--- a/integration/auth_oidc_test.go
+++ b/integration/auth_oidc_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juanfont/headscale/hscontrol/util"
 	"github.com/juanfont/headscale/integration/dockertestutil"
 	"github.com/juanfont/headscale/integration/hsic"
+	"github.com/juanfont/headscale/integration/tsic"
 	"github.com/oauth2-proxy/mockoidc"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
@@ -512,7 +513,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 	assertNoErr(t, err)
 	assert.Len(t, listUsers, 0)
 
-	ts, err := scenario.CreateTailscaleNode("unstable")
+	ts, err := scenario.CreateTailscaleNode("unstable", tsic.WithNetwork(scenario.networks[TestDefaultNetwork]))
 	assertNoErr(t, err)
 
 	u, err := ts.LoginWithURL(headscale.GetEndpoint())
@@ -743,7 +744,7 @@ func (s *AuthOIDCScenario) runMockOIDC(accessTTL time.Duration, users []mockoidc
 		PortBindings: map[docker.Port][]docker.PortBinding{
 			docker.Port(portNotation): {{HostPort: strconv.Itoa(port)}},
 		},
-		Networks: s.Scenario.networks,
+		Networks: s.Scenario.Networks(),
 		Env: []string{
 			fmt.Sprintf("MOCKOIDC_ADDR=%s", hostname),
 			fmt.Sprintf("MOCKOIDC_PORT=%d", port),

--- a/integration/auth_oidc_test.go
+++ b/integration/auth_oidc_test.go
@@ -1,51 +1,21 @@
 package integration
 
 import (
-	"context"
-	"crypto/tls"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
-	"log"
-	"net"
-	"net/http"
-	"net/http/cookiejar"
 	"net/netip"
-	"net/url"
 	"sort"
-	"strconv"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "github.com/juanfont/headscale/gen/go/headscale/v1"
-	"github.com/juanfont/headscale/hscontrol/types"
-	"github.com/juanfont/headscale/hscontrol/util"
-	"github.com/juanfont/headscale/integration/dockertestutil"
 	"github.com/juanfont/headscale/integration/hsic"
 	"github.com/juanfont/headscale/integration/tsic"
 	"github.com/oauth2-proxy/mockoidc"
-	"github.com/ory/dockertest/v3"
-	"github.com/ory/dockertest/v3/docker"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
-
-const (
-	dockerContextPath      = "../."
-	hsicOIDCMockHashLength = 6
-	defaultAccessTTL       = 10 * time.Minute
-)
-
-var errStatusCodeNotOK = errors.New("status code not OK")
-
-type AuthOIDCScenario struct {
-	*Scenario
-
-	mockOIDC *dockertest.Resource
-}
 
 func TestOIDCAuthenticationPingAll(t *testing.T) {
 	IntegrationSkip(t)
@@ -57,37 +27,30 @@ func TestOIDCAuthenticationPingAll(t *testing.T) {
 	spec := ScenarioSpec{
 		NodesPerUser: 1,
 		Users:        []string{"user1", "user2"},
+		OIDCUsers: []mockoidc.MockUser{
+			oidcMockUser("user1", true),
+			oidcMockUser("user2", false),
+		},
 	}
 
-	baseScenario, err := NewScenario(spec)
+	scenario, err := NewScenario(spec)
 	assertNoErr(t, err)
 
-	scenario := AuthOIDCScenario{
-		Scenario: baseScenario,
-	}
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	mockusers := []mockoidc.MockUser{
-		oidcMockUser("user1", true),
-		oidcMockUser("user2", false),
-	}
-
-	oidcConfig, err := scenario.runMockOIDC(defaultAccessTTL, mockusers)
-	assertNoErrf(t, "failed to run mock OIDC server: %s", err)
-	defer scenario.mockOIDC.Close()
-
 	oidcMap := map[string]string{
-		"HEADSCALE_OIDC_ISSUER":             oidcConfig.Issuer,
-		"HEADSCALE_OIDC_CLIENT_ID":          oidcConfig.ClientID,
+		"HEADSCALE_OIDC_ISSUER":             scenario.mockOIDC.Issuer(),
+		"HEADSCALE_OIDC_CLIENT_ID":          scenario.mockOIDC.ClientID(),
 		"CREDENTIALS_DIRECTORY_TEST":        "/tmp",
 		"HEADSCALE_OIDC_CLIENT_SECRET_PATH": "${CREDENTIALS_DIRECTORY_TEST}/hs_client_oidc_secret",
 	}
 
-	err = scenario.CreateHeadscaleEnv(
+	err = scenario.CreateHeadscaleEnvWithLoginURL(
+		nil,
 		hsic.WithTestName("oidcauthping"),
 		hsic.WithConfigEnv(oidcMap),
 		hsic.WithTLS(),
-		hsic.WithFileInContainer("/tmp/hs_client_oidc_secret", []byte(oidcConfig.ClientSecret)),
+		hsic.WithFileInContainer("/tmp/hs_client_oidc_secret", []byte(scenario.mockOIDC.ClientSecret())),
 	)
 	assertNoErrHeadscaleEnv(t, err)
 
@@ -126,7 +89,7 @@ func TestOIDCAuthenticationPingAll(t *testing.T) {
 			Name:       "user1",
 			Email:      "user1@headscale.net",
 			Provider:   "oidc",
-			ProviderId: oidcConfig.Issuer + "/user1",
+			ProviderId: scenario.mockOIDC.Issuer() + "/user1",
 		},
 		{
 			Id:    3,
@@ -138,7 +101,7 @@ func TestOIDCAuthenticationPingAll(t *testing.T) {
 			Name:       "user2",
 			Email:      "", // Unverified
 			Provider:   "oidc",
-			ProviderId: oidcConfig.Issuer + "/user2",
+			ProviderId: scenario.mockOIDC.Issuer() + "/user2",
 		},
 	}
 
@@ -161,33 +124,25 @@ func TestOIDCExpireNodesBasedOnTokenExpiry(t *testing.T) {
 	spec := ScenarioSpec{
 		NodesPerUser: 1,
 		Users:        []string{"user1", "user2"},
+		OIDCUsers: []mockoidc.MockUser{
+			oidcMockUser("user1", true),
+			oidcMockUser("user2", false),
+		},
 	}
 
-	baseScenario, err := NewScenario(spec)
+	scenario, err := NewScenario(spec)
 	assertNoErr(t, err)
-
-	baseScenario.pool.MaxWait = 5 * time.Minute
-
-	scenario := AuthOIDCScenario{
-		Scenario: baseScenario,
-	}
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	oidcConfig, err := scenario.runMockOIDC(shortAccessTTL, []mockoidc.MockUser{
-		oidcMockUser("user1", true),
-		oidcMockUser("user2", false),
-	})
-	assertNoErrf(t, "failed to run mock OIDC server: %s", err)
-	defer scenario.mockOIDC.Close()
-
 	oidcMap := map[string]string{
-		"HEADSCALE_OIDC_ISSUER":                oidcConfig.Issuer,
-		"HEADSCALE_OIDC_CLIENT_ID":             oidcConfig.ClientID,
-		"HEADSCALE_OIDC_CLIENT_SECRET":         oidcConfig.ClientSecret,
+		"HEADSCALE_OIDC_ISSUER":                scenario.mockOIDC.Issuer(),
+		"HEADSCALE_OIDC_CLIENT_ID":             scenario.mockOIDC.ClientID(),
+		"HEADSCALE_OIDC_CLIENT_SECRET":         scenario.mockOIDC.ClientSecret(),
 		"HEADSCALE_OIDC_USE_EXPIRY_FROM_TOKEN": "1",
 	}
 
-	err = scenario.CreateHeadscaleEnv(
+	err = scenario.CreateHeadscaleEnvWithLoginURL(
+		nil,
 		hsic.WithTestName("oidcexpirenodes"),
 		hsic.WithConfigEnv(oidcMap),
 	)
@@ -340,26 +295,17 @@ func TestOIDC024UserCreation(t *testing.T) {
 				spec.Users = append(spec.Users, user)
 			}
 
-			baseScenario, err := NewScenario(spec)
+			scenario, err := NewScenario(spec)
 			assertNoErr(t, err)
-
-			scenario := AuthOIDCScenario{
-				Scenario: baseScenario,
-			}
 			defer scenario.ShutdownAssertNoPanics(t)
 
-			var mockusers []mockoidc.MockUser
 			for _, user := range tt.oidcUsers {
-				mockusers = append(mockusers, oidcMockUser(user, tt.emailVerified))
+				spec.OIDCUsers = append(spec.OIDCUsers, oidcMockUser(user, tt.emailVerified))
 			}
 
-			oidcConfig, err := scenario.runMockOIDC(defaultAccessTTL, mockusers)
-			assertNoErrf(t, "failed to run mock OIDC server: %s", err)
-			defer scenario.mockOIDC.Close()
-
 			oidcMap := map[string]string{
-				"HEADSCALE_OIDC_ISSUER":             oidcConfig.Issuer,
-				"HEADSCALE_OIDC_CLIENT_ID":          oidcConfig.ClientID,
+				"HEADSCALE_OIDC_ISSUER":             scenario.mockOIDC.Issuer(),
+				"HEADSCALE_OIDC_CLIENT_ID":          scenario.mockOIDC.ClientID(),
 				"CREDENTIALS_DIRECTORY_TEST":        "/tmp",
 				"HEADSCALE_OIDC_CLIENT_SECRET_PATH": "${CREDENTIALS_DIRECTORY_TEST}/hs_client_oidc_secret",
 			}
@@ -368,11 +314,12 @@ func TestOIDC024UserCreation(t *testing.T) {
 				oidcMap[k] = v
 			}
 
-			err = scenario.CreateHeadscaleEnv(
+			err = scenario.CreateHeadscaleEnvWithLoginURL(
+				nil,
 				hsic.WithTestName("oidcmigration"),
 				hsic.WithConfigEnv(oidcMap),
 				hsic.WithTLS(),
-				hsic.WithFileInContainer("/tmp/hs_client_oidc_secret", []byte(oidcConfig.ClientSecret)),
+				hsic.WithFileInContainer("/tmp/hs_client_oidc_secret", []byte(scenario.mockOIDC.ClientSecret())),
 			)
 			assertNoErrHeadscaleEnv(t, err)
 
@@ -384,7 +331,7 @@ func TestOIDC024UserCreation(t *testing.T) {
 			headscale, err := scenario.Headscale()
 			assertNoErr(t, err)
 
-			want := tt.want(oidcConfig.Issuer)
+			want := tt.want(scenario.mockOIDC.Issuer())
 
 			listUsers, err := headscale.ListUsers()
 			assertNoErr(t, err)
@@ -408,37 +355,29 @@ func TestOIDCAuthenticationWithPKCE(t *testing.T) {
 	spec := ScenarioSpec{
 		NodesPerUser: 1,
 		Users:        []string{"user1"},
+		OIDCUsers: []mockoidc.MockUser{
+			oidcMockUser("user1", true),
+		},
 	}
 
-	baseScenario, err := NewScenario(spec)
+	scenario, err := NewScenario(spec)
 	assertNoErr(t, err)
-
-	scenario := AuthOIDCScenario{
-		Scenario: baseScenario,
-	}
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	mockusers := []mockoidc.MockUser{
-		oidcMockUser("user1", true),
-	}
-
-	oidcConfig, err := scenario.runMockOIDC(defaultAccessTTL, mockusers)
-	assertNoErrf(t, "failed to run mock OIDC server: %s", err)
-	defer scenario.mockOIDC.Close()
-
 	oidcMap := map[string]string{
-		"HEADSCALE_OIDC_ISSUER":             oidcConfig.Issuer,
-		"HEADSCALE_OIDC_CLIENT_ID":          oidcConfig.ClientID,
+		"HEADSCALE_OIDC_ISSUER":             scenario.mockOIDC.Issuer(),
+		"HEADSCALE_OIDC_CLIENT_ID":          scenario.mockOIDC.ClientID(),
 		"HEADSCALE_OIDC_CLIENT_SECRET_PATH": "${CREDENTIALS_DIRECTORY_TEST}/hs_client_oidc_secret",
 		"CREDENTIALS_DIRECTORY_TEST":        "/tmp",
 		"HEADSCALE_OIDC_PKCE_ENABLED":       "1", // Enable PKCE
 	}
 
-	err = scenario.CreateHeadscaleEnv(
+	err = scenario.CreateHeadscaleEnvWithLoginURL(
+		nil,
 		hsic.WithTestName("oidcauthpkce"),
 		hsic.WithConfigEnv(oidcMap),
 		hsic.WithTLS(),
-		hsic.WithFileInContainer("/tmp/hs_client_oidc_secret", []byte(oidcConfig.ClientSecret)),
+		hsic.WithFileInContainer("/tmp/hs_client_oidc_secret", []byte(scenario.mockOIDC.ClientSecret())),
 	)
 	assertNoErrHeadscaleEnv(t, err)
 
@@ -465,39 +404,32 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 	t.Parallel()
 
 	// Create no nodes and no users
-	baseScenario, err := NewScenario(ScenarioSpec{})
+	scenario, err := NewScenario(ScenarioSpec{
+		// First login creates the first OIDC user
+		// Second login logs in the same node, which creates a new node
+		// Third login logs in the same node back into the original user
+		OIDCUsers: []mockoidc.MockUser{
+			oidcMockUser("user1", true),
+			oidcMockUser("user2", true),
+			oidcMockUser("user1", true),
+		},
+	})
 	assertNoErr(t, err)
-
-	scenario := AuthOIDCScenario{
-		Scenario: baseScenario,
-	}
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	// First login creates the first OIDC user
-	// Second login logs in the same node, which creates a new node
-	// Third login logs in the same node back into the original user
-	mockusers := []mockoidc.MockUser{
-		oidcMockUser("user1", true),
-		oidcMockUser("user2", true),
-		oidcMockUser("user1", true),
-	}
-
-	oidcConfig, err := scenario.runMockOIDC(defaultAccessTTL, mockusers)
-	assertNoErrf(t, "failed to run mock OIDC server: %s", err)
-	// defer scenario.mockOIDC.Close()
-
 	oidcMap := map[string]string{
-		"HEADSCALE_OIDC_ISSUER":             oidcConfig.Issuer,
-		"HEADSCALE_OIDC_CLIENT_ID":          oidcConfig.ClientID,
+		"HEADSCALE_OIDC_ISSUER":             scenario.mockOIDC.Issuer(),
+		"HEADSCALE_OIDC_CLIENT_ID":          scenario.mockOIDC.ClientID(),
 		"CREDENTIALS_DIRECTORY_TEST":        "/tmp",
 		"HEADSCALE_OIDC_CLIENT_SECRET_PATH": "${CREDENTIALS_DIRECTORY_TEST}/hs_client_oidc_secret",
 	}
 
-	err = scenario.CreateHeadscaleEnv(
+	err = scenario.CreateHeadscaleEnvWithLoginURL(
+		nil,
 		hsic.WithTestName("oidcauthrelog"),
 		hsic.WithConfigEnv(oidcMap),
 		hsic.WithTLS(),
-		hsic.WithFileInContainer("/tmp/hs_client_oidc_secret", []byte(oidcConfig.ClientSecret)),
+		hsic.WithFileInContainer("/tmp/hs_client_oidc_secret", []byte(scenario.mockOIDC.ClientSecret())),
 		hsic.WithEmbeddedDERPServerOnly(),
 	)
 	assertNoErrHeadscaleEnv(t, err)
@@ -527,7 +459,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 			Name:       "user1",
 			Email:      "user1@headscale.net",
 			Provider:   "oidc",
-			ProviderId: oidcConfig.Issuer + "/user1",
+			ProviderId: scenario.mockOIDC.Issuer() + "/user1",
 		},
 	}
 
@@ -572,14 +504,14 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 			Name:       "user1",
 			Email:      "user1@headscale.net",
 			Provider:   "oidc",
-			ProviderId: oidcConfig.Issuer + "/user1",
+			ProviderId: scenario.mockOIDC.Issuer() + "/user1",
 		},
 		{
 			Id:         2,
 			Name:       "user2",
 			Email:      "user2@headscale.net",
 			Provider:   "oidc",
-			ProviderId: oidcConfig.Issuer + "/user2",
+			ProviderId: scenario.mockOIDC.Issuer() + "/user2",
 		},
 	}
 
@@ -629,14 +561,14 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 			Name:       "user1",
 			Email:      "user1@headscale.net",
 			Provider:   "oidc",
-			ProviderId: oidcConfig.Issuer + "/user1",
+			ProviderId: scenario.mockOIDC.Issuer() + "/user1",
 		},
 		{
 			Id:         2,
 			Name:       "user2",
 			Email:      "user2@headscale.net",
 			Provider:   "oidc",
-			ProviderId: oidcConfig.Issuer + "/user2",
+			ProviderId: scenario.mockOIDC.Issuer() + "/user2",
 		},
 	}
 
@@ -673,253 +605,6 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 	// than the version logged in with a different user.
 	assert.Equal(t, listNodesAfterLoggingBackIn[0].MachineKey, listNodesAfterLoggingBackIn[1].MachineKey)
 	assert.NotEqual(t, listNodesAfterLoggingBackIn[0].NodeKey, listNodesAfterLoggingBackIn[1].NodeKey)
-}
-
-func (s *AuthOIDCScenario) CreateHeadscaleEnv(
-	opts ...hsic.Option,
-) error {
-	headscale, err := s.Headscale(opts...)
-	if err != nil {
-		return err
-	}
-
-	err = headscale.WaitForRunning()
-	if err != nil {
-		return err
-	}
-
-	for _, userName := range s.spec.Users {
-		if s.spec.NodesPerUser != 1 {
-			// OIDC scenario only supports one client per user.
-			// This is because the MockOIDC server can only serve login
-			// requests based on a queue it has been given on startup.
-			// We currently only populates it with one login request per user.
-			return fmt.Errorf("client count must be 1 for OIDC scenario.")
-		}
-		log.Printf("creating user %s with %d clients", userName, s.spec.NodesPerUser)
-		err = s.CreateUser(userName)
-		if err != nil {
-			return err
-		}
-
-		err = s.CreateTailscaleNodesInUser(userName, "all", s.spec.NodesPerUser)
-		if err != nil {
-			return err
-		}
-
-		err = s.runTailscaleUp(userName, headscale.GetEndpoint())
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (s *AuthOIDCScenario) runMockOIDC(accessTTL time.Duration, users []mockoidc.MockUser) (*types.OIDCConfig, error) {
-	port, err := dockertestutil.RandomFreeHostPort()
-	if err != nil {
-		log.Fatalf("could not find an open port: %s", err)
-	}
-	portNotation := fmt.Sprintf("%d/tcp", port)
-
-	hash, _ := util.GenerateRandomStringDNSSafe(hsicOIDCMockHashLength)
-
-	hostname := fmt.Sprintf("hs-oidcmock-%s", hash)
-
-	usersJSON, err := json.Marshal(users)
-	if err != nil {
-		return nil, err
-	}
-
-	mockOidcOptions := &dockertest.RunOptions{
-		Name:         hostname,
-		Cmd:          []string{"headscale", "mockoidc"},
-		ExposedPorts: []string{portNotation},
-		PortBindings: map[docker.Port][]docker.PortBinding{
-			docker.Port(portNotation): {{HostPort: strconv.Itoa(port)}},
-		},
-		Networks: s.Scenario.Networks(),
-		Env: []string{
-			fmt.Sprintf("MOCKOIDC_ADDR=%s", hostname),
-			fmt.Sprintf("MOCKOIDC_PORT=%d", port),
-			"MOCKOIDC_CLIENT_ID=superclient",
-			"MOCKOIDC_CLIENT_SECRET=supersecret",
-			fmt.Sprintf("MOCKOIDC_ACCESS_TTL=%s", accessTTL.String()),
-			fmt.Sprintf("MOCKOIDC_USERS=%s", string(usersJSON)),
-		},
-	}
-
-	headscaleBuildOptions := &dockertest.BuildOptions{
-		Dockerfile: hsic.IntegrationTestDockerFileName,
-		ContextDir: dockerContextPath,
-	}
-
-	err = s.pool.RemoveContainerByName(hostname)
-	if err != nil {
-		return nil, err
-	}
-
-	if pmockoidc, err := s.pool.BuildAndRunWithBuildOptions(
-		headscaleBuildOptions,
-		mockOidcOptions,
-		dockertestutil.DockerRestartPolicy); err == nil {
-		s.mockOIDC = pmockoidc
-	} else {
-		return nil, err
-	}
-
-	log.Println("Waiting for headscale mock oidc to be ready for tests")
-	hostEndpoint := fmt.Sprintf("%s:%d", hostname, port)
-
-	if err := s.pool.Retry(func() error {
-		oidcConfigURL := fmt.Sprintf("http://%s/oidc/.well-known/openid-configuration", hostEndpoint)
-		httpClient := &http.Client{}
-		ctx := context.Background()
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, oidcConfigURL, nil)
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			log.Printf("headscale mock OIDC tests is not ready: %s\n", err)
-
-			return err
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return errStatusCodeNotOK
-		}
-
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-
-	log.Printf("headscale mock oidc is ready for tests at %s", hostEndpoint)
-
-	return &types.OIDCConfig{
-		Issuer: fmt.Sprintf(
-			"http://%s/oidc",
-			net.JoinHostPort(hostname, strconv.Itoa(port)),
-		),
-		ClientID:                   "superclient",
-		ClientSecret:               "supersecret",
-		OnlyStartIfOIDCIsAvailable: true,
-	}, nil
-}
-
-type LoggingRoundTripper struct{}
-
-func (t LoggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	noTls := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // nolint
-	}
-	resp, err := noTls.RoundTrip(req)
-	if err != nil {
-		return nil, err
-	}
-
-	log.Printf("---")
-	log.Printf("method: %s | url: %s", resp.Request.Method, resp.Request.URL.String())
-	log.Printf("status: %d | cookies: %+v", resp.StatusCode, resp.Cookies())
-
-	return resp, nil
-}
-
-func (s *AuthOIDCScenario) runTailscaleUp(
-	userStr, loginServer string,
-) error {
-	log.Printf("running tailscale up for user %s", userStr)
-	if user, ok := s.users[userStr]; ok {
-		for _, client := range user.Clients {
-			tsc := client
-			user.joinWaitGroup.Go(func() error {
-				loginURL, err := tsc.LoginWithURL(loginServer)
-				if err != nil {
-					log.Printf("%s failed to run tailscale up: %s", tsc.Hostname(), err)
-				}
-
-				_, err = doLoginURL(tsc.Hostname(), loginURL)
-				if err != nil {
-					return err
-				}
-
-				return nil
-			})
-
-			log.Printf("client %s is ready", client.Hostname())
-		}
-
-		if err := user.joinWaitGroup.Wait(); err != nil {
-			return err
-		}
-
-		for _, client := range user.Clients {
-			err := client.WaitForRunning()
-			if err != nil {
-				return fmt.Errorf(
-					"%s tailscale node has not reached running: %w",
-					client.Hostname(),
-					err,
-				)
-			}
-		}
-
-		return nil
-	}
-
-	return fmt.Errorf("failed to up tailscale node: %w", errNoUserAvailable)
-}
-
-// doLoginURL visits the given login URL and returns the body as a
-// string.
-func doLoginURL(hostname string, loginURL *url.URL) (string, error) {
-	log.Printf("%s login url: %s\n", hostname, loginURL.String())
-
-	var err error
-	hc := &http.Client{
-		Transport: LoggingRoundTripper{},
-	}
-	hc.Jar, err = cookiejar.New(nil)
-	if err != nil {
-		return "", fmt.Errorf("%s failed to create cookiejar	: %w", hostname, err)
-	}
-
-	log.Printf("%s logging in with url", hostname)
-	ctx := context.Background()
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, loginURL.String(), nil)
-	resp, err := hc.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("%s failed to send http request: %w", hostname, err)
-	}
-
-	log.Printf("cookies: %+v", hc.Jar.Cookies(loginURL))
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		log.Printf("body: %s", body)
-
-		return "", fmt.Errorf("%s response code of login request was %w", hostname, err)
-	}
-
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Printf("%s failed to read response body: %s", hostname, err)
-
-		return "", fmt.Errorf("%s failed to read response body: %w", hostname, err)
-	}
-
-	return string(body), nil
-}
-
-func (s *AuthOIDCScenario) Shutdown() {
-	err := s.pool.Purge(s.mockOIDC)
-	if err != nil {
-		log.Printf("failed to remove mock oidc container")
-	}
-
-	s.Scenario.Shutdown()
 }
 
 func assertTailscaleNodesLogout(t *testing.T, clients []TailscaleClient) {

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -528,7 +528,8 @@ func TestPreAuthKeyCorrectUserLoggedInCommand(t *testing.T) {
 	user2 := "user2"
 
 	spec := ScenarioSpec{
-		Users: []string{user1, user2},
+		NodesPerUser: 1,
+		Users:        []string{user1},
 	}
 
 	scenario, err := NewScenario(spec)
@@ -544,6 +545,9 @@ func TestPreAuthKeyCorrectUserLoggedInCommand(t *testing.T) {
 	assertNoErr(t, err)
 
 	headscale, err := scenario.Headscale()
+	assertNoErr(t, err)
+
+	err = headscale.CreateUser(user2)
 	assertNoErr(t, err)
 
 	var user2Key v1.PreAuthKey
@@ -568,10 +572,15 @@ func TestPreAuthKeyCorrectUserLoggedInCommand(t *testing.T) {
 	)
 	assertNoErr(t, err)
 
+	listNodes, err := headscale.ListNodes()
+	require.Nil(t, err)
+	require.Len(t, listNodes, 1)
+	assert.Equal(t, user1, listNodes[0].GetUser().GetName())
+
 	allClients, err := scenario.ListTailscaleClients()
 	assertNoErrListClients(t, err)
 
-	assert.Len(t, allClients, 1)
+	require.Len(t, allClients, 1)
 
 	client := allClients[0]
 
@@ -601,12 +610,11 @@ func TestPreAuthKeyCorrectUserLoggedInCommand(t *testing.T) {
 		t.Fatalf("expected node to be logged in as userid:2, got: %s", status.Self.UserID.String())
 	}
 
-	listNodes, err := headscale.ListNodes()
-	assert.Nil(t, err)
-	assert.Len(t, listNodes, 2)
-
-	assert.Equal(t, "user1", listNodes[0].GetUser().GetName())
-	assert.Equal(t, "user2", listNodes[1].GetUser().GetName())
+	listNodes, err = headscale.ListNodes()
+	require.Nil(t, err)
+	require.Len(t, listNodes, 2)
+	assert.Equal(t, user1, listNodes[0].GetUser().GetName())
+	assert.Equal(t, user2, listNodes[1].GetUser().GetName())
 }
 
 func TestApiKeyCommand(t *testing.T) {

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -52,9 +52,8 @@ func TestUserCommand(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"user1": 0,
-		"user2": 0,
+	spec := ScenarioSpec{
+		Users: []string{"user1", "user2"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
@@ -251,8 +250,8 @@ func TestPreAuthKeyCommand(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		user: 0,
+	spec := ScenarioSpec{
+		Users: []string{user},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clipak"))
@@ -393,8 +392,8 @@ func TestPreAuthKeyCommandWithoutExpiry(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		user: 0,
+	spec := ScenarioSpec{
+		Users: []string{user},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clipaknaexp"))
@@ -456,8 +455,8 @@ func TestPreAuthKeyCommandReusableEphemeral(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		user: 0,
+	spec := ScenarioSpec{
+		Users: []string{user},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clipakresueeph"))
@@ -534,9 +533,8 @@ func TestPreAuthKeyCorrectUserLoggedInCommand(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		user1: 1,
-		user2: 0,
+	spec := ScenarioSpec{
+		Users: []string{user1, user2},
 	}
 
 	err = scenario.CreateHeadscaleEnv(
@@ -624,9 +622,8 @@ func TestApiKeyCommand(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"user1": 0,
-		"user2": 0,
+	spec := ScenarioSpec{
+		Users: []string{"user1", "user2"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
@@ -792,8 +789,8 @@ func TestNodeTagCommand(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"user1": 0,
+	spec := ScenarioSpec{
+		Users: []string{"user1"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
@@ -981,8 +978,9 @@ func TestNodeAdvertiseTagCommand(t *testing.T) {
 			assertNoErr(t, err)
 			defer scenario.ShutdownAssertNoPanics(t)
 
-			spec := map[string]int{
-				"user1": 1,
+			spec := ScenarioSpec{
+				NodesPerUser: 1,
+				Users:        []string{"user1"},
 			}
 
 			err = scenario.CreateHeadscaleEnv(spec,
@@ -996,7 +994,7 @@ func TestNodeAdvertiseTagCommand(t *testing.T) {
 			assertNoErr(t, err)
 
 			// Test list all nodes after added seconds
-			resultMachines := make([]*v1.Node, spec["user1"])
+			resultMachines := make([]*v1.Node, spec.NodesPerUser)
 			err = executeAndUnmarshal(
 				headscale,
 				[]string{
@@ -1033,9 +1031,8 @@ func TestNodeCommand(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"node-user":  0,
-		"other-user": 0,
+	spec := ScenarioSpec{
+		Users: []string{"node-user", "other-user"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
@@ -1273,8 +1270,8 @@ func TestNodeExpireCommand(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"node-expire-user": 0,
+	spec := ScenarioSpec{
+		Users: []string{"node-expire-user"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
@@ -1399,8 +1396,8 @@ func TestNodeRenameCommand(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"node-rename-command": 0,
+	spec := ScenarioSpec{
+		Users: []string{"node-rename-command"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
@@ -1564,9 +1561,8 @@ func TestNodeMoveCommand(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"old-user": 0,
-		"new-user": 0,
+	spec := ScenarioSpec{
+		Users: []string{"old-user", "new-user"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
@@ -1725,8 +1721,8 @@ func TestPolicyCommand(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"user1": 0,
+	spec := ScenarioSpec{
+		Users: []string{"user1"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(
@@ -1812,8 +1808,9 @@ func TestPolicyBrokenConfigCommand(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"user1": 1,
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{"user1"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -48,15 +48,15 @@ func TestUserCommand(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		Users: []string{"user1", "user2"},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("clins"))
 	assertNoErr(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -246,15 +246,15 @@ func TestPreAuthKeyCommand(t *testing.T) {
 	user := "preauthkeyspace"
 	count := 3
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		Users: []string{user},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clipak"))
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("clipak"))
 	assertNoErr(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -387,16 +387,15 @@ func TestPreAuthKeyCommandWithoutExpiry(t *testing.T) {
 	t.Parallel()
 
 	user := "pre-auth-key-without-exp-user"
-
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		Users: []string{user},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clipaknaexp"))
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("clipaknaexp"))
 	assertNoErr(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -450,16 +449,15 @@ func TestPreAuthKeyCommandReusableEphemeral(t *testing.T) {
 	t.Parallel()
 
 	user := "pre-auth-key-reus-ephm-user"
-
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		Users: []string{user},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clipakresueeph"))
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("clipakresueeph"))
 	assertNoErr(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -529,16 +527,15 @@ func TestPreAuthKeyCorrectUserLoggedInCommand(t *testing.T) {
 	user1 := "user1"
 	user2 := "user2"
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		Users: []string{user1, user2},
 	}
 
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
 	err = scenario.CreateHeadscaleEnv(
-		spec,
 		[]tsic.Option{},
 		hsic.WithTestName("clipak"),
 		hsic.WithEmbeddedDERPServerOnly(),
@@ -618,15 +615,15 @@ func TestApiKeyCommand(t *testing.T) {
 
 	count := 5
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		Users: []string{"user1", "user2"},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("clins"))
 	assertNoErr(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -785,15 +782,15 @@ func TestNodeTagCommand(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		Users: []string{"user1"},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("clins"))
 	assertNoErr(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -974,16 +971,16 @@ func TestNodeAdvertiseTagCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			scenario, err := NewScenario(dockertestMaxWait())
-			assertNoErr(t, err)
-			defer scenario.ShutdownAssertNoPanics(t)
-
 			spec := ScenarioSpec{
 				NodesPerUser: 1,
 				Users:        []string{"user1"},
 			}
 
-			err = scenario.CreateHeadscaleEnv(spec,
+			scenario, err := NewScenario(spec)
+			assertNoErr(t, err)
+			defer scenario.ShutdownAssertNoPanics(t)
+
+			err = scenario.CreateHeadscaleEnv(
 				[]tsic.Option{tsic.WithTags([]string{"tag:test"})},
 				hsic.WithTestName("cliadvtags"),
 				hsic.WithACLPolicy(tt.policy),
@@ -1027,15 +1024,15 @@ func TestNodeCommand(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		Users: []string{"node-user", "other-user"},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("clins"))
 	assertNoErr(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -1266,15 +1263,15 @@ func TestNodeExpireCommand(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		Users: []string{"node-expire-user"},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("clins"))
 	assertNoErr(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -1392,15 +1389,15 @@ func TestNodeRenameCommand(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		Users: []string{"node-rename-command"},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("clins"))
 	assertNoErr(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -1557,15 +1554,15 @@ func TestNodeMoveCommand(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		Users: []string{"old-user", "new-user"},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clins"))
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("clins"))
 	assertNoErr(t, err)
 
 	headscale, err := scenario.Headscale()
@@ -1717,16 +1714,15 @@ func TestPolicyCommand(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		Users: []string{"user1"},
 	}
 
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
 	err = scenario.CreateHeadscaleEnv(
-		spec,
 		[]tsic.Option{},
 		hsic.WithTestName("clins"),
 		hsic.WithConfigEnv(map[string]string{
@@ -1804,17 +1800,16 @@ func TestPolicyBrokenConfigCommand(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		NodesPerUser: 1,
 		Users:        []string{"user1"},
 	}
 
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
 	err = scenario.CreateHeadscaleEnv(
-		spec,
 		[]tsic.Option{},
 		hsic.WithTestName("clins"),
 		hsic.WithConfigEnv(map[string]string{

--- a/integration/control.go
+++ b/integration/control.go
@@ -24,5 +24,4 @@ type ControlServer interface {
 	ApproveRoutes(uint64, []netip.Prefix) (*v1.Node, error)
 	GetCert() []byte
 	GetHostname() string
-	GetIP() string
 }

--- a/integration/derp_verify_endpoint_test.go
+++ b/integration/derp_verify_endpoint_test.go
@@ -35,8 +35,9 @@ func TestDERPVerifyEndpoint(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"user1": len(MustTestVersions),
+	spec := ScenarioSpec{
+		NodesPerUser: len(MustTestVersions),
+		Users:        []string{"user1"},
 	}
 
 	derper, err := scenario.CreateDERPServer("head",

--- a/integration/derp_verify_endpoint_test.go
+++ b/integration/derp_verify_endpoint_test.go
@@ -31,14 +31,14 @@ func TestDERPVerifyEndpoint(t *testing.T) {
 	certHeadscale, keyHeadscale, err := integrationutil.CreateCertificate(hostname)
 	assertNoErr(t, err)
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		NodesPerUser: len(MustTestVersions),
 		Users:        []string{"user1"},
 	}
+
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	derper, err := scenario.CreateDERPServer("head",
 		dsic.WithCACert(certHeadscale),
@@ -66,7 +66,7 @@ func TestDERPVerifyEndpoint(t *testing.T) {
 		},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{tsic.WithCACert(derper.GetCert())},
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{tsic.WithCACert(derper.GetCert())},
 		hsic.WithHostname(hostname),
 		hsic.WithPort(headscalePort),
 		hsic.WithCustomTLS(certHeadscale, keyHeadscale),

--- a/integration/dns_test.go
+++ b/integration/dns_test.go
@@ -21,9 +21,9 @@ func TestResolveMagicDNS(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"magicdns1": len(MustTestVersions),
-		"magicdns2": len(MustTestVersions),
+	spec := ScenarioSpec{
+		NodesPerUser: len(MustTestVersions),
+		Users:        []string{"user1", "user2"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("magicdns"))
@@ -91,9 +91,9 @@ func TestResolveMagicDNSExtraRecordsPath(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"magicdns1": 1,
-		"magicdns2": 1,
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{"user1", "user2"},
 	}
 
 	const erPath = "/tmp/extra_records.json"
@@ -368,9 +368,9 @@ func TestValidateResolvConf(t *testing.T) {
 			assertNoErr(t, err)
 			defer scenario.ShutdownAssertNoPanics(t)
 
-			spec := map[string]int{
-				"resolvconf1": 3,
-				"resolvconf2": 3,
+			spec := ScenarioSpec{
+				NodesPerUser: 3,
+				Users:        []string{"user1", "user2"},
 			}
 
 			err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("resolvconf"), hsic.WithConfigEnv(tt.conf))

--- a/integration/dns_test.go
+++ b/integration/dns_test.go
@@ -17,16 +17,16 @@ func TestResolveMagicDNS(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		NodesPerUser: len(MustTestVersions),
 		Users:        []string{"user1", "user2"},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("magicdns"))
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("magicdns"))
 	assertNoErrHeadscaleEnv(t, err)
 
 	allClients, err := scenario.ListTailscaleClients()
@@ -87,14 +87,14 @@ func TestResolveMagicDNSExtraRecordsPath(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		NodesPerUser: 1,
 		Users:        []string{"user1", "user2"},
 	}
+
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	const erPath = "/tmp/extra_records.json"
 
@@ -107,7 +107,7 @@ func TestResolveMagicDNSExtraRecordsPath(t *testing.T) {
 	}
 	b, _ := json.Marshal(extraRecords)
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{
 		tsic.WithDockerEntrypoint([]string{
 			"/bin/sh",
 			"-c",
@@ -364,16 +364,16 @@ func TestValidateResolvConf(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			scenario, err := NewScenario(dockertestMaxWait())
-			assertNoErr(t, err)
-			defer scenario.ShutdownAssertNoPanics(t)
-
 			spec := ScenarioSpec{
 				NodesPerUser: 3,
 				Users:        []string{"user1", "user2"},
 			}
 
-			err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("resolvconf"), hsic.WithConfigEnv(tt.conf))
+			scenario, err := NewScenario(spec)
+			assertNoErr(t, err)
+			defer scenario.ShutdownAssertNoPanics(t)
+
+			err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("resolvconf"), hsic.WithConfigEnv(tt.conf))
 			assertNoErrHeadscaleEnv(t, err)
 
 			allClients, err := scenario.ListTailscaleClients()

--- a/integration/embedded_derp_test.go
+++ b/integration/embedded_derp_test.go
@@ -210,7 +210,6 @@ func (s *EmbeddedDERPServerScenario) CreateHeadscaleEnv(
 	if err != nil {
 		return err
 	}
-	log.Printf("headscale server ip address: %s", hsServer.GetIP())
 
 	hash, err := util.GenerateRandomStringDNSSafe(scenarioHashLength)
 	if err != nil {

--- a/integration/embedded_derp_test.go
+++ b/integration/embedded_derp_test.go
@@ -315,7 +315,6 @@ func (s *EmbeddedDERPServerScenario) CreateTailscaleIsolatedNodesInUser(
 				tsClient, err := tsic.New(
 					s.pool,
 					version,
-					network,
 					opts...,
 				)
 				if err != nil {

--- a/integration/embedded_derp_test.go
+++ b/integration/embedded_derp_test.go
@@ -1,18 +1,12 @@
 package integration
 
 import (
-	"fmt"
-	"log"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/juanfont/headscale/hscontrol/util"
-	"github.com/juanfont/headscale/integration/dockertestutil"
 	"github.com/juanfont/headscale/integration/hsic"
 	"github.com/juanfont/headscale/integration/tsic"
-	"github.com/ory/dockertest/v3"
 )
 
 type ClientsSpec struct {
@@ -20,21 +14,18 @@ type ClientsSpec struct {
 	WebsocketDERP int
 }
 
-type EmbeddedDERPServerScenario struct {
-	*Scenario
-
-	tsicNetworks map[string]*dockertest.Network
-}
-
 func TestDERPServerScenario(t *testing.T) {
-	spec := map[string]ClientsSpec{
-		"user1": {
-			Plain:         len(MustTestVersions),
-			WebsocketDERP: 0,
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{"user1", "user2", "user3"},
+		Networks: map[string][]string{
+			"usernet1": {"user1"},
+			"usernet2": {"user2"},
+			"usernet3": {"user3"},
 		},
 	}
 
-	derpServerScenario(t, spec, func(scenario *EmbeddedDERPServerScenario) {
+	derpServerScenario(t, spec, false, func(scenario *Scenario) {
 		allClients, err := scenario.ListTailscaleClients()
 		assertNoErrListClients(t, err)
 		t.Logf("checking %d clients for websocket connections", len(allClients))
@@ -52,14 +43,17 @@ func TestDERPServerScenario(t *testing.T) {
 }
 
 func TestDERPServerWebsocketScenario(t *testing.T) {
-	spec := map[string]ClientsSpec{
-		"user1": {
-			Plain:         0,
-			WebsocketDERP: 2,
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{"user1", "user2", "user3"},
+		Networks: map[string][]string{
+			"usernet1": []string{"user1"},
+			"usernet2": []string{"user2"},
+			"usernet3": []string{"user3"},
 		},
 	}
 
-	derpServerScenario(t, spec, func(scenario *EmbeddedDERPServerScenario) {
+	derpServerScenario(t, spec, true, func(scenario *Scenario) {
 		allClients, err := scenario.ListTailscaleClients()
 		assertNoErrListClients(t, err)
 		t.Logf("checking %d clients for websocket connections", len(allClients))
@@ -83,23 +77,22 @@ func TestDERPServerWebsocketScenario(t *testing.T) {
 //nolint:thelper
 func derpServerScenario(
 	t *testing.T,
-	spec map[string]ClientsSpec,
-	furtherAssertions ...func(*EmbeddedDERPServerScenario),
+	spec ScenarioSpec,
+	websocket bool,
+	furtherAssertions ...func(*Scenario),
 ) {
 	IntegrationSkip(t)
 	// t.Parallel()
 
-	baseScenario, err := NewScenario(dockertestMaxWait())
+	scenario, err := NewScenario(spec)
 	assertNoErr(t, err)
 
-	scenario := EmbeddedDERPServerScenario{
-		Scenario:     baseScenario,
-		tsicNetworks: map[string]*dockertest.Network{},
-	}
 	defer scenario.ShutdownAssertNoPanics(t)
 
 	err = scenario.CreateHeadscaleEnv(
-		spec,
+		[]tsic.Option{
+			tsic.WithWebsocketDERP(websocket),
+		},
 		hsic.WithTestName("derpserver"),
 		hsic.WithExtraPorts([]string{"3478/udp"}),
 		hsic.WithEmbeddedDERPServerOnly(),
@@ -185,180 +178,6 @@ func derpServerScenario(
 	t.Logf("Run2: %d successful pings out of %d", success, len(allClients)*len(allHostnames))
 
 	for _, check := range furtherAssertions {
-		check(&scenario)
+		check(scenario)
 	}
-}
-
-func (s *EmbeddedDERPServerScenario) CreateHeadscaleEnv(
-	users map[string]ClientsSpec,
-	opts ...hsic.Option,
-) error {
-	hsServer, err := s.Headscale(opts...)
-	if err != nil {
-		return err
-	}
-
-	headscaleEndpoint := hsServer.GetEndpoint()
-	headscaleURL, err := url.Parse(headscaleEndpoint)
-	if err != nil {
-		return err
-	}
-
-	headscaleURL.Host = fmt.Sprintf("%s:%s", hsServer.GetHostname(), headscaleURL.Port())
-
-	err = hsServer.WaitForRunning()
-	if err != nil {
-		return err
-	}
-
-	hash, err := util.GenerateRandomStringDNSSafe(scenarioHashLength)
-	if err != nil {
-		return err
-	}
-
-	for userName, clientCount := range users {
-		err = s.CreateUser(userName)
-		if err != nil {
-			return err
-		}
-
-		if clientCount.Plain > 0 {
-			// Containers that use default DERP config
-			err = s.CreateTailscaleIsolatedNodesInUser(
-				hash,
-				userName,
-				"all",
-				clientCount.Plain,
-			)
-			if err != nil {
-				return err
-			}
-		}
-
-		if clientCount.WebsocketDERP > 0 {
-			// Containers that use DERP-over-WebSocket
-			// Note that these clients *must* be built
-			// from source, which is currently
-			// only done for HEAD.
-			err = s.CreateTailscaleIsolatedNodesInUser(
-				hash,
-				userName,
-				tsic.VersionHead,
-				clientCount.WebsocketDERP,
-				tsic.WithWebsocketDERP(true),
-			)
-			if err != nil {
-				return err
-			}
-		}
-
-		key, err := s.CreatePreAuthKey(userName, true, false)
-		if err != nil {
-			return err
-		}
-
-		err = s.RunTailscaleUp(userName, headscaleURL.String(), key.GetKey())
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (s *EmbeddedDERPServerScenario) CreateTailscaleIsolatedNodesInUser(
-	hash string,
-	userStr string,
-	requestedVersion string,
-	count int,
-	opts ...tsic.Option,
-) error {
-	hsServer, err := s.Headscale()
-	if err != nil {
-		return err
-	}
-
-	if user, ok := s.users[userStr]; ok {
-		for clientN := 0; clientN < count; clientN++ {
-			networkName := fmt.Sprintf("tsnet-%s-%s-%d",
-				hash,
-				userStr,
-				clientN,
-			)
-			network, err := dockertestutil.GetFirstOrCreateNetwork(
-				s.pool,
-				networkName,
-			)
-			if err != nil {
-				return fmt.Errorf("failed to create or get %s network: %w", networkName, err)
-			}
-
-			s.tsicNetworks[networkName] = network
-
-			err = hsServer.ConnectToNetwork(network)
-			if err != nil {
-				return fmt.Errorf("failed to connect headscale to %s network: %w", networkName, err)
-			}
-
-			version := requestedVersion
-			if requestedVersion == "all" {
-				version = MustTestVersions[clientN%len(MustTestVersions)]
-			}
-
-			cert := hsServer.GetCert()
-
-			opts = append(opts,
-				tsic.WithCACert(cert),
-			)
-
-			user.createWaitGroup.Go(func() error {
-				tsClient, err := tsic.New(
-					s.pool,
-					version,
-					opts...,
-				)
-				if err != nil {
-					return fmt.Errorf(
-						"failed to create tailscale (%s) node: %w",
-						tsClient.Hostname(),
-						err,
-					)
-				}
-
-				err = tsClient.WaitForNeedsLogin()
-				if err != nil {
-					return fmt.Errorf(
-						"failed to wait for tailscaled (%s) to need login: %w",
-						tsClient.Hostname(),
-						err,
-					)
-				}
-
-				s.mu.Lock()
-				user.Clients[tsClient.Hostname()] = tsClient
-				s.mu.Unlock()
-
-				return nil
-			})
-		}
-
-		if err := user.createWaitGroup.Wait(); err != nil {
-			return err
-		}
-
-		return nil
-	}
-
-	return fmt.Errorf("failed to add tailscale nodes: %w", errNoUserAvailable)
-}
-
-func (s *EmbeddedDERPServerScenario) Shutdown() {
-	for _, network := range s.tsicNetworks {
-		err := s.pool.RemoveNetwork(network)
-		if err != nil {
-			log.Printf("failed to remove DERP network %s", network.Network.Name)
-		}
-	}
-
-	s.Scenario.Shutdown()
 }

--- a/integration/general_test.go
+++ b/integration/general_test.go
@@ -138,7 +138,7 @@ func testEphemeralWithOptions(t *testing.T, opts ...hsic.Option) {
 			t.Fatalf("failed to create user %s: %s", userName, err)
 		}
 
-		err = scenario.CreateTailscaleNodesInUser(userName, "all", spec.NodesPerUser, []tsic.Option{}...)
+		err = scenario.CreateTailscaleNodesInUser(userName, "all", spec.NodesPerUser, tsic.WithNetwork(scenario.networks[TestDefaultNetwork]))
 		if err != nil {
 			t.Fatalf("failed to create tailscale nodes in user %s: %s", userName, err)
 		}
@@ -216,7 +216,7 @@ func TestEphemeral2006DeletedTooQuickly(t *testing.T) {
 			t.Fatalf("failed to create user %s: %s", userName, err)
 		}
 
-		err = scenario.CreateTailscaleNodesInUser(userName, "all", spec.NodesPerUser, []tsic.Option{}...)
+		err = scenario.CreateTailscaleNodesInUser(userName, "all", spec.NodesPerUser, tsic.WithNetwork(scenario.networks[TestDefaultNetwork]))
 		if err != nil {
 			t.Fatalf("failed to create tailscale nodes in user %s: %s", userName, err)
 		}

--- a/integration/general_test.go
+++ b/integration/general_test.go
@@ -32,11 +32,9 @@ func TestPingAllByIP(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	// TODO(kradalby): it does not look like the user thing works, only second
-	// get created? maybe only when many?
-	spec := map[string]int{
-		"user1": len(MustTestVersions),
-		"user2": len(MustTestVersions),
+	spec := ScenarioSpec{
+		NodesPerUser: len(MustTestVersions),
+		Users:        []string{"user1", "user2"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec,
@@ -75,9 +73,9 @@ func TestPingAllByIPPublicDERP(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"user1": len(MustTestVersions),
-		"user2": len(MustTestVersions),
+	spec := ScenarioSpec{
+		NodesPerUser: len(MustTestVersions),
+		Users:        []string{"user1", "user2"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec,
@@ -312,9 +310,9 @@ func TestPingAllByHostname(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"user3": len(MustTestVersions),
-		"user4": len(MustTestVersions),
+	spec := ScenarioSpec{
+		NodesPerUser: len(MustTestVersions),
+		Users:        []string{"user1", "user2"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("pingallbyname"))
@@ -361,8 +359,9 @@ func TestTaildrop(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"taildrop": len(MustTestVersions),
+	spec := ScenarioSpec{
+		NodesPerUser: len(MustTestVersions),
+		Users:        []string{"user1"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{},
@@ -522,8 +521,6 @@ func TestUpdateHostnameFromClient(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	user := "update-hostname-from-client"
-
 	hostnames := map[string]string{
 		"1": "user1-host",
 		"2": "User2-Host",
@@ -534,8 +531,9 @@ func TestUpdateHostnameFromClient(t *testing.T) {
 	assertNoErrf(t, "failed to create scenario: %s", err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		user: 3,
+	spec := ScenarioSpec{
+		NodesPerUser: 3,
+		Users:        []string{"user1"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("updatehostname"))
@@ -654,8 +652,9 @@ func TestExpireNode(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"user1": len(MustTestVersions),
+	spec := ScenarioSpec{
+		NodesPerUser: len(MustTestVersions),
+		Users:        []string{"user1"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("expirenode"))
@@ -684,7 +683,7 @@ func TestExpireNode(t *testing.T) {
 		assertNoErr(t, err)
 
 		// Assert that we have the original count - self
-		assert.Len(t, status.Peers(), spec["user1"]-1)
+		assert.Len(t, status.Peers(), spec.NodesPerUser-1)
 	}
 
 	headscale, err := scenario.Headscale()
@@ -780,8 +779,9 @@ func TestNodeOnlineStatus(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		"user1": len(MustTestVersions),
+	spec := ScenarioSpec{
+		NodesPerUser: len(MustTestVersions),
+		Users:        []string{"user1"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("online"))
@@ -895,11 +895,9 @@ func TestPingAllByIPManyUpDown(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	// TODO(kradalby): it does not look like the user thing works, only second
-	// get created? maybe only when many?
-	spec := map[string]int{
-		"user1": len(MustTestVersions),
-		"user2": len(MustTestVersions),
+	spec := ScenarioSpec{
+		NodesPerUser: len(MustTestVersions),
+		Users:        []string{"user1", "user2"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec,
@@ -977,11 +975,9 @@ func Test2118DeletingOnlineNodePanics(t *testing.T) {
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	// TODO(kradalby): it does not look like the user thing works, only second
-	// get created? maybe only when many?
-	spec := map[string]int{
-		"user1": 1,
-		"user2": 1,
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{"user1", "user2"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec,

--- a/integration/route_test.go
+++ b/integration/route_test.go
@@ -39,7 +39,9 @@ func TestEnablingRoutes(t *testing.T) {
 	require.NoErrorf(t, err, "failed to create scenario: %s", err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("clienableroute"))
+	err = scenario.CreateHeadscaleEnv(
+		[]tsic.Option{tsic.WithAcceptRoutes()},
+		hsic.WithTestName("clienableroute"))
 	assertNoErrHeadscaleEnv(t, err)
 
 	allClients, err := scenario.ListTailscaleClients()
@@ -189,11 +191,11 @@ func TestEnablingRoutes(t *testing.T) {
 
 			assert.Nil(t, peerStatus.PrimaryRoutes)
 			if peerStatus.ID == "1" {
-				assertPeerSubnetRoutes(t, peerStatus, nil)
+				requirePeerSubnetRoutes(t, peerStatus, nil)
 			} else if peerStatus.ID == "2" {
-				assertPeerSubnetRoutes(t, peerStatus, nil)
+				requirePeerSubnetRoutes(t, peerStatus, nil)
 			} else {
-				assertPeerSubnetRoutes(t, peerStatus, []netip.Prefix{netip.MustParsePrefix("10.0.2.0/24")})
+				requirePeerSubnetRoutes(t, peerStatus, []netip.Prefix{netip.MustParsePrefix("10.0.2.0/24")})
 			}
 		}
 	}
@@ -204,21 +206,26 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	t.Parallel()
 
 	spec := ScenarioSpec{
-		NodesPerUser: 4,
-		Users:        []string{"user1"},
+		NodesPerUser: 3,
+		Users:        []string{"user1", "user2"},
 		Networks: map[string][]string{
 			"usernet1": {"user1"},
+			"usernet2": {"user2"},
 		},
 		ExtraService: map[string][]extraServiceFunc{
 			"usernet1": {Webservice},
 		},
+		// We build the head image with curl and traceroute, so only use
+		// that for this test.
+		Versions: []string{"head"},
 	}
 
 	scenario, err := NewScenario(spec)
 	require.NoErrorf(t, err, "failed to create scenario: %s", err)
-	defer scenario.ShutdownAssertNoPanics(t)
+	// defer scenario.ShutdownAssertNoPanics(t)
 
-	err = scenario.CreateHeadscaleEnv([]tsic.Option{},
+	err = scenario.CreateHeadscaleEnv(
+		[]tsic.Option{tsic.WithAcceptRoutes()},
 		hsic.WithTestName("clienableroute"),
 		hsic.WithEmbeddedDERPServerOnly(),
 		hsic.WithTLS(),
@@ -234,11 +241,22 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	headscale, err := scenario.Headscale()
 	assertNoErrGetHeadscale(t, err)
 
-	expectedRoutes := map[string]string{
-		"1": "10.0.0.0/24",
-		"2": "10.0.0.0/24",
-		"3": "10.0.0.0/24",
-	}
+	prefp, err := scenario.SubnetOfNetwork("usernet1")
+	require.NoError(t, err)
+	pref := *prefp
+	t.Logf("usernet1 prefix: %s", pref.String())
+
+	usernet1, err := scenario.Network("usernet1")
+	require.NoError(t, err)
+
+	services, err := scenario.Services("usernet1")
+	require.NoError(t, err)
+	require.Len(t, services, 1)
+
+	web := services[0]
+	webip := netip.MustParseAddr(web.GetIPInNetwork(usernet1))
+	weburl := fmt.Sprintf("http://%s/etc/hostname", webip)
+	t.Logf("webservice: %s, %s", webip.String(), weburl)
 
 	// Sort nodes by ID
 	sort.SliceStable(allClients, func(i, j int) bool {
@@ -248,6 +266,9 @@ func TestHASubnetRouterFailover(t *testing.T) {
 		return statusI.Self.ID < statusJ.Self.ID
 	})
 
+	// This is ok because the scenario makes users in order, so the three first
+	// nodes, which are subnet routes, will be created first, and the last user
+	// will be created with the second.
 	subRouter1 := allClients[0]
 	subRouter2 := allClients[1]
 	subRouter3 := allClients[2]
@@ -260,28 +281,23 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	// ID 2 will be standby
 	// ID 3 will be standby
 	for _, client := range allClients[:3] {
-		status, err := client.Status()
-		require.NoError(t, err)
-
-		if route, ok := expectedRoutes[string(status.Self.ID)]; ok {
-			command := []string{
-				"tailscale",
-				"set",
-				"--advertise-routes=" + route,
-			}
-			_, _, err = client.Execute(command)
-			require.NoErrorf(t, err, "failed to advertise route: %s", err)
-		} else {
-			t.Fatalf("failed to find route for Node %s (id: %s)", status.Self.HostName, status.Self.ID)
+		command := []string{
+			"tailscale",
+			"set",
+			"--advertise-routes=" + pref.String(),
 		}
+		_, _, err = client.Execute(command)
+		require.NoErrorf(t, err, "failed to advertise route: %s", err)
 	}
 
 	err = scenario.WaitForTailscaleSync()
 	assertNoErrSync(t, err)
 
+	time.Sleep(3 * time.Second)
+
 	nodes, err := headscale.ListNodes()
 	require.NoError(t, err)
-	assert.Len(t, nodes, 4)
+	assert.Len(t, nodes, 6)
 
 	assertNodeRouteCount(t, nodes[0], 1, 0, 0)
 	assertNodeRouteCount(t, nodes[1], 1, 0, 0)
@@ -297,28 +313,30 @@ func TestHASubnetRouterFailover(t *testing.T) {
 			peerStatus := status.Peer[peerKey]
 
 			assert.Nil(t, peerStatus.PrimaryRoutes)
-			assertPeerSubnetRoutes(t, peerStatus, nil)
+			requirePeerSubnetRoutes(t, peerStatus, nil)
 		}
 	}
 
-	// Enable all routes
-	for _, node := range nodes {
-		_, err := headscale.ApproveRoutes(
-			node.GetId(),
-			util.MustStringsToPrefixes(node.GetAvailableRoutes()),
-		)
-		require.NoError(t, err)
-	}
+	// Enable route on node 1
+	t.Logf("Enabling route on subnet router 1, no HA")
+	_, err = headscale.ApproveRoutes(
+		1,
+		[]netip.Prefix{pref},
+	)
+	require.NoError(t, err)
+
+	time.Sleep(3 * time.Second)
 
 	nodes, err = headscale.ListNodes()
 	require.NoError(t, err)
-	assert.Len(t, nodes, 4)
+	assert.Len(t, nodes, 6)
 
 	assertNodeRouteCount(t, nodes[0], 1, 1, 1)
-	assertNodeRouteCount(t, nodes[1], 1, 1, 1)
-	assertNodeRouteCount(t, nodes[2], 1, 1, 1)
+	assertNodeRouteCount(t, nodes[1], 1, 0, 0)
+	assertNodeRouteCount(t, nodes[2], 1, 0, 0)
 
-	// Verify that the client has routes from the primary machine
+	// Verify that the client has routes from the primary machine and can access
+	// the webservice.
 	srs1 := subRouter1.MustStatus()
 	srs2 := subRouter2.MustStatus()
 	srs3 := subRouter3.MustStatus()
@@ -336,10 +354,134 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	assert.Nil(t, srs3PeerStatus.PrimaryRoutes)
 	require.NotNil(t, srs1PeerStatus.PrimaryRoutes)
 
+	requirePeerSubnetRoutes(t, srs1PeerStatus, []netip.Prefix{pref})
+	requirePeerSubnetRoutes(t, srs2PeerStatus, nil)
+	requirePeerSubnetRoutes(t, srs3PeerStatus, nil)
+
+	t.Logf("got list: %v, want in: %v", srs1PeerStatus.PrimaryRoutes.AsSlice(), pref)
 	assert.Contains(t,
 		srs1PeerStatus.PrimaryRoutes.AsSlice(),
-		netip.MustParsePrefix(expectedRoutes[string(srs1.Self.ID)]),
+		pref,
 	)
+
+	t.Logf("Validating access via subnetrouter(%s) to %s, no HA", subRouter1.MustIPv4().String(), webip.String())
+	result, err := client.Curl(weburl)
+	require.NoError(t, err)
+	assert.Len(t, result, 13)
+
+	tr, err := client.Traceroute(webip)
+	require.NoError(t, err)
+	assertTracerouteViaIP(t, tr, subRouter1.MustIPv4())
+
+	// Enable route on node 2, now we will have a HA subnet router
+	t.Logf("Enabling route on subnet router 2, now HA, subnetrouter 1 is primary, 2 is standby")
+	_, err = headscale.ApproveRoutes(
+		2,
+		[]netip.Prefix{pref},
+	)
+	require.NoError(t, err)
+
+	time.Sleep(3 * time.Second)
+
+	nodes, err = headscale.ListNodes()
+	require.NoError(t, err)
+	assert.Len(t, nodes, 6)
+
+	assertNodeRouteCount(t, nodes[0], 1, 1, 1)
+	assertNodeRouteCount(t, nodes[1], 1, 1, 1)
+	assertNodeRouteCount(t, nodes[2], 1, 0, 0)
+
+	// Verify that the client has routes from the primary machine
+	srs1 = subRouter1.MustStatus()
+	srs2 = subRouter2.MustStatus()
+	srs3 = subRouter3.MustStatus()
+	clientStatus = client.MustStatus()
+
+	srs1PeerStatus = clientStatus.Peer[srs1.Self.PublicKey]
+	srs2PeerStatus = clientStatus.Peer[srs2.Self.PublicKey]
+	srs3PeerStatus = clientStatus.Peer[srs3.Self.PublicKey]
+
+	assert.True(t, srs1PeerStatus.Online, "r1 up, r2 up")
+	assert.True(t, srs2PeerStatus.Online, "r1 up, r2 up")
+	assert.True(t, srs3PeerStatus.Online, "r1 up, r2 up")
+
+	assert.Nil(t, srs2PeerStatus.PrimaryRoutes)
+	assert.Nil(t, srs3PeerStatus.PrimaryRoutes)
+	require.NotNil(t, srs1PeerStatus.PrimaryRoutes)
+
+	requirePeerSubnetRoutes(t, srs1PeerStatus, []netip.Prefix{pref})
+	requirePeerSubnetRoutes(t, srs2PeerStatus, nil)
+	requirePeerSubnetRoutes(t, srs3PeerStatus, nil)
+
+	t.Logf("got list: %v, want in: %v", srs1PeerStatus.PrimaryRoutes.AsSlice(), pref)
+	assert.Contains(t,
+		srs1PeerStatus.PrimaryRoutes.AsSlice(),
+		pref,
+	)
+
+	t.Logf("Validating access via subnetrouter(%s) to %s, 2 is standby", subRouter1.MustIPv4().String(), webip.String())
+	result, err = client.Curl(weburl)
+	require.NoError(t, err)
+	assert.Len(t, result, 13)
+
+	tr, err = client.Traceroute(webip)
+	require.NoError(t, err)
+	assertTracerouteViaIP(t, tr, subRouter1.MustIPv4())
+
+	// Enable route on node 3, now we will have a second standby and all will
+	// be enabled.
+	t.Logf("Enabling route on subnet router 3, now HA, subnetrouter 1 is primary, 2 and 3 is standby")
+	_, err = headscale.ApproveRoutes(
+		3,
+		[]netip.Prefix{pref},
+	)
+	require.NoError(t, err)
+
+	time.Sleep(3 * time.Second)
+
+	nodes, err = headscale.ListNodes()
+	require.NoError(t, err)
+	assert.Len(t, nodes, 6)
+
+	assertNodeRouteCount(t, nodes[0], 1, 1, 1)
+	assertNodeRouteCount(t, nodes[1], 1, 1, 1)
+	assertNodeRouteCount(t, nodes[2], 1, 1, 1)
+
+	// Verify that the client has routes from the primary machine
+	srs1 = subRouter1.MustStatus()
+	srs2 = subRouter2.MustStatus()
+	srs3 = subRouter3.MustStatus()
+	clientStatus = client.MustStatus()
+
+	srs1PeerStatus = clientStatus.Peer[srs1.Self.PublicKey]
+	srs2PeerStatus = clientStatus.Peer[srs2.Self.PublicKey]
+	srs3PeerStatus = clientStatus.Peer[srs3.Self.PublicKey]
+
+	assert.True(t, srs1PeerStatus.Online, "r1 up, r2 up")
+	assert.True(t, srs2PeerStatus.Online, "r1 up, r2 up")
+	assert.True(t, srs3PeerStatus.Online, "r1 up, r2 up")
+
+	assert.Nil(t, srs2PeerStatus.PrimaryRoutes)
+	assert.Nil(t, srs3PeerStatus.PrimaryRoutes)
+	require.NotNil(t, srs1PeerStatus.PrimaryRoutes)
+
+	requirePeerSubnetRoutes(t, srs1PeerStatus, []netip.Prefix{pref})
+	requirePeerSubnetRoutes(t, srs2PeerStatus, nil)
+	requirePeerSubnetRoutes(t, srs3PeerStatus, nil)
+
+	t.Logf("got list: %v, want in: %v", srs1PeerStatus.PrimaryRoutes.AsSlice(), pref)
+	assert.Contains(t,
+		srs1PeerStatus.PrimaryRoutes.AsSlice(),
+		pref,
+	)
+
+	result, err = client.Curl(weburl)
+	require.NoError(t, err)
+	assert.Len(t, result, 13)
+
+	tr, err = client.Traceroute(webip)
+	require.NoError(t, err)
+	assertTracerouteViaIP(t, tr, subRouter1.MustIPv4())
 
 	// Take down the current primary
 	t.Logf("taking down subnet router r1 (%s)", subRouter1.Hostname())
@@ -364,11 +506,23 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	require.NotNil(t, srs2PeerStatus.PrimaryRoutes)
 	assert.Nil(t, srs3PeerStatus.PrimaryRoutes)
 
+	requirePeerSubnetRoutes(t, srs1PeerStatus, nil)
+	requirePeerSubnetRoutes(t, srs2PeerStatus, []netip.Prefix{pref})
+	requirePeerSubnetRoutes(t, srs3PeerStatus, nil)
+
 	assert.Contains(
 		t,
 		srs2PeerStatus.PrimaryRoutes.AsSlice(),
-		netip.MustParsePrefix(expectedRoutes[string(srs2.Self.ID)]),
+		pref,
 	)
+
+	result, err = client.Curl(weburl)
+	require.NoError(t, err)
+	assert.Len(t, result, 13)
+
+	tr, err = client.Traceroute(webip)
+	require.NoError(t, err)
+	assertTracerouteViaIP(t, tr, subRouter2.MustIPv4())
 
 	// Take down subnet router 2, leaving none available
 	t.Logf("taking down subnet router r2 (%s)", subRouter2.Hostname())
@@ -395,7 +549,19 @@ func TestHASubnetRouterFailover(t *testing.T) {
 
 	assert.Nil(t, srs1PeerStatus.PrimaryRoutes)
 	assert.Nil(t, srs2PeerStatus.PrimaryRoutes)
-	assert.Nil(t, srs3PeerStatus.PrimaryRoutes)
+	require.NotNil(t, srs3PeerStatus.PrimaryRoutes)
+
+	requirePeerSubnetRoutes(t, srs1PeerStatus, nil)
+	requirePeerSubnetRoutes(t, srs2PeerStatus, nil)
+	requirePeerSubnetRoutes(t, srs3PeerStatus, []netip.Prefix{pref})
+
+	result, err = client.Curl(weburl)
+	require.NoError(t, err)
+	assert.Len(t, result, 13)
+
+	tr, err = client.Traceroute(webip)
+	require.NoError(t, err)
+	assertTracerouteViaIP(t, tr, subRouter3.MustIPv4())
 
 	// Bring up subnet router 1, making the route available from there.
 	t.Logf("bringing up subnet router r1 (%s)", subRouter1.Hostname())
@@ -417,15 +583,27 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	assert.False(t, srs2PeerStatus.Online, "r1 is back up, r2 down")
 	assert.True(t, srs3PeerStatus.Online, "r1 is back up, r3 available")
 
-	assert.NotNil(t, srs1PeerStatus.PrimaryRoutes)
+	assert.Nil(t, srs1PeerStatus.PrimaryRoutes)
 	assert.Nil(t, srs2PeerStatus.PrimaryRoutes)
-	assert.Nil(t, srs3PeerStatus.PrimaryRoutes)
+	require.NotNil(t, srs3PeerStatus.PrimaryRoutes)
+
+	requirePeerSubnetRoutes(t, srs1PeerStatus, nil)
+	requirePeerSubnetRoutes(t, srs2PeerStatus, nil)
+	requirePeerSubnetRoutes(t, srs3PeerStatus, []netip.Prefix{pref})
 
 	assert.Contains(
 		t,
-		srs1PeerStatus.PrimaryRoutes.AsSlice(),
-		netip.MustParsePrefix(expectedRoutes[string(srs1.Self.ID)]),
+		srs3PeerStatus.PrimaryRoutes.AsSlice(),
+		pref,
 	)
+
+	result, err = client.Curl(weburl)
+	require.NoError(t, err)
+	assert.Len(t, result, 13)
+
+	tr, err = client.Traceroute(webip)
+	require.NoError(t, err)
+	assertTracerouteViaIP(t, tr, subRouter3.MustIPv4())
 
 	// Bring up subnet router 2, should result in no change.
 	t.Logf("bringing up subnet router r2 (%s)", subRouter2.Hostname())
@@ -447,30 +625,86 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	assert.True(t, srs2PeerStatus.Online, "r1 up, r2 up")
 	assert.True(t, srs3PeerStatus.Online, "r1 up, r2 up")
 
+	assert.Nil(t, srs1PeerStatus.PrimaryRoutes)
+	assert.Nil(t, srs2PeerStatus.PrimaryRoutes)
+	require.NotNil(t, srs3PeerStatus.PrimaryRoutes)
+
+	requirePeerSubnetRoutes(t, srs1PeerStatus, nil)
+	requirePeerSubnetRoutes(t, srs2PeerStatus, nil)
+	requirePeerSubnetRoutes(t, srs3PeerStatus, []netip.Prefix{pref})
+
+	assert.Contains(
+		t,
+		srs3PeerStatus.PrimaryRoutes.AsSlice(),
+		pref,
+	)
+
+	result, err = client.Curl(weburl)
+	require.NoError(t, err)
+	assert.Len(t, result, 13)
+
+	tr, err = client.Traceroute(webip)
+	require.NoError(t, err)
+	assertTracerouteViaIP(t, tr, subRouter3.MustIPv4())
+
+	t.Logf("disabling route in subnet router r3 (%s)", subRouter3.Hostname())
+	t.Logf("expecting route to failover to r1 (%s), which is still available with r2", subRouter1.Hostname())
+	_, err = headscale.ApproveRoutes(nodes[2].GetId(), []netip.Prefix{})
+
+	time.Sleep(5 * time.Second)
+
+	nodes, err = headscale.ListNodes()
+	require.NoError(t, err)
+	assert.Len(t, nodes, 6)
+
+	assertNodeRouteCount(t, nodes[0], 1, 1, 1)
+	assertNodeRouteCount(t, nodes[1], 1, 1, 1)
+	assertNodeRouteCount(t, nodes[2], 1, 0, 0)
+
+	// Verify that the route is announced from subnet router 1
+	clientStatus, err = client.Status()
+	require.NoError(t, err)
+
+	srs1PeerStatus = clientStatus.Peer[srs1.Self.PublicKey]
+	srs2PeerStatus = clientStatus.Peer[srs2.Self.PublicKey]
+	srs3PeerStatus = clientStatus.Peer[srs3.Self.PublicKey]
+
 	require.NotNil(t, srs1PeerStatus.PrimaryRoutes)
 	assert.Nil(t, srs2PeerStatus.PrimaryRoutes)
 	assert.Nil(t, srs3PeerStatus.PrimaryRoutes)
 
+	requirePeerSubnetRoutes(t, srs1PeerStatus, []netip.Prefix{pref})
+	requirePeerSubnetRoutes(t, srs2PeerStatus, nil)
+	requirePeerSubnetRoutes(t, srs3PeerStatus, nil)
+
 	assert.Contains(
 		t,
 		srs1PeerStatus.PrimaryRoutes.AsSlice(),
-		netip.MustParsePrefix(expectedRoutes[string(srs1.Self.ID)]),
+		pref,
 	)
+
+	result, err = client.Curl(weburl)
+	require.NoError(t, err)
+	assert.Len(t, result, 13)
+
+	tr, err = client.Traceroute(webip)
+	require.NoError(t, err)
+	assertTracerouteViaIP(t, tr, subRouter1.MustIPv4())
 
 	// Disable the route of subnet router 1, making it failover to 2
 	t.Logf("disabling route in subnet router r1 (%s)", subRouter1.Hostname())
-	t.Logf("expecting route to failover to r2 (%s), which is still available with r3", subRouter2.Hostname())
+	t.Logf("expecting route to failover to r2 (%s)", subRouter2.Hostname())
 	_, err = headscale.ApproveRoutes(nodes[0].GetId(), []netip.Prefix{})
 
 	time.Sleep(5 * time.Second)
 
 	nodes, err = headscale.ListNodes()
 	require.NoError(t, err)
-	assert.Len(t, nodes, 4)
+	assert.Len(t, nodes, 6)
 
 	assertNodeRouteCount(t, nodes[0], 1, 0, 0)
 	assertNodeRouteCount(t, nodes[1], 1, 1, 1)
-	assertNodeRouteCount(t, nodes[2], 1, 1, 1)
+	assertNodeRouteCount(t, nodes[2], 1, 0, 0)
 
 	// Verify that the route is announced from subnet router 1
 	clientStatus, err = client.Status()
@@ -481,14 +715,26 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	srs3PeerStatus = clientStatus.Peer[srs3.Self.PublicKey]
 
 	assert.Nil(t, srs1PeerStatus.PrimaryRoutes)
-	assert.NotNil(t, srs2PeerStatus.PrimaryRoutes)
+	require.NotNil(t, srs2PeerStatus.PrimaryRoutes)
 	assert.Nil(t, srs3PeerStatus.PrimaryRoutes)
+
+	requirePeerSubnetRoutes(t, srs1PeerStatus, nil)
+	requirePeerSubnetRoutes(t, srs2PeerStatus, []netip.Prefix{pref})
+	requirePeerSubnetRoutes(t, srs3PeerStatus, nil)
 
 	assert.Contains(
 		t,
 		srs2PeerStatus.PrimaryRoutes.AsSlice(),
-		netip.MustParsePrefix(expectedRoutes[string(srs2.Self.ID)]),
+		pref,
 	)
+
+	result, err = client.Curl(weburl)
+	require.NoError(t, err)
+	assert.Len(t, result, 13)
+
+	tr, err = client.Traceroute(webip)
+	require.NoError(t, err)
+	assertTracerouteViaIP(t, tr, subRouter2.MustIPv4())
 
 	// enable the route of subnet router 1, no change expected
 	t.Logf("enabling route in subnet router 1 (%s)", subRouter1.Hostname())
@@ -502,11 +748,11 @@ func TestHASubnetRouterFailover(t *testing.T) {
 
 	nodes, err = headscale.ListNodes()
 	require.NoError(t, err)
-	assert.Len(t, nodes, 4)
+	assert.Len(t, nodes, 6)
 
 	assertNodeRouteCount(t, nodes[0], 1, 1, 1)
 	assertNodeRouteCount(t, nodes[1], 1, 1, 1)
-	assertNodeRouteCount(t, nodes[2], 1, 1, 1)
+	assertNodeRouteCount(t, nodes[2], 1, 0, 0)
 
 	// Verify that the route is announced from subnet router 1
 	clientStatus, err = client.Status()
@@ -523,8 +769,16 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	assert.Contains(
 		t,
 		srs2PeerStatus.PrimaryRoutes.AsSlice(),
-		netip.MustParsePrefix(expectedRoutes[string(srs2.Self.ID)]),
+		pref,
 	)
+
+	result, err = client.Curl(weburl)
+	require.NoError(t, err)
+	assert.Len(t, result, 13)
+
+	tr, err = client.Traceroute(webip)
+	require.NoError(t, err)
+	assertTracerouteViaIP(t, tr, subRouter2.MustIPv4())
 }
 
 func TestEnableDisableAutoApprovedRoute(t *testing.T) {
@@ -542,7 +796,10 @@ func TestEnableDisableAutoApprovedRoute(t *testing.T) {
 	require.NoErrorf(t, err, "failed to create scenario: %s", err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	err = scenario.CreateHeadscaleEnv([]tsic.Option{tsic.WithTags([]string{"tag:approve"})}, hsic.WithTestName("clienableroute"), hsic.WithACLPolicy(
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{
+		tsic.WithTags([]string{"tag:approve"}),
+		tsic.WithAcceptRoutes(),
+	}, hsic.WithTestName("clienableroute"), hsic.WithACLPolicy(
 		&policyv1.ACLPolicy{
 			ACLs: []policyv1.ACL{
 				{
@@ -640,7 +897,10 @@ func TestAutoApprovedSubRoute2068(t *testing.T) {
 	require.NoErrorf(t, err, "failed to create scenario: %s", err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	err = scenario.CreateHeadscaleEnv([]tsic.Option{tsic.WithTags([]string{"tag:approve"})},
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{
+		tsic.WithTags([]string{"tag:approve"}),
+		tsic.WithAcceptRoutes(),
+	},
 		hsic.WithTestName("clienableroute"),
 		hsic.WithEmbeddedDERPServerOnly(),
 		hsic.WithTLS(),
@@ -712,7 +972,9 @@ func TestSubnetRouteACL(t *testing.T) {
 	require.NoErrorf(t, err, "failed to create scenario: %s", err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("clienableroute"), hsic.WithACLPolicy(
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{
+		tsic.WithAcceptRoutes(),
+	}, hsic.WithTestName("clienableroute"), hsic.WithACLPolicy(
 		&policyv1.ACLPolicy{
 			Groups: policyv1.Groups{
 				"group:admins": {user},
@@ -805,7 +1067,7 @@ func TestSubnetRouteACL(t *testing.T) {
 			peerStatus := status.Peer[peerKey]
 
 			assert.Nil(t, peerStatus.PrimaryRoutes)
-			assertPeerSubnetRoutes(t, peerStatus, nil)
+			requirePeerSubnetRoutes(t, peerStatus, nil)
 		}
 	}
 
@@ -832,7 +1094,7 @@ func TestSubnetRouteACL(t *testing.T) {
 
 	srs1PeerStatus := clientStatus.Peer[srs1.Self.PublicKey]
 
-	assertPeerSubnetRoutes(t, srs1PeerStatus, []netip.Prefix{netip.MustParsePrefix(expectedRoutes["1"])})
+	requirePeerSubnetRoutes(t, srs1PeerStatus, []netip.Prefix{netip.MustParsePrefix(expectedRoutes["1"])})
 
 	clientNm, err := client.Netmap()
 	require.NoError(t, err)
@@ -1010,32 +1272,6 @@ func TestEnablingExitRoutes(t *testing.T) {
 	}
 }
 
-// assertPeerSubnetRoutes asserts that the peer has the expected subnet routes.
-func assertPeerSubnetRoutes(t *testing.T, status *ipnstate.PeerStatus, expected []netip.Prefix) {
-	t.Helper()
-	if status.AllowedIPs.Len() <= 2 && len(expected) != 0 {
-		t.Errorf("peer %s (%s) has no subnet routes, expected %v", status.HostName, status.ID, expected)
-		return
-	}
-
-	if len(expected) == 0 {
-		expected = []netip.Prefix{}
-	}
-
-	got := status.AllowedIPs.AsSlice()[2:]
-
-	if diff := cmp.Diff(expected, got, util.PrefixComparer); diff != "" {
-		t.Errorf("peer %s (%s) subnet routes, unexpected result (-want +got):\n%s", status.HostName, status.ID, diff)
-	}
-}
-
-func assertNodeRouteCount(t *testing.T, node *v1.Node, announced, approved, subnet int) {
-	t.Helper()
-	assert.Len(t, node.GetAvailableRoutes(), announced)
-	assert.Len(t, node.GetApprovedRoutes(), approved)
-	assert.Len(t, node.GetSubnetRoutes(), subnet)
-}
-
 // TestSubnetRouterMultiNetwork is an evolution of the subnet router test.
 // This test will set up multiple docker networks and use two isolated tailscale
 // clients and a service available in one of the networks to validate that a
@@ -1117,7 +1353,7 @@ func TestSubnetRouterMultiNetwork(t *testing.T) {
 		peerStatus := status.Peer[peerKey]
 
 		assert.Nil(t, peerStatus.PrimaryRoutes)
-		assertPeerSubnetRoutes(t, peerStatus, nil)
+		requirePeerSubnetRoutes(t, peerStatus, nil)
 	}
 
 	// Enable route
@@ -1141,7 +1377,7 @@ func TestSubnetRouterMultiNetwork(t *testing.T) {
 	for _, peerKey := range status.Peers() {
 		peerStatus := status.Peer[peerKey]
 
-// TestSubnetRouterMultiNetworkExitNode
+		assert.Contains(t, peerStatus.PrimaryRoutes.AsSlice(), *pref)
 func TestSubnetRouterMultiNetworkExitNode(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
@@ -1275,7 +1511,7 @@ func TestSubnetRouterMultiNetworkExitNode(t *testing.T) {
 }
 
 		assert.Nil(t, peerStatus.PrimaryRoutes)
-		assertPeerSubnetRoutes(t, peerStatus, []netip.Prefix{*pref})
+		requirePeerSubnetRoutes(t, peerStatus, []netip.Prefix{*pref})
 	}
 
 	usernet1, err := scenario.Network("usernet1")

--- a/integration/route_test.go
+++ b/integration/route_test.go
@@ -29,14 +29,13 @@ func TestEnablingRoutes(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	user := "user6"
-
 	scenario, err := NewScenario(dockertestMaxWait())
 	require.NoErrorf(t, err, "failed to create scenario: %s", err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		user: 3,
+	spec := ScenarioSpec{
+		NodesPerUser: 3,
+		Users:        []string{"user1"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clienableroute"))
@@ -203,14 +202,13 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	user := "user9"
-
 	scenario, err := NewScenario(dockertestMaxWait())
 	require.NoErrorf(t, err, "failed to create scenario: %s", err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		user: 4,
+	spec := ScenarioSpec{
+		NodesPerUser: 4,
+		Users:        []string{"user1"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{},
@@ -534,8 +532,9 @@ func TestEnableDisableAutoApprovedRoute(t *testing.T) {
 	require.NoErrorf(t, err, "failed to create scenario: %s", err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		user: 1,
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{"user1"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{tsic.WithTags([]string{"tag:approve"})}, hsic.WithTestName("clienableroute"), hsic.WithACLPolicy(
@@ -631,8 +630,9 @@ func TestAutoApprovedSubRoute2068(t *testing.T) {
 	require.NoErrorf(t, err, "failed to create scenario: %s", err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		user: 1,
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{user},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{tsic.WithTags([]string{"tag:approve"})},
@@ -702,8 +702,9 @@ func TestSubnetRouteACL(t *testing.T) {
 	require.NoErrorf(t, err, "failed to create scenario: %s", err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		user: 2,
+	spec := ScenarioSpec{
+		NodesPerUser: 2,
+		Users:        []string{user},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clienableroute"), hsic.WithACLPolicy(
@@ -924,8 +925,9 @@ func TestEnablingExitRoutes(t *testing.T) {
 	assertNoErrf(t, "failed to create scenario: %s", err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	spec := map[string]int{
-		user: 2,
+	spec := ScenarioSpec{
+		NodesPerUser: 2,
+		Users:        []string{user},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{

--- a/integration/route_test.go
+++ b/integration/route_test.go
@@ -1425,7 +1425,7 @@ func TestSubnetRouterMultiNetworkExitNode(t *testing.T) {
 
 	scenario, err := NewScenario(spec)
 	require.NoErrorf(t, err, "failed to create scenario: %s", err)
-	// defer scenario.ShutdownAssertNoPanics(t)
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	err = scenario.CreateHeadscaleEnv([]tsic.Option{},
 		hsic.WithTestName("clienableroute"),

--- a/integration/route_test.go
+++ b/integration/route_test.go
@@ -222,7 +222,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 
 	scenario, err := NewScenario(spec)
 	require.NoErrorf(t, err, "failed to create scenario: %s", err)
-	// defer scenario.ShutdownAssertNoPanics(t)
+	defer scenario.ShutdownAssertNoPanics(t)
 
 	err = scenario.CreateHeadscaleEnv(
 		[]tsic.Option{tsic.WithAcceptRoutes()},

--- a/integration/route_test.go
+++ b/integration/route_test.go
@@ -1036,6 +1036,10 @@ func assertNodeRouteCount(t *testing.T, node *v1.Node, announced, approved, subn
 	assert.Len(t, node.GetSubnetRoutes(), subnet)
 }
 
+// TestSubnetRouterMultiNetwork is an evolution of the subnet router test.
+// This test will set up multiple docker networks and use two isolated tailscale
+// clients and a service available in one of the networks to validate that a
+// subnet router is working as expected.
 func TestSubnetRouterMultiNetwork(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
@@ -1130,8 +1134,7 @@ func TestSubnetRouterMultiNetwork(t *testing.T) {
 	assert.Len(t, nodes, 2)
 	assertNodeRouteCount(t, nodes[0], 1, 1, 1)
 
-	// Verify that no routes has been sent to the client,
-	// they are not yet enabled.
+	// Verify that the routes have been sent to the client.
 	status, err = user2c.Status()
 	require.NoError(t, err)
 
@@ -1159,8 +1162,8 @@ func TestSubnetRouterMultiNetwork(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, result, 13)
 
-	stdout, stderr, err := user2c.Execute([]string{"traceroute", webip.String()})
-	assert.Contains(t, stdout+stderr, user1c.MustIPv4().String())
+	tr, err := user2c.Traceroute(webip)
+	assert.Contains(t, tr, user1c.MustIPv4().String())
 }
 
 // requirePeerSubnetRoutes asserts that the peer has the expected subnet routes.

--- a/integration/route_test.go
+++ b/integration/route_test.go
@@ -29,16 +29,16 @@ func TestEnablingRoutes(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	require.NoErrorf(t, err, "failed to create scenario: %s", err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		NodesPerUser: 3,
 		Users:        []string{"user1"},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clienableroute"))
+	scenario, err := NewScenario(spec)
+	require.NoErrorf(t, err, "failed to create scenario: %s", err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("clienableroute"))
 	assertNoErrHeadscaleEnv(t, err)
 
 	allClients, err := scenario.ListTailscaleClients()
@@ -202,16 +202,16 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	require.NoErrorf(t, err, "failed to create scenario: %s", err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		NodesPerUser: 4,
 		Users:        []string{"user1"},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{},
+	scenario, err := NewScenario(spec)
+	require.NoErrorf(t, err, "failed to create scenario: %s", err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{},
 		hsic.WithTestName("clienableroute"),
 		hsic.WithEmbeddedDERPServerOnly(),
 		hsic.WithTLS(),
@@ -526,18 +526,16 @@ func TestEnableDisableAutoApprovedRoute(t *testing.T) {
 
 	expectedRoutes := "172.0.0.0/24"
 
-	user := "user2"
-
-	scenario, err := NewScenario(dockertestMaxWait())
-	require.NoErrorf(t, err, "failed to create scenario: %s", err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		NodesPerUser: 1,
 		Users:        []string{"user1"},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{tsic.WithTags([]string{"tag:approve"})}, hsic.WithTestName("clienableroute"), hsic.WithACLPolicy(
+	scenario, err := NewScenario(spec)
+	require.NoErrorf(t, err, "failed to create scenario: %s", err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{tsic.WithTags([]string{"tag:approve"})}, hsic.WithTestName("clienableroute"), hsic.WithACLPolicy(
 		&policyv1.ACLPolicy{
 			ACLs: []policyv1.ACL{
 				{
@@ -547,7 +545,7 @@ func TestEnableDisableAutoApprovedRoute(t *testing.T) {
 				},
 			},
 			TagOwners: map[string][]string{
-				"tag:approve": {user},
+				"tag:approve": {"user1"},
 			},
 			AutoApprovers: policyv1.AutoApprovers{
 				Routes: map[string][]string{
@@ -626,16 +624,16 @@ func TestAutoApprovedSubRoute2068(t *testing.T) {
 
 	user := "user1"
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	require.NoErrorf(t, err, "failed to create scenario: %s", err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		NodesPerUser: 1,
 		Users:        []string{user},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{tsic.WithTags([]string{"tag:approve"})},
+	scenario, err := NewScenario(spec)
+	require.NoErrorf(t, err, "failed to create scenario: %s", err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{tsic.WithTags([]string{"tag:approve"})},
 		hsic.WithTestName("clienableroute"),
 		hsic.WithEmbeddedDERPServerOnly(),
 		hsic.WithTLS(),
@@ -698,16 +696,16 @@ func TestSubnetRouteACL(t *testing.T) {
 
 	user := "user4"
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	require.NoErrorf(t, err, "failed to create scenario: %s", err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		NodesPerUser: 2,
 		Users:        []string{user},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{}, hsic.WithTestName("clienableroute"), hsic.WithACLPolicy(
+	scenario, err := NewScenario(spec)
+	require.NoErrorf(t, err, "failed to create scenario: %s", err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{}, hsic.WithTestName("clienableroute"), hsic.WithACLPolicy(
 		&policyv1.ACLPolicy{
 			Groups: policyv1.Groups{
 				"group:admins": {user},
@@ -921,16 +919,16 @@ func TestEnablingExitRoutes(t *testing.T) {
 
 	user := "user2"
 
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErrf(t, "failed to create scenario: %s", err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
 	spec := ScenarioSpec{
 		NodesPerUser: 2,
 		Users:        []string{user},
 	}
 
-	err = scenario.CreateHeadscaleEnv(spec, []tsic.Option{
+	scenario, err := NewScenario(spec)
+	assertNoErrf(t, "failed to create scenario: %s", err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv([]tsic.Option{
 		tsic.WithExtraLoginArgs([]string{"--advertise-exit-node"}),
 	}, hsic.WithTestName("clienableroute"))
 	assertNoErrHeadscaleEnv(t, err)

--- a/integration/route_test.go
+++ b/integration/route_test.go
@@ -132,23 +132,7 @@ func TestEnablingRoutes(t *testing.T) {
 			assert.NotNil(t, peerStatus.PrimaryRoutes)
 
 			assert.Len(t, peerStatus.AllowedIPs.AsSlice(), 3)
-
-			if peerStatus.AllowedIPs.Len() > 2 {
-				peerRoute := peerStatus.AllowedIPs.At(2)
-
-				// id starts at 1, we created routes with 0 index
-				assert.Equalf(
-					t,
-					expectedRoutes[string(peerStatus.ID)],
-					peerRoute.String(),
-					"expected route %s to be present on peer %s (%s) in %s (%s) status",
-					expectedRoutes[string(peerStatus.ID)],
-					peerStatus.HostName,
-					peerStatus.ID,
-					client.Hostname(),
-					client.ID(),
-				)
-			}
+			requirePeerSubnetRoutes(t, peerStatus, []netip.Prefix{netip.MustParsePrefix(expectedRoutes[string(peerStatus.ID)])})
 		}
 	}
 

--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -134,6 +134,9 @@ type ScenarioSpec struct {
 	// typically dont run Tailscale, e.g. web service to test subnet router.
 	ExtraService map[string][]extraServiceFunc
 
+	// Versions is specific list of versions to use for the test.
+	Versions []string
+
 	// OIDCUsers, if populated, will start a Mock OIDC server and populate
 	// the user login stack with the given users.
 	// If the NodesPerUser is set, it should align with this list to ensure
@@ -514,7 +517,11 @@ func (s *Scenario) CreateTailscaleNodesInUser(
 		for i := range count {
 			version := requestedVersion
 			if requestedVersion == "all" {
-				version = MustTestVersions[i%len(MustTestVersions)]
+				if s.spec.Versions != nil {
+					version = s.spec.Versions[i%len(s.spec.Versions)]
+				} else {
+					version = MustTestVersions[i%len(MustTestVersions)]
+				}
 			}
 			versions = append(versions, version)
 

--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -135,6 +135,9 @@ func (s *Scenario) AddNetwork(name string) (*dockertest.Network, error) {
 }
 
 func (s *Scenario) Networks() []*dockertest.Network {
+	if len(s.networks) == 0 {
+		panic("Scenario.Networks called with empty network list")
+	}
 	return xmaps.Values(s.networks)
 }
 

--- a/integration/scenario_test.go
+++ b/integration/scenario_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/juanfont/headscale/integration/dockertestutil"
+	"github.com/juanfont/headscale/integration/tsic"
 )
 
 // This file is intended to "test the test framework", by proxy it will also test
@@ -110,7 +111,7 @@ func TestTailscaleNodesJoiningHeadcale(t *testing.T) {
 	})
 
 	t.Run("create-tailscale", func(t *testing.T) {
-		err := scenario.CreateTailscaleNodesInUser(user, "unstable", count)
+		err := scenario.CreateTailscaleNodesInUser(user, "unstable", count, tsic.WithNetwork(scenario.networks[TestDefaultNetwork]))
 		if err != nil {
 			t.Fatalf("failed to add tailscale nodes: %s", err)
 		}

--- a/integration/scenario_test.go
+++ b/integration/scenario_test.go
@@ -72,38 +72,6 @@ func TestHeadscale(t *testing.T) {
 // This might mean we approach setup slightly wrong, but for now, ignore
 // the linter
 // nolint:tparallel
-func TestCreateTailscale(t *testing.T) {
-	IntegrationSkip(t)
-	t.Parallel()
-
-	user := "only-create-containers"
-
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
-	defer scenario.ShutdownAssertNoPanics(t)
-
-	scenario.users[user] = &User{
-		Clients: make(map[string]TailscaleClient),
-	}
-
-	t.Run("create-tailscale", func(t *testing.T) {
-		err := scenario.CreateTailscaleNodesInUser(user, "all", 3)
-		if err != nil {
-			t.Fatalf("failed to add tailscale nodes: %s", err)
-		}
-
-		if clients := len(scenario.users[user].Clients); clients != 3 {
-			t.Fatalf("wrong number of tailscale clients: %d != %d", clients, 3)
-		}
-
-		// TODO(kradalby): Test "all" version logic
-	})
-}
-
-// If subtests are parallel, then they will start before setup is run.
-// This might mean we approach setup slightly wrong, but for now, ignore
-// the linter
-// nolint:tparallel
 func TestTailscaleNodesJoiningHeadcale(t *testing.T) {
 	IntegrationSkip(t)
 	t.Parallel()

--- a/integration/scenario_test.go
+++ b/integration/scenario_test.go
@@ -33,7 +33,7 @@ func TestHeadscale(t *testing.T) {
 
 	user := "test-space"
 
-	scenario, err := NewScenario(dockertestMaxWait())
+	scenario, err := NewScenario(ScenarioSpec{})
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 
@@ -82,7 +82,7 @@ func TestTailscaleNodesJoiningHeadcale(t *testing.T) {
 
 	count := 1
 
-	scenario, err := NewScenario(dockertestMaxWait())
+	scenario, err := NewScenario(ScenarioSpec{})
 	assertNoErr(t, err)
 	defer scenario.ShutdownAssertNoPanics(t)
 

--- a/integration/ssh_test.go
+++ b/integration/ssh_test.go
@@ -53,9 +53,9 @@ func sshScenario(t *testing.T, policy *policyv1.ACLPolicy, clientsPerUser int) *
 	scenario, err := NewScenario(dockertestMaxWait())
 	assertNoErr(t, err)
 
-	spec := map[string]int{
-		"user1": clientsPerUser,
-		"user2": clientsPerUser,
+	spec := ScenarioSpec{
+		NodesPerUser: clientsPerUser,
+		Users:        []string{"user1", "user2"},
 	}
 
 	err = scenario.CreateHeadscaleEnv(spec,

--- a/integration/ssh_test.go
+++ b/integration/ssh_test.go
@@ -50,15 +50,15 @@ var retry = func(times int, sleepInterval time.Duration,
 
 func sshScenario(t *testing.T, policy *policyv1.ACLPolicy, clientsPerUser int) *Scenario {
 	t.Helper()
-	scenario, err := NewScenario(dockertestMaxWait())
-	assertNoErr(t, err)
 
 	spec := ScenarioSpec{
 		NodesPerUser: clientsPerUser,
 		Users:        []string{"user1", "user2"},
 	}
+	scenario, err := NewScenario(spec)
+	assertNoErr(t, err)
 
-	err = scenario.CreateHeadscaleEnv(spec,
+	err = scenario.CreateHeadscaleEnv(
 		[]tsic.Option{
 			tsic.WithSSH(),
 

--- a/integration/tailscale.go
+++ b/integration/tailscale.go
@@ -27,6 +27,9 @@ type TailscaleClient interface {
 	Up() error
 	Down() error
 	IPs() ([]netip.Addr, error)
+	MustIPs() []netip.Addr
+	MustIPv4() netip.Addr
+	MustIPv6() netip.Addr
 	FQDN() (string, error)
 	Status(...bool) (*ipnstate.Status, error)
 	MustStatus() *ipnstate.Status

--- a/integration/tailscale.go
+++ b/integration/tailscale.go
@@ -41,6 +41,7 @@ type TailscaleClient interface {
 	WaitForPeers(expected int) error
 	Ping(hostnameOrIP string, opts ...tsic.PingOption) error
 	Curl(url string, opts ...tsic.CurlOption) (string, error)
+	Traceroute(netip.Addr) (string, error)
 	ID() string
 	ReadFile(path string) ([]byte, error)
 

--- a/integration/tailscale.go
+++ b/integration/tailscale.go
@@ -5,6 +5,7 @@ import (
 	"net/netip"
 	"net/url"
 
+	"github.com/juanfont/headscale/hscontrol/util"
 	"github.com/juanfont/headscale/integration/dockertestutil"
 	"github.com/juanfont/headscale/integration/tsic"
 	"tailscale.com/ipn/ipnstate"
@@ -41,7 +42,7 @@ type TailscaleClient interface {
 	WaitForPeers(expected int) error
 	Ping(hostnameOrIP string, opts ...tsic.PingOption) error
 	Curl(url string, opts ...tsic.CurlOption) (string, error)
-	Traceroute(netip.Addr) (string, error)
+	Traceroute(netip.Addr) (util.Traceroute, error)
 	ID() string
 	ReadFile(path string) ([]byte, error)
 

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -1014,6 +1014,7 @@ func (t *TailscaleInContainer) Ping(hostnameOrIP string, opts ...PingOption) err
 		),
 	)
 	if err != nil {
+		log.Printf("command: %v", command)
 		log.Printf(
 			"failed to run ping command from %s to %s, err: %s",
 			t.Hostname(),

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -224,6 +225,10 @@ func New(
 
 	for _, opt := range opts {
 		opt(tsic)
+	}
+
+	if tsic.network == nil {
+		return nil, fmt.Errorf("no network set, called from: \n%s", string(debug.Stack()))
 	}
 
 	tailscaleOptions := &dockertest.RunOptions{

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -101,26 +101,10 @@ func WithCACert(cert []byte) Option {
 	}
 }
 
-// WithOrCreateNetwork sets the Docker container network to use with
-// the Tailscale instance, if the parameter is nil, a new network,
-// isolating the TailscaleClient, will be created. If a network is
-// passed, the Tailscale instance will join the given network.
-func WithOrCreateNetwork(network *dockertest.Network) Option {
+// WithNetwork sets the Docker container network to use with
+// the Tailscale instance.
+func WithNetwork(network *dockertest.Network) Option {
 	return func(tsic *TailscaleInContainer) {
-		if network != nil {
-			tsic.network = network
-
-			return
-		}
-
-		network, err := dockertestutil.GetFirstOrCreateNetwork(
-			tsic.pool,
-			fmt.Sprintf("%s-network", tsic.hostname),
-		)
-		if err != nil {
-			log.Fatalf("failed to create network: %s", err)
-		}
-
 		tsic.network = network
 	}
 }
@@ -216,7 +200,6 @@ func WithExtraLoginArgs(args []string) Option {
 func New(
 	pool *dockertest.Pool,
 	version string,
-	network *dockertest.Network,
 	opts ...Option,
 ) (*TailscaleInContainer, error) {
 	hash, err := util.GenerateRandomStringDNSSafe(tsicHashLength)
@@ -230,8 +213,7 @@ func New(
 		version:  version,
 		hostname: hostname,
 
-		pool:    pool,
-		network: network,
+		pool: pool,
 
 		withEntrypoint: []string{
 			"/bin/sh",

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -1130,14 +1130,19 @@ func (t *TailscaleInContainer) Curl(url string, opts ...CurlOption) (string, err
 	return result, nil
 }
 
-func (t *TailscaleInContainer) Traceroute(ip netip.Addr) (string, error) {
+func (t *TailscaleInContainer) Traceroute(ip netip.Addr) (util.Traceroute, error) {
 	command := []string{
 		"traceroute",
 		ip.String(),
 	}
 
-	var result string
-	result, _, err := t.Execute(command)
+	var result util.Traceroute
+	stdout, stderr, err := t.Execute(command)
+	if err != nil {
+		return result, err
+	}
+
+	result, err = util.ParseTraceroute(stdout + stderr)
 	if err != nil {
 		return result, err
 	}

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -1130,6 +1130,21 @@ func (t *TailscaleInContainer) Curl(url string, opts ...CurlOption) (string, err
 	return result, nil
 }
 
+func (t *TailscaleInContainer) Traceroute(ip netip.Addr) (string, error) {
+	command := []string{
+		"traceroute",
+		ip.String(),
+	}
+
+	var result string
+	result, _, err := t.Execute(command)
+	if err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
 // WriteFile save file inside the Tailscale container.
 func (t *TailscaleInContainer) WriteFile(path string, data []byte) error {
 	return integrationutil.WriteFileToContainer(t.pool, t.container, path, data)


### PR DESCRIPTION
Currently the integration tests only support a single network (with the exception of DERP which has a custom implementation).

This is making it hard to properly test subnet routers (and exit nodes), we currently only look at the output map sent to the nodes.

The goal here is to mold the integration tests into something that supports nodes in multiple docker networks so we can test some basic features.