### PR TITLE
Fix exit node routes when using autoApprovers

### DIFF
--- a/cmd/headscale/cli/nodes.go
+++ b/cmd/headscale/cli/nodes.go
@@ -175,8 +175,10 @@ Use --disable to disable key expiry (node will never expire).`,
 		now := time.Now()
 
 		expiryTime := now
+
 		if expiry != "" {
 			var err error
+
 			expiryTime, err = time.Parse(time.RFC3339, expiry)
 			if err != nil {
 				return fmt.Errorf("parsing expiry time: %w", err)
@@ -397,6 +399,7 @@ func nodesToPtables(
 		}
 
 		var ipBuilder strings.Builder
+
 		for _, addr := range node.GetIpAddresses() {
 			ip, err := netip.ParseAddr(addr)
 			if err == nil {

--- a/cmd/headscale/cli/policy.go
+++ b/cmd/headscale/cli/policy.go
@@ -63,6 +63,7 @@ var getPolicy = &cobra.Command{
 	Aliases: []string{"show", "view", "fetch"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var policyData string
+
 		if bypass, _ := cmd.Flags().GetBool(bypassFlag); bypass {
 			if !confirmAction(cmd, "DO NOT run this command if an instance of headscale is running, are you sure headscale is not running?") {
 				return errAborted

--- a/hscontrol/debug.go
+++ b/hscontrol/debug.go
@@ -359,13 +359,13 @@ func (h *Headscale) debugBatcher() string {
 		}
 
 		if node.activeConnections > 0 {
-			sb.WriteString(fmt.Sprintf("Node %d:\t%s (%d connections)\n", node.id, status, node.activeConnections))
+			fmt.Fprintf(&sb, "Node %d:\t%s (%d connections)\n", node.id, status, node.activeConnections)
 		} else {
-			sb.WriteString(fmt.Sprintf("Node %d:\t%s\n", node.id, status))
+			fmt.Fprintf(&sb, "Node %d:\t%s\n", node.id, status)
 		}
 	}
 
-	sb.WriteString(fmt.Sprintf("\nSummary: %d connected, %d total\n", connectedCount, totalNodes))
+	fmt.Fprintf(&sb, "\nSummary: %d connected, %d total\n", connectedCount, totalNodes)
 
 	return sb.String()
 }

--- a/hscontrol/mapper/batcher_concurrency_test.go
+++ b/hscontrol/mapper/batcher_concurrency_test.go
@@ -786,6 +786,7 @@ func TestBug3_CleanupOfflineNodes_TOCTOU(t *testing.T) {
 	entry.lastUsed.Store(time.Now().Unix())
 	mc.addConnection(entry)
 	mc.markConnected()
+
 	lb.channels[targetNode] = newCh
 
 	// Now run cleanup. Node 3 is in the candidates list (old disconnect

--- a/hscontrol/policy/policyutil/reduce.go
+++ b/hscontrol/policy/policyutil/reduce.go
@@ -60,6 +60,7 @@ func ReduceFilterRules(node types.NodeView, rules []tailcfg.FilterRule) []tailcf
 						if tsaddr.IsExitRoute(routableIP) {
 							continue
 						}
+
 						if expanded.OverlapsPrefix(routableIP) {
 							dests = append(dests, dest)
 							continue DEST_LOOP

--- a/hscontrol/policy/route_approval_test.go
+++ b/hscontrol/policy/route_approval_test.go
@@ -220,7 +220,7 @@ func TestNodeCanApproveRoute(t *testing.T) {
 					}
 				}
 			}`,
