### PR TITLE
config: disallow same server url and base_domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@ towards this code.
 The new policy can be used by setting the environment variable
 `HEADSCALE_EXPERIMENTAL_POLICY_V2` to `1`.
 
+#### Other breaking
+
+- Disallow `server_url` and `base_domain` to be equal
+  [#2544](https://github.com/juanfont/headscale/pull/2544)
+
 ### Changes
 
 - Use Go 1.24 [#2427](https://github.com/juanfont/headscale/pull/2427)

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -33,6 +33,7 @@ const (
 var (
 	errOidcMutuallyExclusive = errors.New("oidc_client_secret and oidc_client_secret_path are mutually exclusive")
 	errServerURLSuffix       = errors.New("server_url cannot be part of base_domain in a way that could make the DERP and headscale server unreachable")
+	errServerURLSame         = errors.New("server_url cannot use the same domain as base_domain in a way that could make the DERP and headscale server unreachable")
 	errInvalidPKCEMethod     = errors.New("pkce.method must be either 'plain' or 'S256'")
 )
 
@@ -997,6 +998,10 @@ func isSafeServerURL(serverURL, baseDomain string) error {
 	server, err := url.Parse(serverURL)
 	if err != nil {
 		return err
+	}
+
+	if server.Hostname() == baseDomain {
+		return errServerURLSame
 	}
 
 	serverDomainParts := strings.Split(server.Host, ".")

--- a/hscontrol/types/config_test.go
+++ b/hscontrol/types/config_test.go
@@ -423,6 +423,7 @@ func TestSafeServerURL(t *testing.T) {
 		{
 			serverURL:  "https://headscale.com",
 			baseDomain: "headscale.com",
+			wantErr:    errServerURLSame.Error(),
 		},
 		{
 			serverURL:  "https://headscale.com",


### PR DESCRIPTION
Remove a footgun.

Fixes #2354