### PR TITLE
db: add comment about removing migrations

### DIFF
--- a/hscontrol/db/db.go
+++ b/hscontrol/db/db.go
@@ -952,6 +952,13 @@ AND auth_key_id NOT IN (
 					return nil
 				},
 			},
+
+			// Migrations **above** this points will be REMOVED in version **0.29.0**
+			// This is to clean up a lot of old migrations that is seldom used
+			// and carries a lot of technical debt.
+			// Any new migrations should be added after the comment below and follow
+			// the rules it sets out.
+
 			// From this point, the following rules must be followed:
 			// - NEVER use gorm.AutoMigrate, write the exact migration steps needed
 			// - AutoMigrate depends on the struct staying exactly the same, which it won't over time.


### PR DESCRIPTION
We want to clean up old migrations (and a lot of testdata) to get rid of old tech debt that has plagued our database for years.  With the lift in 0.27.0 to ensure consistency and integrity, this should now be possible. 

This PR adds a comment that all migrations above it will be removed in 0.29.0 to allow us to clean up all these things.
Any new migrations in 0.28.0 and 0.29.0 should go below that line and remain.

For the rest of the 0.27.x cycle, we should fix up any late reported integrity issues so we get into a clean state.