### PR TITLE
Clarify SIGHUP log message

### DIFF
--- a/hscontrol/app.go
+++ b/hscontrol/app.go
@@ -822,7 +822,7 @@ func (h *Headscale) Serve() error {
 			case syscall.SIGHUP:
 				log.Info().
 					Str("signal", sig.String()).
-					Msg("Received SIGHUP, reloading ACL and Config")
+					Msg("Received SIGHUP, reloading ACL policy")
 
 				if h.cfg.Policy.IsEmpty() {
 					continue


### PR DESCRIPTION
This patch updates the log message on SIGHUP to only mention reloading
of the ACL policy.
