### PR TITLE
state: allow expired auth keys for node re-registration 

### DIFF
--- a/integration/auth_key_test.go
+++ b/integration/auth_key_test.go
@@ -223,6 +223,7 @@ func TestAuthKeyLogoutAndReloginNewUser(t *testing.T) {
 
 	scenario, err := NewScenario(spec)
 	require.NoError(t, err)
+
 	defer scenario.ShutdownAssertNoPanics(t)
 
 	err = scenario.CreateHeadscaleEnv([]tsic.Option{},
@@ -454,3 +455,4 @@ func TestAuthKeyLogoutAndReloginSameUserExpiredKey(t *testing.T) {
 		})
 	}
 }
+

--- a/integration/tailscale.go
+++ b/integration/tailscale.go
@@ -29,6 +29,7 @@ type TailscaleClient interface {
 	Login(loginServer, authKey string) error
 	LoginWithURL(loginServer string) (*url.URL, error)
 	Logout() error
+	Restart() error
 	Up() error
 	Down() error
 	IPs() ([]netip.Addr, error)


### PR DESCRIPTION
Skip auth key validation for existing nodes re-registering with the same
NodeKey. Pre-auth keys are only required for initial authentication.

NodeKey rotation still requires a valid auth key as it is a security-sensitive
operation that changes the node's cryptographic identity.

Fixes #2830

claude was used in this PR.