### PR TITLE
OIDC: Add configurable username mapping via `oidc.username_claim_order`

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -360,6 +360,15 @@ unix_socket_permission: "0770"
 #   # Custom scopes can be configured as needed, be sure to always include the
 #   # required "openid" scope.
 #   scope: ["openid", "profile", "email"]
+
+#   # Optional: control how Headscale derives the username (login name) from OIDC claims.
+#   # The first non-empty, valid value is used.
+#   # Supported values: preferred_username, email_localpart, email, name, sub
+#   # Defaults to [preferred_username, email_localpart, email, name, sub]
+#   # username_claim_order:
+#   #   - preferred_username
+#   #   - email_localpart
+#   #   - email
 #
 #   # Provide custom key/value pairs which get sent to the identity provider's
 #   # authorization endpoint.

--- a/docs/ref/oidc.md
+++ b/docs/ref/oidc.md
@@ -160,6 +160,26 @@ Access Token.
     headscale node expire -i <NODE_ID>
     ```
 
+### Customize username mapping
+
+Some identity providers (notably Google OAuth) do not include the `preferred_username` claim. You can configure how
+Headscale derives the username (login name) by specifying a priority order of OIDC claims. The first non-empty, valid
+value is used.
+
+Supported values: `preferred_username`, `email_localpart`, `email`, `name`, `sub`.
+
+If not set, Headscale uses the default order: `preferred_username`, `email_localpart`, `email`, `name`, `sub`.
+
+Example that prefers the email local-part when `preferred_username` is missing:
+
+```yaml
+oidc:
+  username_claim_order:
+    - preferred_username
+    - email_localpart
+    - email
+```
+
 ### Reference a user in the policy
 
 You may refer to users in the Headscale policy via:
@@ -238,10 +258,15 @@ Authelia is fully supported by Headscale.
 
 ### Google OAuth
 
-!!! warning "No username due to missing preferred_username"
+!!! tip "Derive username with email local-part"
 
-    Google OAuth does not send the `preferred_username` claim when the scope `profile` is requested. The username in
-    Headscale will be blank/not set.
+    Google OAuth does not include the `preferred_username` claim. Configure `oidc.username_claim_order` so Headscale
+    derives a username from the email local-part:
+
+    ```yaml
+    oidc:
+      username_claim_order: [preferred_username, email_localpart, email]
+    ```
 
 In order to integrate Headscale with Google, you'll need to have a [Google Cloud
 Console](https://console.cloud.google.com) account.

--- a/hscontrol/oidc.go
+++ b/hscontrol/oidc.go
@@ -263,7 +263,19 @@ func (a *AuthProviderOIDC) OIDCCallbackHandler(
 		util.LogErr(err, "could not get userinfo; only using claims from id token")
 	}
 
-	// The user claims are now updated from the userinfo endpoint so we can verify the user
+	// The user claims are now updated from the userinfo endpoint so we can derive username
+	// and verify the user against authorization constraints.
+
+	// Derive username according to configured claim order (with sensible defaults)
+	order := a.cfg.UsernameClaimOrder
+	if len(order) == 0 {
+		order = []string{"preferred_username", "email_localpart", "email", "name", "sub"}
+	}
+	if uname := types.DeriveUsername(&claims, order); uname != "" {
+		claims.Username = uname
+	}
+
+	// Now we can verify the user
 	// against allowed emails, email domains, and groups.
 	err = doOIDCAuthorization(a.cfg, &claims)
 	if err != nil {

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -189,6 +189,16 @@ type OIDCConfig struct {
 	Expiry                     time.Duration
 	UseExpiryFromToken         bool
 	PKCE                       PKCEConfig
+	// UsernameClaimOrder controls which OIDC claims are used to derive the
+	// Headscale username (login name) when authenticating via OIDC.
+	// The first non-empty, valid value is selected. Supported values:
+	//   - "preferred_username" (OIDC standard)
+	//   - "email" (full email address)
+	//   - "email_localpart" (portion before '@')
+	//   - "name" (full display name)
+	//   - "sub" (subject)
+	// If empty, the default order is: preferred_username, email_localpart, email, name, sub.
+	UsernameClaimOrder []string
 }
 
 type DERPConfig struct {

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -919,6 +919,18 @@ func oidcMockUser(username string, emailVerified bool) mockoidc.MockUser {
 	}
 }
 
+// oidcMockUserNoPreferredUsername creates a MockUser without PreferredUsername claim.
+// This simulates OIDC providers (like Google) that don't include preferred_username in their claims,
+// useful for testing username derivation from alternative claims (email, subject, etc).
+func oidcMockUserNoPreferredUsername(subject, email string, emailVerified bool) mockoidc.MockUser {
+	return mockoidc.MockUser{
+		Subject:       subject,
+		Email:         email,
+		EmailVerified: emailVerified,
+		// PreferredUsername is intentionally empty
+	}
+}
+
 // GetUserByName retrieves a user by name from the headscale server.
 // This is a common pattern used when creating preauth keys or managing users.
 func GetUserByName(headscale ControlServer, username string) (*v1.User, error) {


### PR DESCRIPTION
Add support for deriving Headscale usernames from configurable OIDC claims, addressing IdPs (like Google) that omit the standard `preferred_username` claim.

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [x] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

Fixes #3002 

## Summary

This PR adds a configurable way to derive the Headscale username from OIDC claims. It addresses IdPs (like Google) that do not emit `preferred_username`, enabling predictable, valid usernames without manual remediation.

## Changes

- Config: Introduce `oidc.username_claim_order` (array) that defines a priority list of claims to try.
  - Supported values: `preferred_username`, `email_localpart`, `email`, `name`, `sub`.
  - Default (when unset): `[preferred_username, email_localpart, email, name, sub]`.
- Username derivation helper: picks the first non-empty, syntactically valid candidate using existing `ValidateUsername` rules.
- OIDC flow: applies the mapping before creating/updating the user record so `Username()` resolves reliably.
- Documentation: added configuration reference and OIDC guide notes (including Google example).
- Tests: unit tests covering the derivation and common fallback cases.

## Example Configuration

```yaml
oidc:
  issuer: "https://accounts.google.com"
  client_id: "..."
  client_secret: "..."
  # Prefer preferred_username, otherwise use email local-part, then email
  username_claim_order:
    - preferred_username
    - email_localpart
    - email
```

## Notes

- Candidates are tried in order and must pass `ValidateUsername`.
- If the list is omitted, the default order is used.
- Default behavior preserves existing installs where `preferred_username` is present.
- No database migrations required.
- Username syntax is validated; all email verification and authorization constraints remain unchanged.
