### PR TITLE
Make matchers part of the Policy interface

### DIFF
--- a/hscontrol/debug.go
+++ b/hscontrol/debug.go
@@ -40,7 +40,7 @@ func (h *Headscale) debugHTTPServer() *http.Server {
 		w.Write(pol)
 	}))
 	debug.Handle("filter", "Current filter", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		filter := h.polMan.Filter()
+		filter, _ := h.polMan.Filter()
 
 		filterJSON, err := json.MarshalIndent(filter, "", "  ")
 		if err != nil {

--- a/hscontrol/mapper/mapper.go
+++ b/hscontrol/mapper/mapper.go
@@ -536,7 +536,7 @@ func appendPeerChanges(
 	changed types.Nodes,
 	cfg *types.Config,
 ) error {
-	filter := polMan.Filter()
+	filter, matchers := polMan.Filter()
 
 	sshPolicy, err := polMan.SSHPolicy(node)
 	if err != nil {
@@ -546,7 +546,6 @@ func appendPeerChanges(
 	// If there are filter rules present, see if there are any nodes that cannot
 	// access each-other at all and remove them from the peers.
 	if len(filter) > 0 {
-		matchers := polMan.Matchers()
 		changed = policy.FilterNodesByACL(node, changed, matchers)
 	}
 

--- a/hscontrol/mapper/mapper.go
+++ b/hscontrol/mapper/mapper.go
@@ -546,7 +546,8 @@ func appendPeerChanges(
 	// If there are filter rules present, see if there are any nodes that cannot
 	// access each-other at all and remove them from the peers.
 	if len(filter) > 0 {
-		changed = policy.FilterNodesByACL(node, changed, filter)
+		matchers := polMan.Matchers()
+		changed = policy.FilterNodesByACL(node, changed, matchers)
 	}
 
 	profiles := generateUserProfiles(node, changed)

--- a/hscontrol/policy/matcher/matcher.go
+++ b/hscontrol/policy/matcher/matcher.go
@@ -13,6 +13,14 @@ type Match struct {
 	dests *netipx.IPSet
 }
 
+func MatchesFromFilterRules(rules []tailcfg.FilterRule) []Match {
+	matches := make([]Match, 0, len(rules))
+	for _, rule := range rules {
+		matches = append(matches, MatchFromFilterRule(rule))
+	}
+	return matches
+}
+
 func MatchFromFilterRule(rule tailcfg.FilterRule) Match {
 	dests := []string{}
 	for _, dest := range rule.DstPorts {

--- a/hscontrol/policy/pm.go
+++ b/hscontrol/policy/pm.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"github.com/juanfont/headscale/hscontrol/policy/matcher"
 	"net/netip"
 
 	policyv1 "github.com/juanfont/headscale/hscontrol/policy/v1"
@@ -16,6 +17,8 @@ var (
 
 type PolicyManager interface {
 	Filter() []tailcfg.FilterRule
+	// Matchers returns the matchers for the current filter rules.
+	Matchers() []matcher.Match
 	SSHPolicy(*types.Node) (*tailcfg.SSHPolicy, error)
 	SetPolicy([]byte) (bool, error)
 	SetUsers(users []types.User) (bool, error)

--- a/hscontrol/policy/pm.go
+++ b/hscontrol/policy/pm.go
@@ -16,9 +16,8 @@ var (
 )
 
 type PolicyManager interface {
-	Filter() []tailcfg.FilterRule
-	// Matchers returns the matchers for the current filter rules.
-	Matchers() []matcher.Match
+	// Filter returns the current filter rules for the entire tailnet and the associated matchers.
+	Filter() ([]tailcfg.FilterRule, []matcher.Match)
 	SSHPolicy(*types.Node) (*tailcfg.SSHPolicy, error)
 	SetPolicy([]byte) (bool, error)
 	SetUsers(users []types.User) (bool, error)

--- a/hscontrol/policy/policy.go
+++ b/hscontrol/policy/policy.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"github.com/juanfont/headscale/hscontrol/policy/matcher"
 	"net/netip"
 	"slices"
 
@@ -15,7 +16,7 @@ import (
 func FilterNodesByACL(
 	node *types.Node,
 	nodes types.Nodes,
-	filter []tailcfg.FilterRule,
+	matchers []matcher.Match,
 ) types.Nodes {
 	var result types.Nodes
 
@@ -24,7 +25,7 @@ func FilterNodesByACL(
 			continue
 		}
 
-		if node.CanAccess(filter, nodes[index]) || peer.CanAccess(filter, node) {
+		if node.CanAccess(matchers, nodes[index]) || peer.CanAccess(matchers, node) {
 			result = append(result, peer)
 		}
 	}

--- a/hscontrol/policy/policy_test.go
+++ b/hscontrol/policy/policy_test.go
@@ -770,7 +770,7 @@ func TestReduceFilterRules(t *testing.T) {
 				var err error
 				pm, err = pmf(users, append(tt.peers, tt.node))
 				require.NoError(t, err)
-				got := pm.Filter()
+				got, _ := pm.Filter()
 				got = ReduceFilterRules(tt.node, got)
 
 				if diff := cmp.Diff(tt.want, got); diff != "" {

--- a/hscontrol/policy/policy_test.go
+++ b/hscontrol/policy/policy_test.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"fmt"
+	"github.com/juanfont/headscale/hscontrol/policy/matcher"
 	"net/netip"
 	"testing"
 
@@ -1425,10 +1426,11 @@ func TestFilterNodesByACL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			matchers := matcher.MatchesFromFilterRules(tt.args.rules)
 			got := FilterNodesByACL(
 				tt.args.node,
 				tt.args.nodes,
-				tt.args.rules,
+				matchers,
 			)
 			if diff := cmp.Diff(tt.want, got, util.Comparers...); diff != "" {
 				t.Errorf("FilterNodesByACL() unexpected result (-want +got):\n%s", diff)

--- a/hscontrol/policy/v1/policy.go
+++ b/hscontrol/policy/v1/policy.go
@@ -89,15 +89,10 @@ func (pm *PolicyManager) updateLocked() (bool, error) {
 	return true, nil
 }
 
-func (pm *PolicyManager) Filter() []tailcfg.FilterRule {
+func (pm *PolicyManager) Filter() ([]tailcfg.FilterRule, []matcher.Match) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
-	return pm.filter
-}
-
-func (pm *PolicyManager) Matchers() []matcher.Match {
-	filter := pm.Filter()
-	return matcher.MatchesFromFilterRules(filter)
+	return pm.filter, matcher.MatchesFromFilterRules(pm.filter)
 }
 
 func (pm *PolicyManager) SSHPolicy(node *types.Node) (*tailcfg.SSHPolicy, error) {

--- a/hscontrol/policy/v1/policy.go
+++ b/hscontrol/policy/v1/policy.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"fmt"
+	"github.com/juanfont/headscale/hscontrol/policy/matcher"
 	"io"
 	"net/netip"
 	"os"
@@ -92,6 +93,11 @@ func (pm *PolicyManager) Filter() []tailcfg.FilterRule {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 	return pm.filter
+}
+
+func (pm *PolicyManager) Matchers() []matcher.Match {
+	filter := pm.Filter()
+	return matcher.MatchesFromFilterRules(filter)
 }
 
 func (pm *PolicyManager) SSHPolicy(node *types.Node) (*tailcfg.SSHPolicy, error) {

--- a/hscontrol/policy/v1/policy_test.go
+++ b/hscontrol/policy/v1/policy_test.go
@@ -150,7 +150,8 @@ func TestPolicySetChange(t *testing.T) {
 				assert.Equal(t, tt.wantNodesChange, change)
 			}
 
-			if diff := cmp.Diff(tt.wantFilter, pm.Filter()); diff != "" {
+			filter, _ := pm.Filter()
+			if diff := cmp.Diff(tt.wantFilter, filter); diff != "" {
 				t.Errorf("TestPolicySetChange() unexpected result (-want +got):\n%s", diff)
 			}
 		})

--- a/hscontrol/policy/v1/policy_test.go
+++ b/hscontrol/policy/v1/policy_test.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"github.com/juanfont/headscale/hscontrol/policy/matcher"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -27,6 +28,7 @@ func TestPolicySetChange(t *testing.T) {
 		wantNodesChange  bool
 		wantPolicyChange bool
 		wantFilter       []tailcfg.FilterRule
+		wantMatchers     []matcher.Match
 	}{
 		{
 			name: "set-nodes",
@@ -42,6 +44,9 @@ func TestPolicySetChange(t *testing.T) {
 					DstPorts: []tailcfg.NetPortRange{{IP: "100.64.0.1/32", Ports: tailcfg.PortRangeAny}},
 				},
 			},
+			wantMatchers: []matcher.Match{
+				matcher.MatchFromStrings([]string{}, []string{"100.64.0.1/32"}),
+			},
 		},
 		{
 			name:            "set-users",
@@ -51,6 +56,9 @@ func TestPolicySetChange(t *testing.T) {
 				{
 					DstPorts: []tailcfg.NetPortRange{{IP: "100.64.0.1/32", Ports: tailcfg.PortRangeAny}},
 				},
+			},
+			wantMatchers: []matcher.Match{
+				matcher.MatchFromStrings([]string{}, []string{"100.64.0.1/32"}),
 			},
 		},
 		{
@@ -69,6 +77,9 @@ func TestPolicySetChange(t *testing.T) {
 					SrcIPs:   []string{"100.64.0.2/32"},
 					DstPorts: []tailcfg.NetPortRange{{IP: "100.64.0.1/32", Ports: tailcfg.PortRangeAny}},
 				},
+			},
+			wantMatchers: []matcher.Match{
+				matcher.MatchFromStrings([]string{"100.64.0.2/32"}, []string{"100.64.0.1/32"}),
 			},
 		},
 		{
@@ -94,6 +105,9 @@ func TestPolicySetChange(t *testing.T) {
 					SrcIPs:   []string{"100.64.0.61/32"},
 					DstPorts: []tailcfg.NetPortRange{{IP: "100.64.0.62/32", Ports: tailcfg.PortRangeAny}},
 				},
+			},
+			wantMatchers: []matcher.Match{
+				matcher.MatchFromStrings([]string{"100.64.0.61/32"}, []string{"100.64.0.62/32"}),
 			},
 		},
 	}
@@ -150,9 +164,16 @@ func TestPolicySetChange(t *testing.T) {
 				assert.Equal(t, tt.wantNodesChange, change)
 			}
 
-			filter, _ := pm.Filter()
+			filter, matchers := pm.Filter()
 			if diff := cmp.Diff(tt.wantFilter, filter); diff != "" {
-				t.Errorf("TestPolicySetChange() unexpected result (-want +got):\n%s", diff)
+				t.Errorf("TestPolicySetChange() unexpected filter (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(
+				tt.wantMatchers,
+				matchers,
+				cmp.AllowUnexported(matcher.Match{}),
+			); diff != "" {
+				t.Errorf("TestPolicySetChange() unexpected matchers (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -149,17 +149,11 @@ func (pm *PolicyManager) SetPolicy(polB []byte) (bool, error) {
 	return pm.updateLocked()
 }
 
-// Filter returns the current filter rules for the entire tailnet.
-func (pm *PolicyManager) Filter() []tailcfg.FilterRule {
+// Filter returns the current filter rules for the entire tailnet and the associated matchers.
+func (pm *PolicyManager) Filter() ([]tailcfg.FilterRule, []matcher.Match) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
-	return pm.filter
-}
-
-func (pm *PolicyManager) Matchers() []matcher.Match {
-	pm.mu.Lock()
-	defer pm.mu.Unlock()
-	return pm.matchers
+	return pm.filter, pm.matchers
 }
 
 // SetUsers updates the users in the policy manager and updates the filter rules.

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -70,7 +70,7 @@ func (pm *PolicyManager) updateLocked() (bool, error) {
 	}
 
 	filterHash := deephash.Hash(&filter)
-	filterChanged := filterHash == pm.filterHash
+	filterChanged := filterHash != pm.filterHash
 	pm.filter = filter
 	pm.filterHash = filterHash
 	if filterChanged {

--- a/hscontrol/policy/v2/policy_test.go
+++ b/hscontrol/policy/v2/policy_test.go
@@ -47,7 +47,7 @@ func TestPolicyManager(t *testing.T) {
 			pm, err := NewPolicyManager([]byte(tt.pol), users, tt.nodes)
 			require.NoError(t, err)
 
-			filter := pm.Filter()
+			filter, _ := pm.Filter()
 			if diff := cmp.Diff(filter, tt.wantFilter); diff != "" {
 				t.Errorf("Filter() mismatch (-want +got):\n%s", diff)
 			}

--- a/hscontrol/policy/v2/policy_test.go
+++ b/hscontrol/policy/v2/policy_test.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"github.com/juanfont/headscale/hscontrol/policy/matcher"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -29,16 +30,18 @@ func TestPolicyManager(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		pol        string
-		nodes      types.Nodes
-		wantFilter []tailcfg.FilterRule
+		name         string
+		pol          string
+		nodes        types.Nodes
+		wantFilter   []tailcfg.FilterRule
+		wantMatchers []matcher.Match
 	}{
 		{
-			name:       "empty-policy",
-			pol:        "{}",
-			nodes:      types.Nodes{},
-			wantFilter: nil,
+			name:         "empty-policy",
+			pol:          "{}",
+			nodes:        types.Nodes{},
+			wantFilter:   nil,
+			wantMatchers: nil,
 		},
 	}
 
@@ -47,9 +50,16 @@ func TestPolicyManager(t *testing.T) {
 			pm, err := NewPolicyManager([]byte(tt.pol), users, tt.nodes)
 			require.NoError(t, err)
 
-			filter, _ := pm.Filter()
-			if diff := cmp.Diff(filter, tt.wantFilter); diff != "" {
-				t.Errorf("Filter() mismatch (-want +got):\n%s", diff)
+			filter, matchers := pm.Filter()
+			if diff := cmp.Diff(tt.wantFilter, filter); diff != "" {
+				t.Errorf("Filter() filter mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(
+				tt.wantMatchers,
+				matchers,
+				cmp.AllowUnexported(matcher.Match{}),
+			); diff != "" {
+				t.Errorf("Filter() matchers mismatch (-want +got):\n%s", diff)
 			}
 
 			// TODO(kradalby): Test SSH Policy

--- a/hscontrol/policy/v2/policy_test.go
+++ b/hscontrol/policy/v2/policy_test.go
@@ -41,7 +41,7 @@ func TestPolicyManager(t *testing.T) {
 			pol:          "{}",
 			nodes:        types.Nodes{},
 			wantFilter:   nil,
-			wantMatchers: nil,
+			wantMatchers: []matcher.Match{},
 		},
 	}
 

--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -270,17 +270,9 @@ func (node *Node) AppendToIPSet(build *netipx.IPSetBuilder) {
 	}
 }
 
-func (node *Node) CanAccess(filter []tailcfg.FilterRule, node2 *Node) bool {
+func (node *Node) CanAccess(matchers []matcher.Match, node2 *Node) bool {
 	src := node.IPs()
 	allowedIPs := node2.IPs()
-
-	// TODO(kradalby): Regenerate this every time the filter change, instead of
-	// every time we use it.
-	// Part of #2416
-	matchers := make([]matcher.Match, len(filter))
-	for i, rule := range filter {
-		matchers[i] = matcher.MatchFromFilterRule(rule)
-	}
 
 	for _, matcher := range matchers {
 		if !matcher.SrcsContainsIPs(src...) {

--- a/hscontrol/types/node_test.go
+++ b/hscontrol/types/node_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"github.com/juanfont/headscale/hscontrol/policy/matcher"
 	"net/netip"
 	"strings"
 	"testing"
@@ -116,7 +117,8 @@ func Test_NodeCanAccess(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.node1.CanAccess(tt.rules, &tt.node2)
+			matchers := matcher.MatchesFromFilterRules(tt.rules)
+			got := tt.node1.CanAccess(matchers, &tt.node2)
 
 			if got != tt.want {
 				t.Errorf("canAccess() failed: want (%t), got (%t)", tt.want, got)


### PR DESCRIPTION
This PR makes the `Match`es that are computed from `FilterRule`s part of the `Policy` interface, so that they don't have to be recomputed at each call to `Node.CanAccess`. There have already been some discussion on this approach in #2416.

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

