### PR TITLE
Fix goreleaser deprecation warnings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,8 @@ builds:
 archives:
   - id: golang-cross
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
-    format: binary
+    formats:
+      - binary
 
 source:
   enabled: true
@@ -55,7 +56,7 @@ nfpms:
   # List file contents: dpkg -c dist/headscale...deb
   # Package metadata: dpkg --info dist/headscale....deb
   #
-  - builds:
+  - ids:
       - headscale
     package_name: headscale
     priority: optional


### PR DESCRIPTION
See https://goreleaser.com/deprecations/#archivesformat and https://goreleaser.com/deprecations/#nfpmsbuilds

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md
