### PR TITLE
Fix node expiration success message

### DIFF
--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -276,7 +276,8 @@ var expireNodeCmd = &cobra.Command{
 
 			return
 		}
-		expiryTime := time.Now()
+		now := time.Now()
+		expiryTime := now
 		if expiry != "" {
 			expiryTime, err = time.Parse(time.RFC3339, expiry)
 			if err != nil {
@@ -311,7 +312,11 @@ var expireNodeCmd = &cobra.Command{
 			)
 		}
 
-		SuccessOutput(response.GetNode(), "Node expired", output)
+		if now.Equal(expiryTime) || now.After(expiryTime) {
+			SuccessOutput(response.GetNode(), "Node expired", output)
+		} else {
+			SuccessOutput(response.GetNode(), "Node expiration updated", output)
+		}
 	},
 }
 


### PR DESCRIPTION
A node is expired when the requested expiration is either now or in the past.

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
