### PR TITLE
update bug template with debug

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -71,19 +71,27 @@ body:
           required: false
   - type: textarea
     attributes:
-      label: Anything else?
+      label: Debug information
       description: |
-        Links? References? Anything that will give us more context about the issue you are encountering!
+        Links? References? Anything that will give us more context about the issue you are encountering.
+        If **any** of these are omitted we will likely close your issue, do **not** ignore them.
 
         - Client netmap dump (see below)
-        - ACL configuration
+        - Policy configuration
         - Headscale configuration
+        - Headscale log (with `trace` enabled)
 
         Dump the netmap of tailscale clients:
         `tailscale debug netmap > DESCRIPTIVE_NAME.json`
 
-        Please provide information describing the netmap, which client, which headscale version etc.
+        Dump the status of tailscale clients:
+        `tailscale status --json > DESCRIPTIVE_NAME.json`
+
+        Get the logs of a Tailscale client that is not working as expected.
+        `tailscale daemon-logs`
 
         Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+        **Ensure** you use formatting for files you attach.
+        Do **not** paste in long files.
     validations:
-      required: false
+      required: true


### PR DESCRIPTION
updates the debug template with stricter language about debug info, warn users that poorly collected information will have your issue closed.