### PR TITLE
Tags: reimplement, make first class

### DIFF
--- a/hscontrol/auth.go
+++ b/hscontrol/auth.go
@@ -193,8 +193,8 @@ func (h *Headscale) handleRegisterWithAuthKey(
 
 	nodeToRegister := types.Node{
 		Hostname:       regReq.Hostinfo.Hostname,
-		UserID:         pak.User.ID,
-		User:           pak.User,
+		UserID:         ptr.To(pak.User.ID),
+		User:           ptr.To(pak.User),
 		MachineKey:     machineKey,
 		NodeKey:        regReq.NodeKey,
 		Hostinfo:       regReq.Hostinfo,
@@ -204,9 +204,9 @@ func (h *Headscale) handleRegisterWithAuthKey(
 		// TODO(kradalby): This should not be set on the node,
 		// they should be looked up through the key, which is
 		// attached to the node.
-		ForcedTags: pak.Proto().GetAclTags(),
-		AuthKey:    pak,
-		AuthKeyID:  &pak.ID,
+		Tags:      pak.Proto().GetAclTags(),
+		AuthKey:   pak,
+		AuthKeyID: &pak.ID,
 	}
 
 	if !regReq.Expiry.IsZero() {

--- a/hscontrol/db/db.go
+++ b/hscontrol/db/db.go
@@ -718,6 +718,22 @@ AND auth_key_id NOT IN (
 				},
 				Rollback: func(db *gorm.DB) error { return nil },
 			},
+			// Migrate node table to make users optional.
+			// Rename forced_tags to tags
+			{
+				ID: "202505211519-node-user-optional-tags",
+				Migrate: func(tx *gorm.DB) error {
+					_ = tx.Migrator().RenameColumn(&types.Node{}, "forced_tags", "tags")
+
+					err = tx.AutoMigrate(&types.Node{})
+					if err != nil {
+						return fmt.Errorf("automigrating types.Node: %w", err)
+					}
+
+					return nil
+				},
+				Rollback: func(db *gorm.DB) error { return nil },
+			},
 		},
 	)
 

