### PR TITLE
Remove map_legacy_users from example configuration

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -375,19 +375,6 @@ unix_socket_permission: "0770"
 #     # - plain: Use plain code verifier
 #     # - S256: Use SHA256 hashed code verifier (default, recommended)
 #     method: S256
-#
-#   # Map legacy users from pre-0.24.0 versions of headscale to the new OIDC users
-#   # by taking the username from the legacy user and matching it with the username
-#   # provided by the OIDC. This is useful when migrating from legacy users to OIDC
-#   # to force them using the unique identifier from the OIDC and to give them a
-#   # proper display name and picture if available.
-#   # Note that this will only work if the username from the legacy user is the same
-#   # and there is a possibility for account takeover should a username have changed
-#   # with the provider.
-#   # When this feature is disabled, it will cause all new logins to be created as new users.
-#   # Note this option will be removed in the future and should be set to false
-#   # on all new installations, or when all users have logged in with OIDC once.
-#   map_legacy_users: false
 
 # Logtail configuration
 # Logtail is Tailscales logging and auditing infrastructure, it allows the control panel


### PR DESCRIPTION
This option was removed in #2411

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
