### PR TITLE
hostname: normalize before validation

### DIFF
--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -585,15 +585,23 @@ func (node *Node) ApplyHostnameFromHostInfo(hostInfo *tailcfg.Hostinfo) {
 		return
 	}
 
-	newHostname := strings.ToLower(hostInfo.Hostname)
-	if err := util.ValidateHostname(newHostname); err != nil {
+	newHostname, err := util.NormaliseHostname(hostInfo.Hostname)
+	if err != nil {
 		log.Warn().
 			Str("node.id", node.ID.String()).
 			Str("current_hostname", node.Hostname).
-			Str("rejected_hostname", hostInfo.Hostname).
+			Str("original_hostname", hostInfo.Hostname).
 			Err(err).
-			Msg("Rejecting invalid hostname update from hostinfo")
+			Msg("Hostname normalization failed, keeping current hostname")
 		return
+	}
+
+	if hostInfo.Hostname != newHostname {
+		log.Info().
+			Str("node.id", node.ID.String()).
+			Str("original", hostInfo.Hostname).
+			Str("sanitized", newHostname).
+			Msg("Hostname sanitized during update")
 	}
 
 	if node.Hostname != newHostname {

--- a/hscontrol/util/util.go
+++ b/hscontrol/util/util.go
@@ -287,12 +287,12 @@ func EnsureHostname(hostinfo *tailcfg.Hostinfo, machineKey, nodeKey string) stri
 		return fmt.Sprintf("node-%s", keyPrefix)
 	}
 
-	lowercased := strings.ToLower(hostinfo.Hostname)
-	if err := ValidateHostname(lowercased); err == nil {
-		return lowercased
+	normalized, err := NormaliseHostname(hostinfo.Hostname)
+	if err != nil {
+		return InvalidString()
 	}
 
-	return InvalidString()
+	return normalized
 }
 
 // GenerateRegistrationKey generates a vanity key for tracking web authentication


### PR DESCRIPTION
Apply NormaliseHostname() before ValidateHostname() in ApplyHostnameFromHostInfo() and EnsureHostname() to sanitize hostnames with minor invalid characters instead of replacing them with generic identifiers like "invalid-abc123".

This allows hostnames like "My-PC!" to become "my-pc" rather than being rejected.

Fixes #2926

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
