### PR TITLE
fix: DestroyUser should only delete the target user's preauthkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ internet is a security-sensitive choice. `autogroup:danger-all` can only be used
 - Fix non-wildcard source IPs being dropped when combined with wildcard `*` in the same ACL rule [#2180](https://github.com/juanfont/headscale/pull/2180)
 - Fix exit node approval not triggering filter rule recalculation for peers [#2180](https://github.com/juanfont/headscale/pull/2180)
 - Policy validation error messages now include field context (e.g., `src=`, `dst=`) and are more descriptive [#2180](https://github.com/juanfont/headscale/pull/2180)
+- Fix `DestroyUser` deleting all pre-auth keys in the database instead of only the target user's keys [#3154](https://github.com/juanfont/headscale/issues/3154)
 
 ## 0.28.0 (2026-02-04)
 

--- a/hscontrol/db/preauth_keys.go
+++ b/hscontrol/db/preauth_keys.go
@@ -170,6 +170,18 @@ func ListPreAuthKeys(tx *gorm.DB) ([]types.PreAuthKey, error) {
 	return keys, nil
 }
 
+// ListPreAuthKeysByUser returns all PreAuthKeys belonging to a specific user.
+func ListPreAuthKeysByUser(tx *gorm.DB, uid types.UserID) ([]types.PreAuthKey, error) {
+	var keys []types.PreAuthKey
+
+	err := tx.Preload("User").Where("user_id = ?", uint(uid)).Find(&keys).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return keys, nil
+}
+
 var (
 	ErrPreAuthKeyFailedToParse    = errors.New("failed to parse auth-key")
 	ErrPreAuthKeyNotTaggedOrOwned = errors.New("auth-key must be either tagged or owned by user")

--- a/hscontrol/db/users.go
+++ b/hscontrol/db/users.go
@@ -65,7 +65,7 @@ func DestroyUser(tx *gorm.DB, uid types.UserID) error {
 		return ErrUserStillHasNodes
 	}
 
-	keys, err := ListPreAuthKeys(tx)
+	keys, err := ListPreAuthKeysByUser(tx, uid)
 	if err != nil {
 		return err
 	}

--- a/hscontrol/db/users_test.go
+++ b/hscontrol/db/users_test.go
@@ -63,6 +63,38 @@ func TestDestroyUserErrors(t *testing.T) {
 			},
 		},
 		{
+			// https://github.com/juanfont/headscale/issues/3154
+			// Deleting a user must only remove that user's preauthkeys,
+			// not every key in the database.
+			name: "success_only_deletes_own_preauthkeys",
+			test: func(t *testing.T, db *HSDatabase) {
+				t.Helper()
+
+				userA := db.CreateUserForTest("usera")
+				userB := db.CreateUserForTest("userb")
+
+				pakA, err := db.CreatePreAuthKey(userA.TypedID(), false, false, nil, nil)
+				require.NoError(t, err)
+
+				pakB, err := db.CreatePreAuthKey(userB.TypedID(), false, false, nil, nil)
+				require.NoError(t, err)
+
+				// Delete userB — only userB's key should be removed.
+				err = db.DestroyUser(types.UserID(userB.ID))
+				require.NoError(t, err)
+
+				// userA's key must still exist.
+				var foundPakA types.PreAuthKey
+				result := db.DB.First(&foundPakA, "id = ?", pakA.ID)
+				require.NoError(t, result.Error)
+
+				// userB's key must be gone.
+				var foundPakB types.PreAuthKey
+				result = db.DB.First(&foundPakB, "id = ?", pakB.ID)
+				assert.ErrorIs(t, result.Error, gorm.ErrRecordNotFound)
+			},
+		},
+		{
 			name: "error_user_has_nodes",
 			test: func(t *testing.T, db *HSDatabase) {
 				t.Helper()


### PR DESCRIPTION
ListPreAuthKeys(tx) was called without filtering by user ID, causing all preauthkeys in the database to be deleted when any single user was destroyed.

Replace with ListPreAuthKeysByUser(tx, uid) to scope deletion.

Fixes: https://github.com/juanfont/headscale/issues/3154

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
