### PR TITLE
Add docs about how to communicate with the service as non headscale local user

### DIFF
--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -41,6 +41,23 @@ options, run:
       headscale <COMMAND> --help
     ```
 
+!!! note "Manage headscale from another local user"
+
+    By default only the user `headscale` or `root` will have the necessary permissions to access the unix socket
+    (`/var/run/headscale/headscale.sock`) that is used to communicate with the service. In order to be able to
+    communicate with the headscale service you have to make sure the unix socket is accessible by the user that runs
+    the commands. In general you can achieve this by any of the following methods:
+
+      * using `sudo`
+      * run the commands as user `headscale`
+      * add your user to the `headscale` group
+    
+    To verify you can run the following command using your preferred method:
+
+    ```shell
+    headscale users list
+    ```
+
 ## Manage headscale users
 
 In headscale, a node (also known as machine or device) is always assigned to a


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [X] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

With a freshly installed headscale it is not possible to communicate with the headscale service unless the user is added into the `headscale` group. I added a small section about this in the documentation, because I have run into this issue:

```
user@host:~$ sudo dpkg -i headscale_0.27.1_linux_amd64.deb 
[sudo] password for user: 
Selecting previously unselected package headscale.
(Reading database ... 33581 files and directories currently installed.)
Preparing to unpack headscale_0.27.1_linux_amd64.deb ...
Unpacking headscale (0.27.1) ...
Setting up headscale (0.27.1) ...
Created symlink /etc/systemd/system/multi-user.target.wants/headscale.service → /lib/systemd/system/headscale.service.
user@host:~$ sudo systemctl status headscale
● headscale.service - headscale coordination server for Tailscale
     Loaded: loaded (/lib/systemd/system/headscale.service; enabled; preset: enabled)
     Active: active (running) since Sat 2025-11-15 20:00:59 CET; 21s ago
   Main PID: 734 (headscale)
      Tasks: 9 (limit: 9482)
     Memory: 15.3M
        CPU: 108ms
     CGroup: /system.slice/headscale.service
             └─734 /usr/bin/headscale serve

Nov 15 20:00:59 user systemd[1]: Started headscale.service - headscale coordination server for Tailscale.
Nov 15 20:00:59 user headscale[734]: 2025-11-15T20:00:59+01:00 INF No private key file at path, creating... path=/var/lib/headscale/noise_private.key
Nov 15 20:00:59 user headscale[734]: 2025-11-15T20:00:59+01:00 INF Opening database database=sqlite3 path=/var/lib/headscale/db.sqlite
Nov 15 20:00:59 user headscale[734]: 2025-11-15T20:00:59+01:00 INF Starting schema recreation with table renaming
Nov 15 20:00:59 user headscale[734]: 2025-11-15T20:00:59+01:00 INF Schema recreation completed successfully
Nov 15 20:00:59 user headscale[734]: 2025-11-15T20:00:59+01:00 INF Starting Headscale commit=f658a8eacd4d86edc65424b50635afed46ca4b2a version=v0.27.1+dirty
Nov 15 20:00:59 user headscale[734]: 2025-11-15T20:00:59+01:00 INF Clients with a lower minimum version will be rejected minimum_version=v1.64.0
Nov 15 20:00:59 user headscale[734]: 2025-11-15T20:00:59+01:00 INF listening and serving HTTP on: 127.0.0.1:8080
Nov 15 20:00:59 user headscale[734]: 2025-11-15T20:00:59+01:00 INF listening and serving debug and metrics on: 127.0.0.1:9090
user@host:~$ headscale status
Error: unknown command "status" for "headscale"
Run 'headscale --help' for usage.
unknown command "status" for "headscale"
user@host:~$ headscale user list
2025-11-15T20:01:41+01:00 FTL Unable to read/write to headscale socket, do you have the correct permissions? error="open /var/run/headscale/headscale.sock: permission denied" socket=/var/run/headscale/headscale.sock
```

I haven't ticked all the boxes, because I think they don't apply.