### PR TITLE
Add headscale-console web UI to docs

### DIFF
--- a/docs/ref/integration/web-ui.md
+++ b/docs/ref/integration/web-ui.md
@@ -7,13 +7,14 @@
 
 Headscale doesn't provide a built-in web interface but users may pick one from the available options.
 
-| Name                   | Repository Link                                            | Description                                                                          |
-| ---------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| headscale-ui           | [Github](https://github.com/gurucomputing/headscale-ui)    | A web frontend for the headscale Tailscale-compatible coordination server            |
-| HeadscaleUi            | [GitHub](https://github.com/simcu/headscale-ui)            | A static headscale admin ui, no backend environment required                         |
-| Headplane              | [GitHub](https://github.com/tale/headplane)                | An advanced Tailscale inspired frontend for headscale                                |
-| headscale-admin        | [Github](https://github.com/GoodiesHQ/headscale-admin)     | Headscale-Admin is meant to be a simple, modern web interface for headscale          |
-| ouroboros              | [Github](https://github.com/yellowsink/ouroboros)          | Ouroboros is designed for users to manage their own devices, rather than for admins  |
-| unraid-headscale-admin | [Github](https://github.com/ich777/unraid-headscale-admin) | A simple headscale admin UI for Unraid, it offers Local (`docker exec`) and API Mode |
+| Name                   | Repository Link                                             | Description                                                                                  |
+| ---------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| headscale-ui           | [Github](https://github.com/gurucomputing/headscale-ui)     | A web frontend for the headscale Tailscale-compatible coordination server                    |
+| HeadscaleUi            | [GitHub](https://github.com/simcu/headscale-ui)             | A static headscale admin ui, no backend environment required                                 |
+| Headplane              | [GitHub](https://github.com/tale/headplane)                 | An advanced Tailscale inspired frontend for headscale                                        |
+| headscale-admin        | [Github](https://github.com/GoodiesHQ/headscale-admin)      | Headscale-Admin is meant to be a simple, modern web interface for headscale                  |
+| ouroboros              | [Github](https://github.com/yellowsink/ouroboros)           | Ouroboros is designed for users to manage their own devices, rather than for admins          |
+| unraid-headscale-admin | [Github](https://github.com/ich777/unraid-headscale-admin)  | A simple headscale admin UI for Unraid, it offers Local (`docker exec`) and API Mode         |
+| headscale-console      | [Github](https://github.com/rickli-cloud/headscale-console) | WebAssembly-based client supporting SSH, VNC and RDP with optional self-service capabilities |
 
 You can ask for support on our [Discord server](https://discord.gg/c84AZQhmpx) in the "web-interfaces" channel.


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [X] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [X] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

This PR adds [headscale-console](https://github.com/rickli-cloud/headscale-console) to the documentation. The table was reformatted to accommodate the additional text.

headscale-console is not a traditional UI that directly binds into the REST API. Instead, it was inspired by the [Tailscale WASM client](https://github.com/tailscale/tailscale/tree/main/cmd/tsconnect) and slowly grew supporting more and more protocols (SSH, VNC & RDP). It also includes an optional self-service tsnet server binding into the headscale GRPC unix socket.