### PR TITLE
Fix invocation of golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,10 @@ jobs:
         if: steps.changed-files.outputs.files == 'true'
         run: nix develop --command -- golangci-lint run
           --new-from-rev=${{github.event.pull_request.base.sha}}
-          --format=colored-line-number
+          --output.text.path=stdout
+          --output.text.print-linter-name
+          --output.text.print-issued-lines
+          --output.text.colors
 
   prettier-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The argument `--format=colored-line-number` is invalid and `--out-format=colored-line-number` is no longer available. Fixup according to the migration guide.

Tested this locally via:

```console
$ nix develop
$ golangci-lint run --new-from-rev=3123d5286bbeb1d4958cec3c92d5a0969b201a9b --output.text.path=stdout --output.text.print-linter-name --output.text.print-issued-lines --output.text.colors
hscontrol/oidc.go:281:29: printf: (*github.com/rs/zerolog.Event).Msgf format %s has arg userinfo of wrong type *github.com/coreos/go-oidc/v3/oidc.UserInfo (govet)
        log.Info().Msgf("UserInfo: %s", userinfo)
                                   ^
hscontrol/oidc.go:404:33: printf: (*github.com/rs/zerolog.Event).Msgf format %s has arg oauth2Token of wrong type *golang.org/x/oauth2.Token (govet)
        log.Info().Msgf("oauth2 Token: %s", oauth2Token)
                                       ^
hscontrol/oidc.go:417:2: missing whitespace above this line (invalid statement above expr) (wsl_v5)
        log.Info().Msgf("ID Token: %s", rawIDToken)
        ^
3 issues:
* govet: 2
* wsl_v5: 1
```

---

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md