### PR TITLE
db: add sqlite "source of truth" schema

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
 
           # When updating go.mod or go.sum, a new sha will need to be calculated,
           # update this if you have a mismatch after doing a change to those files.
-          vendorHash = "sha256-dR8xmUIDMIy08lhm7r95GNNMAbXv4qSH3v9HR40HlNk=";
+          vendorHash = "sha256-3OKZxOIY5f06Uk9TlYXS16Dtwbnli1KeZfK9UGtjjSc=";
 
           subPackages = ["cmd/headscale"];
 

--- a/go.mod
+++ b/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/containerd/console v1.0.4 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6 // indirect
-	github.com/creachadair/mds v0.24.1 // indirect
+	github.com/creachadair/mds v0.24.3 // indirect
 	github.com/dblohm7/wingoes v0.0.0-20240123200102-b75a8a7d7eb0 // indirect
 	github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e // indirect
 	github.com/docker/cli v28.1.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creachadair/mds v0.24.1 h1:bzL4ItCtAUxxO9KkotP0PVzlw4tnJicAcjPu82v2mGs=
 github.com/creachadair/mds v0.24.1/go.mod h1:ArfS0vPHoLV/SzuIzoqTEZfoYmac7n9Cj8XPANHocvw=
+github.com/creachadair/mds v0.24.3 h1:X7cM2ymZSyl4IVWnfyXLxRXMJ6awhbcWvtLPhfnTaqI=
+github.com/creachadair/mds v0.24.3/go.mod h1:0oeHt9QWu8VfnmskOL4zi2CumjEvB29ScmtOmdrhFeU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/creack/pty v1.1.23 h1:4M6+isWdcStXEf15G/RbrMPOQj1dZ7HPZCGwE4kOeP0=

