### PR TITLE
fix: change FormatUint base from 64 to 10 in preauthkeys list command

### DIFF
--- a/cmd/headscale/cli/preauthkeys.go
+++ b/cmd/headscale/cli/preauthkeys.go
@@ -112,7 +112,7 @@ var listPreAuthKeys = &cobra.Command{
 			aclTags = strings.TrimLeft(aclTags, ",")
 
 			tableData = append(tableData, []string{
-				strconv.FormatUint(key.GetId(), 64),
+				strconv.FormatUint(key.GetId(), 10),
 				key.GetKey(),
 				strconv.FormatBool(key.GetReusable()),
 				strconv.FormatBool(key.GetEphemeral()),


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ /] raised a GitHub issue or discussed it on the projects chat beforehand
- [ x] added unit tests
- [ x] added integration tests
- [ x] updated documentation if needed
- [ x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

Fixes #2586
