### PR TITLE
oidc: try to get username from userinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ The new policy can be used by setting the environment variable
   [#2493](https://github.com/juanfont/headscale/pull/2493)
   - If a OIDC provider doesn't include the `email_verified` claim in its ID
     tokens, Headscale will attempt to get it from the UserInfo endpoint.
+- OIDC: Try to populate name, email and username from UserInfo
+  [#2545](https://github.com/juanfont/headscale/pull/2545)
 - Improve performance by only querying relevant nodes from the database for node
   updates [#2509](https://github.com/juanfont/headscale/pull/2509)
 - node FQDNs in the netmap will now contain a dot (".") at the end. This aligns

--- a/hscontrol/types/users.go
+++ b/hscontrol/types/users.go
@@ -157,7 +157,7 @@ func (u *User) Proto() *v1.User {
 type FlexibleBoolean bool
 
 func (bit *FlexibleBoolean) UnmarshalJSON(data []byte) error {
-	var val interface{}
+	var val any
 	err := json.Unmarshal(data, &val)
 	if err != nil {
 		return fmt.Errorf("could not unmarshal data: %w", err)
@@ -201,6 +201,17 @@ func (c *OIDCClaims) Identifier() string {
 		}
 	}
 	return c.Iss + "/" + c.Sub
+}
+
+type OIDCUserInfo struct {
+	Sub               string          `json:"sub"`
+	Name              string          `json:"name"`
+	GivenName         string          `json:"given_name"`
+	FamilyName        string          `json:"family_name"`
+	PreferredUsername string          `json:"preferred_username"`
+	Email             string          `json:"email"`
+	EmailVerified     FlexibleBoolean `json:"email_verified,omitempty"`
+	Picture           string          `json:"picture"`
 }
 
 // FromClaim overrides a User from OIDC claims.


### PR DESCRIPTION
This builds on #2493 to get more useful information from userinfo if it is not set in the claim.

@benley would be interested to have your review on this pr.

Fixes #2516