### PR TITLE
fix: node list-routes output formatting

### DIFF
--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -733,9 +733,9 @@ func nodeRoutesToPtables(
 		nodeData := []string{
 			strconv.FormatUint(node.GetId(), util.Base10),
 			node.GetGivenName(),
-			strings.Join(node.GetApprovedRoutes(), ", "),
-			strings.Join(node.GetAvailableRoutes(), ", "),
-			strings.Join(node.GetSubnetRoutes(), ", "),
+			strings.Join(node.GetApprovedRoutes(), "\n"),
+			strings.Join(node.GetAvailableRoutes(), "\n"),
+			strings.Join(node.GetSubnetRoutes(), "\n"),
 		}
 		tableData = append(
 			tableData,


### PR DESCRIPTION
Small fix for `node list-routes` formatting.

### Problem:
If you have many routes for one node, this will result in incorrect output that will be unusable.

```
ID | Hostname                     | Approved                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Available                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Serving (Primary)
2  | vpn-router           | 0.0.0.0/0, 234.2.0.0/16, 234.3.0.0/16, 234.4.0.0/16, 234.5.0.0/16, 234.6.0.0/16, 234.7.0.0/16, 234.9.0.0/16, 234.234.0.0/16, 234.12.0.0/16, 234.14.0.0/16, 234.16.0.0/16, 234.17.0.0/16, 234.18.0.0/16, 234.19.0.0/16, 234.21.0.0/16, 234.23.0.0/16, 234.24.0.0/16, 234.25.0.0/16, 234.26.0.0/16, 234.27.0.0/16, 234.28.0.0/16, 234.29.0.0/16, 234.34.0.0/16, 234.35.0.0/16, 234.37.0.0/16, 234.38.0.0/16, 234.40.0.0/16, 234.205.0.0/16, 234.252.16.0/23, 234.31.0.0/24, ....
```

### Fix:
This fix propagates a change to replace the comma-separated list with a list separated by line breaks.
Plus it makes routes analysis much easier.

```
ID | Hostname     | Approved.       | Available       | Serving (Primary)
2  | vpn-router   | 0.0.0.0/0       | 0.0.0.0/0       | 234.2.0.0/16
   |              | 234.2.0.0/16    | 234.2.0.0/16    | 234.3.0.0/16
   |              | 234.3.0.0/16    | 234.3.0.0/16    | 234.4.0.0/16
   |              | 234.4.0.0/16    | 234.4.0.0/16    | 234.5.0.0/16
   |              | 234.5.0.0/16    | 234.5.0.0/16    | 234.6.0.0/16
   |              | 234.6.0.0/16    | 234.6.0.0/16    | 234.7.0.0/16
   |              | 234.7.0.0/16    | 234.7.0.0/16    | 234.9.0.0/16
   |              | 234.9.0.0/16    | 234.9.0.0/16    | 234.234.0.0/16
   |              | 234.234.0.0/16  | 234.234.0.0/16  | 234.12.0.0/16
   |              | 234.12.0.0/16   | 234.12.0.0/16   | 234.14.0.0/16
   |              | 234.14.0.0/16   | 234.14.0.0/16   | 234.16.0.0/16
   |              | 234.16.0.0/16   | 234.16.0.0/16   | 234.17.0.0/16
   |              | 234.17.0.0/16   | 234.17.0.0/16   | 234.18.0.0/16
   |              | 234.18.0.0/16   | 234.18.0.0/16   | 234.19.0.0/16
   |              | 234.19.0.0/16   | 234.19.0.0/16   | 234.21.0.0/16
   |              | 234.21.0.0/16   | 234.21.0.0/16   | 234.23.0.0/16
```