### PR TITLE
cli: better formatting of lists

### DIFF
--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -561,23 +561,26 @@ func nodesToPtables(
 
 		var forcedTags string
 		for _, tag := range node.GetForcedTags() {
-			forcedTags += "," + tag
+			forcedTags += "\n" + tag
 		}
-		forcedTags = strings.TrimLeft(forcedTags, ",")
+
+		forcedTags = strings.TrimLeft(forcedTags, "\n")
 		var invalidTags string
 		for _, tag := range node.GetInvalidTags() {
 			if !slices.Contains(node.GetForcedTags(), tag) {
-				invalidTags += "," + pterm.LightRed(tag)
+				invalidTags += "\n" + pterm.LightRed(tag)
 			}
 		}
-		invalidTags = strings.TrimLeft(invalidTags, ",")
+
+		invalidTags = strings.TrimLeft(invalidTags, "\n")
 		var validTags string
 		for _, tag := range node.GetValidTags() {
 			if !slices.Contains(node.GetForcedTags(), tag) {
-				validTags += "," + pterm.LightGreen(tag)
+				validTags += "\n" + pterm.LightGreen(tag)
 			}
 		}
-		validTags = strings.TrimLeft(validTags, ",")
+
+		validTags = strings.TrimLeft(validTags, "\n")
 
 		var user string
 		if currentUser == "" || (currentUser == node.GetUser().GetName()) {
@@ -639,9 +642,9 @@ func nodeRoutesToPtables(
 		nodeData := []string{
 			strconv.FormatUint(node.GetId(), util.Base10),
 			node.GetGivenName(),
-			strings.Join(node.GetApprovedRoutes(), ", "),
-			strings.Join(node.GetAvailableRoutes(), ", "),
-			strings.Join(node.GetSubnetRoutes(), ", "),
+			strings.Join(node.GetApprovedRoutes(), "\n"),
+			strings.Join(node.GetAvailableRoutes(), "\n"),
+			strings.Join(node.GetSubnetRoutes(), "\n"),
 		}
 		tableData = append(
 			tableData,

--- a/cmd/headscale/cli/preauthkeys.go
+++ b/cmd/headscale/cli/preauthkeys.go
@@ -107,10 +107,10 @@ var listPreAuthKeys = &cobra.Command{
 			aclTags := ""
 
 			for _, tag := range key.GetAclTags() {
-				aclTags += "," + tag
+				aclTags += "\n" + tag
 			}
 
-			aclTags = strings.TrimLeft(aclTags, ",")
+			aclTags = strings.TrimLeft(aclTags, "\n")
 
 			tableData = append(tableData, []string{
 				strconv.FormatUint(key.GetId(), 10),


### PR DESCRIPTION
This commit changes lists in cli to be new line instead of commas, making them easier to read when they are large.

Also adds a separator between items in tables with multi lines list.

Fixes #2612
