### PR TITLE
types: use Username() in User.Proto() for consistent user display

### DIFF
--- a/hscontrol/types/users.go
+++ b/hscontrol/types/users.go
@@ -174,9 +174,17 @@ func (u UserView) TailscaleUserProfile() tailcfg.UserProfile {
 }
 
 func (u *User) Proto() *v1.User {
+	// Use Name if set, otherwise fall back to Username() which provides
+	// a display-friendly identifier (Email > ProviderIdentifier > ID).
+	// This ensures OIDC users (who typically have empty Name) display
+	// their email, while CLI users retain their original Name.
+	name := u.Name
+	if name == "" {
+		name = u.Username()
+	}
 	return &v1.User{
 		Id:            uint64(u.ID),
-		Name:          u.Name,
+		Name:          name,
 		CreatedAt:     timestamppb.New(u.CreatedAt),
 		DisplayName:   u.DisplayName,
 		Email:         u.Email,


### PR DESCRIPTION
User.Proto() was returning u.Name directly, which is empty for OIDC users who have their identifier in the Email field instead. This caused "headscale nodes list" to show empty user names for OIDC-authenticated nodes.

Use Username() which properly resolves the user identifier by checking Email > Name > ProviderIdentifier > ID, ensuring a meaningful identifier is always returned in the Name field of the proto response.

Fixes #2972

claude was used in this pr.