### PR TITLE
fix(policy/v2): use TrimPrefix for leading @ in username resolution

### DIFF
--- a/hscontrol/policy/v2/types.go
+++ b/hscontrol/policy/v2/types.go
@@ -233,11 +233,11 @@ func (u *Username) CanBeAutoApprover() bool {
 func (u *Username) resolveUser(users types.Users) (types.User, error) {
 	var potentialUsers types.Users
 
-	// At parsetime, we require all usernames to contain an "@" character, if the
-	// username token does not naturally do so (like email), the user have to
-	// add it to the end of the username. We strip it here as we do not expect the
-	// usernames to be stored with the "@".
-	uTrimmed := strings.TrimSuffix(u.String(), "@")
+	// At parsetime, we require all usernames to contain an "@" character.
+	// The policy format uses a leading "@" (e.g., "@username"), while email-style
+	// identifiers have it naturally. Strip both leading and trailing "@" since
+	// usernames are stored without the "@" prefix.
+	uTrimmed := strings.TrimPrefix(strings.TrimSuffix(u.String(), "@"), "@")
 
 	for _, user := range users {
 		if user.ProviderIdentifier.Valid && user.ProviderIdentifier.String == uTrimmed {


### PR DESCRIPTION
## Summary

- Fix `Username.resolveUser` to strip the **leading** `@` from usernames using `TrimPrefix` instead of `TrimSuffix`
- The ACL policy format uses `@username` (leading `@`), but `TrimSuffix` only strips a trailing `@`, so no group member usernames ever matched, causing all group-based ACL rules to silently compile to empty filter sets

## Root Cause

```go
// Before (bug): trailing @ stripped, but policy uses leading @
uTrimmed := strings.TrimSuffix(u.String(), "@")
// "@laronica.lawson" → "@laronica.lawson" (unchanged, never matches)

// After (fix): strip both leading and trailing @
uTrimmed := strings.TrimPrefix(strings.TrimSuffix(u.String(), "@"), "@")
// "@laronica.lawson" → "laronica.lawson" (matches user.Name)
```

## Impact

This bug caused:
- All group-based ACL source rules to produce empty IP sets (silently skipped)
- `/debug/filter` returning `null` when only group-based rules exist
- `ReduceRoutes` and `BuildPeerMap` seeing no matchers, so subnet routes were never distributed to group members
- The `src: *` workaround bypassed the bug because wildcard sources don't go through `resolveUser`

## Verification

Tested on a live headscale v0.27.1 deployment with:
- A subnet router advertising `10.0.0.0/8` and a 4via6 prefix
- Group-based ACLs (`group:n8n → n8n-svc:5678`)
- Before fix: `/debug/filter` = `null`, router not visible in peer netmap
- After fix: filter rules correctly compiled, router visible with scoped routes, end-to-end connectivity confirmed

All existing policy tests pass.

Fixes #3104