### PR TITLE
api: expose node endpoints on GET /api/v1/node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ tailscale/
 .vscode/
 .claude/
 logs/
+.codex
 
 *.prof
 

--- a/gen/go/headscale/v1/node.pb.go
+++ b/gen/go/headscale/v1/node.pb.go
@@ -98,6 +98,7 @@ type Node struct {
 	AvailableRoutes []string `protobuf:"bytes,24,rep,name=available_routes,json=availableRoutes,proto3" json:"available_routes,omitempty"`
 	SubnetRoutes    []string `protobuf:"bytes,25,rep,name=subnet_routes,json=subnetRoutes,proto3" json:"subnet_routes,omitempty"`
 	Tags            []string `protobuf:"bytes,26,rep,name=tags,proto3" json:"tags,omitempty"`
+	Endpoints       []string `protobuf:"bytes,27,rep,name=endpoints,proto3" json:"endpoints,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -254,6 +255,13 @@ func (x *Node) GetSubnetRoutes() []string {
 func (x *Node) GetTags() []string {
 	if x != nil {
 		return x.Tags
+	}
+	return nil
+}
+
+func (x *Node) GetEndpoints() []string {
+	if x != nil {
+		return x.Endpoints
 	}
 	return nil
 }
@@ -1207,7 +1215,7 @@ var File_headscale_v1_node_proto protoreflect.FileDescriptor
 
 const file_headscale_v1_node_proto_rawDesc = "" +
 	"\n" +
-	"\x17headscale/v1/node.proto\x12\fheadscale.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1dheadscale/v1/preauthkey.proto\x1a\x17headscale/v1/user.proto\"\xc9\x05\n" +
+	"\x17headscale/v1/node.proto\x12\fheadscale.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1dheadscale/v1/preauthkey.proto\x1a\x17headscale/v1/user.proto\"\xe7\x05\n" +
 	"\x04Node\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x04R\x02id\x12\x1f\n" +
 	"\vmachine_key\x18\x02 \x01(\tR\n" +
@@ -1231,7 +1239,8 @@ const file_headscale_v1_node_proto_rawDesc = "" +
 	"\x0fapproved_routes\x18\x17 \x03(\tR\x0eapprovedRoutes\x12)\n" +
 	"\x10available_routes\x18\x18 \x03(\tR\x0favailableRoutes\x12#\n" +
 	"\rsubnet_routes\x18\x19 \x03(\tR\fsubnetRoutes\x12\x12\n" +
-	"\x04tags\x18\x1a \x03(\tR\x04tagsJ\x04\b\t\x10\n" +
+	"\x04tags\x18\x1a \x03(\tR\x04tags\x12\x1c\n" +
+	"\tendpoints\x18\x1b \x03(\tR\tendpointsJ\x04\b\t\x10\n" +
 	"J\x04\b\x0e\x10\x15\";\n" +
 	"\x13RegisterNodeRequest\x12\x12\n" +
 	"\x04user\x18\x01 \x01(\tR\x04user\x12\x10\n" +

--- a/gen/openapiv2/headscale/v1/headscale.swagger.json
+++ b/gen/openapiv2/headscale/v1/headscale.swagger.json
@@ -1346,6 +1346,12 @@
           "items": {
             "type": "string"
           }
+        },
+        "endpoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/hscontrol/grpcv1_test.go
+++ b/hscontrol/grpcv1_test.go
@@ -2,6 +2,7 @@ package hscontrol
 
 import (
 	"context"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -14,6 +15,64 @@ import (
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 )
+
+func TestGetNode_IncludesEndpoints(t *testing.T) {
+	t.Parallel()
+
+	app := createTestApp(t)
+
+	user := app.state.CreateUserForTest("endpoint-user")
+	pak, err := app.state.CreatePreAuthKey(user.TypedID(), false, false, nil, nil)
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	nodeKey := key.NewNode()
+
+	regReq := tailcfg.RegisterRequest{
+		Auth: &tailcfg.RegisterResponseAuth{
+			AuthKey: pak.Key,
+		},
+		NodeKey: nodeKey.Public(),
+		Hostinfo: &tailcfg.Hostinfo{
+			Hostname: "endpoint-node",
+		},
+	}
+	_, err = app.handleRegisterWithAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err)
+
+	node, found := app.state.GetNodeByNodeKey(nodeKey.Public())
+	require.True(t, found)
+
+	endpoints := []netip.AddrPort{
+		netip.MustParseAddrPort("198.51.100.42:41642"),
+		netip.MustParseAddrPort("192.0.2.10:56265"),
+		netip.MustParseAddrPort("[2001:db8::42]:56265"),
+	}
+
+	_, err = app.state.UpdateNodeFromMapRequest(node.ID(), tailcfg.MapRequest{
+		NodeKey:   node.NodeKey(),
+		DiscoKey:  node.DiscoKey(),
+		Endpoints: endpoints,
+		Hostinfo: &tailcfg.Hostinfo{
+			Hostname: "endpoint-node",
+		},
+	})
+	require.NoError(t, err)
+
+	apiServer := newHeadscaleV1APIServer(app)
+
+	resp, err := apiServer.GetNode(context.Background(), &v1.GetNodeRequest{
+		NodeId: uint64(node.ID()),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.GetNode())
+	assert.Equal(t, []string{
+		"198.51.100.42:41642",
+		"192.0.2.10:56265",
+		"[2001:db8::42]:56265",
+	}, resp.GetNode().GetEndpoints())
+}
 
 func Test_validateTag(t *testing.T) {
 	type args struct {

--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -301,6 +301,20 @@ func (node *Node) IPsAsString() []string {
 	return ret
 }
 
+func (node *Node) EndpointsAsString() []string {
+	if len(node.Endpoints) == 0 {
+		return nil
+	}
+
+	ret := make([]string, 0, len(node.Endpoints))
+
+	for _, endpoint := range node.Endpoints {
+		ret = append(ret, endpoint.String())
+	}
+
+	return ret
+}
+
 func (node *Node) InIPSet(set *netipx.IPSet) bool {
 	return slices.ContainsFunc(node.IPs(), set.Contains)
 }
@@ -411,6 +425,7 @@ func (node *Node) Proto() *v1.Node {
 		// routes that are actively served from the node.
 		ApprovedRoutes:  util.PrefixesToString(node.ApprovedRoutes),
 		AvailableRoutes: util.PrefixesToString(node.AnnouncedRoutes()),
+		Endpoints:       node.EndpointsAsString(),
 
 		RegisterMethod: node.RegisterMethodToV1Enum(),
 

--- a/proto/headscale/v1/node.proto
+++ b/proto/headscale/v1/node.proto
@@ -53,6 +53,7 @@ message Node {
   repeated string available_routes = 24;
   repeated string subnet_routes = 25;
   repeated string tags = 26;
+  repeated string endpoints = 27;
 }
 
 message RegisterNodeRequest {


### PR DESCRIPTION
Related: #2152 Related: #2272

**Summary**

The headscale database already persists each node's current endpoints ([]netip.AddrPort) via GORM JSON serialisation, populated from UpdateNodeFromMapRequest. However, this field was not surfaced in the REST API response, making it unavailable to operators building external tooling (network maps, dashboards, audit logs).

**Change**

Added repeated string endpoints = 27 to proto/headscale/v1/node.proto (new field number, fully wire-compatible; the old field 16 comment is preserved)

Added EndpointsAsString() []string helper on types.Node to convert []netip.AddrPort to strings

Populated Endpoints in the v1.Node proto conversion, so both GetNode and ListNodes return the field

Regenerated node.pb.go and headscale.swagger.json via buf generate

Added TestGetNode_IncludesEndpoints in grpcv1_test.go that persists endpoints via UpdateNodeFromMapRequest and asserts GetNode returns them; test passes

**Use case**

Operators running external tooling against the headscale API currently have no way to retrieve a node's active endpoints without querying the database directly. This change makes the information available through the existing REST surface with no breaking changes.

**Maintenance**

The field is derived entirely from the existing types.Node.Endpoints value; no new persistence, migration, or external dependency is introduced.

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
