### PR TITLE
Fix typo in comment about fsnotify behavior

### DIFF
--- a/hscontrol/dns/extrarecords.go
+++ b/hscontrol/dns/extrarecords.go
@@ -100,7 +100,7 @@ func (e *ExtraRecordsMan) Run() {
 
 				e.updateRecords()
 
-				// If a file is removed or renamed, fsnotify will loose track of it
+				// If a file is removed or renamed, fsnotify will lose track of it
 				// and not watch it. We will therefore attempt to re-add it with a backoff.
 			case fsnotify.Remove, fsnotify.Rename:
 				_, err := backoff.Retry(context.Background(), func() (struct{}, error) {


### PR DESCRIPTION
Correct loose (opposite of tight) to lose (opposite of keep).

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
