### PR TITLE
OIDC: Query userinfo endpoint before verifying user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ systemctl start headscale
   [#2656](https://github.com/juanfont/headscale/pull/2656)
 - Adds `/robots.txt` endpoint to avoid crawlers
   [#2643](https://github.com/juanfont/headscale/pull/2643)
+- OIDC: Use group claim from UserInfo
+  [#2663](https://github.com/juanfont/headscale/pull/2663)
+- OIDC: Update user with claims from UserInfo *before* comparing with allowed
+  groups, email and domain [#2663](https://github.com/juanfont/headscale/pull/2663)
 
 ## 0.26.1 (2025-06-06)
 

--- a/hscontrol/types/users.go
+++ b/hscontrol/types/users.go
@@ -310,6 +310,7 @@ type OIDCUserInfo struct {
 	PreferredUsername string          `json:"preferred_username"`
 	Email             string          `json:"email"`
 	EmailVerified     FlexibleBoolean `json:"email_verified,omitempty"`
+	Groups            []string        `json:"groups"`
 	Picture           string          `json:"picture"`
 }
 


### PR DESCRIPTION
This patch includes some changes to the OIDC integration in particular:
 - Make sure that userinfo claims are queried *before* comparing the user with the configured allowed groups, email and email domain.
 - Update user with group claim from the userinfo endpoint which is required for allowed groups to work correctly. This is essentially a continuation of #2545.
 - Let userinfo claims take precedence over id token claims.

With these changes I have verified that Headscale works as expected together with Authelia without the documented escape hatch [0], i.e. everything works even if the id token only contain the iss and sub claims.

[0]: https://www.authelia.com/integration/openid-connect/headscale/#configuration-escape-hatch

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
