### PR TITLE
Switch to mkdocs-materialx

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -432,6 +432,7 @@ taildrop:
   # When enabled, nodes can send files to other nodes owned by the same user.
   # Tagged devices and cross-user transfers are not permitted by Tailscale clients.
   enabled: true
+
 # Advanced performance tuning parameters.
 # The defaults are carefully chosen and should rarely need adjustment.
 # Only modify these if you have identified a specific performance issue.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 mike~=2.1
-mkdocs-include-markdown-plugin~=7.1
-mkdocs-macros-plugin~=1.3
-mkdocs-material[imaging]~=9.5
-mkdocs-minify-plugin~=0.7
+mkdocs-include-markdown-plugin~=7.2
+mkdocs-macros-plugin~=1.5
+mkdocs-materialx[imaging]~=10.1
+mkdocs-minify-plugin~=0.8
 mkdocs-redirects~=1.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ copyright: Copyright &copy; 2026 Headscale authors
 
 # Configuration
 theme:
-  name: material
+  name: materialx
   features:
     - announce.dismiss
     - content.action.edit
@@ -138,10 +138,6 @@ markdown_extensions:
       pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.keys
-  - pymdownx.magiclink:
-      repo_url_shorthand: true
-      user: squidfunk
-      repo: mkdocs-material
   - pymdownx.mark
   - pymdownx.smartsymbols
   - pymdownx.superfences:


### PR DESCRIPTION
The project mkdocs-material is in maintenance-only mode and their successor is not ready yet.

Use the modern, refreshed theme and drop the `pymdownx.magiclink` extension.

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
