### PR TITLE
Enable derp.server.verify_clients by default

### DIFF
--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -297,6 +297,7 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("dns.search_domains", []string{})
 
 	viper.SetDefault("derp.server.enabled", false)
+	viper.SetDefault("derp.server.verify_clients", true)
 	viper.SetDefault("derp.server.stun.enabled", true)
 	viper.SetDefault("derp.server.automatically_add_embedded_derp_region", true)
 


### PR DESCRIPTION
This setting is already enabled in example-config.yaml but would default to false if no key is set.

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md