### PR TITLE
allow overriding remote derp map

### DIFF
--- a/hscontrol/derp/derp.go
+++ b/hscontrol/derp/derp.go
@@ -82,6 +82,12 @@ func mergeDERPMaps(derpMaps []*tailcfg.DERPMap) *tailcfg.DERPMap {
 		maps.Copy(result.Regions, derpMap.Regions)
 	}
 
+	for id, region := range result.Regions {
+		if region == nil {
+			delete(result.Regions, id)
+		}
+	}
+
 	return &result
 }
 


### PR DESCRIPTION
- **chore(derp): prioritize loading DERP maps from URLs**
- **chore(derp): allow nil regions in DERPMaps**

This PR enables overriding or removing regions from the default Tailscale DERP map using local files.


<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
