### PR TITLE
Ensure that a username starts with a letter

### DIFF
--- a/hscontrol/util/dns.go
+++ b/hscontrol/util/dns.go
@@ -37,9 +37,9 @@ func ValidateUsername(username string) error {
 		return errors.New("username must be at least 2 characters long")
 	}
 
-	// Ensure the username does not start with a number
-	if unicode.IsDigit(rune(username[0])) {
-		return errors.New("username cannot start with a number")
+	// Ensure the username starts with a letter
+	if !unicode.IsLetter(rune(username[0])) {
+		return errors.New("username must start with a letter")
 	}
 
 	atCount := 0


### PR DESCRIPTION
The docstring for `ValidateUsername()` states:

>   It must be at least 2 characters long, start with a letter, and
>   contain only letters, numbers, hyphens, dots, and underscores.

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md