### PR TITLE
fix: prevent single node timeout from blocking all other updates

### DIFF
--- a/hscontrol/notifier/notifier.go
+++ b/hscontrol/notifier/notifier.go
@@ -281,7 +281,7 @@ func (n *Notifier) sendAll(update types.StateUpdate) {
 				notifierUpdateSent.WithLabelValues("cancelled", update.Type.String(), "send-all").Inc()
 			}
 
-			return
+			continue
 		case c <- update:
 			if debugHighCardinalityMetrics {
 				notifierUpdateSent.WithLabelValues("ok", update.Type.String(), "send-all", id.String()).Inc()


### PR DESCRIPTION
One blocked/slow node in sendAll() was causing early return, skipping
all remaining nodes in iteration. Change return to continue to ensure
all healthy nodes receive updates even when some fail.
