### PR TITLE
Containers should be read-only

### DIFF
--- a/docs/setup/install/container.md
+++ b/docs/setup/install/container.md
@@ -18,10 +18,10 @@ Registry](https://github.com/juanfont/headscale/pkgs/container/headscale). The c
 
 ## Configure and run headscale
 
-1.  Create a directory on the Docker host to store headscale's [configuration](../../ref/configuration.md) and the [SQLite](https://www.sqlite.org/) database:
+1.  Create a directory on the container host to store headscale's [configuration](../../ref/configuration.md) and the [SQLite](https://www.sqlite.org/) database:
 
     ```shell
-    mkdir -p ./headscale/{config,lib,run}
+    mkdir -p ./headscale/{config,lib}
     cd ./headscale
     ```
 
@@ -34,9 +34,10 @@ Registry](https://github.com/juanfont/headscale/pkgs/container/headscale). The c
     docker run \
       --name headscale \
       --detach \
-      --volume "$(pwd)/config:/etc/headscale" \
+      --read-only \
+      --tmpfs /var/run/headscale \
+      --volume "$(pwd)/config:/etc/headscale:ro" \
       --volume "$(pwd)/lib:/var/lib/headscale" \
-      --volume "$(pwd)/run:/var/run/headscale" \
       --publish 127.0.0.1:8080:8080 \
       --publish 127.0.0.1:9090:9090 \
       --health-cmd "CMD headscale health" \
@@ -57,15 +58,17 @@ Registry](https://github.com/juanfont/headscale/pkgs/container/headscale). The c
         image: docker.io/headscale/headscale:<VERSION>
         restart: unless-stopped
         container_name: headscale
+        read_only: true
+        tmpfs:
+          - /var/run/headscale
         ports:
           - "127.0.0.1:8080:8080"
           - "127.0.0.1:9090:9090"
         volumes:
           # Please set <HEADSCALE_PATH> to the absolute path
           # of the previously created headscale directory.
-          - <HEADSCALE_PATH>/config:/etc/headscale
+          - <HEADSCALE_PATH>/config:/etc/headscale:ro
           - <HEADSCALE_PATH>/lib:/var/lib/headscale
-          - <HEADSCALE_PATH>/run:/var/run/headscale
         command: serve
         healthcheck:
             test: ["CMD", "headscale", "health"]
@@ -88,7 +91,7 @@ Registry](https://github.com/juanfont/headscale/pkgs/container/headscale). The c
     Verify headscale is available:
 
     ```shell
-    curl http://127.0.0.1:9090/metrics
+    curl http://127.0.0.1:8080/health
     ```
 
 1.  Create a headscale user:


### PR DESCRIPTION
This improves security and explicitly fails on startup when a user picks the wrong directory to store its data.

- Run in read-only mode
- Make /var/run/headscale a read-write tmpfs
- Mount the config volume read-only
- Use the /health endpoint to check if Headscale is up

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
