### PR TITLE
Fix list-routes -i flag not filtering by node ID under approve-routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,7 @@ connected" routers that maintain their control session but cannot route packets.
 - Remove deprecated `namespace`/`ns` command aliases for `users` and `machine`/`machines` aliases for `nodes` [#3093](https://github.com/juanfont/headscale/pull/3093)
 - **User deletion**: Fix `DestroyUser` deleting all pre-auth keys in the database instead of only the target user's keys [#3155](https://github.com/juanfont/headscale/pull/3155)
 - `headscale policy check` evaluates the `tests` block when invoked with `--bypass-grpc-and-access-database-directly`; without the flag it warns instead of running the tests against empty data [#1803](https://github.com/juanfont/headscale/issues/1803)
+- Fix `headscale nodes approve-routes list-routes -i <id>` so `-i` filters by node; previously the invocation silently cleared all approved routes on the target node [#3147](https://github.com/juanfont/headscale/pull/3147)
 
 #### API
 

--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -49,9 +49,13 @@ func init() {
 	tagCmd.Flags().StringSliceP("tags", "t", []string{}, "List of tags to add to the node")
 	nodeCmd.AddCommand(tagCmd)
 
-	approveRoutesCmd.Flags().Uint64P("identifier", "i", 0, "Node identifier (ID)")
+	approveRoutesCmd.PersistentFlags().Uint64P("identifier", "i", 0, "Node identifier (ID)")
 	mustMarkRequired(approveRoutesCmd, "identifier")
 	approveRoutesCmd.Flags().StringSliceP("routes", "r", []string{}, `List of routes that will be approved (comma-separated, e.g. "10.0.0.0/8,192.168.0.0/24" or empty string to remove all approved routes)`)
+	// Register list-routes as a subcommand of approve-routes so that
+	// `headscale nodes approve-routes list-routes -i <id>` works as expected.
+	// The -i flag is inherited from approve-routes via PersistentFlags.
+	approveRoutesCmd.AddCommand(listNodeRoutesCmd)
 	nodeCmd.AddCommand(approveRoutesCmd)
 
 	nodeCmd.AddCommand(backfillNodeIPsCmd)

--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -49,12 +49,9 @@ func init() {
 	tagCmd.Flags().StringSliceP("tags", "t", []string{}, "List of tags to add to the node")
 	nodeCmd.AddCommand(tagCmd)
 
-	approveRoutesCmd.PersistentFlags().Uint64P("identifier", "i", 0, "Node identifier (ID)")
+	approveRoutesCmd.Flags().Uint64P("identifier", "i", 0, "Node identifier (ID)")
 	mustMarkRequired(approveRoutesCmd, "identifier")
 	approveRoutesCmd.Flags().StringSliceP("routes", "r", []string{}, `List of routes that will be approved (comma-separated, e.g. "10.0.0.0/8,192.168.0.0/24" or empty string to remove all approved routes)`)
-	// Register list-routes as a subcommand of approve-routes so that
-	// `headscale nodes approve-routes list-routes -i <id>` works as expected.
-	// The -i flag is inherited from approve-routes via PersistentFlags.
 	approveRoutesCmd.AddCommand(listNodeRoutesCmd)
 	nodeCmd.AddCommand(approveRoutesCmd)
 
@@ -496,6 +493,7 @@ var tagCmd = &cobra.Command{
 var approveRoutesCmd = &cobra.Command{
 	Use:   "approve-routes",
 	Short: "Manage the approved routes of a node",
+	Args:  cobra.NoArgs,
 	RunE: grpcRunE(func(ctx context.Context, client v1.HeadscaleServiceClient, cmd *cobra.Command, args []string) error {
 		identifier, _ := cmd.Flags().GetUint64("identifier")
 		routes, _ := cmd.Flags().GetStringSlice("routes")

--- a/cmd/headscale/cli/nodes_test.go
+++ b/cmd/headscale/cli/nodes_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import "testing"
+
+const (
+	nodesName         = "nodes"
+	listRoutesName    = "list-routes"
+	approveRoutesName = "approve-routes"
+)
+
+func TestListRoutesReachableUnderBothParents(t *testing.T) {
+	tests := []struct {
+		name string
+		path []string
+	}{
+		{"under nodes", []string{nodesName, listRoutesName}},
+		{"under nodes approve-routes", []string{nodesName, approveRoutesName, listRoutesName}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, _, err := rootCmd.Find(tt.path)
+			if err != nil {
+				t.Fatalf("rootCmd.Find(%v): %v", tt.path, err)
+			}
+
+			if cmd.Name() != listRoutesName {
+				t.Fatalf("expected %s, got %q", listRoutesName, cmd.Name())
+			}
+		})
+	}
+}
+
+func TestApproveRoutesIdentifierIsLocalNotPersistent(t *testing.T) {
+	// PersistentFlags + mustMarkRequired propagates the required-validation
+	// to subcommands, which breaks `nodes approve-routes list-routes` with
+	// no -i (the documented "list all" path).
+	if approveRoutesCmd.PersistentFlags().Lookup("identifier") != nil {
+		t.Fatal("approveRoutesCmd: identifier must be a local Flag, not Persistent")
+	}
+
+	if approveRoutesCmd.Flags().Lookup("identifier") == nil {
+		t.Fatal("approveRoutesCmd: identifier flag missing")
+	}
+}
+
+func TestApproveRoutesRejectsExtraPositionalArgs(t *testing.T) {
+	// Before NoArgs, `nodes approve-routes <typo> -i 12 -r ""` silently
+	// invoked the destructive empty-routes path on node 12.
+	if approveRoutesCmd.Args == nil {
+		t.Fatal("approveRoutesCmd.Args must be set to NoArgs")
+	}
+
+	err := approveRoutesCmd.Args(approveRoutesCmd, []string{"unexpected"})
+	if err == nil {
+		t.Fatal("expected approveRoutesCmd to reject extra positional args")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the `-i` flag being ignored when running `headscale nodes approve-routes list-routes -i <id>`, which returned routes for all nodes instead of the specified one.

## Problem

`list-routes` was registered only as a direct subcommand of `nodes`, not `approve-routes`. Running `headscale nodes approve-routes list-routes -i 12` caused cobra to parse `-i` as belonging to `approve-routes` rather than `list-routes`, so `list-routes` saw `identifier=0` and returned all nodes.

## Fix

- Changed `approve-routes` `-i` flag from `Flags()` to `PersistentFlags()` so subcommands inherit it
- Registered `list-routes` as a subcommand of `approve-routes`
- `list-routes` remains accessible directly via `headscale nodes list-routes -i <id>` for backward compatibility

Both command paths now work correctly:
- `headscale nodes list-routes -i 12`
- `headscale nodes approve-routes list-routes -i 12`

Fixes #2927