### PR TITLE
Add creation_time and ko_data_creation_time to goreleaser.yml kos

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -118,6 +118,8 @@ kos:
       - "{{ .Tag }}"
       - '{{ trimprefix .Tag "v" }}'
       - "sha-{{ .ShortCommit }}"
+    creation_time: "{{.CommitTimestamp}}"
+    ko_data_creation_time: "{{.CommitTimestamp}}"
 
   - id: ghcr-debug
     repositories:


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
Fixes #2796

Options taken from https://goreleaser.com/customization/ko/#docker-images-with-ko


Result of `KO_DOCKER_REPO=ko.local ko build ./cmd/headscale`

```
  "Created" : "2025-10-26T22:20:59-07:00",
```

```json
{
  "Id" : "sha256:40e1e79dc9603fa4de01902d810f6946f7c9d7054fb8c2a3638c794cfec33aaf",
  "RepoTags" : [ "ko.local/headscale-f40b3d8640713cd381403459ebd67e78:d174734f51f81632729f30f7ff8673ee3c31fb914525932d01b6462bc7338249", "ko.local/headscale-f40b3d8640713cd381403459ebd67e78:latest" ],
  "RepoDigests" : [ ],
  "Parent" : "",
  "Comment" : "go build output, at /ko-app/headscale",
  "Created" : "2025-10-26T22:20:59-07:00",
  "DockerVersion" : "",
  "Author" : "github.com/ko-build/ko",
  "Config" : {
    "User" : "65532",
    "Env" : [ "PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin:/ko-app", "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt", "KO_DATA_PATH=/var/run/ko" ],
    "Entrypoint" : [ "/ko-app/headscale" ],
    "Labels" : {
      "dev.chainguard.image.title" : "static",
      "dev.chainguard.package.main" : "",
      "org.opencontainers.image.authors" : "Chainguard Team https://www.chainguard.dev/",
      "org.opencontainers.image.created" : "2025-10-13T16:04:04Z",
      "org.opencontainers.image.source" : "https://github.com/chainguard-images/images/tree/main/images/static",
      "org.opencontainers.image.title" : "static",
      "org.opencontainers.image.url" : "https://images.chainguard.dev/directory/image/static/overview",
      "org.opencontainers.image.vendor" : "Chainguard"
    }
  },
  "Architecture" : "amd64",
  "Os" : "linux",
  "Size" : 83979141,
  "GraphDriver" : {
    "Data" : {
      "LowerDir" : "/var/lib/docker/overlay2/cd03251892b8eca35b2e9b97cebe8329874368bb4eb3a095c7d7bf3142820d32/diff:/var/lib/docker/overlay2/7018abfead4d089c38bc46f4f196e3267a0864db3ba997bbcad21e813ba6ae7c/diff",
      "MergedDir" : "/var/lib/docker/overlay2/24e0a07dbb1c9d7c460d7b1a8f31401f363cf6f4279d585e53b3a2b1ec32a1a5/merged",
      "UpperDir" : "/var/lib/docker/overlay2/24e0a07dbb1c9d7c460d7b1a8f31401f363cf6f4279d585e53b3a2b1ec32a1a5/diff",
      "WorkDir" : "/var/lib/docker/overlay2/24e0a07dbb1c9d7c460d7b1a8f31401f363cf6f4279d585e53b3a2b1ec32a1a5/work"
    },
    "Name" : "overlay2"
  },
  "RootFS" : {
    "Type" : "layers",
    "Layers" : [ "sha256:b49fe7b5d2e8a7f094e5ed7629cc97e1c61ce20774fb950025670721a529deff", "sha256:a5926f0fd0dde9a1b4722de26361d161845eb2d987e03cd9ec8ad7a5760a21d9", "sha256:23fff854c40732908bb28e74aad48197501afc0342e30c1e2c864c7673c416ab" ]
  },
  "Metadata" : {
    "LastTagTime" : "2025-10-27T05:53:38.396148167Z"
  }
}
```
