### PR TITLE
feat(oidc): allow email prefix as username fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## Next
+- OIDC: Fallback to using email prefix as username if is EmailVerified when
+  preferred_username is missing
 
 ### BREAKING
 

--- a/hscontrol/types/users.go
+++ b/hscontrol/types/users.go
@@ -322,9 +322,11 @@ func (u *User) FromClaim(claims *OIDCClaims) {
 
 		if claims.Email != "" && claims.EmailVerified {
 			emailParts := strings.Split(claims.Email, "@")
-			if len(emailParts) > 0 && emailParts[0] != "" {
+			err = util.ValidateUsername(emailParts[0])
+			if err == nil {
 				u.Name = emailParts[0]
-				log.Debug().Msgf("Using email prefix %s as name", u.Name)
+			} else {
+				log.Debug().Err(err).Msgf("Email prefix %s is not valid username", emailParts[0])
 			}
 		}
 	}

--- a/hscontrol/types/users.go
+++ b/hscontrol/types/users.go
@@ -273,7 +273,7 @@ func CleanIdentifier(identifier string) string {
 				cleanParts = append(cleanParts, part)
 			}
 		}
-		
+
 		if len(cleanParts) == 0 {
 			u.Path = ""
 		} else {
@@ -319,6 +319,14 @@ func (u *User) FromClaim(claims *OIDCClaims) {
 		u.Name = claims.Username
 	} else {
 		log.Debug().Err(err).Msgf("Username %s is not valid", claims.Username)
+
+		if claims.Email != "" && claims.EmailVerified {
+			emailParts := strings.Split(claims.Email, "@")
+			if len(emailParts) > 0 && emailParts[0] != "" {
+				u.Name = emailParts[0]
+				log.Debug().Msgf("Using email prefix %s as name", u.Name)
+			}
+		}
 	}
 
 	if claims.EmailVerified {

--- a/hscontrol/types/users_test.go
+++ b/hscontrol/types/users_test.go
@@ -307,6 +307,7 @@ func TestOIDCClaimsJSONToUser(t *testing.T) {
 			want: User{
 				Provider: util.RegisterMethodOIDC,
 				Email:    "test@test.no",
+				Name:     "test", // Expect email prefix to be used as fallback name
 				ProviderIdentifier: sql.NullString{
 					String: "/test",
 					Valid:  true,
@@ -325,6 +326,7 @@ func TestOIDCClaimsJSONToUser(t *testing.T) {
 			want: User{
 				Provider: util.RegisterMethodOIDC,
 				Email:    "test2@test.no",
+				Name:     "test2", // Expect email prefix to be used as fallback name
 				ProviderIdentifier: sql.NullString{
 					String: "/test2",
 					Valid:  true,
@@ -444,6 +446,26 @@ func TestOIDCClaimsJSONToUser(t *testing.T) {
 					Valid:  true,
 				},
 				ProfilePicURL: "https://cdn.casbin.org/img/casbin.svg",
+			},
+		},
+		{
+			name: "empty-username-use-email-prefix",
+			jsonstr: `
+{
+  "sub": "123456789",
+  "email": "johndoe@example.com",
+  "email_verified": true,
+  "iss": "https://auth.example.com"
+}
+			`,
+			want: User{
+				Provider: util.RegisterMethodOIDC,
+				Email:    "johndoe@example.com",
+				Name:     "johndoe", // Should use email prefix
+				ProviderIdentifier: sql.NullString{
+					String: "https://auth.example.com/123456789",
+					Valid:  true,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
When using OIDC login and the username is not properly passed with the claims the login fails with:
```
ERR http internal server error error="creating or updating user: constraint failed: UNIQUE constraint failed: users.name (2067)" code=500
```

The proposed solution is to use the email prefix (before @) as the username when the email is marked as verified. _[Question] Should we use the whole email as fallback?_

This resolves the OIDC login from trusted domains like using Google's OAuth 2.0.
Issue ref: https://github.com/juanfont/headscale/issues/2475