### PR TITLE
fix: list-routes command now respects identifier filter with JSON output

### DIFF
--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -220,10 +220,6 @@ var listNodeRoutesCmd = &cobra.Command{
 			)
 		}
 
-		if output != "" {
-			SuccessOutput(response.GetNodes(), "", output)
-		}
-
 		nodes := response.GetNodes()
 		if identifier != 0 {
 			for _, node := range response.GetNodes() {
@@ -237,6 +233,11 @@ var listNodeRoutesCmd = &cobra.Command{
 		nodes = lo.Filter(nodes, func(n *v1.Node, _ int) bool {
 			return (n.GetSubnetRoutes() != nil && len(n.GetSubnetRoutes()) > 0) || (n.GetApprovedRoutes() != nil && len(n.GetApprovedRoutes()) > 0) || (n.GetAvailableRoutes() != nil && len(n.GetAvailableRoutes()) > 0)
 		})
+
+		if output != "" {
+			SuccessOutput(nodes, "", output)
+			return
+		}
 
 		tableData, err := nodeRoutesToPtables(nodes)
 		if err != nil {


### PR DESCRIPTION
Fixes #2927

## Problem
In v0.27.0, the `list-routes` command with `-i` flag and `-o json` output was returning all nodes instead of just the specified node.

## Root Cause
The JSON output was happening **before** the identifier filtering logic in the `listNodeRoutesCmd` function. When `-i 12 -o json` was specified, the function would output all nodes from `response.GetNodes()` and continue execution, never using the filtered `nodes` variable for JSON output.

## Solution
Moved the JSON output block from before the filtering logic to after it, ensuring it outputs the `nodes` variable (which has been filtered by both identifier and route existence) instead of the unfiltered `response.GetNodes()`.

## Changes
- Moved lines 231-233 (JSON output) to after line 245 (after filtering)
- Changed output from `response.GetNodes()` to `nodes` (filtered variable)
- Added early return after JSON output to prevent table rendering

## Testing
This restores the v0.26.1 behavior where:
```bash
headscale nodes list-routes -i 12 -o json
```
correctly returns only node 12's route information instead of all nodes.