### PR TITLE
feat: add autogroup:member, autogroup:tagged

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -22,6 +22,8 @@ jobs:
           - TestACLNamedHostsCanReach
           - TestACLDevice1CanAccessDevice2
           - TestPolicyUpdateWhileRunningWithCLIInDatabase
+          - TestACLAutogroupMember
+          - TestACLAutogroupTagged
           - TestAuthKeyLogoutAndReloginSameUser
           - TestAuthKeyLogoutAndReloginNewUser
           - TestAuthKeyLogoutAndReloginSameUserExpiredKey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,8 @@ working in v1 and not tested might be broken in v2 (and vice versa).
   [#2438](https://github.com/juanfont/headscale/pull/2438)
 - Add documentation for routes
   [#2496](https://github.com/juanfont/headscale/pull/2496)
+- Add support for `autogroup:member`, `autogroup:tagged`
+  [#2572](https://github.com/juanfont/headscale/pull/2572)
 
 ## 0.25.1 (2025-02-25)
 

--- a/docs/about/features.md
+++ b/docs/about/features.md
@@ -23,7 +23,7 @@ provides on overview of Headscale's feature and compatibility with the Tailscale
 - [x] Access control lists ([GitHub label "policy"](https://github.com/juanfont/headscale/labels/policy%20%F0%9F%93%9D))
     - [x] ACL management via API
     - [x] Some [Autogroups](https://tailscale.com/kb/1396/targets#autogroups), currently: `autogroup:internet`,
-      `autogroup:nonroot`
+      `autogroup:nonroot`, `autogroup:member`, `autogroup:tagged`
     - [x] [Auto approvers](https://tailscale.com/kb/1337/acl-syntax#auto-approvers) for [subnet
       routers](../ref/routes.md#automatically-approve-routes-of-a-subnet-router) and [exit
       nodes](../ref/routes.md#automatically-approve-an-exit-node-with-auto-approvers)

--- a/hscontrol/policy/v2/types.go
+++ b/hscontrol/policy/v2/types.go
@@ -383,15 +383,20 @@ type AutoGroup string
 
 const (
 	AutoGroupInternet AutoGroup = "autogroup:internet"
+	AutoGroupMember   AutoGroup = "autogroup:member"
 	AutoGroupNonRoot  AutoGroup = "autogroup:nonroot"
+	AutoGroupTagged   AutoGroup = "autogroup:tagged"
 
 	// These are not yet implemented.
-	AutoGroupSelf   AutoGroup = "autogroup:self"
-	AutoGroupMember AutoGroup = "autogroup:member"
-	AutoGroupTagged AutoGroup = "autogroup:tagged"
+	AutoGroupSelf AutoGroup = "autogroup:self"
 )
 
-var autogroups = []AutoGroup{AutoGroupInternet}
+var autogroups = []AutoGroup{
+	AutoGroupInternet,
+	AutoGroupMember,
+	AutoGroupNonRoot,
+	AutoGroupTagged,
+}
 
 func (ag AutoGroup) Validate() error {
 	if slices.Contains(autogroups, ag) {
@@ -409,13 +414,76 @@ func (ag *AutoGroup) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (ag AutoGroup) Resolve(_ *Policy, _ types.Users, _ types.Nodes) (*netipx.IPSet, error) {
+func (ag AutoGroup) Resolve(p *Policy, users types.Users, nodes types.Nodes) (*netipx.IPSet, error) {
+	var build netipx.IPSetBuilder
+
 	switch ag {
 	case AutoGroupInternet:
 		return util.TheInternet(), nil
-	}
 
-	return nil, nil
+	case AutoGroupMember:
+		// autogroup:member represents all untagged devices in the tailnet.
+		tagMap, err := resolveTagOwners(p, users, nodes)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, node := range nodes {
+			// Skip if node has forced tags
+			if len(node.ForcedTags) != 0 {
+				continue
+			}
+
+			// Skip if node has any allowed requested tags
+			hasAllowedTag := false
+			if node.Hostinfo != nil && len(node.Hostinfo.RequestTags) != 0 {
+				for _, tag := range node.Hostinfo.RequestTags {
+					if tagips, ok := tagMap[Tag(tag)]; ok && node.InIPSet(tagips) {
+						hasAllowedTag = true
+						break
+					}
+				}
+			}
+			if hasAllowedTag {
+				continue
+			}
+
+			// Node is a member if it has no forced tags and no allowed requested tags
+			node.AppendToIPSet(&build)
+		}
+
+		return build.IPSet()
+
+	case AutoGroupTagged:
+		// autogroup:tagged represents all devices with a tag in the tailnet.
+		tagMap, err := resolveTagOwners(p, users, nodes)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, node := range nodes {
+			// Include if node has forced tags
+			if len(node.ForcedTags) != 0 {
+				node.AppendToIPSet(&build)
+				continue
+			}
+
+			// Include if node has any allowed requested tags
+			if node.Hostinfo != nil && len(node.Hostinfo.RequestTags) != 0 {
+				for _, tag := range node.Hostinfo.RequestTags {
+					if _, ok := tagMap[Tag(tag)]; ok {
+						node.AppendToIPSet(&build)
+						break
+					}
+				}
+			}
+		}
+
+		return build.IPSet()
+
+	default:
+		return nil, fmt.Errorf("unknown autogroup %q", ag)
+	}
 }
 
 func (ag *AutoGroup) Is(c AutoGroup) bool {
@@ -949,12 +1017,13 @@ type Policy struct {
 }
 
 var (
-	autogroupForSrc       = []AutoGroup{}
-	autogroupForDst       = []AutoGroup{AutoGroupInternet}
-	autogroupForSSHSrc    = []AutoGroup{}
-	autogroupForSSHDst    = []AutoGroup{}
+	// TODO(kradalby): Add these checks for tagOwners and autoApprovers
+	autogroupForSrc       = []AutoGroup{AutoGroupMember, AutoGroupTagged}
+	autogroupForDst       = []AutoGroup{AutoGroupInternet, AutoGroupMember, AutoGroupTagged}
+	autogroupForSSHSrc    = []AutoGroup{AutoGroupMember, AutoGroupTagged}
+	autogroupForSSHDst    = []AutoGroup{AutoGroupMember, AutoGroupTagged}
 	autogroupForSSHUser   = []AutoGroup{AutoGroupNonRoot}
-	autogroupNotSupported = []AutoGroup{AutoGroupSelf, AutoGroupMember, AutoGroupTagged}
+	autogroupNotSupported = []AutoGroup{AutoGroupSelf}
 )
 
 func validateAutogroupSupported(ag *AutoGroup) error {

--- a/hscontrol/policy/v2/types_test.go
+++ b/hscontrol/policy/v2/types_test.go
@@ -359,7 +359,7 @@ func TestUnmarshalPolicy(t *testing.T) {
 	],
 }
 `,
-			wantErr: `AutoGroup is invalid, got: "autogroup:invalid", must be one of [autogroup:internet]`,
+			wantErr: `AutoGroup is invalid, got: "autogroup:invalid", must be one of [autogroup:internet autogroup:member autogroup:nonroot autogroup:tagged]`,
 		},
 		{
 			name: "undefined-hostname-errors-2490",
@@ -960,6 +960,135 @@ func TestResolvePolicy(t *testing.T) {
 			toResolve: Wildcard,
 			want:      []netip.Prefix{tsaddr.AllIPv4(), tsaddr.AllIPv6()},
 		},
+		{
+			name:      "autogroup-member-comprehensive",
+			toResolve: ptr.To(AutoGroup(AutoGroupMember)),
+			nodes: types.Nodes{
+				// Node with no tags (should be included)
+				{
+					User: users["testuser"],
+					IPv4: ap("100.100.101.1"),
+				},
+				// Node with forced tags (should be excluded)
+				{
+					User:       users["testuser"],
+					ForcedTags: []string{"tag:test"},
+					IPv4:       ap("100.100.101.2"),
+				},
+				// Node with allowed requested tag (should be excluded)
+				{
+					User: users["testuser"],
+					Hostinfo: &tailcfg.Hostinfo{
+						RequestTags: []string{"tag:test"},
+					},
+					IPv4: ap("100.100.101.3"),
+				},
+				// Node with non-allowed requested tag (should be included)
+				{
+					User: users["testuser"],
+					Hostinfo: &tailcfg.Hostinfo{
+						RequestTags: []string{"tag:notallowed"},
+					},
+					IPv4: ap("100.100.101.4"),
+				},
+				// Node with multiple requested tags, one allowed (should be excluded)
+				{
+					User: users["testuser"],
+					Hostinfo: &tailcfg.Hostinfo{
+						RequestTags: []string{"tag:test", "tag:notallowed"},
+					},
+					IPv4: ap("100.100.101.5"),
+				},
+				// Node with multiple requested tags, none allowed (should be included)
+				{
+					User: users["testuser"],
+					Hostinfo: &tailcfg.Hostinfo{
+						RequestTags: []string{"tag:notallowed1", "tag:notallowed2"},
+					},
+					IPv4: ap("100.100.101.6"),
+				},
+			},
+			pol: &Policy{
+				TagOwners: TagOwners{
+					Tag("tag:test"): Owners{ptr.To(Username("testuser@"))},
+				},
+			},
+			want: []netip.Prefix{
+				mp("100.100.101.1/32"), // No tags
+				mp("100.100.101.4/32"), // Non-allowed requested tag
+				mp("100.100.101.6/32"), // Multiple non-allowed requested tags
+			},
+		},
+		{
+			name:      "autogroup-tagged",
+			toResolve: ptr.To(AutoGroup(AutoGroupTagged)),
+			nodes: types.Nodes{
+				// Node with no tags (should be excluded)
+				{
+					User: users["testuser"],
+					IPv4: ap("100.100.101.1"),
+				},
+				// Node with forced tag (should be included)
+				{
+					User:       users["testuser"],
+					ForcedTags: []string{"tag:test"},
+					IPv4:       ap("100.100.101.2"),
+				},
+				// Node with allowed requested tag (should be included)
+				{
+					User: users["testuser"],
+					Hostinfo: &tailcfg.Hostinfo{
+						RequestTags: []string{"tag:test"},
+					},
+					IPv4: ap("100.100.101.3"),
+				},
+				// Node with non-allowed requested tag (should be excluded)
+				{
+					User: users["testuser"],
+					Hostinfo: &tailcfg.Hostinfo{
+						RequestTags: []string{"tag:notallowed"},
+					},
+					IPv4: ap("100.100.101.4"),
+				},
+				// Node with multiple requested tags, one allowed (should be included)
+				{
+					User: users["testuser"],
+					Hostinfo: &tailcfg.Hostinfo{
+						RequestTags: []string{"tag:test", "tag:notallowed"},
+					},
+					IPv4: ap("100.100.101.5"),
+				},
+				// Node with multiple requested tags, none allowed (should be excluded)
+				{
+					User: users["testuser"],
+					Hostinfo: &tailcfg.Hostinfo{
+						RequestTags: []string{"tag:notallowed1", "tag:notallowed2"},
+					},
+					IPv4: ap("100.100.101.6"),
+				},
+				// Node with multiple forced tags (should be included)
+				{
+					User:       users["testuser"],
+					ForcedTags: []string{"tag:test", "tag:other"},
+					IPv4:       ap("100.100.101.7"),
+				},
+			},
+			pol: &Policy{
+				TagOwners: TagOwners{
+					Tag("tag:test"): Owners{ptr.To(Username("testuser@"))},
+				},
+			},
+			want: []netip.Prefix{
+				mp("100.100.101.2/31"), // Forced tag and allowed requested tag consecutive IPs are put in 31 prefix
+				mp("100.100.101.5/32"), // Multiple requested tags, one allowed
+				mp("100.100.101.7/32"), // Multiple forced tags
+			},
+		},
+		{
+			name:      "autogroup-invalid",
+			toResolve: ptr.To(AutoGroup("autogroup:invalid")),
+			wantErr:   "unknown autogroup",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1123,7 +1252,7 @@ func TestResolveAutoApprovers(t *testing.T) {
 			name: "mixed-routes-and-exit-nodes",
 			policy: &Policy{
 				Groups: Groups{
-					"group:testgroup": Usernames{"user1", "user2"},
+					"group:testgroup": Usernames{"user1@", "user2@"},
 				},
 				AutoApprovers: AutoApproverPolicy{
 					Routes: map[netip.Prefix]AutoApprovers{


### PR DESCRIPTION
This implements two autogroups `autogroup:member` and `autogroup:tagged`. I talked with @kradalby about leaving out `autogroup:self` for now, as that is a bit trickier in the end.

The logic of the autogroups and test is taken from the draft pr #2230, but it has been implemented for the new policy structure. 

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [x] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
