### PR TITLE
hscontrol/users: add SetUser API and CLI to update user profile fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ overall our implementation was very close.
 
 ### Changes
 
+- **Users**: Add `headscale users set` CLI command and `SetUser` gRPC/REST API (`PUT /api/v1/user/{id}`) to update a user's `display_name`, `email`, and `profile_pic_url` on existing users [#2166](https://github.com/juanfont/headscale/issues/2166)
 - **ACL Policy**: Add ICMP and IPv6-ICMP protocols to default filter rules when no protocol is specified [#3036](https://github.com/juanfont/headscale/pull/3036)
 - **ACL Policy**: Fix autogroup:self handling for tagged nodes - tagged nodes no longer incorrectly receive autogroup:self filter rules [#3036](https://github.com/juanfont/headscale/pull/3036)
 - **ACL Policy**: Use CIDR format for autogroup:self destination IPs matching Tailscale behavior [#3036](https://github.com/juanfont/headscale/pull/3036)

--- a/cmd/headscale/cli/users.go
+++ b/cmd/headscale/cli/users.go
@@ -19,6 +19,7 @@ import (
 var (
 	errFlagRequired       = errors.New("--name or --identifier flag is required")
 	errMultipleUsersMatch = errors.New("multiple users match query, specify an ID")
+	errNoFieldsProvided   = errors.New("at least one of --display-name, --email, or --picture-url must be provided")
 )
 
 func usernameAndIDFlag(cmd *cobra.Command) {
@@ -59,6 +60,11 @@ func init() {
 	usernameAndIDFlag(renameUserCmd)
 	renameUserCmd.Flags().StringP("new-name", "r", "", "New username")
 	mustMarkRequired(renameUserCmd, "new-name")
+	userCmd.AddCommand(setUserCmd)
+	usernameAndIDFlag(setUserCmd)
+	setUserCmd.Flags().StringP("display-name", "d", "", "Display name")
+	setUserCmd.Flags().StringP("email", "e", "", "Email")
+	setUserCmd.Flags().StringP("picture-url", "p", "", "Profile picture URL")
 }
 
 var userCmd = &cobra.Command{
@@ -94,7 +100,7 @@ var createUserCmd = &cobra.Command{
 		}
 
 		if pictureURL, _ := cmd.Flags().GetString("picture-url"); pictureURL != "" {
-			if _, err := url.Parse(pictureURL); err != nil { //nolint:noinlineerr
+			if _, err := url.ParseRequestURI(pictureURL); err != nil { //nolint:noinlineerr
 				return fmt.Errorf("invalid picture URL: %w", err)
 			}
 
@@ -239,5 +245,61 @@ var renameUserCmd = &cobra.Command{
 		}
 
 		return printOutput(cmd, response.GetUser(), "User renamed")
+	}),
+}
+
+var setUserCmd = &cobra.Command{
+	Use:     "set --identifier ID or --name NAME",
+	Short:   "Update a user's display name, email, or profile picture URL",
+	Aliases: []string{"update"},
+	RunE: grpcRunE(func(ctx context.Context, client v1.HeadscaleServiceClient, cmd *cobra.Command, args []string) error {
+		id, username, err := usernameAndIDFromFlag(cmd)
+		if err != nil {
+			return err
+		}
+
+		listReq := &v1.ListUsersRequest{
+			Name: username,
+			Id:   id,
+		}
+
+		users, err := client.ListUsers(ctx, listReq)
+		if err != nil {
+			return fmt.Errorf("listing users: %w", err)
+		}
+
+		if len(users.GetUsers()) != 1 {
+			return errMultipleUsersMatch
+		}
+
+		user := users.GetUsers()[0]
+
+		setReq := &v1.SetUserRequest{Id: user.GetId()}
+
+		if cmd.Flags().Changed("display-name") {
+			displayName, _ := cmd.Flags().GetString("display-name")
+			setReq.DisplayName = &displayName
+		}
+
+		if cmd.Flags().Changed("email") {
+			email, _ := cmd.Flags().GetString("email")
+			setReq.Email = &email
+		}
+
+		if cmd.Flags().Changed("picture-url") {
+			pictureURL, _ := cmd.Flags().GetString("picture-url")
+			setReq.PictureUrl = &pictureURL
+		}
+
+		if setReq.DisplayName == nil && setReq.Email == nil && setReq.PictureUrl == nil {
+			return errNoFieldsProvided
+		}
+
+		response, err := client.SetUser(ctx, setReq)
+		if err != nil {
+			return fmt.Errorf("setting user: %w", err)
+		}
+
+		return printOutput(cmd, response.GetUser(), "User updated")
 	}),
 }

--- a/gen/go/headscale/v1/headscale.pb.go
+++ b/gen/go/headscale/v1/headscale.pb.go
@@ -109,7 +109,7 @@ const file_headscale_v1_headscale_proto_rawDesc = "" +
 	"\x1cheadscale/v1/headscale.proto\x12\fheadscale.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x17headscale/v1/user.proto\x1a\x1dheadscale/v1/preauthkey.proto\x1a\x17headscale/v1/node.proto\x1a\x19headscale/v1/apikey.proto\x1a\x19headscale/v1/policy.proto\"\x0f\n" +
 	"\rHealthRequest\"E\n" +
 	"\x0eHealthResponse\x123\n" +
-	"\x15database_connectivity\x18\x01 \x01(\bR\x14databaseConnectivity2\x8c\x17\n" +
+	"\x15database_connectivity\x18\x01 \x01(\bR\x14databaseConnectivity2\xf2\x17\n" +
 	"\x10HeadscaleService\x12h\n" +
 	"\n" +
 	"CreateUser\x12\x1f.headscale.v1.CreateUserRequest\x1a .headscale.v1.CreateUserResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\"\f/api/v1/user\x12\x80\x01\n" +
@@ -117,7 +117,8 @@ const file_headscale_v1_headscale_proto_rawDesc = "" +
 	"RenameUser\x12\x1f.headscale.v1.RenameUserRequest\x1a .headscale.v1.RenameUserResponse\"/\x82\xd3\xe4\x93\x02)\"'/api/v1/user/{old_id}/rename/{new_name}\x12j\n" +
 	"\n" +
 	"DeleteUser\x12\x1f.headscale.v1.DeleteUserRequest\x1a .headscale.v1.DeleteUserResponse\"\x19\x82\xd3\xe4\x93\x02\x13*\x11/api/v1/user/{id}\x12b\n" +
-	"\tListUsers\x12\x1e.headscale.v1.ListUsersRequest\x1a\x1f.headscale.v1.ListUsersResponse\"\x14\x82\xd3\xe4\x93\x02\x0e\x12\f/api/v1/user\x12\x80\x01\n" +
+	"\tListUsers\x12\x1e.headscale.v1.ListUsersRequest\x1a\x1f.headscale.v1.ListUsersResponse\"\x14\x82\xd3\xe4\x93\x02\x0e\x12\f/api/v1/user\x12d\n" +
+	"\aSetUser\x12\x1c.headscale.v1.SetUserRequest\x1a\x1d.headscale.v1.SetUserResponse\"\x1c\x82\xd3\xe4\x93\x02\x16:\x01*\x1a\x11/api/v1/user/{id}\x12\x80\x01\n" +
 	"\x10CreatePreAuthKey\x12%.headscale.v1.CreatePreAuthKeyRequest\x1a&.headscale.v1.CreatePreAuthKeyResponse\"\x1d\x82\xd3\xe4\x93\x02\x17:\x01*\"\x12/api/v1/preauthkey\x12\x87\x01\n" +
 	"\x10ExpirePreAuthKey\x12%.headscale.v1.ExpirePreAuthKeyRequest\x1a&.headscale.v1.ExpirePreAuthKeyResponse\"$\x82\xd3\xe4\x93\x02\x1e:\x01*\"\x19/api/v1/preauthkey/expire\x12}\n" +
 	"\x10DeletePreAuthKey\x12%.headscale.v1.DeletePreAuthKeyRequest\x1a&.headscale.v1.DeletePreAuthKeyResponse\"\x1a\x82\xd3\xe4\x93\x02\x14*\x12/api/v1/preauthkey\x12z\n" +
@@ -163,104 +164,108 @@ var file_headscale_v1_headscale_proto_goTypes = []any{
 	(*RenameUserRequest)(nil),         // 3: headscale.v1.RenameUserRequest
 	(*DeleteUserRequest)(nil),         // 4: headscale.v1.DeleteUserRequest
 	(*ListUsersRequest)(nil),          // 5: headscale.v1.ListUsersRequest
-	(*CreatePreAuthKeyRequest)(nil),   // 6: headscale.v1.CreatePreAuthKeyRequest
-	(*ExpirePreAuthKeyRequest)(nil),   // 7: headscale.v1.ExpirePreAuthKeyRequest
-	(*DeletePreAuthKeyRequest)(nil),   // 8: headscale.v1.DeletePreAuthKeyRequest
-	(*ListPreAuthKeysRequest)(nil),    // 9: headscale.v1.ListPreAuthKeysRequest
-	(*DebugCreateNodeRequest)(nil),    // 10: headscale.v1.DebugCreateNodeRequest
-	(*GetNodeRequest)(nil),            // 11: headscale.v1.GetNodeRequest
-	(*SetTagsRequest)(nil),            // 12: headscale.v1.SetTagsRequest
-	(*SetApprovedRoutesRequest)(nil),  // 13: headscale.v1.SetApprovedRoutesRequest
-	(*RegisterNodeRequest)(nil),       // 14: headscale.v1.RegisterNodeRequest
-	(*DeleteNodeRequest)(nil),         // 15: headscale.v1.DeleteNodeRequest
-	(*ExpireNodeRequest)(nil),         // 16: headscale.v1.ExpireNodeRequest
-	(*RenameNodeRequest)(nil),         // 17: headscale.v1.RenameNodeRequest
-	(*ListNodesRequest)(nil),          // 18: headscale.v1.ListNodesRequest
-	(*BackfillNodeIPsRequest)(nil),    // 19: headscale.v1.BackfillNodeIPsRequest
-	(*CreateApiKeyRequest)(nil),       // 20: headscale.v1.CreateApiKeyRequest
-	(*ExpireApiKeyRequest)(nil),       // 21: headscale.v1.ExpireApiKeyRequest
-	(*ListApiKeysRequest)(nil),        // 22: headscale.v1.ListApiKeysRequest
-	(*DeleteApiKeyRequest)(nil),       // 23: headscale.v1.DeleteApiKeyRequest
-	(*GetPolicyRequest)(nil),          // 24: headscale.v1.GetPolicyRequest
-	(*SetPolicyRequest)(nil),          // 25: headscale.v1.SetPolicyRequest
-	(*CreateUserResponse)(nil),        // 26: headscale.v1.CreateUserResponse
-	(*RenameUserResponse)(nil),        // 27: headscale.v1.RenameUserResponse
-	(*DeleteUserResponse)(nil),        // 28: headscale.v1.DeleteUserResponse
-	(*ListUsersResponse)(nil),         // 29: headscale.v1.ListUsersResponse
-	(*CreatePreAuthKeyResponse)(nil),  // 30: headscale.v1.CreatePreAuthKeyResponse
-	(*ExpirePreAuthKeyResponse)(nil),  // 31: headscale.v1.ExpirePreAuthKeyResponse
-	(*DeletePreAuthKeyResponse)(nil),  // 32: headscale.v1.DeletePreAuthKeyResponse
-	(*ListPreAuthKeysResponse)(nil),   // 33: headscale.v1.ListPreAuthKeysResponse
-	(*DebugCreateNodeResponse)(nil),   // 34: headscale.v1.DebugCreateNodeResponse
-	(*GetNodeResponse)(nil),           // 35: headscale.v1.GetNodeResponse
-	(*SetTagsResponse)(nil),           // 36: headscale.v1.SetTagsResponse
-	(*SetApprovedRoutesResponse)(nil), // 37: headscale.v1.SetApprovedRoutesResponse
-	(*RegisterNodeResponse)(nil),      // 38: headscale.v1.RegisterNodeResponse
-	(*DeleteNodeResponse)(nil),        // 39: headscale.v1.DeleteNodeResponse
-	(*ExpireNodeResponse)(nil),        // 40: headscale.v1.ExpireNodeResponse
-	(*RenameNodeResponse)(nil),        // 41: headscale.v1.RenameNodeResponse
-	(*ListNodesResponse)(nil),         // 42: headscale.v1.ListNodesResponse
-	(*BackfillNodeIPsResponse)(nil),   // 43: headscale.v1.BackfillNodeIPsResponse
-	(*CreateApiKeyResponse)(nil),      // 44: headscale.v1.CreateApiKeyResponse
-	(*ExpireApiKeyResponse)(nil),      // 45: headscale.v1.ExpireApiKeyResponse
-	(*ListApiKeysResponse)(nil),       // 46: headscale.v1.ListApiKeysResponse
-	(*DeleteApiKeyResponse)(nil),      // 47: headscale.v1.DeleteApiKeyResponse
-	(*GetPolicyResponse)(nil),         // 48: headscale.v1.GetPolicyResponse
-	(*SetPolicyResponse)(nil),         // 49: headscale.v1.SetPolicyResponse
+	(*SetUserRequest)(nil),            // 6: headscale.v1.SetUserRequest
+	(*CreatePreAuthKeyRequest)(nil),   // 7: headscale.v1.CreatePreAuthKeyRequest
+	(*ExpirePreAuthKeyRequest)(nil),   // 8: headscale.v1.ExpirePreAuthKeyRequest
+	(*DeletePreAuthKeyRequest)(nil),   // 9: headscale.v1.DeletePreAuthKeyRequest
+	(*ListPreAuthKeysRequest)(nil),    // 10: headscale.v1.ListPreAuthKeysRequest
+	(*DebugCreateNodeRequest)(nil),    // 11: headscale.v1.DebugCreateNodeRequest
+	(*GetNodeRequest)(nil),            // 12: headscale.v1.GetNodeRequest
+	(*SetTagsRequest)(nil),            // 13: headscale.v1.SetTagsRequest
+	(*SetApprovedRoutesRequest)(nil),  // 14: headscale.v1.SetApprovedRoutesRequest
+	(*RegisterNodeRequest)(nil),       // 15: headscale.v1.RegisterNodeRequest
+	(*DeleteNodeRequest)(nil),         // 16: headscale.v1.DeleteNodeRequest
+	(*ExpireNodeRequest)(nil),         // 17: headscale.v1.ExpireNodeRequest
+	(*RenameNodeRequest)(nil),         // 18: headscale.v1.RenameNodeRequest
+	(*ListNodesRequest)(nil),          // 19: headscale.v1.ListNodesRequest
+	(*BackfillNodeIPsRequest)(nil),    // 20: headscale.v1.BackfillNodeIPsRequest
+	(*CreateApiKeyRequest)(nil),       // 21: headscale.v1.CreateApiKeyRequest
+	(*ExpireApiKeyRequest)(nil),       // 22: headscale.v1.ExpireApiKeyRequest
+	(*ListApiKeysRequest)(nil),        // 23: headscale.v1.ListApiKeysRequest
+	(*DeleteApiKeyRequest)(nil),       // 24: headscale.v1.DeleteApiKeyRequest
+	(*GetPolicyRequest)(nil),          // 25: headscale.v1.GetPolicyRequest
+	(*SetPolicyRequest)(nil),          // 26: headscale.v1.SetPolicyRequest
+	(*CreateUserResponse)(nil),        // 27: headscale.v1.CreateUserResponse
+	(*RenameUserResponse)(nil),        // 28: headscale.v1.RenameUserResponse
+	(*DeleteUserResponse)(nil),        // 29: headscale.v1.DeleteUserResponse
+	(*ListUsersResponse)(nil),         // 30: headscale.v1.ListUsersResponse
+	(*SetUserResponse)(nil),           // 31: headscale.v1.SetUserResponse
+	(*CreatePreAuthKeyResponse)(nil),  // 32: headscale.v1.CreatePreAuthKeyResponse
+	(*ExpirePreAuthKeyResponse)(nil),  // 33: headscale.v1.ExpirePreAuthKeyResponse
+	(*DeletePreAuthKeyResponse)(nil),  // 34: headscale.v1.DeletePreAuthKeyResponse
+	(*ListPreAuthKeysResponse)(nil),   // 35: headscale.v1.ListPreAuthKeysResponse
+	(*DebugCreateNodeResponse)(nil),   // 36: headscale.v1.DebugCreateNodeResponse
+	(*GetNodeResponse)(nil),           // 37: headscale.v1.GetNodeResponse
+	(*SetTagsResponse)(nil),           // 38: headscale.v1.SetTagsResponse
+	(*SetApprovedRoutesResponse)(nil), // 39: headscale.v1.SetApprovedRoutesResponse
+	(*RegisterNodeResponse)(nil),      // 40: headscale.v1.RegisterNodeResponse
+	(*DeleteNodeResponse)(nil),        // 41: headscale.v1.DeleteNodeResponse
+	(*ExpireNodeResponse)(nil),        // 42: headscale.v1.ExpireNodeResponse
+	(*RenameNodeResponse)(nil),        // 43: headscale.v1.RenameNodeResponse
+	(*ListNodesResponse)(nil),         // 44: headscale.v1.ListNodesResponse
+	(*BackfillNodeIPsResponse)(nil),   // 45: headscale.v1.BackfillNodeIPsResponse
+	(*CreateApiKeyResponse)(nil),      // 46: headscale.v1.CreateApiKeyResponse
+	(*ExpireApiKeyResponse)(nil),      // 47: headscale.v1.ExpireApiKeyResponse
+	(*ListApiKeysResponse)(nil),       // 48: headscale.v1.ListApiKeysResponse
+	(*DeleteApiKeyResponse)(nil),      // 49: headscale.v1.DeleteApiKeyResponse
+	(*GetPolicyResponse)(nil),         // 50: headscale.v1.GetPolicyResponse
+	(*SetPolicyResponse)(nil),         // 51: headscale.v1.SetPolicyResponse
 }
 var file_headscale_v1_headscale_proto_depIdxs = []int32{
 	2,  // 0: headscale.v1.HeadscaleService.CreateUser:input_type -> headscale.v1.CreateUserRequest
 	3,  // 1: headscale.v1.HeadscaleService.RenameUser:input_type -> headscale.v1.RenameUserRequest
 	4,  // 2: headscale.v1.HeadscaleService.DeleteUser:input_type -> headscale.v1.DeleteUserRequest
 	5,  // 3: headscale.v1.HeadscaleService.ListUsers:input_type -> headscale.v1.ListUsersRequest
-	6,  // 4: headscale.v1.HeadscaleService.CreatePreAuthKey:input_type -> headscale.v1.CreatePreAuthKeyRequest
-	7,  // 5: headscale.v1.HeadscaleService.ExpirePreAuthKey:input_type -> headscale.v1.ExpirePreAuthKeyRequest
-	8,  // 6: headscale.v1.HeadscaleService.DeletePreAuthKey:input_type -> headscale.v1.DeletePreAuthKeyRequest
-	9,  // 7: headscale.v1.HeadscaleService.ListPreAuthKeys:input_type -> headscale.v1.ListPreAuthKeysRequest
-	10, // 8: headscale.v1.HeadscaleService.DebugCreateNode:input_type -> headscale.v1.DebugCreateNodeRequest
-	11, // 9: headscale.v1.HeadscaleService.GetNode:input_type -> headscale.v1.GetNodeRequest
-	12, // 10: headscale.v1.HeadscaleService.SetTags:input_type -> headscale.v1.SetTagsRequest
-	13, // 11: headscale.v1.HeadscaleService.SetApprovedRoutes:input_type -> headscale.v1.SetApprovedRoutesRequest
-	14, // 12: headscale.v1.HeadscaleService.RegisterNode:input_type -> headscale.v1.RegisterNodeRequest
-	15, // 13: headscale.v1.HeadscaleService.DeleteNode:input_type -> headscale.v1.DeleteNodeRequest
-	16, // 14: headscale.v1.HeadscaleService.ExpireNode:input_type -> headscale.v1.ExpireNodeRequest
-	17, // 15: headscale.v1.HeadscaleService.RenameNode:input_type -> headscale.v1.RenameNodeRequest
-	18, // 16: headscale.v1.HeadscaleService.ListNodes:input_type -> headscale.v1.ListNodesRequest
-	19, // 17: headscale.v1.HeadscaleService.BackfillNodeIPs:input_type -> headscale.v1.BackfillNodeIPsRequest
-	20, // 18: headscale.v1.HeadscaleService.CreateApiKey:input_type -> headscale.v1.CreateApiKeyRequest
-	21, // 19: headscale.v1.HeadscaleService.ExpireApiKey:input_type -> headscale.v1.ExpireApiKeyRequest
-	22, // 20: headscale.v1.HeadscaleService.ListApiKeys:input_type -> headscale.v1.ListApiKeysRequest
-	23, // 21: headscale.v1.HeadscaleService.DeleteApiKey:input_type -> headscale.v1.DeleteApiKeyRequest
-	24, // 22: headscale.v1.HeadscaleService.GetPolicy:input_type -> headscale.v1.GetPolicyRequest
-	25, // 23: headscale.v1.HeadscaleService.SetPolicy:input_type -> headscale.v1.SetPolicyRequest
-	0,  // 24: headscale.v1.HeadscaleService.Health:input_type -> headscale.v1.HealthRequest
-	26, // 25: headscale.v1.HeadscaleService.CreateUser:output_type -> headscale.v1.CreateUserResponse
-	27, // 26: headscale.v1.HeadscaleService.RenameUser:output_type -> headscale.v1.RenameUserResponse
-	28, // 27: headscale.v1.HeadscaleService.DeleteUser:output_type -> headscale.v1.DeleteUserResponse
-	29, // 28: headscale.v1.HeadscaleService.ListUsers:output_type -> headscale.v1.ListUsersResponse
-	30, // 29: headscale.v1.HeadscaleService.CreatePreAuthKey:output_type -> headscale.v1.CreatePreAuthKeyResponse
-	31, // 30: headscale.v1.HeadscaleService.ExpirePreAuthKey:output_type -> headscale.v1.ExpirePreAuthKeyResponse
-	32, // 31: headscale.v1.HeadscaleService.DeletePreAuthKey:output_type -> headscale.v1.DeletePreAuthKeyResponse
-	33, // 32: headscale.v1.HeadscaleService.ListPreAuthKeys:output_type -> headscale.v1.ListPreAuthKeysResponse
-	34, // 33: headscale.v1.HeadscaleService.DebugCreateNode:output_type -> headscale.v1.DebugCreateNodeResponse
-	35, // 34: headscale.v1.HeadscaleService.GetNode:output_type -> headscale.v1.GetNodeResponse
-	36, // 35: headscale.v1.HeadscaleService.SetTags:output_type -> headscale.v1.SetTagsResponse
-	37, // 36: headscale.v1.HeadscaleService.SetApprovedRoutes:output_type -> headscale.v1.SetApprovedRoutesResponse
-	38, // 37: headscale.v1.HeadscaleService.RegisterNode:output_type -> headscale.v1.RegisterNodeResponse
-	39, // 38: headscale.v1.HeadscaleService.DeleteNode:output_type -> headscale.v1.DeleteNodeResponse
-	40, // 39: headscale.v1.HeadscaleService.ExpireNode:output_type -> headscale.v1.ExpireNodeResponse
-	41, // 40: headscale.v1.HeadscaleService.RenameNode:output_type -> headscale.v1.RenameNodeResponse
-	42, // 41: headscale.v1.HeadscaleService.ListNodes:output_type -> headscale.v1.ListNodesResponse
-	43, // 42: headscale.v1.HeadscaleService.BackfillNodeIPs:output_type -> headscale.v1.BackfillNodeIPsResponse
-	44, // 43: headscale.v1.HeadscaleService.CreateApiKey:output_type -> headscale.v1.CreateApiKeyResponse
-	45, // 44: headscale.v1.HeadscaleService.ExpireApiKey:output_type -> headscale.v1.ExpireApiKeyResponse
-	46, // 45: headscale.v1.HeadscaleService.ListApiKeys:output_type -> headscale.v1.ListApiKeysResponse
-	47, // 46: headscale.v1.HeadscaleService.DeleteApiKey:output_type -> headscale.v1.DeleteApiKeyResponse
-	48, // 47: headscale.v1.HeadscaleService.GetPolicy:output_type -> headscale.v1.GetPolicyResponse
-	49, // 48: headscale.v1.HeadscaleService.SetPolicy:output_type -> headscale.v1.SetPolicyResponse
-	1,  // 49: headscale.v1.HeadscaleService.Health:output_type -> headscale.v1.HealthResponse
-	25, // [25:50] is the sub-list for method output_type
-	0,  // [0:25] is the sub-list for method input_type
+	6,  // 4: headscale.v1.HeadscaleService.SetUser:input_type -> headscale.v1.SetUserRequest
+	7,  // 5: headscale.v1.HeadscaleService.CreatePreAuthKey:input_type -> headscale.v1.CreatePreAuthKeyRequest
+	8,  // 6: headscale.v1.HeadscaleService.ExpirePreAuthKey:input_type -> headscale.v1.ExpirePreAuthKeyRequest
+	9,  // 7: headscale.v1.HeadscaleService.DeletePreAuthKey:input_type -> headscale.v1.DeletePreAuthKeyRequest
+	10, // 8: headscale.v1.HeadscaleService.ListPreAuthKeys:input_type -> headscale.v1.ListPreAuthKeysRequest
+	11, // 9: headscale.v1.HeadscaleService.DebugCreateNode:input_type -> headscale.v1.DebugCreateNodeRequest
+	12, // 10: headscale.v1.HeadscaleService.GetNode:input_type -> headscale.v1.GetNodeRequest
+	13, // 11: headscale.v1.HeadscaleService.SetTags:input_type -> headscale.v1.SetTagsRequest
+	14, // 12: headscale.v1.HeadscaleService.SetApprovedRoutes:input_type -> headscale.v1.SetApprovedRoutesRequest
+	15, // 13: headscale.v1.HeadscaleService.RegisterNode:input_type -> headscale.v1.RegisterNodeRequest
+	16, // 14: headscale.v1.HeadscaleService.DeleteNode:input_type -> headscale.v1.DeleteNodeRequest
+	17, // 15: headscale.v1.HeadscaleService.ExpireNode:input_type -> headscale.v1.ExpireNodeRequest
+	18, // 16: headscale.v1.HeadscaleService.RenameNode:input_type -> headscale.v1.RenameNodeRequest
+	19, // 17: headscale.v1.HeadscaleService.ListNodes:input_type -> headscale.v1.ListNodesRequest
+	20, // 18: headscale.v1.HeadscaleService.BackfillNodeIPs:input_type -> headscale.v1.BackfillNodeIPsRequest
+	21, // 19: headscale.v1.HeadscaleService.CreateApiKey:input_type -> headscale.v1.CreateApiKeyRequest
+	22, // 20: headscale.v1.HeadscaleService.ExpireApiKey:input_type -> headscale.v1.ExpireApiKeyRequest
+	23, // 21: headscale.v1.HeadscaleService.ListApiKeys:input_type -> headscale.v1.ListApiKeysRequest
+	24, // 22: headscale.v1.HeadscaleService.DeleteApiKey:input_type -> headscale.v1.DeleteApiKeyRequest
+	25, // 23: headscale.v1.HeadscaleService.GetPolicy:input_type -> headscale.v1.GetPolicyRequest
+	26, // 24: headscale.v1.HeadscaleService.SetPolicy:input_type -> headscale.v1.SetPolicyRequest
+	0,  // 25: headscale.v1.HeadscaleService.Health:input_type -> headscale.v1.HealthRequest
+	27, // 26: headscale.v1.HeadscaleService.CreateUser:output_type -> headscale.v1.CreateUserResponse
+	28, // 27: headscale.v1.HeadscaleService.RenameUser:output_type -> headscale.v1.RenameUserResponse
+	29, // 28: headscale.v1.HeadscaleService.DeleteUser:output_type -> headscale.v1.DeleteUserResponse
+	30, // 29: headscale.v1.HeadscaleService.ListUsers:output_type -> headscale.v1.ListUsersResponse
+	31, // 30: headscale.v1.HeadscaleService.SetUser:output_type -> headscale.v1.SetUserResponse
+	32, // 31: headscale.v1.HeadscaleService.CreatePreAuthKey:output_type -> headscale.v1.CreatePreAuthKeyResponse
+	33, // 32: headscale.v1.HeadscaleService.ExpirePreAuthKey:output_type -> headscale.v1.ExpirePreAuthKeyResponse
+	34, // 33: headscale.v1.HeadscaleService.DeletePreAuthKey:output_type -> headscale.v1.DeletePreAuthKeyResponse
+	35, // 34: headscale.v1.HeadscaleService.ListPreAuthKeys:output_type -> headscale.v1.ListPreAuthKeysResponse
+	36, // 35: headscale.v1.HeadscaleService.DebugCreateNode:output_type -> headscale.v1.DebugCreateNodeResponse
+	37, // 36: headscale.v1.HeadscaleService.GetNode:output_type -> headscale.v1.GetNodeResponse
+	38, // 37: headscale.v1.HeadscaleService.SetTags:output_type -> headscale.v1.SetTagsResponse
+	39, // 38: headscale.v1.HeadscaleService.SetApprovedRoutes:output_type -> headscale.v1.SetApprovedRoutesResponse
+	40, // 39: headscale.v1.HeadscaleService.RegisterNode:output_type -> headscale.v1.RegisterNodeResponse
+	41, // 40: headscale.v1.HeadscaleService.DeleteNode:output_type -> headscale.v1.DeleteNodeResponse
+	42, // 41: headscale.v1.HeadscaleService.ExpireNode:output_type -> headscale.v1.ExpireNodeResponse
+	43, // 42: headscale.v1.HeadscaleService.RenameNode:output_type -> headscale.v1.RenameNodeResponse
+	44, // 43: headscale.v1.HeadscaleService.ListNodes:output_type -> headscale.v1.ListNodesResponse
+	45, // 44: headscale.v1.HeadscaleService.BackfillNodeIPs:output_type -> headscale.v1.BackfillNodeIPsResponse
+	46, // 45: headscale.v1.HeadscaleService.CreateApiKey:output_type -> headscale.v1.CreateApiKeyResponse
+	47, // 46: headscale.v1.HeadscaleService.ExpireApiKey:output_type -> headscale.v1.ExpireApiKeyResponse
+	48, // 47: headscale.v1.HeadscaleService.ListApiKeys:output_type -> headscale.v1.ListApiKeysResponse
+	49, // 48: headscale.v1.HeadscaleService.DeleteApiKey:output_type -> headscale.v1.DeleteApiKeyResponse
+	50, // 49: headscale.v1.HeadscaleService.GetPolicy:output_type -> headscale.v1.GetPolicyResponse
+	51, // 50: headscale.v1.HeadscaleService.SetPolicy:output_type -> headscale.v1.SetPolicyResponse
+	1,  // 51: headscale.v1.HeadscaleService.Health:output_type -> headscale.v1.HealthResponse
+	26, // [26:52] is the sub-list for method output_type
+	0,  // [0:26] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/gen/go/headscale/v1/headscale.pb.gw.go
+++ b/gen/go/headscale/v1/headscale.pb.gw.go
@@ -191,6 +191,51 @@ func local_request_HeadscaleService_ListUsers_0(ctx context.Context, marshaler r
 	return msg, metadata, err
 }
 
+func request_HeadscaleService_SetUser_0(ctx context.Context, marshaler runtime.Marshaler, client HeadscaleServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SetUserRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.Uint64(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := client.SetUser(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_HeadscaleService_SetUser_0(ctx context.Context, marshaler runtime.Marshaler, server HeadscaleServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq SetUserRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+	protoReq.Id, err = runtime.Uint64(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+	msg, err := server.SetUser(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_HeadscaleService_CreatePreAuthKey_0(ctx context.Context, marshaler runtime.Marshaler, client HeadscaleServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq CreatePreAuthKeyRequest
@@ -992,6 +1037,26 @@ func RegisterHeadscaleServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_HeadscaleService_ListUsers_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPut, pattern_HeadscaleService_SetUser_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/headscale.v1.HeadscaleService/SetUser", runtime.WithHTTPPathPattern("/api/v1/user/{id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_HeadscaleService_SetUser_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_HeadscaleService_SetUser_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_HeadscaleService_CreatePreAuthKey_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -1520,6 +1585,23 @@ func RegisterHeadscaleServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_HeadscaleService_ListUsers_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPut, pattern_HeadscaleService_SetUser_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/headscale.v1.HeadscaleService/SetUser", runtime.WithHTTPPathPattern("/api/v1/user/{id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_HeadscaleService_SetUser_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_HeadscaleService_SetUser_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_HeadscaleService_CreatePreAuthKey_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -1885,6 +1967,7 @@ var (
 	pattern_HeadscaleService_RenameUser_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4, 1, 0, 4, 1, 5, 5}, []string{"api", "v1", "user", "old_id", "rename", "new_name"}, ""))
 	pattern_HeadscaleService_DeleteUser_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "user", "id"}, ""))
 	pattern_HeadscaleService_ListUsers_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "user"}, ""))
+	pattern_HeadscaleService_SetUser_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "user", "id"}, ""))
 	pattern_HeadscaleService_CreatePreAuthKey_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "preauthkey"}, ""))
 	pattern_HeadscaleService_ExpirePreAuthKey_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "preauthkey", "expire"}, ""))
 	pattern_HeadscaleService_DeletePreAuthKey_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "preauthkey"}, ""))