-			canApprove: false,
+			canApprove: true,
 		},
 		{
 			name:  "all-IPv4-routes-exitnode-approval",
@@ -326,7 +326,7 @@ func TestNodeCanApproveRoute(t *testing.T) {
 					}
 				}
 			}`,
-			canApprove: false,
+			canApprove: true,
 		},
 		{
 			name:  "specific-IPv6-route-with-all-routes-policy",

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -799,6 +799,9 @@ func (pm *PolicyManager) NodeCanApproveRoute(node types.NodeView, route netip.Pr
 		return false
 	}
 
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
 	// If the route to-be-approved is an exit route, then we need to check
 	// if the node is in allowed to approve it. This is treated differently
 	// than the auto-approvers, as the auto-approvers are not allowed to
@@ -806,19 +809,17 @@ func (pm *PolicyManager) NodeCanApproveRoute(node types.NodeView, route netip.Pr
 	// However, an auto approver might be /0, meaning that they can approve
 	// all routes available, just not exit nodes.
 	if tsaddr.IsExitRoute(route) {
-		if pm.exitSet == nil {
-			return false
+		if pm.exitSet != nil && slices.ContainsFunc(node.IPs(), pm.exitSet.Contains) {
+			return true
 		}
 
-		if slices.ContainsFunc(node.IPs(), pm.exitSet.Contains) {
-			return true
+		// Also check autoApproveMap for exit routes configured via the routes map.
+		if approvers, ok := pm.autoApproveMap[route]; ok {
+			return slices.ContainsFunc(node.IPs(), approvers.Contains)
 		}
 
 		return false
 	}
-
-	pm.mu.Lock()
-	defer pm.mu.Unlock()
 
 	// The fast path is that a node requests to approve a prefix
 	// where there is an exact entry, e.g. 10.0.0.0/8, then

--- a/hscontrol/policy/v2/types_test.go
+++ b/hscontrol/policy/v2/types_test.go
@@ -3141,6 +3141,32 @@ func TestNodeCanApproveRoute(t *testing.T) {
 			want:  true,
 		},
 		{
+			name: "exit-node-approval-via-routes",
+			policy: &Policy{
+				AutoApprovers: AutoApproverPolicy{
+					Routes: map[netip.Prefix]AutoApprovers{
+						tsaddr.AllIPv4(): {new(Username("user1@"))},
+					},
+				},
+			},
+			node:  nodes[0],
+			route: tsaddr.AllIPv4(),
+			want:  true,
+		},
+		{
+			name: "exit-node-ipv6-approval-via-routes",
+			policy: &Policy{
+				AutoApprovers: AutoApproverPolicy{
+					Routes: map[netip.Prefix]AutoApprovers{
+						tsaddr.AllIPv6(): {new(Username("user1@"))},
+					},
+				},
+			},
+			node:  nodes[0],
+			route: tsaddr.AllIPv6(),
+			want:  true,
+		},
+		{
 			name: "no-approval",
 			policy: &Policy{
 				AutoApprovers: AutoApproverPolicy{

--- a/hscontrol/state/debug.go
+++ b/hscontrol/state/debug.go
@@ -69,7 +69,7 @@ func (s *State) DebugOverview() string {
 	sb.WriteString("=== Headscale State Overview ===\n\n")
 
 	// Node statistics
-	sb.WriteString(fmt.Sprintf("Nodes: %d total\n", allNodes.Len()))
+	fmt.Fprintf(&sb, "Nodes: %d total\n", allNodes.Len())
 
 	userNodeCounts := make(map[string]int)
 	onlineCount := 0
@@ -97,26 +97,26 @@ func (s *State) DebugOverview() string {
 		}
 	}
 
-	sb.WriteString(fmt.Sprintf("  - Online: %d\n", onlineCount))
-	sb.WriteString(fmt.Sprintf("  - Expired: %d\n", expiredCount))
-	sb.WriteString(fmt.Sprintf("  - Ephemeral: %d\n", ephemeralCount))
+	fmt.Fprintf(&sb, "  - Online: %d\n", onlineCount)
+	fmt.Fprintf(&sb, "  - Expired: %d\n", expiredCount)
+	fmt.Fprintf(&sb, "  - Ephemeral: %d\n", ephemeralCount)
 	sb.WriteString("\n")
 
 	// User statistics
-	sb.WriteString(fmt.Sprintf("Users: %d total\n", len(users)))
+	fmt.Fprintf(&sb, "Users: %d total\n", len(users))
 
 	for userName, nodeCount := range userNodeCounts {
-		sb.WriteString(fmt.Sprintf("  - %s: %d nodes\n", userName, nodeCount))
+		fmt.Fprintf(&sb, "  - %s: %d nodes\n", userName, nodeCount)
 	}
 
 	sb.WriteString("\n")
 
 	// Policy information
 	sb.WriteString("Policy:\n")
-	sb.WriteString(fmt.Sprintf("  - Mode: %s\n", s.cfg.Policy.Mode))
+	fmt.Fprintf(&sb, "  - Mode: %s\n", s.cfg.Policy.Mode)
 
 	if s.cfg.Policy.Mode == types.PolicyModeFile {
-		sb.WriteString(fmt.Sprintf("  - Path: %s\n", s.cfg.Policy.Path))
+		fmt.Fprintf(&sb, "  - Path: %s\n", s.cfg.Policy.Path)
 	}
 
 	sb.WriteString("\n")
@@ -124,7 +124,7 @@ func (s *State) DebugOverview() string {
 	// DERP information
 	derpMap := s.derpMap.Load()
 	if derpMap != nil {
-		sb.WriteString(fmt.Sprintf("DERP: %d regions configured\n", len(derpMap.Regions)))
+		fmt.Fprintf(&sb, "DERP: %d regions configured\n", len(derpMap.Regions))
 	} else {
 		sb.WriteString("DERP: not configured\n")
 	}
@@ -137,7 +137,7 @@ func (s *State) DebugOverview() string {
 		routeCount = 0
 	}
 
-	sb.WriteString(fmt.Sprintf("Primary Routes: %d active\n", routeCount))
+	fmt.Fprintf(&sb, "Primary Routes: %d active\n", routeCount)
 	sb.WriteString("\n")
 
 	// Registration cache
@@ -163,18 +163,18 @@ func (s *State) DebugDERPMap() string {
 
 	sb.WriteString("=== DERP Map Configuration ===\n\n")
 
-	sb.WriteString(fmt.Sprintf("Total Regions: %d\n\n", len(derpMap.Regions)))
+	fmt.Fprintf(&sb, "Total Regions: %d\n\n", len(derpMap.Regions))
 
 	for regionID, region := range derpMap.Regions {
-		sb.WriteString(fmt.Sprintf("Region %d: %s\n", regionID, region.RegionName))
-		sb.WriteString(fmt.Sprintf("  - Nodes: %d\n", len(region.Nodes)))
+		fmt.Fprintf(&sb, "Region %d: %s\n", regionID, region.RegionName)
+		fmt.Fprintf(&sb, "  - Nodes: %d\n", len(region.Nodes))
 
 		for _, node := range region.Nodes {
-			sb.WriteString(fmt.Sprintf("    - %s (%s:%d)\n",
-				node.Name, node.HostName, node.DERPPort))
+			fmt.Fprintf(&sb, "    - %s (%s:%d)\n",
+				node.Name, node.HostName, node.DERPPort)
 
 			if node.STUNPort != 0 {
-				sb.WriteString(fmt.Sprintf("      STUN: %d\n", node.STUNPort))
+				fmt.Fprintf(&sb, "      STUN: %d\n", node.STUNPort)
 			}
 		}
 

--- a/hscontrol/state/node_store.go
+++ b/hscontrol/state/node_store.go
@@ -526,8 +526,8 @@ func (s *NodeStore) DebugString() string {
 	sb.WriteString("=== NodeStore Debug Information ===\n\n")
 
 	// Basic counts
-	sb.WriteString(fmt.Sprintf("Total Nodes: %d\n", len(snapshot.nodesByID)))
-	sb.WriteString(fmt.Sprintf("Users with Nodes: %d\n", len(snapshot.nodesByUser)))
+	fmt.Fprintf(&sb, "Total Nodes: %d\n", len(snapshot.nodesByID))
+	fmt.Fprintf(&sb, "Users with Nodes: %d\n", len(snapshot.nodesByUser))
 	sb.WriteString("\n")
 
 	// User distribution (shows internal UserID tracking, not display owner)
@@ -541,7 +541,7 @@ func (s *NodeStore) DebugString() string {
 				userName = nodes[0].User().Name()
 			}
 
-			sb.WriteString(fmt.Sprintf("  - User %d (%s): %d nodes\n", userID, userName, len(nodes)))
+			fmt.Fprintf(&sb, "  - User %d (%s): %d nodes\n", userID, userName, len(nodes))
 		}
 	}
 
@@ -557,20 +557,20 @@ func (s *NodeStore) DebugString() string {
 
 		totalPeers += peerCount
 		if node, exists := snapshot.nodesByID[nodeID]; exists {
-			sb.WriteString(fmt.Sprintf("  - Node %d (%s): %d peers\n",
-				nodeID, node.Hostname, peerCount))
+			fmt.Fprintf(&sb, "  - Node %d (%s): %d peers\n",
+				nodeID, node.Hostname, peerCount)
 		}
 	}
 
 	if len(snapshot.peersByNode) > 0 {
 		avgPeers := float64(totalPeers) / float64(len(snapshot.peersByNode))
-		sb.WriteString(fmt.Sprintf("  - Average peers per node: %.1f\n", avgPeers))
+		fmt.Fprintf(&sb, "  - Average peers per node: %.1f\n", avgPeers)
 	}
 
 	sb.WriteString("\n")
 
 	// Node key index
-	sb.WriteString(fmt.Sprintf("NodeKey Index: %d entries\n", len(snapshot.nodesByNodeKey)))
+	fmt.Fprintf(&sb, "NodeKey Index: %d entries\n", len(snapshot.nodesByNodeKey))
 	sb.WriteString("\n")
 
 	return sb.String()

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -931,7 +931,7 @@ func warnBanner(lines []string) {
 	b.WriteString("###                                                          ###\n")
 
 	for _, line := range lines {
-		b.WriteString(fmt.Sprintf("###  %-54s  ###\n", line))
+		fmt.Fprintf(&b, "###  %-54s  ###\n", line)
 	}
 
 	b.WriteString("###                                                          ###\n")

--- a/hscontrol/types/version.go
+++ b/hscontrol/types/version.go
@@ -30,10 +30,10 @@ func (v *VersionInfo) String() string {
 		version += "-dirty"
 	}
 
-	sb.WriteString(fmt.Sprintf("headscale version %s\n", version))
-	sb.WriteString(fmt.Sprintf("commit: %s\n", v.Commit))
-	sb.WriteString(fmt.Sprintf("build time: %s\n", v.BuildTime))
-	sb.WriteString(fmt.Sprintf("built with: %s %s/%s\n", v.Go.Version, v.Go.OS, v.Go.Arch))
+	fmt.Fprintf(&sb, "headscale version %s\n", version)
+	fmt.Fprintf(&sb, "commit: %s\n", v.Commit)
+	fmt.Fprintf(&sb, "build time: %s\n", v.BuildTime)
+	fmt.Fprintf(&sb, "built with: %s %s/%s\n", v.Go.Version, v.Go.OS, v.Go.Arch)
 
 	return sb.String()
 }

--- a/hscontrol/util/string.go
+++ b/hscontrol/util/string.go
@@ -98,12 +98,12 @@ func TailcfgFilterRulesToString(rules []tailcfg.FilterRule) string {
 	var sb strings.Builder
 
 	for index, rule := range rules {
-		sb.WriteString(fmt.Sprintf(`
+		fmt.Fprintf(&sb, `
 {
   SrcIPs: %v
   DstIPs: %v
 }
-`, rule.SrcIPs, rule.DstPorts))
+`, rule.SrcIPs, rule.DstPorts)
 
 		if index < len(rules)-1 {
 			sb.WriteString(", ")

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -341,11 +341,11 @@ func requireAllClientsOnlineWithSingleTimeout(t *testing.T, headscale ControlSer
 					stateStr = stateOnline
 				}
 
-				failureReport.WriteString(fmt.Sprintf("node:%d is not fully %s (timestamp: %s):\n", nodeID, stateStr, time.Now().Format(TimestampFormat)))
-				failureReport.WriteString(fmt.Sprintf("  - batcher: %t (expected: %t)\n", status.Batcher, expectedOnline))
-				failureReport.WriteString(fmt.Sprintf("    - conn count: %d\n", status.BatcherConnCount))
-				failureReport.WriteString(fmt.Sprintf("  - mapresponses: %t (expected: %t, down with at least one peer)\n", status.MapResponses, expectedOnline))
-				failureReport.WriteString(fmt.Sprintf("  - nodestore: %t (expected: %t)\n", status.NodeStore, expectedOnline))
+				fmt.Fprintf(&failureReport, "node:%d is not fully %s (timestamp: %s):\n", nodeID, stateStr, time.Now().Format(TimestampFormat))
+				fmt.Fprintf(&failureReport, "  - batcher: %t (expected: %t)\n", status.Batcher, expectedOnline)
+				fmt.Fprintf(&failureReport, "    - conn count: %d\n", status.BatcherConnCount)
+				fmt.Fprintf(&failureReport, "  - mapresponses: %t (expected: %t, down with at least one peer)\n", status.MapResponses, expectedOnline)
+				fmt.Fprintf(&failureReport, "  - nodestore: %t (expected: %t)\n", status.NodeStore, expectedOnline)
 			}
 		}
 
@@ -359,7 +359,7 @@ func requireAllClientsOnlineWithSingleTimeout(t *testing.T, headscale ControlSer
 				prevReport = failureReport.String()
 			}
 
-			failureReport.WriteString(fmt.Sprintf("validation_timestamp: %s\n", time.Now().Format(TimestampFormat)))
+			fmt.Fprintf(&failureReport, "validation_timestamp: %s\n", time.Now().Format(TimestampFormat))
 			// Note: timeout_remaining not available in this context
 
 			assert.Fail(c, failureReport.String())

--- a/tools/capver/main.go
+++ b/tools/capver/main.go
@@ -359,7 +359,7 @@ func writeTestDataFile(versions map[string]tailcfg.CapabilityVersion, minSupport
 	content.WriteString("\t{3, false, []string{")
 
 	for i, version := range latest3 {
-		content.WriteString(fmt.Sprintf("\"%s\"", version))
+		fmt.Fprintf(&content, "\"%s\"", version)
 
 		if i < len(latest3)-1 {
 			content.WriteString(", ")
@@ -374,7 +374,7 @@ func writeTestDataFile(versions map[string]tailcfg.CapabilityVersion, minSupport
 	for i, version := range latest2 {
 		// Strip v prefix for this test case
 		verNoV := strings.TrimPrefix(version, "v")
-		content.WriteString(fmt.Sprintf("\"%s\"", verNoV))
+		fmt.Fprintf(&content, "\"%s\"", verNoV)
 
 		if i < len(latest2)-1 {
 			content.WriteString(", ")
@@ -384,11 +384,11 @@ func writeTestDataFile(versions map[string]tailcfg.CapabilityVersion, minSupport
 	content.WriteString("}},\n")
 
 	// Latest N without v prefix (all supported)
-	content.WriteString(fmt.Sprintf("\t{%d, true, []string{\n", supportedMajorMinorVersions))
+	fmt.Fprintf(&content, "\t{%d, true, []string{\n", supportedMajorMinorVersions)
 
 	for _, version := range latest10 {
 		verNoV := strings.TrimPrefix(version, "v")
-		content.WriteString(fmt.Sprintf("\t\t\"%s\",\n", verNoV))
+		fmt.Fprintf(&content, "\t\t\"%s\",\n", verNoV)
 	}
 
 	content.WriteString("\t}},\n")
@@ -417,7 +417,7 @@ func writeTestDataFile(versions map[string]tailcfg.CapabilityVersion, minSupport
 
 	// Add minimum supported version
 	minVersionString := capVerToTailscaleVer[minSupportedCapVer]
-	content.WriteString(fmt.Sprintf("\t{%d, \"%s\"},\n", minSupportedCapVer, minVersionString))
+	fmt.Fprintf(&content, "\t{%d, \"%s\"},\n", minSupportedCapVer, minVersionString)
 
 	// Add a few more test cases
 	capsSorted := xmaps.Keys(capVerToTailscaleVer)
@@ -431,7 +431,7 @@ func writeTestDataFile(versions map[string]tailcfg.CapabilityVersion, minSupport
 
 		if capVer != minSupportedCapVer { // Don't duplicate the min version test
 			version := capVerToTailscaleVer[capVer]
-			content.WriteString(fmt.Sprintf("\t{%d, \"%s\"},\n", capVer, version))
+			fmt.Fprintf(&content, "\t{%d, \"%s\"},\n", capVer, version)
 
 			testCount++
 		}


### PR DESCRIPTION
Fixes #3178

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

Ran into this when setting up an exit node with autoApprovers. The route approval logic wasn't correctly handling this case and was rejecting the exit node routes. Fixed the policy evaluator in policy.go to properly check routes when autoApprovers are involved.

Added unit tests to cover the scenario. Also did some cleanup on the debug output formatting while I was at it, switched from WriteString/Sprintf to fmt.Fprintf.