### PR TITLE
Set content-type to JSON for some debug endpoints

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -18,10 +18,8 @@ server_url: http://127.0.0.1:8080
 # listen_addr: 0.0.0.0:8080
 listen_addr: 127.0.0.1:8080
 
-# Address to listen to /metrics, you may want
-# to keep this endpoint private to your internal
-# network
-#
+# Address to listen to /metrics and /debug, you may want
+# to keep this endpoint private to your internal network
 metrics_listen_addr: 127.0.0.1:9090
 
 # Address to listen for gRPC.

--- a/hscontrol/debug.go
+++ b/hscontrol/debug.go
@@ -25,7 +25,7 @@ func (h *Headscale) debugHTTPServer() *http.Server {
 			httpError(w, err)
 			return
 		}
-		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write(config)
 	}))
@@ -35,7 +35,7 @@ func (h *Headscale) debugHTTPServer() *http.Server {
 			httpError(w, err)
 			return
 		}
-		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write(pol)
 	}))
@@ -47,7 +47,7 @@ func (h *Headscale) debugHTTPServer() *http.Server {
 			httpError(w, err)
 			return
 		}
-		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write(filterJSON)
 	}))
@@ -74,7 +74,7 @@ func (h *Headscale) debugHTTPServer() *http.Server {
 			httpError(w, err)
 			return
 		}
-		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write(sshJSON)
 	}))
@@ -86,7 +86,7 @@ func (h *Headscale) debugHTTPServer() *http.Server {
 			httpError(w, err)
 			return
 		}
-		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write(dmJSON)
 	}))
@@ -96,7 +96,7 @@ func (h *Headscale) debugHTTPServer() *http.Server {
 			httpError(w, err)
 			return
 		}
-		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write(registrationsJSON)
 	}))


### PR DESCRIPTION
Some endpoints in /debug send JSON data as string. Set the Content-Type header to "application/json" which renders nicely in Firefox.

Mention the /debug route in the example configuration.

---

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md