### PR TITLE
Add unraid-headscale-admin web UI to docs

### DIFF
--- a/docs/ref/integration/web-ui.md
+++ b/docs/ref/integration/web-ui.md
@@ -15,5 +15,6 @@ Headscale doesn't provide a built-in web interface but users may pick one from t
 | Headplane       | [GitHub](https://github.com/tale/headplane)             | An advanced Tailscale inspired frontend for headscale                               |
 | headscale-admin | [Github](https://github.com/GoodiesHQ/headscale-admin)  | Headscale-Admin is meant to be a simple, modern web interface for headscale         |
 | ouroboros       | [Github](https://github.com/yellowsink/ouroboros)       | Ouroboros is designed for users to manage their own devices, rather than for admins |
+| unraid-headscale-admin | [Github](https://github.com/ich777/unraid-headscale-admin) | A simple headscale admin UI for Unraid, it offers Local (`docker exec`) and API Mode |
 
 You can ask for support on our [Discord server](https://discord.gg/c84AZQhmpx) in the "web-interfaces" channel.

--- a/docs/ref/integration/web-ui.md
+++ b/docs/ref/integration/web-ui.md
@@ -7,14 +7,14 @@
 
 Headscale doesn't provide a built-in web interface but users may pick one from the available options.
 
-| Name            | Repository Link                                         | Description                                                                         |
-| --------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| headscale-webui | [Github](https://github.com/ifargle/headscale-webui)    | A simple headscale web UI for small-scale deployments.                              |
-| headscale-ui    | [Github](https://github.com/gurucomputing/headscale-ui) | A web frontend for the headscale Tailscale-compatible coordination server           |
-| HeadscaleUi     | [GitHub](https://github.com/simcu/headscale-ui)         | A static headscale admin ui, no backend environment required                         |
-| Headplane       | [GitHub](https://github.com/tale/headplane)             | An advanced Tailscale inspired frontend for headscale                               |
-| headscale-admin | [Github](https://github.com/GoodiesHQ/headscale-admin)  | Headscale-Admin is meant to be a simple, modern web interface for headscale         |
-| ouroboros       | [Github](https://github.com/yellowsink/ouroboros)       | Ouroboros is designed for users to manage their own devices, rather than for admins |
+| Name                   | Repository Link                                            | Description                                                                          |
+| ---------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| headscale-webui        | [Github](https://github.com/ifargle/headscale-webui)       | A simple headscale web UI for small-scale deployments.                               |
+| headscale-ui           | [Github](https://github.com/gurucomputing/headscale-ui)    | A web frontend for the headscale Tailscale-compatible coordination server            |
+| HeadscaleUi            | [GitHub](https://github.com/simcu/headscale-ui)            | A static headscale admin ui, no backend environment required                         |
+| Headplane              | [GitHub](https://github.com/tale/headplane)                | An advanced Tailscale inspired frontend for headscale                                |
+| headscale-admin        | [Github](https://github.com/GoodiesHQ/headscale-admin)     | Headscale-Admin is meant to be a simple, modern web interface for headscale          |
+| ouroboros              | [Github](https://github.com/yellowsink/ouroboros)          | Ouroboros is designed for users to manage their own devices, rather than for admins  |
 | unraid-headscale-admin | [Github](https://github.com/ich777/unraid-headscale-admin) | A simple headscale admin UI for Unraid, it offers Local (`docker exec`) and API Mode |
 
 You can ask for support on our [Discord server](https://discord.gg/c84AZQhmpx) in the "web-interfaces" channel.


### PR DESCRIPTION
This PR adds unraid-headscale-admin to the docs.

unraid-headscale-admin is a simple Plugin for Unraid which adds a simple WebUI for Headscale directly into Unraid which then can communicate in Local Mode (when running the official Headscale Docker container directly on the same machine through `docker exec`) or API Mode (I think the API Mode is self explanatory) with Headscale.