### PR TITLE
Fix fatal error on missing config file

### DIFF
--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -336,11 +336,11 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("prefixes.allocation", string(IPAllocationStrategySequential))
 
 	if err := viper.ReadInConfig(); err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			log.Warn().Msg("No config file found, using defaults")
-			return nil
-		}
-
+    	if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+        	log.Warn().Msg("No config file found, using defaults")
+        	return nil
+    	}
+    	
 		return fmt.Errorf("fatal error reading config file: %w", err)
 	}
 


### PR DESCRIPTION
This PR fixes a fatal error when no config file is found during CLI operations, ensuring consistent behavior with empty config files. Previously, `LoadConfig` incorrectly checked for `fs.ErrNotExist` instead of Viper's `ConfigFileNotFoundError`, causing the CLI to fail for commands like `headscale nodes list` when relying on environment variables (e.g., `HEADSCALE_CLI_ADDRESS`). Now, a missing config file logs a warning and falls back to defaults, matching the empty config file case.