### PR TITLE
docs: Enable automatic theme switching

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,15 +41,21 @@ theme:
     - toc.follow
     # - toc.integrate
   palette:
-    - scheme: default
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default 
       primary: white
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    - scheme: slate
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       toggle:
         icon: material/brightness-4
-        name: Switch to light mode
+        name: Switch to system preference
   font:
     text: Roboto
     code: Roboto Mono


### PR DESCRIPTION
Hi there :wave:

While browsing the docs for headscale, I noticed that the MkDocs theme was not automatically set to my browser's preferred theme. This feature was introduced in [`mkdocs-material-9.5.0`](https://github.com/squidfunk/mkdocs-material/releases/tag/9.5.0), which is the requested version used by headscale: https://github.com/juanfont/headscale/blob/72d5fd04a74fae6ec248aeaf1b8ad8a5c6920375/docs/requirements.txt#L4

The code comes directly from the reference in the theme's docs with an added `primary: white` option set for the light theme (since that's what was there before): https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#automatic-light-dark-mode. Locally tested, it looks exactly like before, just with the default now showing the browser's [preferred color scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-color-scheme).

I chose not to create a discussion issue about this since it's a fairly unopinionated change and already used by many Material for MkDocs sites across the web. Users can still change it to whatever color scheme they prefer manually by clicking on the theme button, which acts as a 3-way switch.

Thank you for considering this small pull request and have a great weekend.

Cheers

<details>
<summary>PR checklist</summary>

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] ~raised a GitHub issue or discussed it on the projects chat beforehand~
- [ ] ~added unit tests~
- [ ] ~added integration tests~
- [ ] ~updated documentation if needed~
- [ ] ~updated CHANGELOG.md~

</details>

