### PR TITLE
docs(faq): fix minor formatting issue in FAQ

### DIFF
--- a/docs/about/faq.md
+++ b/docs/about/faq.md
@@ -73,12 +73,12 @@ of Headscale:
 
 1. An environment with 1000 servers
 
-   - they rarely "move" (change their endpoints)
-   - new nodes are added rarely
+     - they rarely "move" (change their endpoints)
+     - new nodes are added rarely
 
 2. An environment with 80 laptops/phones (end user devices)
 
-   - nodes move often, e.g. switching from home to office
+     - nodes move often, e.g. switching from home to office
 
 Headscale calculates a map of all nodes that need to talk to each other,
 creating this "world map" requires a lot of CPU time. When an event that


### PR DESCRIPTION
This just fixes a small issue I noticed reading the docs: the two 'scenarios' listed in the scaling section end up showing up as a numbered list of five items, instead of the desired two items + their descriptions.

Before:

<img width="866" height="328" alt="image" src="https://github.com/user-attachments/assets/bc672362-0702-4c89-8681-6ed9359e4089" />

After:

<img width="864" height="327" alt="image" src="https://github.com/user-attachments/assets/d323cde8-d2bf-436c-82a4-59526ba80a7c" />


<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
  - It's just a doc update
- [ ] added unit tests
  - It's just a doc update
- [ ] added integration tests
  - It's just a doc update
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md
  - It's just a doc update

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
