### PR TITLE
Fix config param name in TLS doc

### DIFF
--- a/docs/ref/tls.md
+++ b/docs/ref/tls.md
@@ -2,7 +2,7 @@
 
 ## Bring your own certificate
 
-Headscale can be configured to expose its web service via TLS. To configure the certificate and key file manually, set the `tls_cert_path` and `tls_cert_path` configuration parameters. If the path is relative, it will be interpreted as relative to the directory the configuration file was read from.
+Headscale can be configured to expose its web service via TLS. To configure the certificate and key file manually, set the `tls_cert_path` and `tls_key_path` configuration parameters. If the path is relative, it will be interpreted as relative to the directory the configuration file was read from.
 
 ```yaml title="config.yaml"
 tls_cert_path: ""


### PR DESCRIPTION
This PR fixes a small mistake in the documentation.
