### PR TITLE
fix: persist empty ApprovedRoutes and Endpoints to database

### DIFF
--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -456,24 +456,13 @@ func (s *State) persistNodeToDB(node types.NodeView) (types.NodeView, change.Cha
 	//   auth_key_id to NULL via ON DELETE SET NULL. Without this, Updates() would fail with a
 	//   foreign key constraint error when trying to reference a deleted PreAuthKey.
 	// See also: https://github.com/juanfont/headscale/issues/2862
-	err := s.db.DB.Omit("expiry", "AuthKeyID", "AuthKey").Updates(nodePtr).Error
+	// Use Select("*") to force GORM to persist zero-value fields (e.g. empty slices
+	// like ApprovedRoutes set to [] when rejecting all routes). Without this, GORM's
+	// Updates(struct) silently skips zero-value fields and they are never persisted.
+	// See: https://github.com/juanfont/headscale/issues/3110
+	err := s.db.DB.Omit("expiry", "AuthKeyID", "AuthKey").Select("*").Updates(nodePtr).Error
 	if err != nil {
 		return types.NodeView{}, change.Change{}, fmt.Errorf("saving node: %w", err)
-	}
-
-	// GORM's Updates(struct) skips zero-value fields, which means empty slices
-	// (like ApprovedRoutes set to [] when rejecting all routes) are silently
-	// dropped. Explicitly persist empty slices to ensure they reach the database.
-	// See: https://github.com/juanfont/headscale/issues/3110
-	if len(nodePtr.ApprovedRoutes) == 0 {
-		if err := s.db.DB.Model(&types.Node{}).Where("id = ?", nodePtr.ID).Update("approved_routes", "[]").Error; err != nil {
-			return types.NodeView{}, change.Change{}, fmt.Errorf("persisting empty approved_routes: %w", err)
-		}
-	}
-	if len(nodePtr.Endpoints) == 0 {
-		if err := s.db.DB.Model(&types.Node{}).Where("id = ?", nodePtr.ID).Update("endpoints", "[]").Error; err != nil {
-			return types.NodeView{}, change.Change{}, fmt.Errorf("persisting empty endpoints: %w", err)
-		}
 	}
 
 	// Check if policy manager needs updating

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -461,6 +461,21 @@ func (s *State) persistNodeToDB(node types.NodeView) (types.NodeView, change.Cha
 		return types.NodeView{}, change.Change{}, fmt.Errorf("saving node: %w", err)
 	}
 
+	// GORM's Updates(struct) skips zero-value fields, which means empty slices
+	// (like ApprovedRoutes set to [] when rejecting all routes) are silently
+	// dropped. Explicitly persist empty slices to ensure they reach the database.
+	// See: https://github.com/juanfont/headscale/issues/3110
+	if len(nodePtr.ApprovedRoutes) == 0 {
+		if err := s.db.DB.Model(&types.Node{}).Where("id = ?", nodePtr.ID).Update("approved_routes", "[]").Error; err != nil {
+			return types.NodeView{}, change.Change{}, fmt.Errorf("persisting empty approved_routes: %w", err)
+		}
+	}
+	if len(nodePtr.Endpoints) == 0 {
+		if err := s.db.DB.Model(&types.Node{}).Where("id = ?", nodePtr.ID).Update("endpoints", "[]").Error; err != nil {
+			return types.NodeView{}, change.Change{}, fmt.Errorf("persisting empty endpoints: %w", err)
+		}
+	}
+
 	// Check if policy manager needs updating
 	c, err := s.updatePolicyManagerNodes()
 	if err != nil {

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -460,7 +460,7 @@ func (s *State) persistNodeToDB(node types.NodeView) (types.NodeView, change.Cha
 	// like ApprovedRoutes set to [] when rejecting all routes). Without this, GORM's
 	// Updates(struct) silently skips zero-value fields and they are never persisted.
 	// See: https://github.com/juanfont/headscale/issues/3110
-	err := s.db.DB.Omit("expiry", "AuthKeyID", "AuthKey").Select("*").Updates(nodePtr).Error
+	err := s.db.DB.Omit("expiry", "AuthKeyID", "AuthKey").Select("*").Updates(nodePtr).Error //nolint:unqueryvet // Select("*") is intentional: GORM skips zero-value fields in struct Updates, so empty slices like ApprovedRoutes=[] are never persisted without it
 	if err != nil {
 		return types.NodeView{}, change.Change{}, fmt.Errorf("saving node: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fixes #3110

When an admin rejects all routes for a node (`headscale nodes approve-routes -i 5 -r ""`), the empty `ApprovedRoutes` slice is correctly set in the in-memory NodeStore but never written to the database. On restart, the old routes reappear.

**Root cause**: `persistNodeToDB` uses GORM's `.Updates(struct)`, which silently skips zero-value fields. An empty `[]netip.Prefix` is a zero value, so it's dropped.

**Fix**: After the `.Updates()` call in `persistNodeToDB`, explicitly persist empty `ApprovedRoutes` and `Endpoints` slices by writing `"[]"` — the same pattern already used in `db.SetApprovedRoutes` (node.go:242-244).

This is done in `persistNodeToDB` rather than individual callers so it fixes the issue for all code paths, and also addresses a latent bug where `Endpoints` could similarly fail to persist when empty.

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./hscontrol/state/` passes (including ephemeral tests)
- [ ] Manual: set approved_routes to empty, restart headscale, confirm routes stay empty