--- a/hscontrol/db/ip_test.go
+++ b/hscontrol/db/ip_test.go
@@ -96,7 +96,7 @@ func TestIPAllocatorSequential(t *testing.T) {
 				db.DB.Save(&user)
 
 				db.DB.Save(&types.Node{
-					User: user,
+					User: &user,
 					IPv4: nap("100.64.0.1"),
 					IPv6: nap("fd7a:115c:a1e0::1"),
 				})
@@ -124,7 +124,7 @@ func TestIPAllocatorSequential(t *testing.T) {
 				db.DB.Save(&user)
 
 				db.DB.Save(&types.Node{
-					User: user,
+					User: &user,
 					IPv4: nap("100.64.0.2"),
 					IPv6: nap("fd7a:115c:a1e0::2"),
 				})
@@ -314,7 +314,7 @@ func TestBackfillIPAddresses(t *testing.T) {
 				db.DB.Save(&user)
 
 				db.DB.Save(&types.Node{
-					User: user,
+					User: &user,
 					IPv4: nap("100.64.0.1"),
 				})
 
@@ -339,7 +339,7 @@ func TestBackfillIPAddresses(t *testing.T) {
 				db.DB.Save(&user)
 
 				db.DB.Save(&types.Node{
-					User: user,
+					User: &user,
 					IPv6: nap("fd7a:115c:a1e0::1"),
 				})
 
@@ -364,7 +364,7 @@ func TestBackfillIPAddresses(t *testing.T) {
 				db.DB.Save(&user)
 
 				db.DB.Save(&types.Node{
-					User: user,
+					User: &user,
 					IPv4: nap("100.64.0.1"),
 					IPv6: nap("fd7a:115c:a1e0::1"),
 				})
@@ -388,7 +388,7 @@ func TestBackfillIPAddresses(t *testing.T) {
 				db.DB.Save(&user)
 
 				db.DB.Save(&types.Node{
-					User: user,
+					User: &user,
 					IPv4: nap("100.64.0.1"),
 					IPv6: nap("fd7a:115c:a1e0::1"),
 				})
@@ -412,19 +412,19 @@ func TestBackfillIPAddresses(t *testing.T) {
 				db.DB.Save(&user)
 
 				db.DB.Save(&types.Node{
-					User: user,
+					User: &user,
 					IPv4: nap("100.64.0.1"),
 				})
 				db.DB.Save(&types.Node{
-					User: user,
+					User: &user,
 					IPv4: nap("100.64.0.2"),
 				})
 				db.DB.Save(&types.Node{
-					User: user,
+					User: &user,
 					IPv4: nap("100.64.0.3"),
 				})
 				db.DB.Save(&types.Node{
-					User: user,
+					User: &user,
 					IPv4: nap("100.64.0.4"),
 				})
 

--- a/hscontrol/db/node_test.go
+++ b/hscontrol/db/node_test.go
@@ -43,7 +43,7 @@ func (s *Suite) TestGetNode(c *check.C) {
 		MachineKey:     machineKey.Public(),
 		NodeKey:        nodeKey.Public(),
 		Hostname:       "testnode",
-		UserID:         user.ID,
+		UserID:         &user.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		AuthKeyID:      ptr.To(pak.ID),
 	}
@@ -72,7 +72,7 @@ func (s *Suite) TestGetNodeByID(c *check.C) {
 		MachineKey:     machineKey.Public(),
 		NodeKey:        nodeKey.Public(),
 		Hostname:       "testnode",
-		UserID:         user.ID,
+		UserID:         &user.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		AuthKeyID:      ptr.To(pak.ID),
 	}
@@ -95,7 +95,7 @@ func (s *Suite) TestHardDeleteNode(c *check.C) {
 		MachineKey:     machineKey.Public(),
 		NodeKey:        nodeKey.Public(),
 		Hostname:       "testnode3",
-		UserID:         user.ID,
+		UserID:         &user.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 	}
 	trx := db.DB.Save(&node)
@@ -127,7 +127,7 @@ func (s *Suite) TestListPeers(c *check.C) {
 			MachineKey:     machineKey.Public(),
 			NodeKey:        nodeKey.Public(),
 			Hostname:       "testnode" + strconv.Itoa(index),
-			UserID:         user.ID,
+			UserID:         &user.ID,
 			RegisterMethod: util.RegisterMethodAuthKey,
 			AuthKeyID:      ptr.To(pak.ID),
 		}
@@ -165,7 +165,7 @@ func (s *Suite) TestExpireNode(c *check.C) {
 		MachineKey:     machineKey.Public(),
 		NodeKey:        nodeKey.Public(),
 		Hostname:       "testnode",
-		UserID:         user.ID,
+		UserID:         &user.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		AuthKeyID:      ptr.To(pak.ID),
 		Expiry:         &time.Time{},
@@ -206,7 +206,7 @@ func (s *Suite) TestSetTags(c *check.C) {
 		MachineKey:     machineKey.Public(),
 		NodeKey:        nodeKey.Public(),
 		Hostname:       "testnode",
-		UserID:         user.ID,
+		UserID:         &user.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		AuthKeyID:      ptr.To(pak.ID),
 	}
@@ -220,7 +220,7 @@ func (s *Suite) TestSetTags(c *check.C) {
 	c.Assert(err, check.IsNil)
 	node, err = db.getNode(types.UserID(user.ID), "testnode")
 	c.Assert(err, check.IsNil)
-	c.Assert(node.ForcedTags, check.DeepEquals, sTags)
+	c.Assert(node.Tags, check.DeepEquals, sTags)
 
 	// assign duplicate tags, expect no errors but no doubles in DB
 	eTags := []string{"tag:bar", "tag:test", "tag:unknown", "tag:test"}
@@ -229,7 +229,7 @@ func (s *Suite) TestSetTags(c *check.C) {
 	node, err = db.getNode(types.UserID(user.ID), "testnode")
 	c.Assert(err, check.IsNil)
 	c.Assert(
-		node.ForcedTags,
+		node.Tags,
 		check.DeepEquals,
 		[]string{"tag:bar", "tag:test", "tag:unknown"},
 	)
@@ -239,7 +239,7 @@ func (s *Suite) TestSetTags(c *check.C) {
 	c.Assert(err, check.IsNil)
 	node, err = db.getNode(types.UserID(user.ID), "testnode")
 	c.Assert(err, check.IsNil)
-	c.Assert(node.ForcedTags, check.DeepEquals, []string{})
+	c.Assert(node.Tags, check.DeepEquals, []string{})
 }
 
 func TestHeadscale_generateGivenName(t *testing.T) {
@@ -451,7 +451,7 @@ func TestAutoApproveRoutes(t *testing.T) {
 					MachineKey:     key.NewMachine().Public(),
 					NodeKey:        key.NewNode().Public(),
 					Hostname:       "testnode",
-					UserID:         user.ID,
+					UserID:         &user.ID,
 					RegisterMethod: util.RegisterMethodAuthKey,
 					Hostinfo: &tailcfg.Hostinfo{
 						RoutableIPs: tt.routes,
@@ -467,13 +467,13 @@ func TestAutoApproveRoutes(t *testing.T) {
 					MachineKey:     key.NewMachine().Public(),
 					NodeKey:        key.NewNode().Public(),
 					Hostname:       "taggednode",
-					UserID:         taggedUser.ID,
+					UserID:         &taggedUser.ID,
 					RegisterMethod: util.RegisterMethodAuthKey,
 					Hostinfo: &tailcfg.Hostinfo{
 						RoutableIPs: tt.routes,
 					},
-					ForcedTags: []string{"tag:exit"},
-					IPv4:       ptr.To(netip.MustParseAddr("100.64.0.2")),
+					Tags: []string{"tag:exit"},
+					IPv4: ptr.To(netip.MustParseAddr("100.64.0.2")),
 				}
 
 				err = adb.DB.Save(&nodeTagged).Error
@@ -612,7 +612,7 @@ func TestListEphemeralNodes(t *testing.T) {
 		MachineKey:     key.NewMachine().Public(),
 		NodeKey:        key.NewNode().Public(),
 		Hostname:       "test",
-		UserID:         user.ID,
+		UserID:         &user.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		AuthKeyID:      ptr.To(pak.ID),
 	}
@@ -622,7 +622,7 @@ func TestListEphemeralNodes(t *testing.T) {
 		MachineKey:     key.NewMachine().Public(),
 		NodeKey:        key.NewNode().Public(),
 		Hostname:       "ephemeral",
-		UserID:         user.ID,
+		UserID:         &user.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		AuthKeyID:      ptr.To(pakEph.ID),
 	}
@@ -665,7 +665,7 @@ func TestRenameNode(t *testing.T) {
 		MachineKey:     key.NewMachine().Public(),
 		NodeKey:        key.NewNode().Public(),
 		Hostname:       "test",
-		UserID:         user.ID,
+		UserID:         &user.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		Hostinfo:       &tailcfg.Hostinfo{},
 	}
@@ -675,7 +675,7 @@ func TestRenameNode(t *testing.T) {
 		MachineKey:     key.NewMachine().Public(),
 		NodeKey:        key.NewNode().Public(),
 		Hostname:       "test",
-		UserID:         user2.ID,
+		UserID:         &user2.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		Hostinfo:       &tailcfg.Hostinfo{},
 	}
@@ -765,7 +765,7 @@ func TestListPeers(t *testing.T) {
 		MachineKey:     key.NewMachine().Public(),
 		NodeKey:        key.NewNode().Public(),
 		Hostname:       "test1",
-		UserID:         user.ID,
+		UserID:         &user.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		Hostinfo:       &tailcfg.Hostinfo{},
 	}
@@ -775,7 +775,7 @@ func TestListPeers(t *testing.T) {
 		MachineKey:     key.NewMachine().Public(),
 		NodeKey:        key.NewNode().Public(),
 		Hostname:       "test2",
-		UserID:         user2.ID,
+		UserID:         &user2.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		Hostinfo:       &tailcfg.Hostinfo{},
 	}
@@ -849,7 +849,7 @@ func TestListNodes(t *testing.T) {
 		MachineKey:     key.NewMachine().Public(),
 		NodeKey:        key.NewNode().Public(),
 		Hostname:       "test1",
-		UserID:         user.ID,
+		UserID:         &user.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		Hostinfo:       &tailcfg.Hostinfo{},
 	}
@@ -859,7 +859,7 @@ func TestListNodes(t *testing.T) {
 		MachineKey:     key.NewMachine().Public(),
 		NodeKey:        key.NewNode().Public(),
 		Hostname:       "test2",
-		UserID:         user2.ID,
+		UserID:         &user2.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		Hostinfo:       &tailcfg.Hostinfo{},
 	}

--- a/hscontrol/db/preauth_keys_test.go
+++ b/hscontrol/db/preauth_keys_test.go
@@ -74,7 +74,7 @@ func TestCannotDeleteAssignedPreAuthKey(t *testing.T) {
 	node := types.Node{
 		ID:             0,
 		Hostname:       "testest",
-		UserID:         user.ID,
+		UserID:         &user.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		AuthKeyID:      ptr.To(key.ID),
 	}

--- a/hscontrol/db/users.go
+++ b/hscontrol/db/users.go
@@ -7,6 +7,7 @@ import (
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/util"
 	"gorm.io/gorm"
+	"tailscale.com/types/ptr"
 )
 
 var (
@@ -192,7 +193,7 @@ func (hsdb *HSDatabase) GetUserByName(name string) (*types.User, error) {
 // ListNodesByUser gets all the nodes in a given user.
 func ListNodesByUser(tx *gorm.DB, uid types.UserID) (types.Nodes, error) {
 	nodes := types.Nodes{}
-	if err := tx.Preload("AuthKey").Preload("AuthKey.User").Preload("User").Where(&types.Node{UserID: uint(uid)}).Find(&nodes).Error; err != nil {
+	if err := tx.Preload("AuthKey").Preload("AuthKey.User").Preload("User").Where(&types.Node{UserID: ptr.To(uint(uid))}).Find(&nodes).Error; err != nil {
 		return nil, err
 	}
 
@@ -211,7 +212,7 @@ func AssignNodeToUser(tx *gorm.DB, node *types.Node, uid types.UserID) error {
 	if err != nil {
 		return err
 	}
-	node.User = *user
+	node.User = user
 	if result := tx.Save(&node); result.Error != nil {
 		return result.Error
 	}

--- a/hscontrol/db/users_test.go
+++ b/hscontrol/db/users_test.go
@@ -52,7 +52,7 @@ func (s *Suite) TestDestroyUserErrors(c *check.C) {
 	node := types.Node{
 		ID:             0,
 		Hostname:       "testnode",
-		UserID:         user.ID,
+		UserID:         &user.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		AuthKeyID:      ptr.To(pak.ID),
 	}
@@ -110,17 +110,17 @@ func (s *Suite) TestSetMachineUser(c *check.C) {
 	node := types.Node{
 		ID:             0,
 		Hostname:       "testnode",
-		UserID:         oldUser.ID,
+		UserID:         &oldUser.ID,
 		RegisterMethod: util.RegisterMethodAuthKey,
 		AuthKeyID:      ptr.To(pak.ID),
 	}
 	trx := db.DB.Save(&node)
 	c.Assert(trx.Error, check.IsNil)
-	c.Assert(node.UserID, check.Equals, oldUser.ID)
+	c.Assert(*node.UserID, check.Equals, oldUser.ID)
 
 	err = db.AssignNodeToUser(&node, types.UserID(newUser.ID))
 	c.Assert(err, check.IsNil)
-	c.Assert(node.UserID, check.Equals, newUser.ID)
+	c.Assert(*node.UserID, check.Equals, newUser.ID)
 	c.Assert(node.User.Name, check.Equals, newUser.Name)
 
 	err = db.AssignNodeToUser(&node, 9584849)
@@ -128,6 +128,6 @@ func (s *Suite) TestSetMachineUser(c *check.C) {
 
 	err = db.AssignNodeToUser(&node, types.UserID(newUser.ID))
 	c.Assert(err, check.IsNil)
-	c.Assert(node.UserID, check.Equals, newUser.ID)
+	c.Assert(*node.UserID, check.Equals, newUser.ID)
 	c.Assert(node.User.Name, check.Equals, newUser.Name)
 }

--- a/hscontrol/grpcv1.go
+++ b/hscontrol/grpcv1.go
@@ -552,7 +552,7 @@ func nodesToProto(polMan policy.PolicyManager, isLikelyConnected *xsync.MapOf[ty
 				tags = append(tags, tag)
 			}
 		}
-		resp.ValidTags = lo.Uniq(append(tags, node.ForcedTags...))
+		resp.ValidTags = lo.Uniq(append(tags, node.Tags...))
 		resp.SubnetRoutes = util.PrefixesToString(append(pr.PrimaryRoutes(node.ID), node.ExitRoutes()...))
 		response[index] = resp
 	}
@@ -819,7 +819,7 @@ func (api headscaleV1APIServer) DebugCreateNode(
 			NodeKey:    key.NewNode().Public(),
 			MachineKey: key.NewMachine().Public(),
 			Hostname:   request.GetName(),
-			User:       *user,
+			User:       user,
 
 			Expiry:   &time.Time{},
 			LastSeen: &time.Time{},

--- a/hscontrol/mapper/mapper.go
+++ b/hscontrol/mapper/mapper.go
@@ -104,11 +104,16 @@ func generateUserProfiles(
 ) []tailcfg.UserProfile {
 	userMap := make(map[uint]*types.User)
 	ids := make([]uint, 0, len(userMap))
-	userMap[node.User.ID] = &node.User
-	ids = append(ids, node.User.ID)
-	for _, peer := range peers {
-		userMap[peer.User.ID] = &peer.User
-		ids = append(ids, peer.User.ID)
+	var tagged bool
+	if node.IsUserOwned() {
+		userMap[node.User.ID] = node.User
+		ids = append(ids, node.User.ID)
+		for _, peer := range peers {
+			userMap[peer.User.ID] = peer.User
+			ids = append(ids, peer.User.ID)
+		}
+	} else {
+		tagged = true
 	}
 
 	slices.Sort(ids)
@@ -118,6 +123,10 @@ func generateUserProfiles(
 		if userMap[id] != nil {
 			profiles = append(profiles, userMap[id].TailscaleUserProfile())
 		}
+	}
+
+	if tagged {
+		profiles = append(profiles, types.TaggedDevices.TailscaleUserProfile())
 	}
 
 	return profiles

--- a/hscontrol/mapper/mapper_test.go
+++ b/hscontrol/mapper/mapper_test.go
@@ -53,8 +53,8 @@ func TestDNSConfigMapResponse(t *testing.T) {
 			mach := func(hostname, username string, userid uint) *types.Node {
 				return &types.Node{
 					Hostname: hostname,
-					UserID:   userid,
-					User: types.User{
+					UserID:   &userid,
+					User: &types.User{
 						Name: username,
 					},
 				}
@@ -128,15 +128,15 @@ func Test_fullMapResponse(t *testing.T) {
 		DiscoKey: mustDK(
 			"discokey:cf7b0fd05da556fdc3bab365787b506fd82d64a70745db70e00e86c1b1c03084",
 		),
-		IPv4:       iap("100.64.0.1"),
-		Hostname:   "mini",
-		GivenName:  "mini",
-		UserID:     user1.ID,
-		User:       user1,
-		ForcedTags: []string{},
-		AuthKey:    &types.PreAuthKey{},
-		LastSeen:   &lastSeen,
-		Expiry:     &expire,
+		IPv4:      iap("100.64.0.1"),
+		Hostname:  "mini",
+		GivenName: "mini",
+		UserID:    &user1.ID,
+		User:      &user1,
+		Tags:      []string{},
+		AuthKey:   &types.PreAuthKey{},
+		LastSeen:  &lastSeen,
+		Expiry:    &expire,
 		Hostinfo: &tailcfg.Hostinfo{
 			RoutableIPs: []netip.Prefix{
 				tsaddr.AllIPv4(),
@@ -205,16 +205,16 @@ func Test_fullMapResponse(t *testing.T) {
 		DiscoKey: mustDK(
 			"discokey:cf7b0fd05da556fdc3bab365787b506fd82d64a70745db70e00e86c1b1c03084",
 		),
-		IPv4:       iap("100.64.0.2"),
-		Hostname:   "peer1",
-		GivenName:  "peer1",
-		UserID:     user2.ID,
-		User:       user2,
-		ForcedTags: []string{},
-		LastSeen:   &lastSeen,
-		Expiry:     &expire,
-		Hostinfo:   &tailcfg.Hostinfo{},
-		CreatedAt:  created,
+		IPv4:      iap("100.64.0.2"),
+		Hostname:  "peer1",
+		GivenName: "peer1",
+		UserID:    &user2.ID,
+		User:      &user2,
+		Tags:      []string{},
+		LastSeen:  &lastSeen,
+		Expiry:    &expire,
+		Hostinfo:  &tailcfg.Hostinfo{},
+		CreatedAt: created,
 	}
 
 	tailPeer1 := &tailcfg.Node{

--- a/hscontrol/mapper/tail_test.go
+++ b/hscontrol/mapper/tail_test.go
@@ -15,6 +15,7 @@ import (
 	"tailscale.com/net/tsaddr"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
+	"tailscale.com/types/ptr"
 )
 
 func TestTailNode(t *testing.T) {
@@ -70,7 +71,6 @@ func TestTailNode(t *testing.T) {
 				HomeDERP:          0,
 				LegacyDERPString:  "127.3.3.40:0",
 				Hostinfo:          hiview(tailcfg.Hostinfo{}),
-				Tags:              []string{},
 				MachineAuthorized: true,
 
 				CapMap: tailcfg.NodeCapMap{
@@ -97,14 +97,13 @@ func TestTailNode(t *testing.T) {
 				IPv4:      iap("100.64.0.1"),
 				Hostname:  "mini",
 				GivenName: "mini",
-				UserID:    0,
-				User: types.User{
+				UserID:    ptr.To(uint(0)),
+				User: &types.User{
 					Name: "mini",
 				},
-				ForcedTags: []string{},
-				AuthKey:    &types.PreAuthKey{},
-				LastSeen:   &lastSeen,
-				Expiry:     &expire,
+				AuthKey:  &types.PreAuthKey{},
+				LastSeen: &lastSeen,
+				Expiry:   &expire,
 				Hostinfo: &tailcfg.Hostinfo{
 					RoutableIPs: []netip.Prefix{
 						tsaddr.AllIPv4(),
@@ -156,8 +155,6 @@ func TestTailNode(t *testing.T) {
 				}),
 				Created: created,
 
-				Tags: []string{},
-
 				LastSeen:          &lastSeen,
 				MachineAuthorized: true,
 
@@ -184,7 +181,6 @@ func TestTailNode(t *testing.T) {
 				HomeDERP:          0,
 				LegacyDERPString:  "127.3.3.40:0",
 				Hostinfo:          hiview(tailcfg.Hostinfo{}),
-				Tags:              []string{},
 				MachineAuthorized: true,
 
 				CapMap: tailcfg.NodeCapMap{

--- a/hscontrol/policy/policy_test.go
+++ b/hscontrol/policy/policy_test.go
@@ -17,6 +17,7 @@ import (
 	"gorm.io/gorm"
 	"tailscale.com/net/tsaddr"
 	"tailscale.com/tailcfg"
+	"tailscale.com/types/ptr"
 	"tailscale.com/util/must"
 )
 
@@ -142,15 +143,17 @@ func TestReduceFilterRules(t *testing.T) {
 }
 `,
 			node: &types.Node{
-				IPv4: ap("100.64.0.1"),
-				IPv6: ap("fd7a:115c:a1e0:ab12:4843:2222:6273:2221"),
-				User: users[0],
+				IPv4:   ap("100.64.0.1"),
+				IPv6:   ap("fd7a:115c:a1e0:ab12:4843:2222:6273:2221"),
+				User:   &users[0],
+				UserID: &users[0].ID,
 			},
 			peers: types.Nodes{
 				&types.Node{
-					IPv4: ap("100.64.0.2"),
-					IPv6: ap("fd7a:115c:a1e0:ab12:4843:2222:6273:2222"),
-					User: users[0],
+					IPv4:   ap("100.64.0.2"),
+					IPv6:   ap("fd7a:115c:a1e0:ab12:4843:2222:6273:2222"),
+					User:   &users[0],
+					UserID: &users[0].ID,
 				},
 			},
 			want: []tailcfg.FilterRule{},
@@ -189,9 +192,10 @@ func TestReduceFilterRules(t *testing.T) {
 }
 `,
 			node: &types.Node{
-				IPv4: ap("100.64.0.1"),
-				IPv6: ap("fd7a:115c:a1e0::1"),
-				User: users[1],
+				IPv4:   ap("100.64.0.1"),
+				IPv6:   ap("fd7a:115c:a1e0::1"),
+				User:   &users[1],
+				UserID: &users[1].ID,
 				Hostinfo: &tailcfg.Hostinfo{
 					RoutableIPs: []netip.Prefix{
 						netip.MustParsePrefix("10.33.0.0/16"),
@@ -200,9 +204,10 @@ func TestReduceFilterRules(t *testing.T) {
 			},
 			peers: types.Nodes{
 				&types.Node{
-					IPv4: ap("100.64.0.2"),
-					IPv6: ap("fd7a:115c:a1e0::2"),
-					User: users[1],
+					IPv4:   ap("100.64.0.2"),
+					IPv6:   ap("fd7a:115c:a1e0::2"),
+					User:   &users[1],
+					UserID: &users[1].ID,
 				},
 			},
 			want: []tailcfg.FilterRule{
@@ -279,21 +284,24 @@ func TestReduceFilterRules(t *testing.T) {
 }
 `,
 			node: &types.Node{
-				IPv4: ap("100.64.0.1"),
-				IPv6: ap("fd7a:115c:a1e0::1"),
-				User: users[1],
+				IPv4:   ap("100.64.0.1"),
+				IPv6:   ap("fd7a:115c:a1e0::1"),
+				User:   &users[1],
+				UserID: &users[1].ID,
 			},
 			peers: types.Nodes{
 				&types.Node{
-					IPv4: ap("100.64.0.2"),
-					IPv6: ap("fd7a:115c:a1e0::2"),
-					User: users[2],
+					IPv4:   ap("100.64.0.2"),
+					IPv6:   ap("fd7a:115c:a1e0::2"),
+					User:   &users[2],
+					UserID: &users[2].ID,
 				},
 				// "internal" exit node
 				&types.Node{
-					IPv4: ap("100.64.0.100"),
-					IPv6: ap("fd7a:115c:a1e0::100"),
-					User: users[3],
+					IPv4:   ap("100.64.0.100"),
+					IPv6:   ap("fd7a:115c:a1e0::100"),
+					User:   &users[3],
+					UserID: &users[3].ID,
 					Hostinfo: &tailcfg.Hostinfo{
 						RoutableIPs: tsaddr.ExitRoutes(),
 					},
@@ -340,23 +348,26 @@ func TestReduceFilterRules(t *testing.T) {
 }
 `,
 			node: &types.Node{
-				IPv4: ap("100.64.0.100"),
-				IPv6: ap("fd7a:115c:a1e0::100"),
-				User: users[3],
+				IPv4:   ap("100.64.0.100"),
+				IPv6:   ap("fd7a:115c:a1e0::100"),
+				User:   &users[3],
+				UserID: &users[3].ID,
 				Hostinfo: &tailcfg.Hostinfo{
 					RoutableIPs: tsaddr.ExitRoutes(),
 				},
 			},
 			peers: types.Nodes{
 				&types.Node{
-					IPv4: ap("100.64.0.2"),
-					IPv6: ap("fd7a:115c:a1e0::2"),
-					User: users[2],
+					IPv4:   ap("100.64.0.2"),
+					IPv6:   ap("fd7a:115c:a1e0::2"),
+					User:   &users[2],
+					UserID: &users[2].ID,
 				},
 				&types.Node{
-					IPv4: ap("100.64.0.1"),
-					IPv6: ap("fd7a:115c:a1e0::1"),
-					User: users[1],
+					IPv4:   ap("100.64.0.1"),
+					IPv6:   ap("fd7a:115c:a1e0::1"),
+					User:   &users[1],
+					UserID: &users[1].ID,
 				},
 			},
 			want: []tailcfg.FilterRule{
@@ -447,23 +458,26 @@ func TestReduceFilterRules(t *testing.T) {
 }
 `,
 			node: &types.Node{
-				IPv4: ap("100.64.0.100"),
-				IPv6: ap("fd7a:115c:a1e0::100"),
-				User: users[3],
+				IPv4:   ap("100.64.0.100"),
+				IPv6:   ap("fd7a:115c:a1e0::100"),
+				User:   &users[3],
+				UserID: &users[3].ID,
 				Hostinfo: &tailcfg.Hostinfo{
 					RoutableIPs: tsaddr.ExitRoutes(),
 				},
 			},
 			peers: types.Nodes{
 				&types.Node{
-					IPv4: ap("100.64.0.2"),
-					IPv6: ap("fd7a:115c:a1e0::2"),
-					User: users[2],
+					IPv4:   ap("100.64.0.2"),
+					IPv6:   ap("fd7a:115c:a1e0::2"),
+					User:   &users[2],
+					UserID: &users[2].ID,
 				},
 				&types.Node{
-					IPv4: ap("100.64.0.1"),
-					IPv6: ap("fd7a:115c:a1e0::1"),
-					User: users[1],
+					IPv4:   ap("100.64.0.1"),
+					IPv6:   ap("fd7a:115c:a1e0::1"),
+					User:   &users[1],
+					UserID: &users[1].ID,
 				},
 			},
 			want: []tailcfg.FilterRule{
@@ -557,23 +571,26 @@ func TestReduceFilterRules(t *testing.T) {
 }
 `,
 			node: &types.Node{
-				IPv4: ap("100.64.0.100"),
-				IPv6: ap("fd7a:115c:a1e0::100"),
-				User: users[3],
+				IPv4:   ap("100.64.0.100"),
+				IPv6:   ap("fd7a:115c:a1e0::100"),
+				User:   &users[3],
+				UserID: &users[3].ID,
 				Hostinfo: &tailcfg.Hostinfo{
 					RoutableIPs: []netip.Prefix{netip.MustParsePrefix("8.0.0.0/16"), netip.MustParsePrefix("16.0.0.0/16")},
 				},
 			},
 			peers: types.Nodes{
 				&types.Node{
-					IPv4: ap("100.64.0.2"),
-					IPv6: ap("fd7a:115c:a1e0::2"),
-					User: users[2],
+					IPv4:   ap("100.64.0.2"),
+					IPv6:   ap("fd7a:115c:a1e0::2"),
+					User:   &users[2],
+					UserID: &users[2].ID,
 				},
 				&types.Node{
-					IPv4: ap("100.64.0.1"),
-					IPv6: ap("fd7a:115c:a1e0::1"),
-					User: users[1],
+					IPv4:   ap("100.64.0.1"),
+					IPv6:   ap("fd7a:115c:a1e0::1"),
+					User:   &users[1],
+					UserID: &users[1].ID,
 				},
 			},
 			want: []tailcfg.FilterRule{
@@ -645,23 +662,26 @@ func TestReduceFilterRules(t *testing.T) {
 }
 `,
 			node: &types.Node{
-				IPv4: ap("100.64.0.100"),
-				IPv6: ap("fd7a:115c:a1e0::100"),
-				User: users[3],
+				IPv4:   ap("100.64.0.100"),
+				IPv6:   ap("fd7a:115c:a1e0::100"),
+				User:   &users[3],
+				UserID: &users[3].ID,
 				Hostinfo: &tailcfg.Hostinfo{
 					RoutableIPs: []netip.Prefix{netip.MustParsePrefix("8.0.0.0/8"), netip.MustParsePrefix("16.0.0.0/8")},
 				},
 			},
 			peers: types.Nodes{
 				&types.Node{
-					IPv4: ap("100.64.0.2"),
-					IPv6: ap("fd7a:115c:a1e0::2"),
-					User: users[2],
+					IPv4:   ap("100.64.0.2"),
+					IPv6:   ap("fd7a:115c:a1e0::2"),
+					User:   &users[2],
+					UserID: &users[2].ID,
 				},
 				&types.Node{
-					IPv4: ap("100.64.0.1"),
-					IPv6: ap("fd7a:115c:a1e0::1"),
-					User: users[1],
+					IPv4:   ap("100.64.0.1"),
+					IPv6:   ap("fd7a:115c:a1e0::1"),
+					User:   &users[1],
+					UserID: &users[1].ID,
 				},
 			},
 			want: []tailcfg.FilterRule{
@@ -725,19 +745,21 @@ func TestReduceFilterRules(t *testing.T) {
 }
 `,
 			node: &types.Node{
-				IPv4: ap("100.64.0.100"),
-				IPv6: ap("fd7a:115c:a1e0::100"),
-				User: users[3],
+				IPv4:   ap("100.64.0.100"),
+				IPv6:   ap("fd7a:115c:a1e0::100"),
+				User:   &users[3],
+				UserID: &users[3].ID,
 				Hostinfo: &tailcfg.Hostinfo{
 					RoutableIPs: []netip.Prefix{netip.MustParsePrefix("172.16.0.0/24")},
 				},
-				ForcedTags: []string{"tag:access-servers"},
+				Tags: []string{"tag:access-servers"},
 			},
 			peers: types.Nodes{
 				&types.Node{
-					IPv4: ap("100.64.0.1"),
-					IPv6: ap("fd7a:115c:a1e0::1"),
-					User: users[1],
+					IPv4:   ap("100.64.0.1"),
+					IPv6:   ap("fd7a:115c:a1e0::1"),
+					User:   &users[1],
+					UserID: &users[1].ID,
 				},
 			},
 			want: []tailcfg.FilterRule{
@@ -791,15 +813,17 @@ func TestReduceFilterRules(t *testing.T) {
 }
 `,
 			node: &types.Node{
-				IPv4: ap("100.64.0.2"),
-				IPv6: ap("fd7a:115c:a1e0::2"),
-				User: users[3],
+				IPv4:   ap("100.64.0.2"),
+				IPv6:   ap("fd7a:115c:a1e0::2"),
+				User:   &users[3],
+				UserID: &users[3].ID,
 			},
 			peers: types.Nodes{
 				&types.Node{
-					IPv4: ap("100.64.0.1"),
-					IPv6: ap("fd7a:115c:a1e0::1"),
-					User: users[1],
+					IPv4:   ap("100.64.0.1"),
+					IPv6:   ap("fd7a:115c:a1e0::1"),
+					User:   &users[1],
+					UserID: &users[1].ID,
 					Hostinfo: &tailcfg.Hostinfo{
 						RoutableIPs: []netip.Prefix{p("172.16.0.0/24"), p("10.10.11.0/24"), p("10.10.12.0/24")},
 					},
@@ -846,19 +870,22 @@ func TestReduceNodes(t *testing.T) {
 			args: args{
 				nodes: types.Nodes{ // list of all nodes in the database
 					&types.Node{
-						ID:   1,
-						IPv4: ap("100.64.0.1"),
-						User: types.User{Name: "joe"},
+						ID:     1,
+						IPv4:   ap("100.64.0.1"),
+						User:   &types.User{Name: "joe", Model: gorm.Model{ID: 1}},
+						UserID: ptr.To(uint(1)),
 					},
 					&types.Node{
-						ID:   2,
-						IPv4: ap("100.64.0.2"),
-						User: types.User{Name: "marc"},
+						ID:     2,
+						IPv4:   ap("100.64.0.2"),
+						User:   &types.User{Name: "marc", Model: gorm.Model{ID: 2}},
+						UserID: ptr.To(uint(2)),
 					},
 					&types.Node{
-						ID:   3,
-						IPv4: ap("100.64.0.3"),
-						User: types.User{Name: "mickael"},
+						ID:     3,
+						IPv4:   ap("100.64.0.3"),
+						User:   &types.User{Name: "mickael", Model: gorm.Model{ID: 3}},
+						UserID: ptr.To(uint(3)),
 					},
 				},
 				rules: []tailcfg.FilterRule{
@@ -870,21 +897,24 @@ func TestReduceNodes(t *testing.T) {
 					},
 				},
 				node: &types.Node{ // current nodes
-					ID:   1,
-					IPv4: ap("100.64.0.1"),
-					User: types.User{Name: "joe"},
+					ID:     1,
+					IPv4:   ap("100.64.0.1"),
+					User:   &types.User{Name: "joe", Model: gorm.Model{ID: 1}},
+					UserID: ptr.To(uint(1)),
 				},
 			},
 			want: types.Nodes{
 				&types.Node{
-					ID:   2,
-					IPv4: ap("100.64.0.2"),
-					User: types.User{Name: "marc"},
+					ID:     2,
+					IPv4:   ap("100.64.0.2"),
+					User:   &types.User{Name: "marc", Model: gorm.Model{ID: 2}},
+					UserID: ptr.To(uint(2)),
 				},
 				&types.Node{
-					ID:   3,
-					IPv4: ap("100.64.0.3"),
-					User: types.User{Name: "mickael"},
+					ID:     3,
+					IPv4:   ap("100.64.0.3"),
+					User:   &types.User{Name: "mickael", Model: gorm.Model{ID: 3}},
+					UserID: ptr.To(uint(3)),
 				},
 			},
 		},
@@ -893,19 +923,22 @@ func TestReduceNodes(t *testing.T) {
 			args: args{
 				nodes: types.Nodes{ // list of all nodes in the database
 					&types.Node{
-						ID:   1,
-						IPv4: ap("100.64.0.1"),
-						User: types.User{Name: "joe"},
+						ID:     1,
+						IPv4:   ap("100.64.0.1"),
+						User:   &types.User{Name: "joe", Model: gorm.Model{ID: 1}},
+						UserID: ptr.To(uint(1)),
 					},
 					&types.Node{
-						ID:   2,
-						IPv4: ap("100.64.0.2"),
-						User: types.User{Name: "marc"},
+						ID:     2,
+						IPv4:   ap("100.64.0.2"),
+						User:   &types.User{Name: "marc", Model: gorm.Model{ID: 2}},
+						UserID: ptr.To(uint(2)),
 					},
 					&types.Node{
-						ID:   3,
-						IPv4: ap("100.64.0.3"),
-						User: types.User{Name: "mickael"},
+						ID:     3,
+						IPv4:   ap("100.64.0.3"),
+						User:   &types.User{Name: "mickael", Model: gorm.Model{ID: 3}},
+						UserID: ptr.To(uint(3)),
 					},
 				},
 				rules: []tailcfg.FilterRule{ // list of all ACLRules registered
@@ -917,16 +950,18 @@ func TestReduceNodes(t *testing.T) {
 					},
 				},
 				node: &types.Node{ // current nodes
-					ID:   1,
-					IPv4: ap("100.64.0.1"),
-					User: types.User{Name: "joe"},
+					ID:     1,
+					IPv4:   ap("100.64.0.1"),
+					User:   &types.User{Name: "joe", Model: gorm.Model{ID: 1}},
+					UserID: ptr.To(uint(1)),
 				},
 			},
 			want: types.Nodes{
 				&types.Node{
-					ID:   2,
-					IPv4: ap("100.64.0.2"),
-					User: types.User{Name: "marc"},
+					ID:     2,
+					IPv4:   ap("100.64.0.2"),
+					User:   &types.User{Name: "marc", Model: gorm.Model{ID: 2}},
+					UserID: ptr.To(uint(2)),
 				},
 			},
 		},
@@ -935,19 +970,22 @@ func TestReduceNodes(t *testing.T) {
 			args: args{
 				nodes: types.Nodes{ // list of all nodes in the database
 					&types.Node{
-						ID:   1,
-						IPv4: ap("100.64.0.1"),
-						User: types.User{Name: "joe"},
+						ID:     1,
+						IPv4:   ap("100.64.0.1"),
+						User:   &types.User{Name: "joe", Model: gorm.Model{ID: 1}},
+						UserID: ptr.To(uint(1)),
 					},
 					&types.Node{
-						ID:   2,
-						IPv4: ap("100.64.0.2"),
-						User: types.User{Name: "marc"},
+						ID:     2,
+						IPv4:   ap("100.64.0.2"),
+						User:   &types.User{Name: "marc", Model: gorm.Model{ID: 2}},
+						UserID: ptr.To(uint(2)),
 					},
 					&types.Node{
-						ID:   3,
-						IPv4: ap("100.64.0.3"),
-						User: types.User{Name: "mickael"},
+						ID:     3,
+						IPv4:   ap("100.64.0.3"),
+						User:   &types.User{Name: "mickael", Model: gorm.Model{ID: 3}},
+						UserID: ptr.To(uint(3)),
 					},
 				},
 				rules: []tailcfg.FilterRule{ // list of all ACLRules registered
@@ -959,16 +997,18 @@ func TestReduceNodes(t *testing.T) {
 					},
 				},
 				node: &types.Node{ // current nodes
-					ID:   2,
-					IPv4: ap("100.64.0.2"),
-					User: types.User{Name: "marc"},
+					ID:     2,
+					IPv4:   ap("100.64.0.2"),
+					User:   &types.User{Name: "marc", Model: gorm.Model{ID: 2}},
+					UserID: ptr.To(uint(2)),
 				},
 			},
 			want: types.Nodes{
 				&types.Node{
-					ID:   3,
-					IPv4: ap("100.64.0.3"),
-					User: types.User{Name: "mickael"},
+					ID:     3,
+					IPv4:   ap("100.64.0.3"),
+					User:   &types.User{Name: "mickael", Model: gorm.Model{ID: 3}},
+					UserID: ptr.To(uint(3)),
 				},
 			},
 		},
@@ -977,19 +1017,22 @@ func TestReduceNodes(t *testing.T) {
 			args: args{
 				nodes: types.Nodes{ // list of all nodes in the database
 					&types.Node{
-						ID:   1,
-						IPv4: ap("100.64.0.1"),
-						User: types.User{Name: "joe"},
+						ID:     1,
+						IPv4:   ap("100.64.0.1"),
+						User:   &types.User{Name: "joe", Model: gorm.Model{ID: 1}},
+						UserID: ptr.To(uint(1)),
 					},
 					&types.Node{
-						ID:   2,
-						IPv4: ap("100.64.0.2"),
-						User: types.User{Name: "marc"},
+						ID:     2,
+						IPv4:   ap("100.64.0.2"),
+						User:   &types.User{Name: "marc", Model: gorm.Model{ID: 2}},
+						UserID: ptr.To(uint(2)),
 					},
 					&types.Node{
-						ID:   3,
-						IPv4: ap("100.64.0.3"),
-						User: types.User{Name: "mickael"},
+						ID:     3,
+						IPv4:   ap("100.64.0.3"),
+						User:   &types.User{Name: "mickael", Model: gorm.Model{ID: 3}},
+						UserID: ptr.To(uint(3)),
 					},
 				},
 				rules: []tailcfg.FilterRule{ // list of all ACLRules registered
@@ -1001,16 +1044,18 @@ func TestReduceNodes(t *testing.T) {
 					},
 				},
 				node: &types.Node{ // current nodes
-					ID:   1,
-					IPv4: ap("100.64.0.1"),
-					User: types.User{Name: "joe"},
+					ID:     1,
+					IPv4:   ap("100.64.0.1"),
+					User:   &types.User{Name: "joe", Model: gorm.Model{ID: 1}},
+					UserID: ptr.To(uint(1)),
 				},
 			},
 			want: types.Nodes{
 				&types.Node{
-					ID:   2,
-					IPv4: ap("100.64.0.2"),
-					User: types.User{Name: "marc"},
+					ID:     2,
+					IPv4:   ap("100.64.0.2"),
+					UserID: ptr.To(uint(2)),
+					User:   &types.User{Name: "marc", Model: gorm.Model{ID: 2}},
 				},
 			},
 		},
@@ -1019,19 +1064,22 @@ func TestReduceNodes(t *testing.T) {
 			args: args{
 				nodes: types.Nodes{ // list of all nodes in the database
 					&types.Node{
-						ID:   1,
-						IPv4: ap("100.64.0.1"),
-						User: types.User{Name: "joe"},
+						ID:     1,
+						IPv4:   ap("100.64.0.1"),
+						User:   &types.User{Name: "joe", Model: gorm.Model{ID: 1}},
+						UserID: ptr.To(uint(1)),
 					},
 					&types.Node{
-						ID:   2,
-						IPv4: ap("100.64.0.2"),
-						User: types.User{Name: "marc"},
+						ID:     2,
+						IPv4:   ap("100.64.0.2"),
+						User:   &types.User{Name: "marc", Model: gorm.Model{ID: 2}},
+						UserID: ptr.To(uint(2)),
 					},
 					&types.Node{
-						ID:   3,
-						IPv4: ap("100.64.0.3"),
-						User: types.User{Name: "mickael"},
+						ID:     3,
+						IPv4:   ap("100.64.0.3"),
+						User:   &types.User{Name: "mickael", Model: gorm.Model{ID: 3}},
+						UserID: ptr.To(uint(3)),
 					},
 				},
 				rules: []tailcfg.FilterRule{ // list of all ACLRules registered
@@ -1043,21 +1091,24 @@ func TestReduceNodes(t *testing.T) {
 					},
 				},
 				node: &types.Node{ // current nodes
-					ID:   2,
-					IPv4: ap("100.64.0.2"),
-					User: types.User{Name: "marc"},
+					ID:     2,
+					IPv4:   ap("100.64.0.2"),
+					User:   &types.User{Name: "marc", Model: gorm.Model{ID: 2}},
+					UserID: ptr.To(uint(2)),
 				},
 			},
 			want: types.Nodes{
 				&types.Node{
-					ID:   1,
-					IPv4: ap("100.64.0.1"),
-					User: types.User{Name: "joe"},
+					ID:     1,
+					IPv4:   ap("100.64.0.1"),
+					User:   &types.User{Name: "joe", Model: gorm.Model{ID: 1}},
+					UserID: ptr.To(uint(1)),
 				},
 				&types.Node{
-					ID:   3,
-					IPv4: ap("100.64.0.3"),
-					User: types.User{Name: "mickael"},
+					ID:     3,
+					IPv4:   ap("100.64.0.3"),
+					User:   &types.User{Name: "mickael", Model: gorm.Model{ID: 3}},
+					UserID: ptr.To(uint(3)),
 				},
 			},
 		},
@@ -1066,19 +1117,22 @@ func TestReduceNodes(t *testing.T) {
 			args: args{
 				nodes: types.Nodes{ // list of all nodes in the database
 					&types.Node{
-						ID:   1,
-						IPv4: ap("100.64.0.1"),
-						User: types.User{Name: "joe"},
+						ID:     1,
+						IPv4:   ap("100.64.0.1"),
+						User:   &types.User{Name: "joe", Model: gorm.Model{ID: 1}},
+						UserID: ptr.To(uint(1)),
 					},
 					&types.Node{
-						ID:   2,
-						IPv4: ap("100.64.0.2"),
-						User: types.User{Name: "marc"},
+						ID:     2,
+						IPv4:   ap("100.64.0.2"),
+						User:   &types.User{Name: "marc", Model: gorm.Model{ID: 2}},
+						UserID: ptr.To(uint(2)),
 					},
 					&types.Node{
-						ID:   3,
-						IPv4: ap("100.64.0.3"),
-						User: types.User{Name: "mickael"},
+						ID:     3,
+						IPv4:   ap("100.64.0.3"),
+						User:   &types.User{Name: "mickael", Model: gorm.Model{ID: 3}},
+						UserID: ptr.To(uint(3)),
 					},
 				},
 				rules: []tailcfg.FilterRule{ // list of all ACLRules registered
@@ -1090,21 +1144,24 @@ func TestReduceNodes(t *testing.T) {
 					},
 				},
 				node: &types.Node{ // current nodes
-					ID:   2,
-					IPv4: ap("100.64.0.2"),
-					User: types.User{Name: "marc"},
+					ID:     2,
+					IPv4:   ap("100.64.0.2"),
+					User:   &types.User{Name: "marc", Model: gorm.Model{ID: 2}},
+					UserID: ptr.To(uint(2)),
 				},
 			},
 			want: types.Nodes{
 				&types.Node{
-					ID:   1,
-					IPv4: ap("100.64.0.1"),
-					User: types.User{Name: "joe"},
+					ID:     1,
+					IPv4:   ap("100.64.0.1"),
+					User:   &types.User{Name: "joe", Model: gorm.Model{ID: 1}},
+					UserID: ptr.To(uint(1)),
 				},
 				&types.Node{
-					ID:   3,
-					IPv4: ap("100.64.0.3"),
-					User: types.User{Name: "mickael"},
+					ID:     3,
+					IPv4:   ap("100.64.0.3"),
+					User:   &types.User{Name: "mickael", Model: gorm.Model{ID: 3}},
+					UserID: ptr.To(uint(3)),
 				},
 			},
 		},
@@ -1113,27 +1170,31 @@ func TestReduceNodes(t *testing.T) {
 			args: args{
 				nodes: types.Nodes{ // list of all nodes in the database
 					&types.Node{
-						ID:   1,
-						IPv4: ap("100.64.0.1"),
-						User: types.User{Name: "joe"},
+						ID:     1,
+						IPv4:   ap("100.64.0.1"),
+						User:   &types.User{Name: "joe", Model: gorm.Model{ID: 1}},
+						UserID: ptr.To(uint(1)),
 					},
 					&types.Node{
-						ID:   2,
-						IPv4: ap("100.64.0.2"),
-						User: types.User{Name: "marc"},
+						ID:     2,
+						IPv4:   ap("100.64.0.2"),
+						User:   &types.User{Name: "marc", Model: gorm.Model{ID: 2}},
+						UserID: ptr.To(uint(2)),
 					},
 					&types.Node{
-						ID:   3,
-						IPv4: ap("100.64.0.3"),
-						User: types.User{Name: "mickael"},
+						ID:     3,
+						IPv4:   ap("100.64.0.3"),
+						User:   &types.User{Name: "mickael", Model: gorm.Model{ID: 3}},
+						UserID: ptr.To(uint(3)),
 					},
 				},
 				rules: []tailcfg.FilterRule{ // list of all ACLRules registered
 				},
 				node: &types.Node{ // current nodes
-					ID:   2,
-					IPv4: ap("100.64.0.2"),
-					User: types.User{Name: "marc"},
+					ID:     2,
+					IPv4:   ap("100.64.0.2"),
+					User:   &types.User{Name: "marc", Model: gorm.Model{ID: 2}},
+					UserID: ptr.To(uint(2)),
 				},
 			},
 			want: nil,
@@ -1151,28 +1212,32 @@ func TestReduceNodes(t *testing.T) {
 						Hostname: "ts-head-upcrmb",
 						IPv4:     ap("100.64.0.3"),
 						IPv6:     ap("fd7a:115c:a1e0::3"),
-						User:     types.User{Name: "user1"},
+						User:     &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+						UserID:   ptr.To(uint(1)),
 					},
 					&types.Node{
 						ID:       2,
 						Hostname: "ts-unstable-rlwpvr",
 						IPv4:     ap("100.64.0.4"),
 						IPv6:     ap("fd7a:115c:a1e0::4"),
-						User:     types.User{Name: "user1"},
+						User:     &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+						UserID:   ptr.To(uint(1)),
 					},
 					&types.Node{
 						ID:       3,
 						Hostname: "ts-head-8w6paa",
 						IPv4:     ap("100.64.0.1"),
 						IPv6:     ap("fd7a:115c:a1e0::1"),
-						User:     types.User{Name: "user2"},
+						User:     &types.User{Name: "user2", Model: gorm.Model{ID: 2}},
+						UserID:   ptr.To(uint(2)),
 					},
 					&types.Node{
 						ID:       4,
 						Hostname: "ts-unstable-lys2ib",
 						IPv4:     ap("100.64.0.2"),
 						IPv6:     ap("fd7a:115c:a1e0::2"),
-						User:     types.User{Name: "user2"},
+						User:     &types.User{Name: "user2", Model: gorm.Model{ID: 2}},
+						UserID:   ptr.To(uint(2)),
 					},
 				},
 				rules: []tailcfg.FilterRule{ // list of all ACLRules registered
@@ -1194,7 +1259,8 @@ func TestReduceNodes(t *testing.T) {
 					Hostname: "ts-head-8w6paa",
 					IPv4:     ap("100.64.0.1"),
 					IPv6:     ap("fd7a:115c:a1e0::1"),
-					User:     types.User{Name: "user2"},
+					User:     &types.User{Name: "user2", Model: gorm.Model{ID: 2}},
+					UserID:   ptr.To(uint(2)),
 				},
 			},
 			want: types.Nodes{
@@ -1203,14 +1269,16 @@ func TestReduceNodes(t *testing.T) {
 					Hostname: "ts-head-upcrmb",
 					IPv4:     ap("100.64.0.3"),
 					IPv6:     ap("fd7a:115c:a1e0::3"),
-					User:     types.User{Name: "user1"},
+					User:     &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+					UserID:   ptr.To(uint(1)),
 				},
 				&types.Node{
 					ID:       2,
 					Hostname: "ts-unstable-rlwpvr",
 					IPv4:     ap("100.64.0.4"),
 					IPv6:     ap("fd7a:115c:a1e0::4"),
-					User:     types.User{Name: "user1"},
+					User:     &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+					UserID:   ptr.To(uint(1)),
 				},
 			},
 		},
@@ -1222,13 +1290,15 @@ func TestReduceNodes(t *testing.T) {
 						ID:       1,
 						IPv4:     ap("100.64.0.2"),
 						Hostname: "peer1",
-						User:     types.User{Name: "mini"},
+						User:     &types.User{Name: "mini", Model: gorm.Model{ID: 1}},
+						UserID:   ptr.To(uint(1)),
 					},
 					{
 						ID:       2,
 						IPv4:     ap("100.64.0.3"),
 						Hostname: "peer2",
-						User:     types.User{Name: "peer2"},
+						User:     &types.User{Name: "peer2", Model: gorm.Model{ID: 2}},
+						UserID:   ptr.To(uint(2)),
 					},
 				},
 				rules: []tailcfg.FilterRule{
@@ -1244,7 +1314,8 @@ func TestReduceNodes(t *testing.T) {
 					ID:       0,
 					IPv4:     ap("100.64.0.1"),
 					Hostname: "mini",
-					User:     types.User{Name: "mini"},
+					User:     &types.User{Name: "mini", Model: gorm.Model{ID: 1}},
+					UserID:   ptr.To(uint(1)),
 				},
 			},
 			want: []*types.Node{
@@ -1252,7 +1323,8 @@ func TestReduceNodes(t *testing.T) {
 					ID:       2,
 					IPv4:     ap("100.64.0.3"),
 					Hostname: "peer2",
-					User:     types.User{Name: "peer2"},
+					User:     &types.User{Name: "peer2", Model: gorm.Model{ID: 2}},
+					UserID:   ptr.To(uint(2)),
 				},
 			},
 		},
@@ -1264,19 +1336,22 @@ func TestReduceNodes(t *testing.T) {
 						ID:       1,
 						IPv4:     ap("100.64.0.2"),
 						Hostname: "user1-2",
-						User:     types.User{Name: "user1"},
+						User:     &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+						UserID:   ptr.To(uint(1)),
 					},
 					{
 						ID:       0,
 						IPv4:     ap("100.64.0.1"),
 						Hostname: "user1-1",
-						User:     types.User{Name: "user1"},
+						User:     &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+						UserID:   ptr.To(uint(1)),
 					},
 					{
 						ID:       3,
 						IPv4:     ap("100.64.0.4"),
 						Hostname: "user2-2",
-						User:     types.User{Name: "user2"},
+						User:     &types.User{Name: "user2", Model: gorm.Model{ID: 2}},
+						UserID:   ptr.To(uint(2)),
 					},
 				},
 				rules: []tailcfg.FilterRule{
@@ -1313,7 +1388,8 @@ func TestReduceNodes(t *testing.T) {
 					ID:       2,
 					IPv4:     ap("100.64.0.3"),
 					Hostname: "user-2-1",
-					User:     types.User{Name: "user2"},
+					User:     &types.User{Name: "user2", Model: gorm.Model{ID: 2}},
+					UserID:   ptr.To(uint(2)),
 				},
 			},
 			want: []*types.Node{
@@ -1321,19 +1397,22 @@ func TestReduceNodes(t *testing.T) {
 					ID:       1,
 					IPv4:     ap("100.64.0.2"),
 					Hostname: "user1-2",
-					User:     types.User{Name: "user1"},
+					User:     &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+					UserID:   ptr.To(uint(1)),
 				},
 				{
 					ID:       0,
 					IPv4:     ap("100.64.0.1"),
 					Hostname: "user1-1",
-					User:     types.User{Name: "user1"},
+					User:     &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+					UserID:   ptr.To(uint(1)),
 				},
 				{
 					ID:       3,
 					IPv4:     ap("100.64.0.4"),
 					Hostname: "user2-2",
-					User:     types.User{Name: "user2"},
+					User:     &types.User{Name: "user2", Model: gorm.Model{ID: 2}},
+					UserID:   ptr.To(uint(2)),
 				},
 			},
 		},
@@ -1345,19 +1424,22 @@ func TestReduceNodes(t *testing.T) {
 						ID:       1,
 						IPv4:     ap("100.64.0.2"),
 						Hostname: "user1-2",
-						User:     types.User{Name: "user1"},
+						User:     &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+						UserID:   ptr.To(uint(1)),
 					},
 					{
 						ID:       2,
 						IPv4:     ap("100.64.0.3"),
 						Hostname: "user-2-1",
-						User:     types.User{Name: "user2"},
+						User:     &types.User{Name: "user2", Model: gorm.Model{ID: 2}},
+						UserID:   ptr.To(uint(2)),
 					},
 					{
 						ID:       3,
 						IPv4:     ap("100.64.0.4"),
 						Hostname: "user2-2",
-						User:     types.User{Name: "user2"},
+						User:     &types.User{Name: "user2", Model: gorm.Model{ID: 2}},
+						UserID:   ptr.To(uint(2)),
 					},
 				},
 				rules: []tailcfg.FilterRule{
@@ -1394,7 +1476,8 @@ func TestReduceNodes(t *testing.T) {
 					ID:       0,
 					IPv4:     ap("100.64.0.1"),
 					Hostname: "user1-1",
-					User:     types.User{Name: "user1"},
+					User:     &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+					UserID:   ptr.To(uint(1)),
 				},
 			},
 			want: []*types.Node{
@@ -1402,19 +1485,22 @@ func TestReduceNodes(t *testing.T) {
 					ID:       1,
 					IPv4:     ap("100.64.0.2"),
 					Hostname: "user1-2",
-					User:     types.User{Name: "user1"},
+					User:     &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+					UserID:   ptr.To(uint(1)),
 				},
 				{
 					ID:       2,
 					IPv4:     ap("100.64.0.3"),
-					Hostname: "user-2-1",
-					User:     types.User{Name: "user2"},
+					Hostname: "user-2-1", 
+					User:     &types.User{Name: "user2", Model: gorm.Model{ID: 2}},
+					UserID:   ptr.To(uint(2)),
 				},
 				{
 					ID:       3,
 					IPv4:     ap("100.64.0.4"),
 					Hostname: "user2-2",
-					User:     types.User{Name: "user2"},
+					User:     &types.User{Name: "user2", Model: gorm.Model{ID: 2}},
+					UserID:   ptr.To(uint(2)),
 				},
 			},
 		},
@@ -1426,13 +1512,15 @@ func TestReduceNodes(t *testing.T) {
 						ID:       1,
 						IPv4:     ap("100.64.0.1"),
 						Hostname: "user1",
-						User:     types.User{Name: "user1"},
+						User:     &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+						UserID:   ptr.To(uint(1)),
 					},
 					{
 						ID:       2,
 						IPv4:     ap("100.64.0.2"),
 						Hostname: "router",
-						User:     types.User{Name: "router"},
+						User:     &types.User{Name: "router", Model: gorm.Model{ID: 2}},
+						UserID:   ptr.To(uint(2)),
 						Hostinfo: &tailcfg.Hostinfo{
 							RoutableIPs: []netip.Prefix{netip.MustParsePrefix("10.33.0.0/16")},
 						},
@@ -1453,7 +1541,8 @@ func TestReduceNodes(t *testing.T) {
 					ID:       1,
 					IPv4:     ap("100.64.0.1"),
 					Hostname: "user1",
-					User:     types.User{Name: "user1"},
+					User:     &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+					UserID:   ptr.To(uint(1)),
 				},
 			},
 			want: []*types.Node{
@@ -1461,7 +1550,8 @@ func TestReduceNodes(t *testing.T) {
 					ID:       2,
 					IPv4:     ap("100.64.0.2"),
 					Hostname: "router",
-					User:     types.User{Name: "router"},
+					User:     &types.User{Name: "router", Model: gorm.Model{ID: 2}},
+					UserID:   ptr.To(uint(2)),
 					Hostinfo: &tailcfg.Hostinfo{
 						RoutableIPs: []netip.Prefix{netip.MustParsePrefix("10.33.0.0/16")},
 					},
@@ -1477,7 +1567,8 @@ func TestReduceNodes(t *testing.T) {
 						ID:       1,
 						IPv4:     ap("100.64.0.1"),
 						Hostname: "router",
-						User:     types.User{Name: "router"},
+						User:     &types.User{Name: "router", Model: gorm.Model{ID: 1}},
+						UserID:   ptr.To(uint(1)),
 						Hostinfo: &tailcfg.Hostinfo{
 							RoutableIPs: []netip.Prefix{netip.MustParsePrefix("10.99.0.0/16")},
 						},
@@ -1487,7 +1578,8 @@ func TestReduceNodes(t *testing.T) {
 						ID:       2,
 						IPv4:     ap("100.64.0.2"),
 						Hostname: "node",
-						User:     types.User{Name: "node"},
+						User:     &types.User{Name: "node", Model: gorm.Model{ID: 2}},
+						UserID:   ptr.To(uint(2)),
 					},
 				},
 				rules: []tailcfg.FilterRule{
@@ -1504,7 +1596,8 @@ func TestReduceNodes(t *testing.T) {
 					ID:       1,
 					IPv4:     ap("100.64.0.1"),
 					Hostname: "router",
-					User:     types.User{Name: "router"},
+					User:     &types.User{Name: "router", Model: gorm.Model{ID: 1}},
+					UserID:   ptr.To(uint(1)),
 					Hostinfo: &tailcfg.Hostinfo{
 						RoutableIPs: []netip.Prefix{netip.MustParsePrefix("10.99.0.0/16")},
 					},
@@ -1516,7 +1609,8 @@ func TestReduceNodes(t *testing.T) {
 					ID:       2,
 					IPv4:     ap("100.64.0.2"),
 					Hostname: "node",
-					User:     types.User{Name: "node"},
+					User:     &types.User{Name: "node", Model: gorm.Model{ID: 2}},
+					UserID:   ptr.To(uint(2)),
 				},
 			},
 		},
@@ -1528,7 +1622,8 @@ func TestReduceNodes(t *testing.T) {
 						ID:       1,
 						IPv4:     ap("100.64.0.1"),
 						Hostname: "router",
-						User:     types.User{Name: "router"},
+						User:     &types.User{Name: "router", Model: gorm.Model{ID: 1}},
+						UserID:   ptr.To(uint(1)),
 						Hostinfo: &tailcfg.Hostinfo{
 							RoutableIPs: []netip.Prefix{netip.MustParsePrefix("10.99.0.0/16")},
 						},
@@ -1538,7 +1633,8 @@ func TestReduceNodes(t *testing.T) {
 						ID:       2,
 						IPv4:     ap("100.64.0.2"),
 						Hostname: "node",
-						User:     types.User{Name: "node"},
+						User:     &types.User{Name: "node", Model: gorm.Model{ID: 2}},
+						UserID:   ptr.To(uint(2)),
 					},
 				},
 				rules: []tailcfg.FilterRule{
@@ -1555,7 +1651,8 @@ func TestReduceNodes(t *testing.T) {
 					ID:       2,
 					IPv4:     ap("100.64.0.2"),
 					Hostname: "node",
-					User:     types.User{Name: "node"},
+					User:     &types.User{Name: "node", Model: gorm.Model{ID: 2}},
+					UserID:   ptr.To(uint(2)),
 				},
 			},
 			want: []*types.Node{
@@ -1563,7 +1660,8 @@ func TestReduceNodes(t *testing.T) {
 					ID:       1,
 					IPv4:     ap("100.64.0.1"),
 					Hostname: "router",
-					User:     types.User{Name: "router"},
+					User:     &types.User{Name: "router", Model: gorm.Model{ID: 1}},
+					UserID:   ptr.To(uint(1)),
 					Hostinfo: &tailcfg.Hostinfo{
 						RoutableIPs: []netip.Prefix{netip.MustParsePrefix("10.99.0.0/16")},
 					},
@@ -1599,28 +1697,28 @@ func TestSSHPolicyRules(t *testing.T) {
 	nodeUser1 := types.Node{
 		Hostname: "user1-device",
 		IPv4:     ap("100.64.0.1"),
-		UserID:   1,
-		User:     users[0],
+		User:     &users[0],
+		UserID:   ptr.To(users[0].ID),
 	}
 	nodeUser2 := types.Node{
 		Hostname: "user2-device",
 		IPv4:     ap("100.64.0.2"),
-		UserID:   2,
-		User:     users[1],
+		User:     &users[1],
+		UserID:   ptr.To(users[1].ID),
 	}
 	taggedServer := types.Node{
-		Hostname:   "tagged-server",
-		IPv4:       ap("100.64.0.3"),
-		UserID:     3,
-		User:       users[2],
-		ForcedTags: []string{"tag:server"},
+		Hostname: "tagged-server",
+		IPv4:     ap("100.64.0.3"),
+		User:     &users[2],
+		UserID:   ptr.To(users[2].ID),
+		Tags:     []string{"tag:server"},
 	}
 	taggedClient := types.Node{
-		Hostname:   "tagged-client",
-		IPv4:       ap("100.64.0.4"),
-		UserID:     2,
-		User:       users[1],
-		ForcedTags: []string{"tag:client"},
+		Hostname: "tagged-client",
+		IPv4:     ap("100.64.0.4"),
+		User:     &users[1],
+		UserID:   ptr.To(users[1].ID),
+		Tags:     []string{"tag:client"},
 	}
 
 	tests := []struct {
@@ -1984,9 +2082,10 @@ func TestReduceRoutes(t *testing.T) {
 			name: "node-can-access-all-routes",
 			args: args{
 				node: &types.Node{
-					ID:   1,
-					IPv4: ap("100.64.0.1"),
-					User: types.User{Name: "user1"},
+					ID:     1,
+					IPv4:   ap("100.64.0.1"),
+					User:   &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+					UserID: ptr.To(uint(1)),
 				},
 				routes: []netip.Prefix{
 					netip.MustParsePrefix("10.0.0.0/24"),
@@ -2014,7 +2113,7 @@ func TestReduceRoutes(t *testing.T) {
 				node: &types.Node{
 					ID:   1,
 					IPv4: ap("100.64.0.1"),
-					User: types.User{Name: "user1"},
+					User: &types.User{Name: "user1"},
 				},
 				routes: []netip.Prefix{
 					netip.MustParsePrefix("10.0.0.0/24"),
@@ -2040,7 +2139,7 @@ func TestReduceRoutes(t *testing.T) {
 				node: &types.Node{
 					ID:   1,
 					IPv4: ap("100.64.0.1"),
-					User: types.User{Name: "user1"},
+					User: &types.User{Name: "user1"},
 				},
 				routes: []netip.Prefix{
 					netip.MustParsePrefix("10.0.0.0/24"),
@@ -2068,7 +2167,7 @@ func TestReduceRoutes(t *testing.T) {
 				node: &types.Node{
 					ID:   1,
 					IPv4: ap("100.64.0.1"),
-					User: types.User{Name: "user1"},
+					User: &types.User{Name: "user1"},
 				},
 				routes: []netip.Prefix{
 					netip.MustParsePrefix("10.0.0.0/24"),
@@ -2095,7 +2194,7 @@ func TestReduceRoutes(t *testing.T) {
 				node: &types.Node{
 					ID:   1,
 					IPv4: ap("100.64.0.1"),
-					User: types.User{Name: "user1"},
+					User: &types.User{Name: "user1"},
 				},
 				routes: []netip.Prefix{
 					netip.MustParsePrefix("10.0.0.0/24"),
@@ -2117,10 +2216,11 @@ func TestReduceRoutes(t *testing.T) {
 			name: "node-with-both-ipv4-and-ipv6",
 			args: args{
 				node: &types.Node{
-					ID:   1,
-					IPv4: ap("100.64.0.1"),
-					IPv6: ap("fd7a:115c:a1e0::1"),
-					User: types.User{Name: "user1"},
+					ID:     1,
+					IPv4:   ap("100.64.0.1"),
+					IPv6:   ap("fd7a:115c:a1e0::1"),
+					User:   &types.User{Name: "user1", Model: gorm.Model{ID: 1}},
+					UserID: ptr.To(uint(1)),
 				},
 				routes: []netip.Prefix{
 					netip.MustParsePrefix("10.0.0.0/24"),
@@ -2151,9 +2251,10 @@ func TestReduceRoutes(t *testing.T) {
 			name: "router-with-multiple-routes-and-node-with-specific-access",
 			args: args{
 				node: &types.Node{
-					ID:   2,
-					IPv4: ap("100.64.0.2"), // Node IP
-					User: types.User{Name: "node"},
+					ID:     2,
+					IPv4:   ap("100.64.0.2"), // Node IP
+					User:   &types.User{Name: "node", Model: gorm.Model{ID: 2}},
+					UserID: ptr.To(uint(2)),
 				},
 				routes: []netip.Prefix{
 					netip.MustParsePrefix("10.10.10.0/24"),
@@ -2183,9 +2284,10 @@ func TestReduceRoutes(t *testing.T) {
 			name: "node-with-access-to-one-subnet-and-partial-overlap",
 			args: args{
 				node: &types.Node{
-					ID:   2,
-					IPv4: ap("100.64.0.2"),
-					User: types.User{Name: "node"},
+					ID:     2,
+					IPv4:   ap("100.64.0.2"),
+					User:   &types.User{Name: "node", Model: gorm.Model{ID: 2}},
+					UserID: ptr.To(uint(2)),
 				},
 				routes: []netip.Prefix{
 					netip.MustParsePrefix("10.10.10.0/24"),
@@ -2212,7 +2314,7 @@ func TestReduceRoutes(t *testing.T) {
 				node: &types.Node{
 					ID:   2,
 					IPv4: ap("100.64.0.2"),
-					User: types.User{Name: "node"},
+					User: &types.User{Name: "node"},
 				},
 				routes: []netip.Prefix{
 					netip.MustParsePrefix("10.10.10.0/24"),
@@ -2240,7 +2342,7 @@ func TestReduceRoutes(t *testing.T) {
 				node: &types.Node{
 					ID:   2,
 					IPv4: ap("100.64.0.2"),
-					User: types.User{Name: "node"},
+					User: &types.User{Name: "node"},
 				},
 				routes: []netip.Prefix{
 					netip.MustParsePrefix("10.10.10.0/24"),
@@ -2278,7 +2380,7 @@ func TestReduceRoutes(t *testing.T) {
 				node: &types.Node{
 					ID:   2,
 					IPv4: ap("100.64.0.2"), // node with IP 100.64.0.2
-					User: types.User{Name: "node"},
+					User: &types.User{Name: "node"},
 				},
 				routes: []netip.Prefix{
 					netip.MustParsePrefix("10.10.10.0/24"),
@@ -2311,9 +2413,10 @@ func TestReduceRoutes(t *testing.T) {
 			args: args{
 				// When testing from router node's perspective
 				node: &types.Node{
-					ID:   1,
-					IPv4: ap("100.64.0.1"), // router with IP 100.64.0.1
-					User: types.User{Name: "router"},
+					ID:     1,
+					IPv4:   ap("100.64.0.1"), // router with IP 100.64.0.1
+					User:   &types.User{Name: "router", Model: gorm.Model{ID: 1}},
+					UserID: ptr.To(uint(1)),
 				},
 				routes: []netip.Prefix{
 					netip.MustParsePrefix("10.10.10.0/24"),
@@ -2353,9 +2456,10 @@ func TestReduceRoutes(t *testing.T) {
 			name: "acl-specific-port-ranges-for-subnets",
 			args: args{
 				node: &types.Node{
-					ID:   2,
-					IPv4: ap("100.64.0.2"), // node
-					User: types.User{Name: "node"},
+					ID:     2,
+					IPv4:   ap("100.64.0.2"), // node
+					User:   &types.User{Name: "node", Model: gorm.Model{ID: 2}},
+					UserID: ptr.To(uint(2)),
 				},
 				routes: []netip.Prefix{
 					netip.MustParsePrefix("10.10.10.0/24"),
@@ -2389,7 +2493,7 @@ func TestReduceRoutes(t *testing.T) {
 				node: &types.Node{
 					ID:   2,
 					IPv4: ap("100.64.0.2"), // node
-					User: types.User{Name: "node"},
+					User: &types.User{Name: "node"},
 				},
 				routes: []netip.Prefix{
 					netip.MustParsePrefix("10.10.10.0/24"),

--- a/hscontrol/policy/route_approval_test.go
+++ b/hscontrol/policy/route_approval_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
+	"tailscale.com/types/ptr"
 )
 
 func TestNodeCanApproveRoute(t *testing.T) {
@@ -24,34 +25,34 @@ func TestNodeCanApproveRoute(t *testing.T) {
 		ID:       1,
 		Hostname: "user1-device",
 		IPv4:     ap("100.64.0.1"),
-		UserID:   1,
-		User:     users[0],
+		UserID:   ptr.To(uint(1)),
+		User:     &users[0],
 	}
 
 	exitNode := types.Node{
 		ID:       2,
 		Hostname: "user2-device",
 		IPv4:     ap("100.64.0.2"),
-		UserID:   2,
-		User:     users[1],
+		UserID:   ptr.To(uint(2)),
+		User:     &users[1],
 	}
 
 	taggedNode := types.Node{
-		ID:         3,
-		Hostname:   "tagged-server",
-		IPv4:       ap("100.64.0.3"),
-		UserID:     3,
-		User:       users[2],
-		ForcedTags: []string{"tag:router"},
+		ID:       3,
+		Hostname: "tagged-server",
+		IPv4:     ap("100.64.0.3"),
+		UserID:   ptr.To(uint(3)),
+		User:     &users[2],
+		Tags:     []string{"tag:router"},
 	}
 
 	multiTagNode := types.Node{
-		ID:         4,
-		Hostname:   "multi-tag-node",
-		IPv4:       ap("100.64.0.4"),
-		UserID:     2,
-		User:       users[1],
-		ForcedTags: []string{"tag:router", "tag:server"},
+		ID:       4,
+		Hostname: "multi-tag-node",
+		IPv4:     ap("100.64.0.4"),
+		UserID:   ptr.To(uint(2)),
+		User:     &users[1],
+		Tags:     []string{"tag:router", "tag:server"},
 	}
 
 	tests := []struct {

--- a/hscontrol/policy/v2/filter_test.go
+++ b/hscontrol/policy/v2/filter_test.go
@@ -359,7 +359,8 @@ func TestParsing(t *testing.T) {
 					},
 					&types.Node{
 						IPv4:     ap("200.200.200.200"),
-						User:     users[0],
+						User:     &users[0],
+						UserID:   &users[0].ID,
 						Hostinfo: &tailcfg.Hostinfo{},
 					},
 				})

--- a/hscontrol/policy/v2/policy_test.go
+++ b/hscontrol/policy/v2/policy_test.go
@@ -1,8 +1,9 @@
 package v2
 
 import (
-	"github.com/juanfont/headscale/hscontrol/policy/matcher"
 	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/policy/matcher"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/juanfont/headscale/hscontrol/types"
@@ -17,8 +18,8 @@ func node(name, ipv4, ipv6 string, user types.User, hostinfo *tailcfg.Hostinfo) 
 		Hostname: name,
 		IPv4:     ap(ipv4),
 		IPv6:     ap(ipv6),
-		User:     user,
-		UserID:   user.ID,
+		User:     &user,
+		UserID:   &user.ID,
 		Hostinfo: hostinfo,
 	}
 }

--- a/hscontrol/policy/v2/types.go
+++ b/hscontrol/policy/v2/types.go
@@ -189,7 +189,7 @@ func (u Username) Resolve(_ *Policy, users types.Users, nodes types.Nodes) (*net
 	}
 
 	for _, node := range nodes {
-		if node.IsTagged() {
+		if !node.IsUserOwned() {
 			continue
 		}
 
@@ -515,7 +515,7 @@ func (ag AutoGroup) Resolve(p *Policy, users types.Users, nodes types.Nodes) (*n
 
 		for _, node := range nodes {
 			// Skip if node has forced tags
-			if len(node.ForcedTags) != 0 {
+			if len(node.Tags) != 0 {
 				continue
 			}
 
@@ -548,7 +548,7 @@ func (ag AutoGroup) Resolve(p *Policy, users types.Users, nodes types.Nodes) (*n
 
 		for _, node := range nodes {
 			// Include if node has forced tags
-			if len(node.ForcedTags) != 0 {
+			if len(node.Tags) != 0 {
 				node.AppendToIPSet(&build)
 				continue
 			}

--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -567,7 +567,9 @@ func (nodes Nodes) DebugString() string {
 func (node Node) DebugString() string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "%s(%s):\n", node.Hostname, node.ID)
-	fmt.Fprintf(&sb, "\tUser: %s (%d, %q)\n", node.User.Display(), node.User.ID, node.User.Username())
+	if node.IsUserOwned() {
+		fmt.Fprintf(&sb, "\tUser: %s (%d, %q)\n", node.User.Display(), node.User.ID, node.User.Username())
+	}
 	fmt.Fprintf(&sb, "\tTags: %v\n", node.Tags)
 	fmt.Fprintf(&sb, "\tIPs: %v\n", node.IPs())
 	fmt.Fprintf(&sb, "\tApprovedRoutes: %v\n", node.ApprovedRoutes)

--- a/hscontrol/types/node_test.go
+++ b/hscontrol/types/node_test.go
@@ -2,10 +2,11 @@ package types
 
 import (
 	"fmt"
-	"github.com/juanfont/headscale/hscontrol/policy/matcher"
 	"net/netip"
 	"strings"
 	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/policy/matcher"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -139,7 +140,7 @@ func TestNodeFQDN(t *testing.T) {
 			name: "no-dnsconfig-with-username",
 			node: Node{
 				GivenName: "test",
-				User: User{
+				User: &User{
 					Name: "user",
 				},
 			},
@@ -150,7 +151,7 @@ func TestNodeFQDN(t *testing.T) {
 			name: "all-set",
 			node: Node{
 				GivenName: "test",
-				User: User{
+				User: &User{
 					Name: "user",
 				},
 			},
@@ -160,7 +161,7 @@ func TestNodeFQDN(t *testing.T) {
 		{
 			name: "no-given-name",
 			node: Node{
-				User: User{
+				User: &User{
 					Name: "user",
 				},
 			},
@@ -179,7 +180,7 @@ func TestNodeFQDN(t *testing.T) {
 			name: "no-dnsconfig",
 			node: Node{
 				GivenName: "test",
-				User: User{
+				User: &User{
 					Name: "user",
 				},
 			},

--- a/hscontrol/types/users.go
+++ b/hscontrol/types/users.go
@@ -18,6 +18,16 @@ import (
 	"tailscale.com/tailcfg"
 )
 
+// TaggedDevices is a special user that is used to
+// populate the tagged devices in the Tailscale MapResponse.
+var TaggedDevices = User{
+	// This ID is arbitrarily chosen, it is naively high to avoid
+	// and conflicts with other IDs.
+	Model:       gorm.Model{ID: 2147455555},
+	Name:        "tagged-devices",
+	DisplayName: "Tagged Devices",
+}
+
 type UserID uint64
 
 type Users []User
@@ -273,7 +283,7 @@ func CleanIdentifier(identifier string) string {
 				cleanParts = append(cleanParts, part)
 			}
 		}
-		
+
 		if len(cleanParts) == 0 {
 			u.Path = ""
 		} else {


### PR DESCRIPTION
This PR is going to be the core work of #2417, redoing our Tags support.

From the [tailscale docs](https://tailscale.com/kb/1068/tags):
> Tailscale tags are how you authenticate and identify non-user devices, such as servers and [ephemeral nodes](https://tailscale.com/kb/1111/ephemeral-nodes). They serve two primary purposes: to provide an identity to non-user devices and to let you manage [access control policies](https://tailscale.com/kb/1393/access-control) based on purpose. In this context, a purpose could be anything from hosting a web server to serving as a [subnet router](https://tailscale.com/kb/1019/subnets) for employees in a specific geographic location.

We do not really implement tags this way, as a node is _always_ associated with a user, even if it is tagged.

After this PR, we will stream line tags to work in the same way as upstream, and making sure we align and ensure that tagged devices are truly not associated with a user.

This is an important building block to ensure that the Tags part of the Policy works in the correct way and provide the correct isolation.