### PR TITLE
fix: compilation error in auth_test.go - CreatePreAuthKey expects pointer

### DIFF
--- a/hscontrol/auth_test.go
+++ b/hscontrol/auth_test.go
@@ -3234,7 +3234,8 @@ func TestIssue2830_ExistingNodeReregistersWithExpiredKey(t *testing.T) {
 
 	// Create a valid key (will expire it later)
 	expiry := time.Now().Add(1 * time.Hour)
-	pak, err := app.state.CreatePreAuthKey(types.UserID(user.ID), false, false, &expiry, nil)
+	userID := types.UserID(user.ID)
+	pak, err := app.state.CreatePreAuthKey(&userID, false, false, &expiry, nil)
 	require.NoError(t, err)
 
 	machineKey := key.NewMachine()


### PR DESCRIPTION
Fixes a compilation error in `hscontrol/auth_test.go` where `CreatePreAuthKey` was being called with a value instead of a pointer.

## Changes
- Updated test at line 3237 to pass `*types.UserID` (pointer) instead of `types.UserID` (value)
- Creates a `userID` variable and passes its address to match the function signature

## Error Fixed
```
cannot use types.UserID(user.ID) (value of type types.UserID) as
*types.UserID value in argument to app.state.CreatePreAuthKey
```

## Context
This is part of the work discussed in #2902 to add ping functionality to headscale.

---
*Note: This code was generated with assistance from Claude Sonnet 4.5 via cline.bot*
