### PR TITLE
Only read relevant nodes from database in PeerChangedResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ The new policy can be used by setting the environment variable
   [#2493](https://github.com/juanfont/headscale/pull/2493)
   - If a OIDC provider doesn't include the `email_verified` claim in its ID
     tokens, Headscale will attempt to get it from the UserInfo endpoint.
-- Improve performance by only querying relevant nodes from the database for node updates
+- Improve performance by only querying relevant nodes from the database for node updates [#2509](https://github.com/juanfont/headscale/pull/2509)
 
 ## 0.25.1 (2025-02-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ The new policy can be used by setting the environment variable
   [#2493](https://github.com/juanfont/headscale/pull/2493)
   - If a OIDC provider doesn't include the `email_verified` claim in its ID
     tokens, Headscale will attempt to get it from the UserInfo endpoint.
+- Improve performance by only querying relevant nodes from the database for node updates
 
 ## 0.25.1 (2025-02-25)
 

--- a/hscontrol/db/node.go
+++ b/hscontrol/db/node.go
@@ -58,26 +58,23 @@ func ListPeers(tx *gorm.DB, nodeID types.NodeID) (types.Nodes, error) {
 	return nodes, nil
 }
 
-func (hsdb *HSDatabase) ListNodes(nodeIDs ...types.NodeIDs) (types.Nodes, error) {
+// ListNodes queries the database for either all nodes if no parameters are given
+// or for the given nodes if at least one node ID is given as parameter
+func (hsdb *HSDatabase) ListNodes(nodeIDs ...types.NodeID) (types.Nodes, error) {
 	return Read(hsdb.DB, func(rx *gorm.DB) (types.Nodes, error) {
 		return ListNodes(rx, nodeIDs...)
 	})
 }
 
-func ListNodes(tx *gorm.DB, nodeIDs ...types.NodeIDs) (types.Nodes, error) {
-	if len(nodeIDs) > 0 && len(nodeIDs[0]) == 0 {
-		return types.Nodes{}, nil
-	}
-	var nodeFilter types.NodeIDs = nil
-	if len(nodeIDs) > 0 {
-		nodeFilter = nodeIDs[0]
-	}
+// ListNodes queries the database for either all nodes if no parameters are given
+// or for the given nodes if at least one node ID is given as parameter
+func ListNodes(tx *gorm.DB, nodeIDs ...types.NodeID) (types.Nodes, error) {
 	nodes := types.Nodes{}
 	if err := tx.
 		Preload("AuthKey").
 		Preload("AuthKey.User").
 		Preload("User").
-		Where(nodeFilter).Find(&nodes).Error; err != nil {
+		Where(nodeIDs).Find(&nodes).Error; err != nil {
 		return nil, err
 	}
 

--- a/hscontrol/db/node.go
+++ b/hscontrol/db/node.go
@@ -35,21 +35,26 @@ var (
 	)
 )
 
-func (hsdb *HSDatabase) ListPeers(nodeID types.NodeID) (types.Nodes, error) {
+// ListPeers returns peers of node, regardless of any Policy or if the node is expired.
+// If no peer IDs are given, all peers are returned.
+// If at least one peer ID is given, only these peer nodes will be returned.
+func (hsdb *HSDatabase) ListPeers(nodeID types.NodeID, peerIDs ...types.NodeID) (types.Nodes, error) {
 	return Read(hsdb.DB, func(rx *gorm.DB) (types.Nodes, error) {
-		return ListPeers(rx, nodeID)
+		return ListPeers(rx, nodeID, peerIDs...)
 	})
 }
 
-// ListPeers returns all peers of node, regardless of any Policy or if the node is expired.
-func ListPeers(tx *gorm.DB, nodeID types.NodeID) (types.Nodes, error) {
+// ListPeers returns peers of node, regardless of any Policy or if the node is expired.
+// If no peer IDs are given, all peers are returned.
+// If at least one peer ID is given, only these peer nodes will be returned.
+func ListPeers(tx *gorm.DB, nodeID types.NodeID, peerIDs ...types.NodeID) (types.Nodes, error) {
 	nodes := types.Nodes{}
 	if err := tx.
 		Preload("AuthKey").
 		Preload("AuthKey.User").
 		Preload("User").
-		Where("id <> ?",
-			nodeID).Find(&nodes).Error; err != nil {
+		Where("id <> ?", nodeID).
+		Where(peerIDs).Find(&nodes).Error; err != nil {
 		return types.Nodes{}, err
 	}
 

--- a/hscontrol/db/node.go
+++ b/hscontrol/db/node.go
@@ -84,6 +84,9 @@ func (hsdb *HSDatabase) ListNodesSubset(nodeIDs types.NodeIDs) (types.Nodes, err
 }
 
 func ListNodesSubset(tx *gorm.DB, nodeIDs types.NodeIDs) (types.Nodes, error) {
+	if len(nodeIDs) < 1 {
+		return types.Nodes{}, nil
+	}
 	nodes := types.Nodes{}
 	if err := tx.
 		Preload("AuthKey").

--- a/hscontrol/db/node.go
+++ b/hscontrol/db/node.go
@@ -58,41 +58,26 @@ func ListPeers(tx *gorm.DB, nodeID types.NodeID) (types.Nodes, error) {
 	return nodes, nil
 }
 
-func (hsdb *HSDatabase) ListNodes() (types.Nodes, error) {
+func (hsdb *HSDatabase) ListNodes(nodeIDs ...types.NodeIDs) (types.Nodes, error) {
 	return Read(hsdb.DB, func(rx *gorm.DB) (types.Nodes, error) {
-		return ListNodes(rx)
+		return ListNodes(rx, nodeIDs...)
 	})
 }
 
-func ListNodes(tx *gorm.DB) (types.Nodes, error) {
-	nodes := types.Nodes{}
-	if err := tx.
-		Preload("AuthKey").
-		Preload("AuthKey.User").
-		Preload("User").
-		Find(&nodes).Error; err != nil {
-		return nil, err
-	}
-
-	return nodes, nil
-}
-
-func (hsdb *HSDatabase) ListNodesSubset(nodeIDs types.NodeIDs) (types.Nodes, error) {
-	return Read(hsdb.DB, func(rx *gorm.DB) (types.Nodes, error) {
-		return ListNodesSubset(rx, nodeIDs)
-	})
-}
-
-func ListNodesSubset(tx *gorm.DB, nodeIDs types.NodeIDs) (types.Nodes, error) {
-	if len(nodeIDs) < 1 {
+func ListNodes(tx *gorm.DB, nodeIDs ...types.NodeIDs) (types.Nodes, error) {
+	if len(nodeIDs) > 0 && len(nodeIDs[0]) == 0 {
 		return types.Nodes{}, nil
 	}
+	var nodeFilter types.NodeIDs = nil
+	if len(nodeIDs) > 0 {
+		nodeFilter = nodeIDs[0]
+	}
 	nodes := types.Nodes{}
 	if err := tx.
 		Preload("AuthKey").
 		Preload("AuthKey.User").
 		Preload("User").
-		Where(nodeIDs).Find(&nodes).Error; err != nil {
+		Where(nodeFilter).Find(&nodes).Error; err != nil {
 		return nil, err
 	}
 

--- a/hscontrol/db/node.go
+++ b/hscontrol/db/node.go
@@ -77,6 +77,25 @@ func ListNodes(tx *gorm.DB) (types.Nodes, error) {
 	return nodes, nil
 }
 
+func (hsdb *HSDatabase) ListNodesSubset(nodeIDs types.NodeIDs) (types.Nodes, error) {
+	return Read(hsdb.DB, func(rx *gorm.DB) (types.Nodes, error) {
+		return ListNodesSubset(rx, nodeIDs)
+	})
+}
+
+func ListNodesSubset(tx *gorm.DB, nodeIDs types.NodeIDs) (types.Nodes, error) {
+	nodes := types.Nodes{}
+	if err := tx.
+		Preload("AuthKey").
+		Preload("AuthKey.User").
+		Preload("User").
+		Where(nodeIDs).Find(&nodes).Error; err != nil {
+		return nil, err
+	}
+
+	return nodes, nil
+}
+
 func (hsdb *HSDatabase) ListEphemeralNodes() (types.Nodes, error) {
 	return Read(hsdb.DB, func(rx *gorm.DB) (types.Nodes, error) {
 		nodes := types.Nodes{}

--- a/hscontrol/db/node_test.go
+++ b/hscontrol/db/node_test.go
@@ -752,3 +752,81 @@ func TestRenameNode(t *testing.T) {
 	})
 	assert.ErrorContains(t, err, "name is not unique")
 }
+
+func TestListNodesSubset(t *testing.T) {
+	// Setup test database
+	db, err := newSQLiteTestDB()
+	if err != nil {
+		t.Fatalf("creating db: %s", err)
+	}
+
+	user, err := db.CreateUser(types.User{Name: "test"})
+	require.NoError(t, err)
+
+	user2, err := db.CreateUser(types.User{Name: "user2"})
+	require.NoError(t, err)
+
+	node1 := types.Node{
+		ID:             0,
+		MachineKey:     key.NewMachine().Public(),
+		NodeKey:        key.NewNode().Public(),
+		Hostname:       "test1",
+		UserID:         user.ID,
+		RegisterMethod: util.RegisterMethodAuthKey,
+		Hostinfo:       &tailcfg.Hostinfo{},
+	}
+
+	node2 := types.Node{
+		ID:             0,
+		MachineKey:     key.NewMachine().Public(),
+		NodeKey:        key.NewNode().Public(),
+		Hostname:       "test2",
+		UserID:         user2.ID,
+		RegisterMethod: util.RegisterMethodAuthKey,
+		Hostinfo:       &tailcfg.Hostinfo{},
+	}
+
+	err = db.DB.Save(&node1).Error
+	require.NoError(t, err)
+
+	err = db.DB.Save(&node2).Error
+	require.NoError(t, err)
+
+	err = db.DB.Transaction(func(tx *gorm.DB) error {
+		_, err := RegisterNode(tx, node1, nil, nil)
+		if err != nil {
+			return err
+		}
+		_, err = RegisterNode(tx, node2, nil, nil)
+		return err
+	})
+	require.NoError(t, err)
+
+	nodes, err := db.ListNodes()
+	require.NoError(t, err)
+
+	assert.Len(t, nodes, 2)
+
+	// Empty node list should return empty list
+	nodes, err = db.ListNodesSubset(types.NodeIDs{})
+	require.NoError(t, err)
+	assert.Equal(t, len(nodes), 0)
+
+	// No match in IDs should return empty list and no error
+	nodes, err = db.ListNodesSubset(types.NodeIDs{3, 4, 5})
+	require.NoError(t, err)
+	assert.Equal(t, len(nodes), 0)
+
+	// Partial match in IDs
+	nodes, err = db.ListNodesSubset(types.NodeIDs{2, 3})
+	require.NoError(t, err)
+	assert.Equal(t, len(nodes), 1)
+	assert.Equal(t, "test2", nodes[0].Hostname)
+
+	// Several matched IDs
+	nodes, err = db.ListNodesSubset(types.NodeIDs{1, 2, 3})
+	require.NoError(t, err)
+	assert.Equal(t, len(nodes), 2)
+	assert.Equal(t, "test1", nodes[0].Hostname)
+	assert.Equal(t, "test2", nodes[1].Hostname)
+}

--- a/hscontrol/db/node_test.go
+++ b/hscontrol/db/node_test.go
@@ -814,24 +814,26 @@ func TestListNodes(t *testing.T) {
 	assert.Equal(t, "test1", nodes[0].Hostname)
 	assert.Equal(t, "test2", nodes[1].Hostname)
 
-	// Empty node list should return empty list
-	nodes, err = db.ListNodes(types.NodeIDs{})
+	// Empty node list should return all nodes
+	nodes, err = db.ListNodes(types.NodeIDs{}...)
 	require.NoError(t, err)
-	assert.Equal(t, len(nodes), 0)
+	assert.Equal(t, len(nodes), 2)
+	assert.Equal(t, "test1", nodes[0].Hostname)
+	assert.Equal(t, "test2", nodes[1].Hostname)
 
 	// No match in IDs should return empty list and no error
-	nodes, err = db.ListNodes(types.NodeIDs{3, 4, 5})
+	nodes, err = db.ListNodes(types.NodeIDs{3, 4, 5}...)
 	require.NoError(t, err)
 	assert.Equal(t, len(nodes), 0)
 
 	// Partial match in IDs
-	nodes, err = db.ListNodes(types.NodeIDs{2, 3})
+	nodes, err = db.ListNodes(types.NodeIDs{2, 3}...)
 	require.NoError(t, err)
 	assert.Equal(t, len(nodes), 1)
 	assert.Equal(t, "test2", nodes[0].Hostname)
 
 	// Several matched IDs
-	nodes, err = db.ListNodes(types.NodeIDs{1, 2, 3})
+	nodes, err = db.ListNodes(types.NodeIDs{1, 2, 3}...)
 	require.NoError(t, err)
 	assert.Equal(t, len(nodes), 2)
 	assert.Equal(t, "test1", nodes[0].Hostname)

--- a/hscontrol/db/node_test.go
+++ b/hscontrol/db/node_test.go
@@ -753,7 +753,7 @@ func TestRenameNode(t *testing.T) {
 	assert.ErrorContains(t, err, "name is not unique")
 }
 
-func TestListNodesSubset(t *testing.T) {
+func TestListNodes(t *testing.T) {
 	// Setup test database
 	db, err := newSQLiteTestDB()
 	if err != nil {
@@ -807,24 +807,31 @@ func TestListNodesSubset(t *testing.T) {
 
 	assert.Len(t, nodes, 2)
 
+	// No parameter means no filter, should return all nodes
+	nodes, err = db.ListNodes()
+	require.NoError(t, err)
+	assert.Equal(t, len(nodes), 2)
+	assert.Equal(t, "test1", nodes[0].Hostname)
+	assert.Equal(t, "test2", nodes[1].Hostname)
+
 	// Empty node list should return empty list
-	nodes, err = db.ListNodesSubset(types.NodeIDs{})
+	nodes, err = db.ListNodes(types.NodeIDs{})
 	require.NoError(t, err)
 	assert.Equal(t, len(nodes), 0)
 
 	// No match in IDs should return empty list and no error
-	nodes, err = db.ListNodesSubset(types.NodeIDs{3, 4, 5})
+	nodes, err = db.ListNodes(types.NodeIDs{3, 4, 5})
 	require.NoError(t, err)
 	assert.Equal(t, len(nodes), 0)
 
 	// Partial match in IDs
-	nodes, err = db.ListNodesSubset(types.NodeIDs{2, 3})
+	nodes, err = db.ListNodes(types.NodeIDs{2, 3})
 	require.NoError(t, err)
 	assert.Equal(t, len(nodes), 1)
 	assert.Equal(t, "test2", nodes[0].Hostname)
 
 	// Several matched IDs
-	nodes, err = db.ListNodesSubset(types.NodeIDs{1, 2, 3})
+	nodes, err = db.ListNodes(types.NodeIDs{1, 2, 3})
 	require.NoError(t, err)
 	assert.Equal(t, len(nodes), 2)
 	assert.Equal(t, "test1", nodes[0].Hostname)

--- a/hscontrol/mapper/mapper.go
+++ b/hscontrol/mapper/mapper.go
@@ -269,7 +269,7 @@ func (m *Mapper) PeerChangedResponse(
 		}
 	}
 
-	changedNodes, err := m.ListNodesSubset(changedIDs)
+	changedNodes, err := m.ListNodes(changedIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -491,8 +491,8 @@ func (m *Mapper) ListPeers(nodeID types.NodeID) (types.Nodes, error) {
 	return peers, nil
 }
 
-func (m *Mapper) ListNodesSubset(nodeIDs []types.NodeID) (types.Nodes, error) {
-	nodes, err := m.db.ListNodesSubset(nodeIDs)
+func (m *Mapper) ListNodes(nodeIDs ...types.NodeIDs) (types.Nodes, error) {
+	nodes, err := m.db.ListNodes(nodeIDs...)
 	if err != nil {
 		return nil, err
 	}

--- a/hscontrol/mapper/mapper.go
+++ b/hscontrol/mapper/mapper.go
@@ -480,8 +480,11 @@ func (m *Mapper) baseWithConfigMapResponse(
 	return &resp, nil
 }
 
-func (m *Mapper) ListPeers(nodeID types.NodeID) (types.Nodes, error) {
-	peers, err := m.db.ListPeers(nodeID)
+// ListPeers returns peers of node, regardless of any Policy or if the node is expired.
+// If no peer IDs are given, all peers are returned.
+// If at least one peer ID is given, only these peer nodes will be returned.
+func (m *Mapper) ListPeers(nodeID types.NodeID, peerIDs ...types.NodeID) (types.Nodes, error) {
+	peers, err := m.db.ListPeers(nodeID, peerIDs...)
 	if err != nil {
 		return nil, err
 	}

--- a/hscontrol/mapper/mapper.go
+++ b/hscontrol/mapper/mapper.go
@@ -255,6 +255,7 @@ func (m *Mapper) PeerChangedResponse(
 	patches []*tailcfg.PeerChange,
 	messages ...string,
 ) ([]byte, error) {
+	var err error
 	resp := m.baseMapResponse()
 
 	var removedIDs []tailcfg.NodeID
@@ -268,10 +269,12 @@ func (m *Mapper) PeerChangedResponse(
 			removedIDs = append(removedIDs, nodeID.NodeID())
 		}
 	}
-
-	changedNodes, err := m.ListNodes(changedIDs)
-	if err != nil {
-		return nil, err
+	changedNodes := types.Nodes{}
+	if len(changedIDs) > 0 {
+		changedNodes, err = m.ListNodes(changedIDs...)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	err = appendPeerChanges(
@@ -491,7 +494,9 @@ func (m *Mapper) ListPeers(nodeID types.NodeID) (types.Nodes, error) {
 	return peers, nil
 }
 
-func (m *Mapper) ListNodes(nodeIDs ...types.NodeIDs) (types.Nodes, error) {
+// ListNodes queries the database for either all nodes if no parameters are given
+// or for the given nodes if at least one node ID is given as parameter
+func (m *Mapper) ListNodes(nodeIDs ...types.NodeID) (types.Nodes, error) {
 	nodes, err := m.db.ListNodes(nodeIDs...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Querying the whole database becomes a performance issue if a lot of nodes exist in it, even if all those nodes are offline. In `PeerChangedResponse` we actually know which nodes need to be queried, so we can restrict the database queries to these nodes.

In my tests, `PeerChangedResponse` usually needed to query less than 5 nodes, so the change resulted in an order of magnitude better performance for a database with several hundred nodes (most of them offline).

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md

I can also write a test if desired. The PR should not change any behavior, so I wanted to base tests on existing tests for `PeerChangedResponse`. However, I did not find any existing tests for this function, so I am happy for pointers where to start for testing `PeerChangedResponse`.
