### PR TITLE
Remove subnet router visibility workaround from docs

### DIFF
--- a/docs/ref/acls.md
+++ b/docs/ref/acls.md
@@ -149,13 +149,11 @@ Here are the ACL's to implement the same permissions as above:
     },
     // developers have access to the internal network through the router.
     // the internal network is composed of HTTPS endpoints and Postgresql
-    // database servers. There's an additional rule to allow traffic to be
-    // forwarded to the internal subnet, 10.20.0.0/16. See this issue
-    // https://github.com/juanfont/headscale/issues/502
+    // database servers.
     {
       "action": "accept",
       "src": ["group:dev"],
-      "dst": ["10.20.0.0/16:443,5432", "router.internal:0"]
+      "dst": ["10.20.0.0/16:443,5432"]
     },
 
     // servers should be able to talk to database in tcp/5432. Database should not be able to initiate connections to

--- a/docs/ref/routes.md
+++ b/docs/ref/routes.md
@@ -76,27 +76,19 @@ The routes announced by subnet routers are available to the nodes in a tailnet. 
 nodes can accept and use such routes. Configure an ACL to explicitly manage who can use routes.
 
 The ACL snippet below defines three hosts, a subnet router `router`, a regular node `node` and `service.example.net` as
-internal service that can be reached via a route on the subnet router `router`. The first ACL rule allows anyone to see
-the subnet router `router` without allowing access to any service of the subnet router itself. The second ACL rule
-allows the node `node` to access `service.example.net` on port 80 and 443 which is reachable via the subnet router.
+internal service that can be reached via a route on the subnet router `router`. It allows the node `node` to access
+`service.example.net` on port 80 and 443 which is reachable via the subnet router. Access to the subnet router itself is
+denied.
 
 ```json title="Access the routes of a subnet router without the subnet router itself"
 {
   "hosts": {
+    // the router is not referenced but announces 192.168.0.0/24"
     "router": "100.64.0.1/32",
     "node": "100.64.0.2/32",
     "service.example.net": "192.168.0.1/32"
   },
   "acls": [
-    {
-      "action": "accept",
-      "src": [
-        "*"
-      ],
-      "dst": [
-        "router:0"
-      ]
-    },
     {
       "action": "accept",
       "src": [


### PR DESCRIPTION
Previous Headscale versions required a dedicated rule to make a subnet router visible to clients. This workaround is no longer required.

- [ ] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md
