### PR TITLE
Log registrationID to simplify interactive node registration

### DIFF
--- a/hscontrol/auth.go
+++ b/hscontrol/auth.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/types/change"
+	"github.com/rs/zerolog/log"
 
 	"gorm.io/gorm"
 	"tailscale.com/tailcfg"
@@ -264,6 +265,7 @@ func (h *Headscale) handleRegisterInteractive(
 		nodeToRegister,
 	)
 
+	log.Info().Msgf("Starting node registration using key: %s", registrationId)
 	return &tailcfg.RegisterResponse{
 		AuthURL: h.authProvider.AuthURL(registrationId),
 	}, nil


### PR DESCRIPTION
Some clients such as Android make it hard to transfer the registrationID to the server, its easier to get it from the server logs.

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md