### PR TITLE
fix: DestroyUser should only delete the target user's pre-auth keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,12 @@ internet is a security-sensitive choice. `autogroup:danger-all` can only be used
 - Fix exit node approval not triggering filter rule recalculation for peers [#2180](https://github.com/juanfont/headscale/pull/2180)
 - Policy validation error messages now include field context (e.g., `src=`, `dst=`) and are more descriptive [#2180](https://github.com/juanfont/headscale/pull/2180)
 
+## 0.28.1 (202x-xx-xx)
+
+### Changes
+
+- **User deletion**: Fix `DestroyUser` deleting all pre-auth keys in the database instead of only the target user's keys [#3155](https://github.com/juanfont/headscale/pull/3155)
+
 ## 0.28.0 (2026-02-04)
 
 **Minimum supported Tailscale client version: v1.74.0**

--- a/hscontrol/db/preauth_keys.go
+++ b/hscontrol/db/preauth_keys.go
@@ -170,6 +170,18 @@ func ListPreAuthKeys(tx *gorm.DB) ([]types.PreAuthKey, error) {
 	return keys, nil
 }
 
+// ListPreAuthKeysByUser returns all PreAuthKeys belonging to a specific user.
+func ListPreAuthKeysByUser(tx *gorm.DB, uid types.UserID) ([]types.PreAuthKey, error) {
+	var keys []types.PreAuthKey
+
+	err := tx.Preload("User").Where("user_id = ?", uint(uid)).Find(&keys).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return keys, nil
+}
+
 var (
 	ErrPreAuthKeyFailedToParse    = errors.New("failed to parse auth-key")
 	ErrPreAuthKeyNotTaggedOrOwned = errors.New("auth-key must be either tagged or owned by user")

--- a/hscontrol/db/users.go
+++ b/hscontrol/db/users.go
@@ -65,7 +65,7 @@ func DestroyUser(tx *gorm.DB, uid types.UserID) error {
 		return ErrUserStillHasNodes
 	}
 
-	keys, err := ListPreAuthKeys(tx)
+	keys, err := ListPreAuthKeysByUser(tx, uid)
 	if err != nil {
 		return err
 	}

--- a/hscontrol/db/users_test.go
+++ b/hscontrol/db/users_test.go
@@ -160,6 +160,48 @@ func TestDestroyUserErrors(t *testing.T) {
 				require.ErrorIs(t, err, ErrUserStillHasNodes)
 			},
 		},
+		{
+			// Regression test for https://github.com/juanfont/headscale/issues/3154
+			// DestroyUser must only delete the target user's pre-auth keys,
+			// not all pre-auth keys in the database.
+			name: "success_only_deletes_own_preauthkeys",
+			test: func(t *testing.T, db *HSDatabase) {
+				t.Helper()
+
+				userA := db.CreateUserForTest("usera")
+				userB := db.CreateUserForTest("userb")
+
+				// Create 2 keys for userA, 1 key for userB.
+				_, err := db.CreatePreAuthKey(userA.TypedID(), false, false, nil, nil)
+				require.NoError(t, err)
+				_, err = db.CreatePreAuthKey(userA.TypedID(), false, false, nil, nil)
+				require.NoError(t, err)
+				_, err = db.CreatePreAuthKey(userB.TypedID(), false, false, nil, nil)
+				require.NoError(t, err)
+
+				// Sanity check: 3 keys exist.
+				allKeys, err := db.ListPreAuthKeys()
+				require.NoError(t, err)
+				require.Len(t, allKeys, 3)
+
+				// Delete userB.
+				err = db.DestroyUser(types.UserID(userB.ID))
+				require.NoError(t, err)
+
+				// Only userA's 2 keys should remain.
+				remaining, err := db.ListPreAuthKeys()
+				require.NoError(t, err)
+				assert.Len(t, remaining, 2,
+					"expected 2 keys for userA, got %d — DestroyUser deleted keys from other users",
+					len(remaining))
+
+				for _, key := range remaining {
+					assert.NotNil(t, key.UserID)
+					assert.Equal(t, userA.ID, *key.UserID,
+						"remaining key should belong to userA")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [x] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

Fixes #3154

## Summary

`DestroyUser` in `hscontrol/db/users.go` calls `ListPreAuthKeys(tx)` which returns **all** pre-auth keys in the database, then deletes every one of them. This means deleting any single user wipes all pre-auth keys for the entire system.

## Change

- **`hscontrol/db/users.go`**: Replace `ListPreAuthKeys(tx)` (all keys) with `tx.Where("user_id = ?", uid).Find(&keys)` (only target user's keys)
- **`hscontrol/db/users_test.go`**: Add `TestDestroyUserOnlyDeletesOwnPreAuthKeys` unit test
- **`integration/control.go`**: Add `ListPreAuthKeys()` to `ControlServer` interface
- **`integration/hsic/hsic.go`**: Implement `ListPreAuthKeys()` for `HeadscaleInContainer`
- **`integration/auth_key_test.go`**: Add `TestDeleteUserPreservesOtherUsersPreAuthKeys` integration test

## Testing

- Unit test passes: `go test ./hscontrol/db/ -run TestDestroyUserOnlyDeletesOwnPreAuthKeys -v`
- All existing `TestCreateAndDestroyUser` and `TestDestroyUserErrors` tests pass
- Integration test passes: `TestDeleteUserPreservesOtherUsersPreAuthKeys` verified on Linux (Docker 28.4.0, Go 1.26.1, Nix)
- Manually verified on a production headscale instance (v0.28.0 with this patch applied)