### PR TITLE
feat: add client version to node list

### DIFF
--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -497,6 +497,7 @@ func nodesToPtables(
 		"Expiration",
 		"Connected",
 		"Expired",
+		"Client Version",
 	}
 	tableData := pterm.TableData{tableHeader}
 
@@ -596,6 +597,7 @@ func nodesToPtables(
 			expiryTime,
 			online,
 			expired,
+			node.GetClientVersion(),
 		}
 		tableData = append(
 			tableData,

--- a/gen/go/headscale/v1/node.pb.go
+++ b/gen/go/headscale/v1/node.pb.go
@@ -98,6 +98,7 @@ type Node struct {
 	AvailableRoutes []string `protobuf:"bytes,24,rep,name=available_routes,json=availableRoutes,proto3" json:"available_routes,omitempty"`
 	SubnetRoutes    []string `protobuf:"bytes,25,rep,name=subnet_routes,json=subnetRoutes,proto3" json:"subnet_routes,omitempty"`
 	Tags            []string `protobuf:"bytes,26,rep,name=tags,proto3" json:"tags,omitempty"`
+	ClientVersion   string   `protobuf:"bytes,27,opt,name=client_version,json=clientVersion,proto3" json:"client_version,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -256,6 +257,13 @@ func (x *Node) GetTags() []string {
 		return x.Tags
 	}
 	return nil
+}
+
+func (x *Node) GetClientVersion() string {
+	if x != nil {
+		return x.ClientVersion
+	}
+	return ""
 }
 
 type RegisterNodeRequest struct {

--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -412,6 +412,10 @@ func (node *Node) Proto() *v1.Node {
 		nodeProto.Expiry = timestamppb.New(*node.Expiry)
 	}
 
+	if node.Hostinfo != nil {
+		nodeProto.ClientVersion = node.Hostinfo.View().IPNVersion()
+	}
+
 	return nodeProto
 }
 

--- a/hscontrol/types/node_test.go
+++ b/hscontrol/types/node_test.go
@@ -969,3 +969,46 @@ func TestHasNetworkChanges(t *testing.T) {
 		})
 	}
 }
+
+func TestNodeProto_ClientVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		hostinfo    *tailcfg.Hostinfo
+		wantVersion string
+	}{
+		{
+			name:        "node-with-client-version",
+			hostinfo:    &tailcfg.Hostinfo{IPNVersion: "1.50.0"},
+			wantVersion: "1.50.0",
+		},
+		{
+			name:        "node-with-different-version",
+			hostinfo:    &tailcfg.Hostinfo{IPNVersion: "1.76.1"},
+			wantVersion: "1.76.1",
+		},
+		{
+			name:        "node-without-hostinfo",
+			hostinfo:    nil,
+			wantVersion: "",
+		},
+		{
+			name:        "node-with-empty-version",
+			hostinfo:    &tailcfg.Hostinfo{IPNVersion: ""},
+			wantVersion: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &Node{
+				ID:       1,
+				Hostname: "test-node",
+				Hostinfo: tt.hostinfo,
+			}
+			proto := node.Proto()
+			if got := proto.GetClientVersion(); got != tt.wantVersion {
+				t.Errorf("Proto().GetClientVersion() = %q, want %q", got, tt.wantVersion)
+			}
+		})
+	}
+}

--- a/proto/headscale/v1/node.proto
+++ b/proto/headscale/v1/node.proto
@@ -53,6 +53,7 @@ message Node {
   repeated string available_routes = 24;
   repeated string subnet_routes = 25;
   repeated string tags = 26;
+  string client_version = 27;
 }
 
 message RegisterNodeRequest {


### PR DESCRIPTION
Adds client_version field to the Node proto message and displays it in the 'headscale nodes list' CLI output.
Includes unit tests for client version extraction from Hostinfo.
Fixes #2356
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.
This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.
Headscale is open to code contributions for bug fixes without discussion.
If you find mistakes in the documentation, please submit a fix to the documentation.
-->
<!-- Please tick if the following things apply. You… -->
- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md
<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->