### PR TITLE
Explicitly drop `apt-get clean` and use `dist-clean`

### DIFF
--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -8,8 +8,7 @@ ENV GOPATH /go
 WORKDIR /go/src/headscale
 
 RUN apt-get --update install --no-install-recommends --yes less jq sqlite3 dnsutils \
-  && rm -rf /var/lib/apt/lists/* \
-  && apt-get clean
+  && apt-get dist-clean
 RUN mkdir -p /var/run/headscale
 
 # Install delve debugger


### PR DESCRIPTION
The former is a no-op in the base images (https://github.com/debuerreotype/debuerreotype/blob/45491f2c5c8ac76630e1e2d27503528ca29e1f6f/scripts/debuerreotype-minimizing-config#L87-L109), and `apt-get dist-clean` is a safer/better version of the `rm -rf /var/lib/apt/lists/*` that keeps the cryptographic bits that help prevent downgrade attacks.

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
  - (hopefully this one is simple enough that we don't need to, but happy to discuss more if necessary!)
- [ ] ~~added unit tests~~
- [ ] ~~added integration tests~~
- [ ] ~~updated documentation if needed~~
- [ ] ~~updated CHANGELOG.md~~

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

Refs https://github.com/juanfont/headscale/pull/2827/files#r2516919325