### PR TITLE
feat: Add `magicdns_peer_aaaa` config option

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -50,6 +50,7 @@ jobs:
           - TestDERPVerifyEndpoint
           - TestResolveMagicDNS
           - TestResolveMagicDNSExtraRecordsPath
+          - TestMagicDNSPeerAAAA
           - TestDERPServerScenario
           - TestDERPServerWebsocketScenario
           - TestPingAllByIP

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -404,3 +404,11 @@ logtail:
 # default static port 41641. This option is intended as a workaround for some buggy
 # firewall devices. See https://tailscale.com/kb/1181/firewalls/ for more information.
 randomize_client_port: false
+
+
+# Enables MagicDNS AAAA query resolution for tailnet nodes with IPv6.
+# When this option is enabled, devices that have a valid overlay IPv6 address will
+# automatically gain the `magicdns-aaaa` Node Attribute.
+# This attribute allows them to resolve AAAA (IPv6) DNS queries through MagicDNS for 
+# other nodes within the tailnet.
+magicdns_peer_aaaa: false

--- a/hscontrol/mapper/tail.go
+++ b/hscontrol/mapper/tail.go
@@ -78,14 +78,17 @@ func tailNode(
 	}
 
 	var tags []string
+
 	for _, tag := range node.RequestTagsSlice().All() {
 		if checker.NodeCanHaveTag(node, tag) {
 			tags = append(tags, tag)
 		}
 	}
+
 	for _, tag := range node.ForcedTags().All() {
 		tags = append(tags, tag)
 	}
+
 	tags = lo.Uniq(tags)
 
 	routes := primaryRouteFunc(node.ID())
@@ -131,6 +134,12 @@ func tailNode(
 
 	if cfg.RandomizeClientPort {
 		tNode.CapMap[tailcfg.NodeAttrRandomizeClientPort] = []tailcfg.RawMessage{}
+	}
+
+	// Enable NodeAttrMagicDNSPeerAAAA only if requested in
+	// the config and for nodes with a valid v6 overlay address
+	if cfg.MagicDNSPeerAAAA && node.IPv6().Valid() {
+		tNode.CapMap[tailcfg.NodeAttrMagicDNSPeerAAAA] = []tailcfg.RawMessage{}
 	}
 
 	if !node.IsOnline().Valid() || !node.IsOnline().Get() {

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -98,6 +98,12 @@ type Config struct {
 	Policy PolicyConfig
 
 	Tuning Tuning
+
+	// Controls the automatic addition of the `magicdns-aaaa` node attribute
+	// If set to true, the attributes will be set for all nodes that have
+	// a valid Overlay IPv6 Address.
+	// This is separate from the real DNS
+	MagicDNSPeerAAAA bool
 }
 
 type DNSConfig struct {
@@ -334,6 +340,8 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("tuning.node_mapsession_buffered_chan_size", 30)
 
 	viper.SetDefault("prefixes.allocation", string(IPAllocationStrategySequential))
+
+	viper.SetDefault("magicdns_peer_aaaa", false)
 
 	if err := viper.ReadInConfig(); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -872,6 +880,7 @@ func LoadServerConfig() (*Config, error) {
 	derpConfig := derpConfig()
 	logTailConfig := logtailConfig()
 	randomizeClientPort := viper.GetBool("randomize_client_port")
+	magicDNSPeerAAAA := viper.GetBool("magicdns_peer_aaaa")
 
 	oidcClientSecret := viper.GetString("oidc.client_secret")
 	oidcClientSecretPath := viper.GetString("oidc.client_secret_path")
@@ -999,6 +1008,8 @@ func LoadServerConfig() (*Config, error) {
 				return DefaultBatcherWorkers()
 			}(),
 		},
+
+		MagicDNSPeerAAAA: magicDNSPeerAAAA,
 	}, nil
 }
 


### PR DESCRIPTION
This change introduces a new boolean config option, `magicdns_peer_aaaa`.

When enabled, it adds the `magicdns-aaaa` node attribute to devices with a valid overlay IPv6 address.
This attribute allows MagicDNS to resolve AAAA (IPv6) DNS queries for other nodes in the tailnet.

This is a new opt-in feature for Tailscale 1.84+ and is implemented as a global config option, similar to `RandomizeClientPort`, since support for configuring node attributes via policies is not yet available.

Fixes #2723 

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [x] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
