### PR TITLE
Fix `/machine/map` endpoint vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@
 - Refactor Debian/Ubuntu packaging and drop support for Ubuntu 20.04.
   [#2614](https://github.com/juanfont/headscale/pull/2614)
 
+## 0.26.1 (2025-06-06)
+
+### Changes
+
+- Ensure nodes are matching both node key and machine key
+  when connecting.
+  [#2642](https://github.com/juanfont/headscale/pull/2642)
+
 ## 0.26.0 (2025-05-14)
 
 ### BREAKING

--- a/hscontrol/noise.go
+++ b/hscontrol/noise.go
@@ -210,18 +210,19 @@ func (ns *noiseServer) NoisePollNetMapHandler(
 	}
 
 	node, err := ns.headscale.db.GetNodeByMachineKey(ns.machineKey)
-
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			httpError(writer, NewHTTPError(http.StatusNotFound, "node not found", nil))
 			return
 		}
 		httpError(writer, err)
+
 		return
 	}
 
+	// Ensure the NodeKey in the request matches the one associated with the machine key from the Noise session
 	if node.NodeKey != mapRequest.NodeKey {
-		httpError(writer, NewHTTPError(http.StatusNotFound, "node does not belong to machine key", nil))
+		httpError(writer, NewHTTPError(http.StatusNotFound, "node key in request does not match the one associated with this machine key", nil))
 		return
 	}
 
@@ -274,6 +275,7 @@ func (ns *noiseServer) NoiseRegistrationHandler(
 				return &regReq, resp
 			} else {
 			}
+
 			return &regReq, regErr(err)
 		}
 

--- a/hscontrol/noise.go
+++ b/hscontrol/noise.go
@@ -220,7 +220,7 @@ func (ns *noiseServer) NoisePollNetMapHandler(
 		return
 	}
 
-	if ns.nodeKey != mapRequest.NodeKey {
+	if node.NodeKey != mapRequest.NodeKey {
 		httpError(writer, NewHTTPError(http.StatusNotFound, "node does not belong to machine key", nil))
 		return
 	}

--- a/hscontrol/noise.go
+++ b/hscontrol/noise.go
@@ -100,6 +100,10 @@ func (h *Headscale) NoiseUpgradeHandler(
 
 	router.HandleFunc("/machine/register", noiseServer.NoiseRegistrationHandler).
 		Methods(http.MethodPost)
+
+	// Endpoints outside of the register endpoint must use getAndValidateNode to
+	// get the node to ensure that the MachineKey matches the Node setting up the
+	// connection.
 	router.HandleFunc("/machine/map", noiseServer.NoisePollNetMapHandler)
 
 	noiseServer.httpBaseConfig = &http.Server{


### PR DESCRIPTION
### Current Behavior

`POST /machine/map` requests are processed by extracting the Node from the public `NodeKey` provided in the request, without any additional verification. This allows an attacker who possesses the public key of any Node in the network to:

1. Establish a Noise connection using a new machine key,
2. Submit a `MapRequest` containing a `NodeKey` that does not belong to them, and
3. Receive a stream of `MapResponse`s.

As a result, the attacker can learn sensitive details about the entire Tailnet.

### Problem

The current approach implicitly trusts the `NodeKey` in the request, even though the client has not proven ownership of its corresponding private key.

### Proposed Change

Instead, we should retrieve the Node based on the machine key used in the Noise connection, as the client must possess the corresponding private key to establish the session. This provides proper authentication and matches the behavior of Tailscale servers. This is what Tailscale control plane returns in this case:
![image](https://github.com/user-attachments/assets/179c34b3-06dd-491c-8957-d88afe223d27)


<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
