### PR TITLE
chore: fix autogroup:self with other acl rules

### DIFF
--- a/hscontrol/policy/v2/filter.go
+++ b/hscontrol/policy/v2/filter.go
@@ -99,14 +99,16 @@ func (pol *Policy) compileFilterRulesForNode(
 			return nil, ErrInvalidAction
 		}
 
-		rule, err := pol.compileACLWithAutogroupSelf(acl, users, node, nodes)
+		aclRules, err := pol.compileACLWithAutogroupSelf(acl, users, node, nodes)
 		if err != nil {
 			log.Trace().Err(err).Msgf("compiling ACL")
 			continue
 		}
 
-		if rule != nil {
-			rules = append(rules, *rule)
+		for _, rule := range aclRules {
+			if rule != nil {
+				rules = append(rules, *rule)
+			}
 		}
 	}
 
@@ -115,27 +117,32 @@ func (pol *Policy) compileFilterRulesForNode(
 
 // compileACLWithAutogroupSelf compiles a single ACL rule, handling
 // autogroup:self per-node while supporting all other alias types normally.
+// It returns a slice of filter rules because when an ACL has both autogroup:self
+// and other destinations, they need to be split into separate rules with different
+// source filtering logic.
 func (pol *Policy) compileACLWithAutogroupSelf(
 	acl ACL,
 	users types.Users,
 	node types.NodeView,
 	nodes views.Slice[types.NodeView],
-) (*tailcfg.FilterRule, error) {
-	// Check if any destination uses autogroup:self
-	hasAutogroupSelfInDst := false
+) ([]*tailcfg.FilterRule, error) {
+	var autogroupSelfDests []AliasWithPorts
+	var otherDests []AliasWithPorts
 
 	for _, dest := range acl.Destinations {
 		if ag, ok := dest.Alias.(*AutoGroup); ok && ag.Is(AutoGroupSelf) {
-			hasAutogroupSelfInDst = true
-			break
+			autogroupSelfDests = append(autogroupSelfDests, dest)
+		} else {
+			otherDests = append(otherDests, dest)
 		}
 	}
 
-	var srcIPs netipx.IPSetBuilder
+	protocols, _ := acl.Protocol.parseProtocol()
+	var rules []*tailcfg.FilterRule
 
-	// Resolve sources to only include devices from the same user as the target node.
+	var resolvedSrcIPs []*netipx.IPSet
+
 	for _, src := range acl.Sources {
-		// autogroup:self is not allowed in sources
 		if ag, ok := src.(*AutoGroup); ok && ag.Is(AutoGroupSelf) {
 			return nil, fmt.Errorf("autogroup:self cannot be used in sources")
 		}
@@ -147,92 +154,121 @@ func (pol *Policy) compileACLWithAutogroupSelf(
 		}
 
 		if ips != nil {
-			if hasAutogroupSelfInDst {
-				// Instead of iterating all addresses (which could be millions),
-				// check each node's IPs against the source set
-				for _, n := range nodes.All() {
-					if n.User().ID == node.User().ID && !n.IsTagged() {
-						// Check if any of this node's IPs are in the source set
-						for _, nodeIP := range n.IPs() {
-							if ips.Contains(nodeIP) {
-								n.AppendToIPSet(&srcIPs)
-								break // Found this node, move to next
-							}
-						}
-					}
-				}
-			} else {
-				// No autogroup:self in destination, use all resolved sources
-				srcIPs.AddSet(ips)
-			}
+			resolvedSrcIPs = append(resolvedSrcIPs, ips)
 		}
 	}
 
-	srcSet, err := srcIPs.IPSet()
-	if err != nil {
-		return nil, err
+	if len(resolvedSrcIPs) == 0 {
+		return rules, nil
 	}
 
-	if srcSet == nil || len(srcSet.Prefixes()) == 0 {
-		// No sources resolved, skip this rule
-		return nil, nil //nolint:nilnil
-	}
+	// Handle autogroup:self destinations (if any)
+	if len(autogroupSelfDests) > 0 {
+		// Pre-filter to same-user untagged devices once - reuse for both sources and destinations
+		sameUserNodes := make([]types.NodeView, 0)
+		for _, n := range nodes.All() {
+			if n.User().ID == node.User().ID && !n.IsTagged() {
+				sameUserNodes = append(sameUserNodes, n)
+			}
+		}
 
-	protocols, _ := acl.Protocol.parseProtocol()
-
-	var destPorts []tailcfg.NetPortRange
-
-	for _, dest := range acl.Destinations {
-		if ag, ok := dest.Alias.(*AutoGroup); ok && ag.Is(AutoGroupSelf) {
-			for _, n := range nodes.All() {
-				if n.User().ID == node.User().ID && !n.IsTagged() {
-					for _, port := range dest.Ports {
-						for _, ip := range n.IPs() {
-							pr := tailcfg.NetPortRange{
-								IP:    ip.String(),
-								Ports: port,
-							}
-							destPorts = append(destPorts, pr)
+		if len(sameUserNodes) > 0 {
+			// Filter sources to only same-user untagged devices
+			var srcIPs netipx.IPSetBuilder
+			for _, ips := range resolvedSrcIPs {
+				for _, n := range sameUserNodes {
+					// Check if any of this node's IPs are in the source set
+					for _, nodeIP := range n.IPs() {
+						if ips.Contains(nodeIP) {
+							n.AppendToIPSet(&srcIPs)
+							break
 						}
 					}
 				}
 			}
-		} else {
-			ips, err := dest.Resolve(pol, users, nodes)
+
+			srcSet, err := srcIPs.IPSet()
 			if err != nil {
-				log.Trace().Err(err).Msgf("resolving destination ips")
-				continue
+				return nil, err
 			}
 
-			if ips == nil {
-				log.Debug().Msgf("destination resolved to nil ips: %v", dest)
-				continue
-			}
-
-			prefixes := ips.Prefixes()
-
-			for _, pref := range prefixes {
-				for _, port := range dest.Ports {
-					pr := tailcfg.NetPortRange{
-						IP:    pref.String(),
-						Ports: port,
+			if srcSet != nil && len(srcSet.Prefixes()) > 0 {
+				var destPorts []tailcfg.NetPortRange
+				for _, dest := range autogroupSelfDests {
+					for _, n := range sameUserNodes {
+						for _, port := range dest.Ports {
+							for _, ip := range n.IPs() {
+								destPorts = append(destPorts, tailcfg.NetPortRange{
+									IP:    ip.String(),
+									Ports: port,
+								})
+							}
+						}
 					}
-					destPorts = append(destPorts, pr)
+				}
+
+				if len(destPorts) > 0 {
+					rules = append(rules, &tailcfg.FilterRule{
+						SrcIPs:   ipSetToPrefixStringList(srcSet),
+						DstPorts: destPorts,
+						IPProto:  protocols,
+					})
 				}
 			}
 		}
 	}
 
-	if len(destPorts) == 0 {
-		// No destinations resolved, skip this rule
-		return nil, nil //nolint:nilnil
+	if len(otherDests) > 0 {
+		var srcIPs netipx.IPSetBuilder
+
+		for _, ips := range resolvedSrcIPs {
+			srcIPs.AddSet(ips)
+		}
+
+		srcSet, err := srcIPs.IPSet()
+		if err != nil {
+			return nil, err
+		}
+
+		if srcSet != nil && len(srcSet.Prefixes()) > 0 {
+			var destPorts []tailcfg.NetPortRange
+
+			for _, dest := range otherDests {
+				ips, err := dest.Resolve(pol, users, nodes)
+				if err != nil {
+					log.Trace().Err(err).Msgf("resolving destination ips")
+					continue
+				}
+
+				if ips == nil {
+					log.Debug().Msgf("destination resolved to nil ips: %v", dest)
+					continue
+				}
+
+				prefixes := ips.Prefixes()
+
+				for _, pref := range prefixes {
+					for _, port := range dest.Ports {
+						pr := tailcfg.NetPortRange{
+							IP:    pref.String(),
+							Ports: port,
+						}
+						destPorts = append(destPorts, pr)
+					}
+				}
+			}
+
+			if len(destPorts) > 0 {
+				rules = append(rules, &tailcfg.FilterRule{
+					SrcIPs:   ipSetToPrefixStringList(srcSet),
+					DstPorts: destPorts,
+					IPProto:  protocols,
+				})
+			}
+		}
 	}
 
-	return &tailcfg.FilterRule{
-		SrcIPs:   ipSetToPrefixStringList(srcSet),
-		DstPorts: destPorts,
-		IPProto:  protocols,
-	}, nil
+	return rules, nil
 }
 
 func sshAction(accept bool, duration time.Duration) tailcfg.SSHAction {
@@ -260,46 +296,30 @@ func (pol *Policy) compileSSHPolicy(
 	var rules []*tailcfg.SSHRule
 
 	for index, rule := range pol.SSHs {
-		// Check if any destination uses autogroup:self
-		hasAutogroupSelfInDst := false
+		// Separate destinations into autogroup:self and others
+		// This is needed because autogroup:self requires filtering sources to same-user only,
+		// while other destinations should use all resolved sources
+		var autogroupSelfDests []Alias
+		var otherDests []Alias
+
 		for _, dst := range rule.Destinations {
 			if ag, ok := dst.(*AutoGroup); ok && ag.Is(AutoGroupSelf) {
-				hasAutogroupSelfInDst = true
-				break
-			}
-		}
-
-		// If autogroup:self is used, skip tagged nodes
-		if hasAutogroupSelfInDst && node.IsTagged() {
-			continue
-		}
-
-		var dest netipx.IPSetBuilder
-		for _, src := range rule.Destinations {
-			// Handle autogroup:self specially
-			if ag, ok := src.(*AutoGroup); ok && ag.Is(AutoGroupSelf) {
-				// For autogroup:self, only include the target user's untagged devices
-				for _, n := range nodes.All() {
-					if n.User().ID == node.User().ID && !n.IsTagged() {
-						n.AppendToIPSet(&dest)
-					}
-				}
+				autogroupSelfDests = append(autogroupSelfDests, dst)
 			} else {
-				ips, err := src.Resolve(pol, users, nodes)
-				if err != nil {
-					log.Trace().Caller().Err(err).Msgf("resolving destination ips")
-					continue
-				}
-				dest.AddSet(ips)
+				otherDests = append(otherDests, dst)
 			}
 		}
 
-		destSet, err := dest.IPSet()
+		// Note: Tagged nodes can't match autogroup:self destinations, but can still match other destinations
+
+		// Resolve sources once - we'll use them differently for each destination type
+		srcIPs, err := rule.Sources.Resolve(pol, users, nodes)
 		if err != nil {
-			return nil, err
+			log.Trace().Caller().Err(err).Msgf("SSH policy compilation failed resolving source ips for rule %+v", rule)
+			continue // Skip this rule if we can't resolve sources
 		}
 
-		if !node.InIPSet(destSet) {
+		if srcIPs == nil || len(srcIPs.Prefixes()) == 0 {
 			continue
 		}
 
@@ -313,50 +333,9 @@ func (pol *Policy) compileSSHPolicy(
 			return nil, fmt.Errorf("parsing SSH policy, unknown action %q, index: %d: %w", rule.Action, index, err)
 		}
 
-		var principals []*tailcfg.SSHPrincipal
-		srcIPs, err := rule.Sources.Resolve(pol, users, nodes)
-		if err != nil {
-			log.Trace().Caller().Err(err).Msgf("SSH policy compilation failed resolving source ips for rule %+v", rule)
-			continue // Skip this rule if we can't resolve sources
-		}
-
-		// If autogroup:self is in destinations, filter sources to same user only
-		if hasAutogroupSelfInDst {
-			var filteredSrcIPs netipx.IPSetBuilder
-			// Instead of iterating all addresses, check each node's IPs
-			for _, n := range nodes.All() {
-				if n.User().ID == node.User().ID && !n.IsTagged() {
-					// Check if any of this node's IPs are in the source set
-					for _, nodeIP := range n.IPs() {
-						if srcIPs.Contains(nodeIP) {
-							n.AppendToIPSet(&filteredSrcIPs)
-							break // Found this node, move to next
-						}
-					}
-				}
-			}
-
-			srcIPs, err = filteredSrcIPs.IPSet()
-			if err != nil {
-				return nil, err
-			}
-
-			if srcIPs == nil || len(srcIPs.Prefixes()) == 0 {
-				// No valid sources after filtering, skip this rule
-				continue
-			}
-		}
-
-		for addr := range util.IPSetAddrIter(srcIPs) {
-			principals = append(principals, &tailcfg.SSHPrincipal{
-				NodeIP: addr.String(),
-			})
-		}
-
 		userMap := make(map[string]string, len(rule.Users))
 		if rule.Users.ContainsNonRoot() {
 			userMap["*"] = "="
-
 			// by default, we do not allow root unless explicitly stated
 			userMap["root"] = ""
 		}
@@ -366,11 +345,108 @@ func (pol *Policy) compileSSHPolicy(
 		for _, u := range rule.Users.NormalUsers() {
 			userMap[u.String()] = u.String()
 		}
-		rules = append(rules, &tailcfg.SSHRule{
-			Principals: principals,
-			SSHUsers:   userMap,
-			Action:     &action,
-		})
+
+		// Handle autogroup:self destinations (if any)
+		// Note: Tagged nodes can't match autogroup:self, so skip this block for tagged nodes
+		if len(autogroupSelfDests) > 0 && !node.IsTagged() {
+			// Build destination set for autogroup:self (same-user untagged devices only)
+			var dest netipx.IPSetBuilder
+			for _, n := range nodes.All() {
+				if n.User().ID == node.User().ID && !n.IsTagged() {
+					n.AppendToIPSet(&dest)
+				}
+			}
+
+			destSet, err := dest.IPSet()
+			if err != nil {
+				return nil, err
+			}
+
+			// Only create rule if this node is in the destination set
+			if node.InIPSet(destSet) {
+				// Filter sources to only same-user untagged devices
+				// Pre-filter to same-user untagged devices for efficiency
+				sameUserNodes := make([]types.NodeView, 0)
+				for _, n := range nodes.All() {
+					if n.User().ID == node.User().ID && !n.IsTagged() {
+						sameUserNodes = append(sameUserNodes, n)
+					}
+				}
+
+				var filteredSrcIPs netipx.IPSetBuilder
+				for _, n := range sameUserNodes {
+					// Check if any of this node's IPs are in the source set
+					for _, nodeIP := range n.IPs() {
+						if srcIPs.Contains(nodeIP) {
+							n.AppendToIPSet(&filteredSrcIPs)
+							break // Found this node, move to next
+						}
+					}
+				}
+
+				filteredSrcSet, err := filteredSrcIPs.IPSet()
+				if err != nil {
+					return nil, err
+				}
+
+				if filteredSrcSet != nil && len(filteredSrcSet.Prefixes()) > 0 {
+					var principals []*tailcfg.SSHPrincipal
+					for addr := range util.IPSetAddrIter(filteredSrcSet) {
+						principals = append(principals, &tailcfg.SSHPrincipal{
+							NodeIP: addr.String(),
+						})
+					}
+
+					if len(principals) > 0 {
+						rules = append(rules, &tailcfg.SSHRule{
+							Principals: principals,
+							SSHUsers:   userMap,
+							Action:     &action,
+						})
+					}
+				}
+			}
+		}
+
+		// Handle other destinations (if any)
+		if len(otherDests) > 0 {
+			// Build destination set for other destinations
+			var dest netipx.IPSetBuilder
+			for _, dst := range otherDests {
+				ips, err := dst.Resolve(pol, users, nodes)
+				if err != nil {
+					log.Trace().Caller().Err(err).Msgf("resolving destination ips")
+					continue
+				}
+				if ips != nil {
+					dest.AddSet(ips)
+				}
+			}
+
+			destSet, err := dest.IPSet()
+			if err != nil {
+				return nil, err
+			}
+
+			// Only create rule if this node is in the destination set
+			if node.InIPSet(destSet) {
+				// For non-autogroup:self destinations, use all resolved sources (no filtering)
+				var principals []*tailcfg.SSHPrincipal
+				for addr := range util.IPSetAddrIter(srcIPs) {
+					principals = append(principals, &tailcfg.SSHPrincipal{
+						NodeIP: addr.String(),
+					})
+				}
+
+				if len(principals) > 0 {
+					rules = append(rules, &tailcfg.SSHRule{
+						Principals: principals,
+						SSHUsers:   userMap,
+						Action:     &action,
+					})
+				}
+			}
+		}
 	}
 
 	return &tailcfg.SSHPolicy{


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [ ] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

I try to fix this #2838 issue and add tests that catch this issue. 
Cursor AI was used for the tests and logic validation.
