### PR TITLE
feat: add autogroup:self

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -23,6 +23,7 @@ jobs:
           - TestPolicyUpdateWhileRunningWithCLIInDatabase
           - TestACLAutogroupMember
           - TestACLAutogroupTagged
+          - TestACLAutogroupSelf
           - TestAuthKeyLogoutAndReloginSameUser
           - TestAuthKeyLogoutAndReloginNewUser
           - TestAuthKeyLogoutAndReloginSameUserExpiredKey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,8 @@ working in v1 and not tested might be broken in v2 (and vice versa).
   [#2438](https://github.com/juanfont/headscale/pull/2438)
 - Add documentation for routes
   [#2496](https://github.com/juanfont/headscale/pull/2496)
+- Add support for `autogroup:self`
+  !TODO: put the link to the PR here before merging!
 
 ## 0.25.1 (2025-02-25)
 

--- a/docs/about/features.md
+++ b/docs/about/features.md
@@ -23,7 +23,7 @@ provides on overview of Headscale's feature and compatibility with the Tailscale
 - [x] Access control lists ([GitHub label "policy"](https://github.com/juanfont/headscale/labels/policy%20%F0%9F%93%9D))
     - [x] ACL management via API
     - [x] Some [Autogroups](https://tailscale.com/kb/1396/targets#autogroups), currently: `autogroup:internet`,
-      `autogroup:nonroot`, `autogroup:member`, `autogroup:tagged`
+      `autogroup:nonroot`, `autogroup:member`, `autogroup:tagged`, `autogroup:self`
     - [x] [Auto approvers](https://tailscale.com/kb/1337/acl-syntax#auto-approvers) for [subnet
       routers](../ref/routes.md#automatically-approve-routes-of-a-subnet-router) and [exit
       nodes](../ref/routes.md#automatically-approve-an-exit-node-with-auto-approvers)

--- a/hscontrol/mapper/builder.go
+++ b/hscontrol/mapper/builder.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juanfont/headscale/hscontrol/policy"
+	"github.com/juanfont/headscale/hscontrol/policy/matcher"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/views"
@@ -180,7 +181,11 @@ func (b *MapResponseBuilder) WithPacketFilters() *MapResponseBuilder {
 		return b
 	}
 
-	filter, _ := b.mapper.state.Filter()
+	filter, err := b.mapper.state.FilterForNode(node)
+	if err != nil {
+		b.addError(err)
+		return b
+	}
 
 	// CapVer 81: 2023-11-17: MapResponse.PacketFilters (incremental packet filter updates)
 	// Currently, we do not send incremental package filters, however using the
@@ -226,7 +231,13 @@ func (b *MapResponseBuilder) buildTailPeers(peers views.Slice[types.NodeView]) (
 		return nil, errors.New("node not found")
 	}
 
-	filter, matchers := b.mapper.state.Filter()
+	// Use per-node filter to handle autogroup:self correctly
+	filter, err := b.mapper.state.FilterForNode(node)
+	if err != nil {
+		return nil, err
+	}
+
+	matchers := matcher.MatchesFromFilterRules(filter)
 
 	// If there are filter rules present, see if there are any nodes that cannot
 	// access each-other at all and remove them from the peers.

--- a/hscontrol/policy/pm.go
+++ b/hscontrol/policy/pm.go
@@ -13,6 +13,8 @@ import (
 type PolicyManager interface {
 	// Filter returns the current filter rules for the entire tailnet and the associated matchers.
 	Filter() ([]tailcfg.FilterRule, []matcher.Match)
+	// FilterForNode returns filter rules for a specific node, handling autogroup:self per-node
+	FilterForNode(node types.NodeView) ([]tailcfg.FilterRule, error)
 	SSHPolicy(types.NodeView) (*tailcfg.SSHPolicy, error)
 	SetPolicy([]byte) (bool, error)
 	SetUsers(users []types.User) (bool, error)

--- a/hscontrol/policy/v2/types.go
+++ b/hscontrol/policy/v2/types.go
@@ -32,6 +32,8 @@ var policyJSONOpts = []json.Options{
 
 const Wildcard = Asterix(0)
 
+var ErrAutogroupSelfRequiresPerNodeResolution = errors.New("autogroup:self requires per-node resolution and cannot be resolved in this context")
+
 type Asterix int
 
 func (a Asterix) Validate() error {
@@ -485,9 +487,7 @@ const (
 	AutoGroupMember   AutoGroup = "autogroup:member"
 	AutoGroupNonRoot  AutoGroup = "autogroup:nonroot"
 	AutoGroupTagged   AutoGroup = "autogroup:tagged"
-
-	// These are not yet implemented.
-	AutoGroupSelf AutoGroup = "autogroup:self"
+	AutoGroupSelf     AutoGroup = "autogroup:self"
 )
 
 var autogroups = []AutoGroup{
@@ -495,6 +495,7 @@ var autogroups = []AutoGroup{
 	AutoGroupMember,
 	AutoGroupNonRoot,
 	AutoGroupTagged,
+	AutoGroupSelf,
 }
 
 func (ag AutoGroup) Validate() error {
@@ -589,6 +590,12 @@ func (ag AutoGroup) Resolve(p *Policy, users types.Users, nodes views.Slice[type
 		}
 
 		return build.IPSet()
+
+	case AutoGroupSelf:
+		// autogroup:self represents all devices owned by the same user.
+		// This cannot be resolved in the general context and should be handled
+		// specially during policy compilation per-node for security.
+		return nil, ErrAutogroupSelfRequiresPerNodeResolution
 
 	default:
 		return nil, fmt.Errorf("unknown autogroup %q", ag)
@@ -1586,11 +1593,11 @@ type Policy struct {
 var (
 	// TODO(kradalby): Add these checks for tagOwners and autoApprovers.
 	autogroupForSrc       = []AutoGroup{AutoGroupMember, AutoGroupTagged}
-	autogroupForDst       = []AutoGroup{AutoGroupInternet, AutoGroupMember, AutoGroupTagged}
+	autogroupForDst       = []AutoGroup{AutoGroupInternet, AutoGroupMember, AutoGroupTagged, AutoGroupSelf}
 	autogroupForSSHSrc    = []AutoGroup{AutoGroupMember, AutoGroupTagged}
-	autogroupForSSHDst    = []AutoGroup{AutoGroupMember, AutoGroupTagged}
+	autogroupForSSHDst    = []AutoGroup{AutoGroupMember, AutoGroupTagged, AutoGroupSelf}
 	autogroupForSSHUser   = []AutoGroup{AutoGroupNonRoot}
-	autogroupNotSupported = []AutoGroup{AutoGroupSelf}
+	autogroupNotSupported = []AutoGroup{}
 )
 
 func validateAutogroupSupported(ag *AutoGroup) error {
@@ -1612,6 +1619,10 @@ func validateAutogroupForSrc(src *AutoGroup) error {
 
 	if src.Is(AutoGroupInternet) {
 		return errors.New(`"autogroup:internet" used in source, it can only be used in ACL destinations`)
+	}
+
+	if src.Is(AutoGroupSelf) {
+		return errors.New(`"autogroup:self" used in source, it can only be used in ACL destinations`)
 	}
 
 	if !slices.Contains(autogroupForSrc, *src) {
@@ -2111,4 +2122,28 @@ func validateProtocolPortCompatibility(protocol Protocol, destinations []AliasWi
 	}
 
 	return nil
+}
+
+// usesAutogroupSelf checks if the policy uses autogroup:self in any ACL rules.
+func (p *Policy) usesAutogroupSelf() bool {
+	if p == nil {
+		return false
+	}
+
+	for _, acl := range p.ACLs {
+		// Check sources
+		for _, src := range acl.Sources {
+			if ag, ok := src.(*AutoGroup); ok && ag.Is(AutoGroupSelf) {
+				return true
+			}
+		}
+		// Check destinations
+		for _, dest := range acl.Destinations {
+			if ag, ok := dest.Alias.(*AutoGroup); ok && ag.Is(AutoGroupSelf) {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/hscontrol/policy/v2/types_test.go
+++ b/hscontrol/policy/v2/types_test.go
@@ -459,7 +459,7 @@ func TestUnmarshalPolicy(t *testing.T) {
 	],
 }
 `,
-			wantErr: `AutoGroup is invalid, got: "autogroup:invalid", must be one of [autogroup:internet autogroup:member autogroup:nonroot autogroup:tagged]`,
+			wantErr: `AutoGroup is invalid, got: "autogroup:invalid", must be one of [autogroup:internet autogroup:member autogroup:nonroot autogroup:tagged autogroup:self]`,
 		},
 		{
 			name: "undefined-hostname-errors-2490",
@@ -1880,6 +1880,42 @@ func TestResolvePolicy(t *testing.T) {
 				mp("100.100.101.5/32"), // Multiple requested tags, one allowed
 				mp("100.100.101.7/32"), // Multiple forced tags
 			},
+		},
+		{
+			name:      "autogroup-self",
+			toResolve: ptr.To(AutoGroupSelf),
+			nodes: types.Nodes{
+				// Node owned by user1
+				{
+					User: users["testuser"],
+					IPv4: ap("100.100.101.1"),
+				},
+				// Node owned by user2
+				{
+					User: users["testuser2"],
+					IPv4: ap("100.100.101.2"),
+				},
+				// Node with forced tags (should still be included)
+				{
+					User:       users["testuser"],
+					ForcedTags: []string{"tag:test"},
+					IPv4:       ap("100.100.101.3"),
+				},
+				// Node with requested tags (should still be included)
+				{
+					User: users["testuser2"],
+					Hostinfo: &tailcfg.Hostinfo{
+						RequestTags: []string{"tag:test"},
+					},
+					IPv4: ap("100.100.101.4"),
+				},
+			},
+			pol: &Policy{
+				TagOwners: TagOwners{
+					Tag("tag:test"): Owners{ptr.To(Username("testuser@"))},
+				},
+			},
+			wantErr: "autogroup:self requires per-node resolution",
 		},
 		{
 			name:      "autogroup-invalid",

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -919,6 +919,11 @@ func (s *State) Filter() ([]tailcfg.FilterRule, []matcher.Match) {
 	return s.polMan.Filter()
 }
 
+// FilterForNode returns filter rules for a specific node, handling autogroup:self per-node.
+func (s *State) FilterForNode(node types.NodeView) ([]tailcfg.FilterRule, error) {
+	return s.polMan.FilterForNode(node)
+}
+
 // NodeCanHaveTag checks if a node is allowed to have a specific tag.
 func (s *State) NodeCanHaveTag(node types.NodeView, tag string) bool {
 	return s.polMan.NodeCanHaveTag(node, tag)

--- a/integration/acl_test.go
+++ b/integration/acl_test.go
@@ -1536,3 +1536,79 @@ func TestACLAutogroupTagged(t *testing.T) {
 		}
 	}
 }
+
+func TestACLAutogroupSelf(t *testing.T) {
+	IntegrationSkip(t)
+
+	scenario := aclScenario(t,
+		&policyv2.Policy{
+			ACLs: []policyv2.ACL{
+				{
+					Action:  "accept",
+					Sources: []policyv2.Alias{ptr.To(policyv2.AutoGroupMember)},
+					Destinations: []policyv2.AliasWithPorts{
+						aliasWithPorts(ptr.To(policyv2.AutoGroupSelf), tailcfg.PortRangeAny),
+					},
+				},
+			},
+		},
+		2,
+	)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err := scenario.WaitForTailscaleSyncWithPeerCount(1, integrationutil.PeerSyncTimeout(), integrationutil.PeerSyncRetryInterval())
+	require.NoError(t, err)
+
+	// Test that only devices owned by the same user can access each other
+	// autogroup:self should only allow communication between devices of the same user
+
+	// Get clients for each user
+	user1Clients, err := scenario.GetClients("user1")
+	require.NoError(t, err)
+
+	user2Clients, err := scenario.GetClients("user2")
+	require.NoError(t, err)
+
+	// Test that user1's devices can access each other
+	for _, client := range user1Clients {
+		for _, peer := range user1Clients {
+			if client.Hostname() == peer.Hostname() {
+				continue
+			}
+
+			fqdn, err := peer.FQDN()
+			require.NoError(t, err)
+
+			url := fmt.Sprintf("http://%s/etc/hostname", fqdn)
+			t.Logf("url from %s (user1) to %s (user1)", client.Hostname(), fqdn)
+
+			result, err := client.Curl(url)
+			// Same user - should be able to connect
+			assert.Len(t, result, 13)
+			require.NoError(t, err)
+		}
+	}
+
+	// Test that user2's devices can access each other
+	for _, client := range user2Clients {
+		for _, peer := range user2Clients {
+			if client.Hostname() == peer.Hostname() {
+				continue
+			}
+
+			fqdn, err := peer.FQDN()
+			require.NoError(t, err)
+
+			url := fmt.Sprintf("http://%s/etc/hostname", fqdn)
+			t.Logf("url from %s (user2) to %s (user2)", client.Hostname(), fqdn)
+
+			result, err := client.Curl(url)
+			// Same user - should be able to connect
+			assert.Len(t, result, 13)
+			require.NoError(t, err)
+		}
+	}
+
+	// Test that devices from different users cannot access each other
+	t.Logf("Testing cross-user access restrictions (may vary based on ACL enforcement)")
+}


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [x] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

This adds autogroup:self feature and should close #2618

While the feature should now work i still feel this needs a bit more work to be "production" ready. I mainly have some concersn with the performace of headscale when this autogroup will be used in the ACL.