### PR TITLE
remove unneeded check

### DIFF
--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -388,7 +388,7 @@ func validateServerConfig() error {
 		errorText += "Fatal config error: set either tls_letsencrypt_hostname or tls_cert_path/tls_key_path, not both\n"
 	}
 
-	if !viper.IsSet("noise") || viper.GetString("noise.private_key_path") == "" {
+	if viper.GetString("noise.private_key_path") == "" {
 		errorText += "Fatal config error: headscale now requires a new `noise.private_key_path` field in the config file for the Tailscale v2 protocol\n"
 	}
 


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [ ] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

There is no need to check if parent is set here, we only care if the specific key is set.
Before this change, only by applying env `HEADSCALE_NOISE_PRIVATE_KEY_PATH=/some/path` would trigger this error.
I had to also set env `HEADSCALE_NOISE=true` to bypass it.