### PR TITLE
nix: use testers.nixosTest instead of nixosTest

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -229,7 +229,7 @@
         apps.default = apps.headscale;
 
         checks = {
-          headscale = pkgs.nixosTest (import ./nix/tests/headscale.nix);
+          headscale = pkgs.testers.nixosTest (import ./nix/tests/headscale.nix);
         };
       });
 }


### PR DESCRIPTION
## Summary
- Update `pkgs.nixosTest` to `pkgs.testers.nixosTest` in `flake.nix`
- The `nixosTest` function was renamed to `testers.nixosTest` in nixpkgs

## Test plan
- [x] NixOS test should pass with the updated function name

🤖 Generated with [Claude Code](https://claude.com/claude-code)