### PR TITLE
ensure final dot on node name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,11 @@ The new policy can be used by setting the environment variable
   [#2493](https://github.com/juanfont/headscale/pull/2493)
   - If a OIDC provider doesn't include the `email_verified` claim in its ID
     tokens, Headscale will attempt to get it from the UserInfo endpoint.
-- Improve performance by only querying relevant nodes from the database for node updates [#2509](https://github.com/juanfont/headscale/pull/2509)
+- Improve performance by only querying relevant nodes from the database for node
+  updates [#2509](https://github.com/juanfont/headscale/pull/2509)
+- node FQDNs in the netmap will now contain a dot (".") at the end. This aligns
+  with behaviour of tailscale.com
+  [#2503](https://github.com/juanfont/headscale/pull/2503)
 
 ## 0.25.1 (2025-02-25)
 

--- a/hscontrol/mapper/tail_test.go
+++ b/hscontrol/mapper/tail_test.go
@@ -169,6 +169,32 @@ func TestTailNode(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "check-dot-suffix-on-node-name",
+			node: &types.Node{
+				GivenName: "minimal",
+				Hostinfo:  &tailcfg.Hostinfo{},
+			},
+			dnsConfig:  &tailcfg.DNSConfig{},
+			baseDomain: "example.com",
+			want: &tailcfg.Node{
+				// a node name should have a dot appended
+				Name:              "minimal.example.com.",
+				StableID:          "0",
+				HomeDERP:          0,
+				LegacyDERPString:  "127.3.3.40:0",
+				Hostinfo:          hiview(tailcfg.Hostinfo{}),
+				Tags:              []string{},
+				MachineAuthorized: true,
+
+				CapMap: tailcfg.NodeCapMap{
+					tailcfg.CapabilityFileSharing: []tailcfg.RawMessage{},
+					tailcfg.CapabilityAdmin:       []tailcfg.RawMessage{},
+					tailcfg.CapabilitySSH:         []tailcfg.RawMessage{},
+				},
+			},
+			wantErr: false,
+		},
 		// TODO: Add tests to check other aspects of the node conversion:
 		// - With tags and policy
 		// - dnsconfig and basedomain

--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -364,7 +364,7 @@ func (node *Node) GetFQDN(baseDomain string) (string, error) {
 
 	if baseDomain != "" {
 		hostname = fmt.Sprintf(
-			"%s.%s",
+			"%s.%s.",
 			node.GivenName,
 			baseDomain,
 		)

--- a/hscontrol/types/node_test.go
+++ b/hscontrol/types/node_test.go
@@ -142,7 +142,7 @@ func TestNodeFQDN(t *testing.T) {
 				},
 			},
 			domain: "example.com",
-			want:   "test.example.com",
+			want:   "test.example.com.",
 		},
 		{
 			name: "all-set",
@@ -153,7 +153,7 @@ func TestNodeFQDN(t *testing.T) {
 				},
 			},
 			domain: "example.com",
-			want:   "test.example.com",
+			want:   "test.example.com.",
 		},
 		{
 			name: "no-given-name",
@@ -171,7 +171,7 @@ func TestNodeFQDN(t *testing.T) {
 				GivenName: strings.Repeat("a", 256),
 			},
 			domain:  "example.com",
-			wantErr: fmt.Sprintf("failed to create valid FQDN (%s.example.com): hostname too long, cannot except 255 ASCII chars", strings.Repeat("a", 256)),
+			wantErr: fmt.Sprintf("failed to create valid FQDN (%s.example.com.): hostname too long, cannot except 255 ASCII chars", strings.Repeat("a", 256)),
 		},
 		{
 			name: "no-dnsconfig",
@@ -182,7 +182,7 @@ func TestNodeFQDN(t *testing.T) {
 				},
 			},
 			domain: "example.com",
-			want:   "test.example.com",
+			want:   "test.example.com.",
 		},
 	}
 

--- a/integration/auth_oidc_test.go
+++ b/integration/auth_oidc_test.go
@@ -170,10 +170,11 @@ func TestOIDCExpireNodesBasedOnTokenExpiry(t *testing.T) {
 	t.Logf("%d successful pings out of %d (before expiry)", success, len(allClients)*len(allIps))
 
 	// This is not great, but this sadly is a time dependent test, so the
-	// safe thing to do is wait out the whole TTL time before checking if
-	// the clients have logged out. The Wait function can't do it itself
-	// as it has an upper bound of 1 min.
-	time.Sleep(shortAccessTTL)
+	// safe thing to do is wait out the whole TTL time (and a bit more out
+	// of safety reasons) before checking if the clients have logged out.
+	// The Wait function can't do it itself as it has an upper bound of 1
+	// min.
+	time.Sleep(shortAccessTTL + 10*time.Second)
 
 	assertTailscaleNodesLogout(t, allClients)
 }

--- a/integration/dns_test.go
+++ b/integration/dns_test.go
@@ -49,7 +49,7 @@ func TestResolveMagicDNS(t *testing.T) {
 			// It is safe to ignore this error as we handled it when caching it
 			peerFQDN, _ := peer.FQDN()
 
-			assert.Equal(t, fmt.Sprintf("%s.headscale.net", peer.Hostname()), peerFQDN)
+			assert.Equal(t, fmt.Sprintf("%s.headscale.net.", peer.Hostname()), peerFQDN)
 
 			command := []string{
 				"tailscale",


### PR DESCRIPTION
This ensures that nodes which have a base domain set, will have a dot appended to their FQDN. This way, nodes in a netmap will look the same as they do when using tailscale.com services.

Fixes: https://github.com/juanfont/headscale/issues/2501

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