@@ -1913,6 +1996,7 @@ var (
 	forward_HeadscaleService_RenameUser_0        = runtime.ForwardResponseMessage
 	forward_HeadscaleService_DeleteUser_0        = runtime.ForwardResponseMessage
 	forward_HeadscaleService_ListUsers_0         = runtime.ForwardResponseMessage
+	forward_HeadscaleService_SetUser_0           = runtime.ForwardResponseMessage
 	forward_HeadscaleService_CreatePreAuthKey_0  = runtime.ForwardResponseMessage
 	forward_HeadscaleService_ExpirePreAuthKey_0  = runtime.ForwardResponseMessage
 	forward_HeadscaleService_DeletePreAuthKey_0  = runtime.ForwardResponseMessage

--- a/gen/go/headscale/v1/headscale_grpc.pb.go
+++ b/gen/go/headscale/v1/headscale_grpc.pb.go
@@ -23,6 +23,7 @@ const (
 	HeadscaleService_RenameUser_FullMethodName        = "/headscale.v1.HeadscaleService/RenameUser"
 	HeadscaleService_DeleteUser_FullMethodName        = "/headscale.v1.HeadscaleService/DeleteUser"
 	HeadscaleService_ListUsers_FullMethodName         = "/headscale.v1.HeadscaleService/ListUsers"
+	HeadscaleService_SetUser_FullMethodName           = "/headscale.v1.HeadscaleService/SetUser"
 	HeadscaleService_CreatePreAuthKey_FullMethodName  = "/headscale.v1.HeadscaleService/CreatePreAuthKey"
 	HeadscaleService_ExpirePreAuthKey_FullMethodName  = "/headscale.v1.HeadscaleService/ExpirePreAuthKey"
 	HeadscaleService_DeletePreAuthKey_FullMethodName  = "/headscale.v1.HeadscaleService/DeletePreAuthKey"
@@ -55,6 +56,7 @@ type HeadscaleServiceClient interface {
 	RenameUser(ctx context.Context, in *RenameUserRequest, opts ...grpc.CallOption) (*RenameUserResponse, error)
 	DeleteUser(ctx context.Context, in *DeleteUserRequest, opts ...grpc.CallOption) (*DeleteUserResponse, error)
 	ListUsers(ctx context.Context, in *ListUsersRequest, opts ...grpc.CallOption) (*ListUsersResponse, error)
+	SetUser(ctx context.Context, in *SetUserRequest, opts ...grpc.CallOption) (*SetUserResponse, error)
 	// --- PreAuthKeys start ---
 	CreatePreAuthKey(ctx context.Context, in *CreatePreAuthKeyRequest, opts ...grpc.CallOption) (*CreatePreAuthKeyResponse, error)
 	ExpirePreAuthKey(ctx context.Context, in *ExpirePreAuthKeyRequest, opts ...grpc.CallOption) (*ExpirePreAuthKeyResponse, error)
@@ -125,6 +127,16 @@ func (c *headscaleServiceClient) ListUsers(ctx context.Context, in *ListUsersReq
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListUsersResponse)
 	err := c.cc.Invoke(ctx, HeadscaleService_ListUsers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *headscaleServiceClient) SetUser(ctx context.Context, in *SetUserRequest, opts ...grpc.CallOption) (*SetUserResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SetUserResponse)
+	err := c.cc.Invoke(ctx, HeadscaleService_SetUser_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -350,6 +362,7 @@ type HeadscaleServiceServer interface {
 	RenameUser(context.Context, *RenameUserRequest) (*RenameUserResponse, error)
 	DeleteUser(context.Context, *DeleteUserRequest) (*DeleteUserResponse, error)
 	ListUsers(context.Context, *ListUsersRequest) (*ListUsersResponse, error)
+	SetUser(context.Context, *SetUserRequest) (*SetUserResponse, error)
 	// --- PreAuthKeys start ---
 	CreatePreAuthKey(context.Context, *CreatePreAuthKeyRequest) (*CreatePreAuthKeyResponse, error)
 	ExpirePreAuthKey(context.Context, *ExpirePreAuthKeyRequest) (*ExpirePreAuthKeyResponse, error)
@@ -397,6 +410,9 @@ func (UnimplementedHeadscaleServiceServer) DeleteUser(context.Context, *DeleteUs
 }
 func (UnimplementedHeadscaleServiceServer) ListUsers(context.Context, *ListUsersRequest) (*ListUsersResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListUsers not implemented")
+}
+func (UnimplementedHeadscaleServiceServer) SetUser(context.Context, *SetUserRequest) (*SetUserResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetUser not implemented")
 }
 func (UnimplementedHeadscaleServiceServer) CreatePreAuthKey(context.Context, *CreatePreAuthKeyRequest) (*CreatePreAuthKeyResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreatePreAuthKey not implemented")
@@ -550,6 +566,24 @@ func _HeadscaleService_ListUsers_Handler(srv interface{}, ctx context.Context, d
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(HeadscaleServiceServer).ListUsers(ctx, req.(*ListUsersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _HeadscaleService_SetUser_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetUserRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(HeadscaleServiceServer).SetUser(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: HeadscaleService_SetUser_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(HeadscaleServiceServer).SetUser(ctx, req.(*SetUserRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -954,6 +988,10 @@ var HeadscaleService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListUsers",
 			Handler:    _HeadscaleService_ListUsers_Handler,
+		},
+		{
+			MethodName: "SetUser",
+			Handler:    _HeadscaleService_SetUser_Handler,
 		},
 		{
 			MethodName: "CreatePreAuthKey",

--- a/gen/go/headscale/v1/user.pb.go
+++ b/gen/go/headscale/v1/user.pb.go
@@ -410,6 +410,122 @@ func (*DeleteUserResponse) Descriptor() ([]byte, []int) {
 	return file_headscale_v1_user_proto_rawDescGZIP(), []int{6}
 }
 
+// SetUserRequest updates profile fields for an existing user.
+// Only fields that are explicitly set are applied; omitted fields leave the
+// current value unchanged.
+// picture_url follows the same naming convention as CreateUserRequest.
+type SetUserRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            uint64                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	DisplayName   *string                `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3,oneof" json:"display_name,omitempty"`
+	Email         *string                `protobuf:"bytes,3,opt,name=email,proto3,oneof" json:"email,omitempty"`
+	PictureUrl    *string                `protobuf:"bytes,4,opt,name=picture_url,json=pictureUrl,proto3,oneof" json:"picture_url,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetUserRequest) Reset() {
+	*x = SetUserRequest{}
+	mi := &file_headscale_v1_user_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetUserRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetUserRequest) ProtoMessage() {}
+
+func (x *SetUserRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_headscale_v1_user_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetUserRequest.ProtoReflect.Descriptor instead.
+func (*SetUserRequest) Descriptor() ([]byte, []int) {
+	return file_headscale_v1_user_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *SetUserRequest) GetId() uint64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *SetUserRequest) GetDisplayName() string {
+	if x != nil && x.DisplayName != nil {
+		return *x.DisplayName
+	}
+	return ""
+}
+
+func (x *SetUserRequest) GetEmail() string {
+	if x != nil && x.Email != nil {
+		return *x.Email
+	}
+	return ""
+}
+
+func (x *SetUserRequest) GetPictureUrl() string {
+	if x != nil && x.PictureUrl != nil {
+		return *x.PictureUrl
+	}
+	return ""
+}
+
+type SetUserResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	User          *User                  `protobuf:"bytes,1,opt,name=user,proto3" json:"user,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetUserResponse) Reset() {
+	*x = SetUserResponse{}
+	mi := &file_headscale_v1_user_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetUserResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetUserResponse) ProtoMessage() {}
+
+func (x *SetUserResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_headscale_v1_user_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetUserResponse.ProtoReflect.Descriptor instead.
+func (*SetUserResponse) Descriptor() ([]byte, []int) {
+	return file_headscale_v1_user_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *SetUserResponse) GetUser() *User {
+	if x != nil {
+		return x.User
+	}
+	return nil
+}
+
 type ListUsersRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            uint64                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -421,7 +537,7 @@ type ListUsersRequest struct {
 
 func (x *ListUsersRequest) Reset() {
 	*x = ListUsersRequest{}
-	mi := &file_headscale_v1_user_proto_msgTypes[7]
+	mi := &file_headscale_v1_user_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -433,7 +549,7 @@ func (x *ListUsersRequest) String() string {
 func (*ListUsersRequest) ProtoMessage() {}
 
 func (x *ListUsersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_headscale_v1_user_proto_msgTypes[7]
+	mi := &file_headscale_v1_user_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -446,7 +562,7 @@ func (x *ListUsersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUsersRequest.ProtoReflect.Descriptor instead.
 func (*ListUsersRequest) Descriptor() ([]byte, []int) {
-	return file_headscale_v1_user_proto_rawDescGZIP(), []int{7}
+	return file_headscale_v1_user_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ListUsersRequest) GetId() uint64 {
@@ -479,7 +595,7 @@ type ListUsersResponse struct {
 
 func (x *ListUsersResponse) Reset() {
 	*x = ListUsersResponse{}
-	mi := &file_headscale_v1_user_proto_msgTypes[8]
+	mi := &file_headscale_v1_user_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -491,7 +607,7 @@ func (x *ListUsersResponse) String() string {
 func (*ListUsersResponse) ProtoMessage() {}
 
 func (x *ListUsersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_headscale_v1_user_proto_msgTypes[8]
+	mi := &file_headscale_v1_user_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -504,7 +620,7 @@ func (x *ListUsersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUsersResponse.ProtoReflect.Descriptor instead.
 func (*ListUsersResponse) Descriptor() ([]byte, []int) {
-	return file_headscale_v1_user_proto_rawDescGZIP(), []int{8}
+	return file_headscale_v1_user_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ListUsersResponse) GetUsers() []*User {
@@ -545,7 +661,18 @@ const file_headscale_v1_user_proto_rawDesc = "" +
 	"\x04user\x18\x01 \x01(\v2\x12.headscale.v1.UserR\x04user\"#\n" +
 	"\x11DeleteUserRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x04R\x02id\"\x14\n" +
-	"\x12DeleteUserResponse\"L\n" +
+	"\x12DeleteUserResponse\"\xb4\x01\n" +
+	"\x0eSetUserRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\x04R\x02id\x12&\n" +
+	"\fdisplay_name\x18\x02 \x01(\tH\x00R\vdisplayName\x88\x01\x01\x12\x19\n" +
+	"\x05email\x18\x03 \x01(\tH\x01R\x05email\x88\x01\x01\x12$\n" +
+	"\vpicture_url\x18\x04 \x01(\tH\x02R\n" +
+	"pictureUrl\x88\x01\x01B\x0f\n" +
+	"\r_display_nameB\b\n" +
+	"\x06_emailB\x0e\n" +
+	"\f_picture_url\"9\n" +
+	"\x0fSetUserResponse\x12&\n" +
+	"\x04user\x18\x01 \x01(\v2\x12.headscale.v1.UserR\x04user\"L\n" +
 	"\x10ListUsersRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x04R\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +
@@ -565,7 +692,7 @@ func file_headscale_v1_user_proto_rawDescGZIP() []byte {
 	return file_headscale_v1_user_proto_rawDescData
 }
 
-var file_headscale_v1_user_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_headscale_v1_user_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_headscale_v1_user_proto_goTypes = []any{
 	(*User)(nil),                  // 0: headscale.v1.User
 	(*CreateUserRequest)(nil),     // 1: headscale.v1.CreateUserRequest
@@ -574,20 +701,23 @@ var file_headscale_v1_user_proto_goTypes = []any{
 	(*RenameUserResponse)(nil),    // 4: headscale.v1.RenameUserResponse
 	(*DeleteUserRequest)(nil),     // 5: headscale.v1.DeleteUserRequest
 	(*DeleteUserResponse)(nil),    // 6: headscale.v1.DeleteUserResponse
-	(*ListUsersRequest)(nil),      // 7: headscale.v1.ListUsersRequest
-	(*ListUsersResponse)(nil),     // 8: headscale.v1.ListUsersResponse
-	(*timestamppb.Timestamp)(nil), // 9: google.protobuf.Timestamp
+	(*SetUserRequest)(nil),        // 7: headscale.v1.SetUserRequest
+	(*SetUserResponse)(nil),       // 8: headscale.v1.SetUserResponse
+	(*ListUsersRequest)(nil),      // 9: headscale.v1.ListUsersRequest
+	(*ListUsersResponse)(nil),     // 10: headscale.v1.ListUsersResponse
+	(*timestamppb.Timestamp)(nil), // 11: google.protobuf.Timestamp
 }
 var file_headscale_v1_user_proto_depIdxs = []int32{
-	9, // 0: headscale.v1.User.created_at:type_name -> google.protobuf.Timestamp
-	0, // 1: headscale.v1.CreateUserResponse.user:type_name -> headscale.v1.User
-	0, // 2: headscale.v1.RenameUserResponse.user:type_name -> headscale.v1.User
-	0, // 3: headscale.v1.ListUsersResponse.users:type_name -> headscale.v1.User
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	11, // 0: headscale.v1.User.created_at:type_name -> google.protobuf.Timestamp
+	0,  // 1: headscale.v1.CreateUserResponse.user:type_name -> headscale.v1.User
+	0,  // 2: headscale.v1.RenameUserResponse.user:type_name -> headscale.v1.User
+	0,  // 3: headscale.v1.SetUserResponse.user:type_name -> headscale.v1.User
+	0,  // 4: headscale.v1.ListUsersResponse.users:type_name -> headscale.v1.User
+	5,  // [5:5] is the sub-list for method output_type
+	5,  // [5:5] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_headscale_v1_user_proto_init() }
@@ -595,13 +725,14 @@ func file_headscale_v1_user_proto_init() {
 	if File_headscale_v1_user_proto != nil {
 		return
 	}
+	file_headscale_v1_user_proto_msgTypes[7].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_headscale_v1_user_proto_rawDesc), len(file_headscale_v1_user_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/openapiv2/headscale/v1/headscale.swagger.json
+++ b/gen/openapiv2/headscale/v1/headscale.swagger.json
@@ -780,6 +780,43 @@
         "tags": [
           "HeadscaleService"
         ]
+      },
+      "put": {
+        "operationId": "HeadscaleService_SetUser",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SetUserResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "format": "uint64"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/HeadscaleServiceSetUserBody"
+            }
+          }
+        ],
+        "tags": [
+          "HeadscaleService"
+        ]
       }
     },
     "/api/v1/user/{oldId}/rename/{newName}": {
@@ -842,6 +879,21 @@
           }
         }
       }
+    },
+    "HeadscaleServiceSetUserBody": {
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "pictureUrl": {
+          "type": "string"
+        }
+      },
+      "description": "SetUserRequest updates profile fields for an existing user.\nOnly fields that are explicitly set are applied; omitted fields leave the\ncurrent value unchanged.\npicture_url follows the same naming convention as CreateUserRequest."
     },
     "protobufAny": {
       "type": "object",
@@ -1316,6 +1368,14 @@
       "properties": {
         "node": {
           "$ref": "#/definitions/v1Node"
+        }
+      }
+    },
+    "v1SetUserResponse": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "$ref": "#/definitions/v1User"
         }
       }
     },

--- a/hscontrol/grpcv1.go
+++ b/hscontrol/grpcv1.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/netip"
+	"net/url"
 	"os"
 	"slices"
 	"sort"
@@ -108,6 +109,39 @@ func (api headscaleV1APIServer) DeleteUser(
 	api.h.Change(policyChanged)
 
 	return &v1.DeleteUserResponse{}, nil
+}
+
+func (api headscaleV1APIServer) SetUser(
+	ctx context.Context,
+	request *v1.SetUserRequest,
+) (*v1.SetUserResponse, error) {
+	if request.PictureUrl != nil {
+		if pic := request.GetPictureUrl(); pic != "" {
+			if _, err := url.ParseRequestURI(pic); err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid picture URL: %s", err)
+			}
+		}
+	}
+
+	updated, c, err := api.h.state.UpdateUser(types.UserID(request.GetId()), func(u *types.User) error {
+		if request.DisplayName != nil {
+			u.DisplayName = request.GetDisplayName()
+		}
+		if request.Email != nil {
+			u.Email = request.GetEmail()
+		}
+		if request.PictureUrl != nil {
+			u.ProfilePicURL = request.GetPictureUrl()
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "updating user: %s", err)
+	}
+
+	api.h.Change(c)
+
+	return &v1.SetUserResponse{User: updated.Proto()}, nil
 }
 
 func (api headscaleV1APIServer) ListUsers(

--- a/hscontrol/grpcv1_test.go
+++ b/hscontrol/grpcv1_test.go
@@ -543,3 +543,92 @@ func TestDeleteApiKey_BothIdentifiers(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, st.Code())
 	assert.Contains(t, st.Message(), "provide either id or prefix, not both")
 }
+
+func TestSetUser_UpdatesFields(t *testing.T) {
+	t.Parallel()
+
+	app := createTestApp(t)
+	apiServer := newHeadscaleV1APIServer(app)
+
+	user := app.state.CreateUserForTest("test-user")
+	require.NotNil(t, user)
+
+	displayName, email, pictureUrl := "Display Name", "user@example.com", "https://example.com/pic.png"
+	resp, err := apiServer.SetUser(context.Background(), &v1.SetUserRequest{
+		Id:          uint64(user.ID),
+		DisplayName: &displayName,
+		Email:       &email,
+		PictureUrl:  &pictureUrl,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Display Name", resp.GetUser().GetDisplayName())
+	assert.Equal(t, "user@example.com", resp.GetUser().GetEmail())
+	assert.Equal(t, "https://example.com/pic.png", resp.GetUser().GetProfilePicUrl())
+}
+
+func TestSetUser_PartialUpdate(t *testing.T) {
+	t.Parallel()
+
+	app := createTestApp(t)
+	apiServer := newHeadscaleV1APIServer(app)
+
+	user := app.state.CreateUserForTest("test-user")
+	require.NotNil(t, user)
+
+	// Set all fields first
+	initialName, initialEmail := "Initial Name", "initial@example.com"
+	_, err := apiServer.SetUser(context.Background(), &v1.SetUserRequest{
+		Id:          uint64(user.ID),
+		DisplayName: &initialName,
+		Email:       &initialEmail,
+	})
+	require.NoError(t, err)
+
+	// Update only display name; email should be preserved
+	updatedName := "Updated Name"
+	resp, err := apiServer.SetUser(context.Background(), &v1.SetUserRequest{
+		Id:          uint64(user.ID),
+		DisplayName: &updatedName,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Updated Name", resp.GetUser().GetDisplayName())
+	assert.Equal(t, "initial@example.com", resp.GetUser().GetEmail(), "email should be preserved on partial update")
+}
+
+func TestSetUser_InvalidPictureURL(t *testing.T) {
+	t.Parallel()
+
+	app := createTestApp(t)
+	apiServer := newHeadscaleV1APIServer(app)
+
+	user := app.state.CreateUserForTest("test-user")
+	require.NotNil(t, user)
+
+	badURL := "not-a-valid-url"
+	_, err := apiServer.SetUser(context.Background(), &v1.SetUserRequest{
+		Id:         uint64(user.ID),
+		PictureUrl: &badURL,
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "invalid picture URL")
+}
+
+func TestSetUser_NotFound(t *testing.T) {
+	t.Parallel()
+
+	app := createTestApp(t)
+	apiServer := newHeadscaleV1APIServer(app)
+
+	displayName := "Ghost"
+	_, err := apiServer.SetUser(context.Background(), &v1.SetUserRequest{
+		Id:          99999,
+		DisplayName: &displayName,
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -131,6 +131,41 @@ func TestUserCommand(t *testing.T) {
 		)
 	}, 20*time.Second, 1*time.Second)
 
+	_, err = headscale.Execute(
+		[]string{
+			"headscale",
+			"users",
+			"set",
+			"--output=json",
+			"--identifier=1",
+			"--display-name=User One",
+			"--email=userone@example.com",
+			"--picture-url=https://example.com/avatar.png",
+		},
+	)
+	require.NoError(t, err)
+
+	var listAfterSetUsers []*v1.User
+
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := executeAndUnmarshal(headscale,
+			[]string{
+				"headscale",
+				"users",
+				"list",
+				"--output",
+				"json",
+				"--identifier=1",
+			},
+			&listAfterSetUsers,
+		)
+		assert.NoError(ct, err)
+		assert.Len(ct, listAfterSetUsers, 1)
+		assert.Equal(ct, "User One", listAfterSetUsers[0].GetDisplayName(), "display name should be updated")
+		assert.Equal(ct, "userone@example.com", listAfterSetUsers[0].GetEmail(), "email should be updated")
+		assert.Equal(ct, "https://example.com/avatar.png", listAfterSetUsers[0].GetProfilePicUrl(), "picture url should be updated")
+	}, 20*time.Second, 1*time.Second)
+
 	var listByUsername []*v1.User
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -152,9 +187,11 @@ func TestUserCommand(t *testing.T) {
 
 	want := []*v1.User{
 		{
-			Id:    1,
-			Name:  "user1",
-			Email: "user1@test.no",
+			Id:            1,
+			Name:          "user1",
+			DisplayName:   "User One",
+			Email:         "userone@example.com",
+			ProfilePicUrl: "https://example.com/avatar.png",
 		},
 	}
 
@@ -183,9 +220,11 @@ func TestUserCommand(t *testing.T) {
 
 	want = []*v1.User{
 		{
-			Id:    1,
-			Name:  "user1",
-			Email: "user1@test.no",
+			Id:            1,
+			Name:          "user1",
+			DisplayName:   "User One",
+			Email:         "userone@example.com",
+			ProfilePicUrl: "https://example.com/avatar.png",
 		},
 	}
 

--- a/proto/headscale/v1/headscale.proto
+++ b/proto/headscale/v1/headscale.proto
@@ -36,6 +36,13 @@ service HeadscaleService {
       get : "/api/v1/user"
     };
   }
+
+  rpc SetUser(SetUserRequest) returns (SetUserResponse) {
+    option (google.api.http) = {
+      put : "/api/v1/user/{id}"
+      body : "*"
+    };
+  }
   // --- User end ---
 
   // --- PreAuthKeys start ---

--- a/proto/headscale/v1/user.proto
+++ b/proto/headscale/v1/user.proto
@@ -35,6 +35,19 @@ message DeleteUserRequest { uint64 id = 1; }
 
 message DeleteUserResponse {}
 
+// SetUserRequest updates profile fields for an existing user.
+// Only fields that are explicitly set are applied; omitted fields leave the
+// current value unchanged.
+// picture_url follows the same naming convention as CreateUserRequest.
+message SetUserRequest {
+  uint64 id = 1;
+  optional string display_name = 2;
+  optional string email = 3;
+  optional string picture_url = 4;
+}
+
+message SetUserResponse { User user = 1; }
+
 message ListUsersRequest {
   uint64 id = 1;
   string name = 2;


### PR DESCRIPTION
Add `SetUser` gRPC/REST endpoint (`PUT /api/v1/user/{id}`) and `headscale users set` CLI command to update a user's `display_name`, `email`, and `profile_pic_url` fields.

Uses `optional` proto fields so only explicitly provided values are applied — omitted fields preserve their current value.

Fixes #2166

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [x] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md