### PR TITLE
Minor documentation correction

### DIFF
--- a/docs/ref/dns.md
+++ b/docs/ref/dns.md
@@ -23,7 +23,7 @@ hostname and port combination "http://hostname-in-magic-dns.myvpn.example.com:30
 
 !!! warning "Limitations"
 
-    Currently, [only A and AAAA records are processed by Tailscale](https://github.com/tailscale/tailscale/blob/v1.78.3/ipn/ipnlocal/local.go#L4461-L4479).
+    Currently, [only A and AAAA records are processed by Tailscale](https://github.com/tailscale/tailscale/blob/v1.86.5/ipn/ipnlocal/node_backend.go#L662).
 
 1.  Configure extra DNS records using one of the available configuration options:
 


### PR DESCRIPTION
Just a small documentation fix.
Tailscale has moved Extra DNS mapping to a different location in its codebase.

https://github.com/tailscale/tailscale/blob/v1.86.5/ipn/ipnlocal/node_backend.go#L662

_I suggest to use the link to the latest version v1.86.5, since the difference between v1.86.5 and v1.84.3 (the current headscale used) is only in line numbers._