### PR TITLE
docs(tools): Add tailscale-exporter

### DIFF
--- a/docs/ref/integration/tools.md
+++ b/docs/ref/integration/tools.md
@@ -7,10 +7,11 @@
 
 This page collects third-party tools, client libraries, and scripts related to headscale.
 
-| Name                  | Repository Link                                                 | Description                                                          |
-| --------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------- |
-| tailscale-manager     | [Github](https://github.com/singlestore-labs/tailscale-manager) | Dynamically manage Tailscale route advertisements                    |
-| headscalebacktosqlite | [Github](https://github.com/bigbozza/headscalebacktosqlite)     | Migrate headscale from PostgreSQL back to SQLite                     |
-| headscale-pf          | [Github](https://github.com/YouSysAdmin/headscale-pf)           | Populates user groups based on user groups in Jumpcloud or Authentik |
-| headscale-client-go   | [Github](https://github.com/hibare/headscale-client-go)         | A Go client implementation for the Headscale HTTP API.               |
-| headscale-zabbix      | [Github](https://github.com/dblanque/headscale-zabbix)          | A Zabbix Monitoring Template for the Headscale Service.              |
+| Name                  | Repository Link                                                 | Description                                                                                      |
+| --------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| tailscale-manager     | [Github](https://github.com/singlestore-labs/tailscale-manager) | Dynamically manage Tailscale route advertisements                                                |
+| headscalebacktosqlite | [Github](https://github.com/bigbozza/headscalebacktosqlite)     | Migrate headscale from PostgreSQL back to SQLite                                                 |
+| headscale-pf          | [Github](https://github.com/YouSysAdmin/headscale-pf)           | Populates user groups based on user groups in Jumpcloud or Authentik                             |
+| headscale-client-go   | [Github](https://github.com/hibare/headscale-client-go)         | A Go client implementation for the Headscale HTTP API.                                           |
+| headscale-zabbix      | [Github](https://github.com/dblanque/headscale-zabbix)          | A Zabbix Monitoring Template for the Headscale Service.                                          |
+| tailscale-exporter    | [Github](https://github.com/adinhodovic/tailscale-exporter)     | A Prometheus exporter for Headscale that provides network-level metrics using the Headscale API. |


### PR DESCRIPTION
A Prometheus exporter for Headscale that provides network-level metrics using the Headscale API.

<img width="3814" height="1757" alt="image" src="https://github.com/user-attachments/assets/6e9dcc8a-2964-4983-8804-1a2b85b0ecba" />

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
