### PR TITLE
hscontrol/oidc: fix ACL policy not applied to new OIDC nodes

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -33,6 +33,7 @@ jobs:
           - TestAuthKeyLogoutAndReloginNewUser
           - TestAuthKeyLogoutAndReloginSameUserExpiredKey
           - TestAuthKeyDeleteKey
+          - TestAuthKeyLogoutAndReloginRoutesPreserved
           - TestOIDCAuthenticationPingAll
           - TestOIDCExpireNodesBasedOnTokenExpiry
           - TestOIDC024UserCreation
@@ -42,6 +43,8 @@ jobs:
           - TestOIDCMultipleOpenedLoginUrls
           - TestOIDCReloginSameNodeSameUser
           - TestOIDCExpiryAfterRestart
+          - TestOIDCACLPolicyOnJoin
+          - TestOIDCReloginSameUserRoutesPreserved
           - TestAuthWebFlowAuthenticationPingAll
           - TestAuthWebFlowLogoutAndReloginSameUser
           - TestAuthWebFlowLogoutAndReloginNewUser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Changes
 
+## 0.27.2 (2025-xx-xx)
+
+### Changes
+
+- Fix ACL policy not applied to new OIDC nodes until client restart
+  [#2890](https://github.com/juanfont/headscale/pull/2890)
+
 ## 0.27.1 (2025-11-11)
 
 **Minimum supported Tailscale client version: v1.64.0**

--- a/hscontrol/grpcv1.go
+++ b/hscontrol/grpcv1.go
@@ -294,13 +294,13 @@ func (api headscaleV1APIServer) RegisterNode(
 	// ensure we send an update.
 	// This works, but might be another good candidate for doing some sort of
 	// eventbus.
-	_ = api.h.state.AutoApproveRoutes(node)
-	_, _, err = api.h.state.SaveNode(node)
+	routeChange, err := api.h.state.AutoApproveRoutes(node)
 	if err != nil {
-		return nil, fmt.Errorf("saving auto approved routes to node: %w", err)
+		return nil, fmt.Errorf("auto approving routes: %w", err)
 	}
 
-	api.h.Change(nodeChange)
+	// Send both changes. Empty changes are ignored by Change().
+	api.h.Change(nodeChange, routeChange)
 
 	return &v1.RegisterNodeResponse{Node: node.Proto()}, nil
 }

--- a/hscontrol/oidc.go
+++ b/hscontrol/oidc.go
@@ -42,10 +42,6 @@ var (
 	errOIDCAllowedUsers  = errors.New(
 		"authenticated principal does not match any allowed user",
 	)
-	errOIDCInvalidNodeState = errors.New(
-		"requested node state key expired before authorisation completed",
-	)
-	errOIDCNodeKeyMissing = errors.New("could not get node key from cache")
 )
 
 // RegistrationInfo contains both machine key and verifier information for OIDC validation.
@@ -108,16 +104,8 @@ func (a *AuthProviderOIDC) AuthURL(registrationID types.RegistrationID) string {
 		registrationID.String())
 }
 
-func (a *AuthProviderOIDC) determineNodeExpiry(idTokenExpiration time.Time) time.Time {
-	if a.cfg.UseExpiryFromToken {
-		return idTokenExpiration
-	}
-
-	return time.Now().Add(a.cfg.Expiry)
-}
-
-// RegisterOIDC redirects to the OIDC provider for authentication
-// Puts NodeKey in cache so the callback can retrieve it using the oidc state param
+// RegisterHandler registers the OIDC callback handler with the given router.
+// It puts NodeKey in cache so the callback can retrieve it using the oidc state param.
 // Listens in /register/:registration_id.
 func (a *AuthProviderOIDC) RegisterHandler(
 	writer http.ResponseWriter,
@@ -304,7 +292,7 @@ func (a *AuthProviderOIDC) OIDCCallbackHandler(
 		return
 	}
 
-	user, c, err := a.createOrUpdateUserFromClaim(&claims)
+	user, _, err := a.createOrUpdateUserFromClaim(&claims)
 	if err != nil {
 		log.Error().
 			Err(err).
@@ -322,9 +310,6 @@ func (a *AuthProviderOIDC) OIDCCallbackHandler(
 
 		return
 	}
-
-	// Send policy update notifications if needed
-	a.h.Change(c)
 
 	// TODO(kradalby): Is this comment right?
 	// If the node exists, then the node should be reauthenticated,
@@ -370,6 +355,14 @@ func (a *AuthProviderOIDC) OIDCCallbackHandler(
 	// Neither node nor machine key was found in the state cache meaning
 	// that we could not reauth nor register the node.
 	httpError(writer, NewHTTPError(http.StatusGone, "login session expired, try again", nil))
+}
+
+func (a *AuthProviderOIDC) determineNodeExpiry(idTokenExpiration time.Time) time.Time {
+	if a.cfg.UseExpiryFromToken {
+		return idTokenExpiration
+	}
+
+	return time.Now().Add(a.cfg.Expiry)
 }
 
 func extractCodeAndStateParamFromRequest(
@@ -504,8 +497,8 @@ func (a *AuthProviderOIDC) createOrUpdateUserFromClaim(
 	}
 
 	// if the user is still not found, create a new empty user.
-	// TODO(kradalby): This might cause us to not have an ID below which
-	// is a problem.
+	// TODO(kradalby): This context is not inherited from the request, which is probably not ideal.
+	// However, we need a context to use the OIDC provider.
 	if user == nil {
 		newUser = true
 		user = &types.User{}
@@ -557,18 +550,13 @@ func (a *AuthProviderOIDC) handleRegistration(
 	// ensure we send an update.
 	// This works, but might be another good candidate for doing some sort of
 	// eventbus.
-	_ = a.h.state.AutoApproveRoutes(node)
-	_, policyChange, err := a.h.state.SaveNode(node)
+	routesChange, err := a.h.state.AutoApproveRoutes(node)
 	if err != nil {
-		return false, fmt.Errorf("saving auto approved routes to node: %w", err)
+		return false, fmt.Errorf("auto approving routes: %w", err)
 	}
 
-	// Policy updates are full and take precedence over node changes.
-	if !policyChange.Empty() {
-		a.h.Change(policyChange)
-	} else {
-		a.h.Change(nodeChange)
-	}
+	// Send both changes. Empty changes are ignored by Change().
+	a.h.Change(nodeChange, routesChange)
 
 	return !nodeChange.Empty(), nil
 }


### PR DESCRIPTION
Remove premature policy change notification after user creation in OIDC callback handler. This was causing a race condition where asynchronous policy updates interfered with node registration, resulting in new OIDC nodes receiving incomplete network maps.

The policy manager is still updated synchronously during user creation, and handleRegistration now sends a single consolidated change notification after node registration completes.

Add integration test to validate OIDC nodes immediately receive correct ACL policies and can see advertised routes without requiring a client restart.

Fixes #2888 

claude was used in this PR.