### PR TITLE
feat(oidc): add use_email_as_username option to fall back to email claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ overall our implementation was very close.
 - **ACL Policy**: Fix autogroup:self handling for tagged nodes - tagged nodes no longer incorrectly receive autogroup:self filter rules [#3036](https://github.com/juanfont/headscale/pull/3036)
 - **ACL Policy**: Use CIDR format for autogroup:self destination IPs matching Tailscale behavior [#3036](https://github.com/juanfont/headscale/pull/3036)
 - **ACL Policy**: Merge filter rules with identical SrcIPs and IPProto matching Tailscale behavior - multiple ACL rules with the same source now produce a single FilterRule with combined DstPorts [#3036](https://github.com/juanfont/headscale/pull/3036)
+- **OIDC**: Add `oidc.use_email_as_username` config option to fall back to the `email` claim as username when `preferred_username` is not available. Useful for providers like Google OAuth that don't include `preferred_username`. Disabled by default for backward compatibility. [#3072](https://github.com/juanfont/headscale/pull/3072)
 
 ## 0.28.0 (2026-02-04)
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -368,6 +368,12 @@ unix_socket_permission: "0770"
 #   # not required.
 #   email_verified_required: true
 #
+#   # Use the email claim as the username when the identity provider does not
+#   # send the "preferred_username" claim. When preferred_username is present,
+#   # it is always used regardless of this setting. Useful for providers like
+#   # Google OAuth that don't include preferred_username.
+#   use_email_as_username: false
+#
 #   # Provide custom key/value pairs which get sent to the identity provider's
 #   # authorization endpoint.
 #   extra_params:

--- a/docs/ref/oidc.md
+++ b/docs/ref/oidc.md
@@ -142,6 +142,22 @@ oidc:
   email_verified_required: false
 ```
 
+### Use email as username
+
+Some identity providers (e.g. Google OAuth) do not send the `preferred_username` claim when the scope `profile` is
+requested. This causes the username in Headscale to be blank/not set. When `use_email_as_username` is enabled,
+Headscale will fall back to using the `email` claim as the username if `preferred_username` is not available.
+
+When `preferred_username` is present, it is always used regardless of this setting.
+
+```yaml hl_lines="5"
+oidc:
+  issuer: "https://sso.example.com"
+  client_id: "headscale"
+  client_secret: "generated-secret"
+  use_email_as_username: true
+```
+
 ### Customize node expiration
 
 The node expiration is the amount of time a node is authenticated with OpenID Connect until it expires and needs to
@@ -210,7 +226,7 @@ endpoint.
 | ------------------- | -------------------- | ------------------------------------------------------------------------------------------------- |
 | email address       | `email`              | Only verified emails are synchronized, unless `email_verified_required: false` is configured      |
 | display name        | `name`               | eg: `Sam Smith`                                                                                   |
-| username            | `preferred_username` | Depends on identity provider, eg: `ssmith`, `ssmith@idp.example.com`, `\\example.com\ssmith`      |
+| username            | `preferred_username` | Depends on identity provider, eg: `ssmith`, `ssmith@idp.example.com`, `\\example.com\ssmith`. Falls back to `email` if [use_email_as_username](#use-email-as-username) is enabled.      |
 | profile picture     | `picture`            | URL to a profile picture or avatar                                                                |
 | provider identifier | `iss`, `sub`         | A stable and unique identifier for a user, typically a combination of `iss` and `sub` OIDC claims |
 |                     | `groups`             | [Only used to filter for allowed groups](#authorize-users-with-filters)                           |
@@ -258,7 +274,7 @@ Authelia is fully supported by Headscale.
 !!! warning "No username due to missing preferred_username"
 
     Google OAuth does not send the `preferred_username` claim when the scope `profile` is requested. The username in
-    Headscale will be blank/not set.
+    Headscale will be blank/not set unless [`use_email_as_username`](#use-email-as-username) is enabled.
 
 In order to integrate Headscale with Google, you'll need to have a [Google Cloud
 Console](https://console.cloud.google.com) account.

--- a/hscontrol/oidc.go
+++ b/hscontrol/oidc.go
@@ -540,7 +540,7 @@ func (a *AuthProviderOIDC) createOrUpdateUserFromClaim(
 		user = &types.User{}
 	}
 
-	user.FromClaim(claims, a.cfg.EmailVerifiedRequired)
+	user.FromClaim(claims, a.cfg.EmailVerifiedRequired, a.cfg.UseEmailAsUsername)
 
 	if newUser {
 		user, c, err = a.h.state.CreateUser(*user)

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -188,6 +188,7 @@ type OIDCConfig struct {
 	AllowedUsers               []string
 	AllowedGroups              []string
 	EmailVerifiedRequired      bool
+	UseEmailAsUsername         bool
 	Expiry                     time.Duration
 	UseExpiryFromToken         bool
 	PKCE                       PKCEConfig
@@ -390,6 +391,7 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("oidc.pkce.enabled", false)
 	viper.SetDefault("oidc.pkce.method", "S256")
 	viper.SetDefault("oidc.email_verified_required", true)
+	viper.SetDefault("oidc.use_email_as_username", false)
 
 	viper.SetDefault("logtail.enabled", false)
 	viper.SetDefault("randomize_client_port", false)
@@ -1044,6 +1046,7 @@ func LoadServerConfig() (*Config, error) {
 			AllowedUsers:          viper.GetStringSlice("oidc.allowed_users"),
 			AllowedGroups:         viper.GetStringSlice("oidc.allowed_groups"),
 			EmailVerifiedRequired: viper.GetBool("oidc.email_verified_required"),
+			UseEmailAsUsername:    viper.GetBool("oidc.use_email_as_username"),
 			Expiry: func() time.Duration {
 				// if set to 0, we assume no expiry
 				if value := viper.GetString("oidc.expiry"); value == "0" {


### PR DESCRIPTION
Some OIDC providers (e.g. Google OAuth) do not send the preferred_username claim when the profile scope is requested, causing the username in Headscale to be blank.

Add oidc.use_email_as_username config option (default: false) that, when enabled, uses the email claim as the username if preferred_username is not available. When preferred_username is present, it is always used regardless of this setting.

- Add UseEmailAsUsername to OIDCConfig with viper wiring
- Extend FromClaim() to accept useEmailAsUsername parameter
- Add 5 test cases covering fallback enabled/disabled, priority, empty email, and unverified email scenarios
- Update docs, config example, and Google OAuth guidance

Fixes #3071.

Cheers!

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand (#3071 )
- [x] added unit tests
- [x] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