--- a/hscontrol/db/db.go
+++ b/hscontrol/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,6 +19,7 @@ import (
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/util"
 	"github.com/rs/zerolog/log"
+	"github.com/tailscale/squibble"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -26,6 +28,9 @@ import (
 	"tailscale.com/util/set"
 	"zgo.at/zcache/v2"
 )
+
+//go:embed schema.sql
+var dbSchema string
 
 func init() {
 	schema.RegisterSerializer("text", TextSerialiser{})
@@ -723,6 +728,30 @@ AND auth_key_id NOT IN (
 
 	if err := runMigrations(cfg, dbConn, migrations); err != nil {
 		log.Fatal().Err(err).Msgf("Migration failed: %v", err)
+	}
+
+	// Validate that the schema ends up in the expected state.
+	// This is currently only done on sqlite as squibble does not
+	// support Postgres and we use our sqlite schema as our source of
+	// truth.
+	if cfg.Type == types.DatabaseSqlite {
+		sqlConn, err := dbConn.DB()
+		if err != nil {
+			return nil, fmt.Errorf("getting DB from gorm: %w", err)
+		}
+
+		// or else it blocks...
+		sqlConn.SetMaxIdleConns(100)
+		sqlConn.SetMaxOpenConns(100)
+		defer sqlConn.SetMaxIdleConns(1)
+		defer sqlConn.SetMaxOpenConns(1)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if err := squibble.Validate(ctx, sqlConn, dbSchema); err != nil {
+			return nil, fmt.Errorf("validating schema: %w", err)
+		}
 	}
 
 	db := HSDatabase{

--- a/hscontrol/db/schema.sql
+++ b/hscontrol/db/schema.sql
@@ -1,0 +1,109 @@
+-- This  file is the representation of the SQLite schema of Headscale.
+-- It is the "source of truth" and is used to validate any migrations
+-- that are run against the database to ensure it ends in the expected state.
+
+CREATE TABLE migrations(id text,PRIMARY KEY(id));
+
+CREATE TABLE users(
+  id integer PRIMARY KEY AUTOINCREMENT,
+  name text,
+  display_name text,
+  email text,
+  provider_identifier text,
+  provider text,
+  profile_pic_url text,
+
+  created_at datetime,
+  updated_at datetime,
+  deleted_at datetime
+);
+CREATE INDEX idx_users_deleted_at ON users(deleted_at);
+
+
+-- The following three UNIQUE indexes work together to enforce the user identity model:
+--
+-- 1. Users can be either local (provider_identifier is NULL) or from external providers (provider_identifier set)
+-- 2. Each external provider identifier must be unique across the system
+-- 3. Local usernames must be unique among local users
+-- 4. The same username can exist across different providers with different identifiers
+--
+-- Examples:
+-- - Can create local user "alice" (provider_identifier=NULL)
+-- - Can create external user "alice" with GitHub (name="alice", provider_identifier="alice_github")
+-- - Can create external user "alice" with Google (name="alice", provider_identifier="alice_google")
+-- - Cannot create another local user "alice" (blocked by idx_name_no_provider_identifier)
+-- - Cannot create another user with provider_identifier="alice_github" (blocked by idx_provider_identifier)
+-- - Cannot create user "bob" with provider_identifier="alice_github" (blocked by idx_name_provider_identifier)
+CREATE UNIQUE INDEX idx_provider_identifier ON users(
+  provider_identifier
+) WHERE provider_identifier IS NOT NULL;
+CREATE UNIQUE INDEX idx_name_provider_identifier ON users(
+  name,
+  provider_identifier
+);
+CREATE UNIQUE INDEX idx_name_no_provider_identifier ON users(
+  name
+) WHERE provider_identifier IS NULL;
+
+CREATE TABLE pre_auth_keys(
+  id integer PRIMARY KEY AUTOINCREMENT,
+  key text,
+  user_id integer,
+  reusable numeric,
+  ephemeral numeric DEFAULT false,
+  used numeric DEFAULT false,
+  tags text,
+  expiration datetime,
+
+  created_at datetime,
+
+  CONSTRAINT fk_pre_auth_keys_user FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE SET NULL
+);
+
+CREATE TABLE api_keys(
+  id integer PRIMARY KEY AUTOINCREMENT,
+  prefix text,
+  hash blob,
+  expiration datetime,
+  last_seen datetime,
+
+  created_at datetime
+);
+CREATE UNIQUE INDEX idx_api_keys_prefix ON api_keys(prefix);
+
+CREATE TABLE IF NOT EXISTS "nodes"(
+  id integer PRIMARY KEY AUTOINCREMENT,
+  machine_key text,
+  node_key text,
+  disco_key text,
+
+  endpoints text,
+  host_info text,
+  ipv4 text,
+  ipv6 text,
+  hostname text,
+  given_name varchar(63),
+  user_id integer,
+  register_method text,
+  forced_tags text,
+  auth_key_id integer,
+  last_seen datetime,
+  expiry datetime,
+
+  created_at datetime,
+  updated_at datetime,
+  deleted_at datetime,
+
+  CONSTRAINT fk_nodes_user FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE,
+  CONSTRAINT fk_nodes_auth_key FOREIGN KEY(auth_key_id) REFERENCES pre_auth_keys(id)
+);
+
+CREATE TABLE policies(
+  id integer PRIMARY KEY AUTOINCREMENT,
+  data text,
+
+  created_at datetime,
+  updated_at datetime,
+  deleted_at datetime
+);
+CREATE INDEX idx_policies_deleted_at ON policies(deleted_at);


### PR DESCRIPTION
This PR is kind of like a "stretch goal". At the moment it does not pass because our migrations does not actually bring various databases into a consistent state. 

This adds a `schema.sql` which should be the source of truth representation of our schema after all migration is applied (for sqlite). This is to ensure you can look one place to figure out how the current schema is defined and not have to do the patchwork of migrations in your head to get an overview.

I suspect we might have strange behaviour and bugs showing up because there exists schemas out there with different constraint than we think they have. In addition, we might have constraint that does not behave the way we expect, simply because we do not have the complete overview of all constraints. #2475 might be a result of this.

  

Thanks to @nblock for discovering this.