### PR TITLE
types, util: normalise hostnames from hostinfo instead of rejecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ internet is a security-sensitive choice. `autogroup:danger-all` can only be used
 - Policy validation error messages now include field context (e.g., `src=`, `dst=`) and are more descriptive [#2180](https://github.com/juanfont/headscale/pull/2180)
 - Remove old migrations for the debian package [#3185](https://github.com/juanfont/headscale/pull/3185)
 - Install `config-example.yaml` as example for the debian package [#3186](https://github.com/juanfont/headscale/pull/3186)
+- Fix hostnames with spaces or non-DNS characters (e.g. `Joe's Mac mini`) being rejected on MapRequest updates; they are now normalised to a valid DNS label [#3188](https://github.com/juanfont/headscale/issues/3188)
 
 ## 0.28.1 (202x-xx-xx)
 

--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -634,14 +634,15 @@ func (node *Node) RegisterMethodToV1Enum() v1.RegisterMethod {
 }
 
 // ApplyHostnameFromHostInfo takes a Hostinfo struct and updates the node.
+// Hostnames that are not valid DNS labels (e.g. "Joe's Mac mini") are run
+// through util.NormaliseHostname; the update is dropped only if the
+// normalised value is still invalid.
 func (node *Node) ApplyHostnameFromHostInfo(hostInfo *tailcfg.Hostinfo) {
 	if hostInfo == nil {
 		return
 	}
 
-	newHostname := strings.ToLower(hostInfo.Hostname)
-
-	err := util.ValidateHostname(newHostname)
+	newHostname, err := util.NormaliseHostname(hostInfo.Hostname)
 	if err != nil {
 		log.Warn().
 			Str("node.id", node.ID.String()).
@@ -651,6 +652,14 @@ func (node *Node) ApplyHostnameFromHostInfo(hostInfo *tailcfg.Hostinfo) {
 			Msg("Rejecting invalid hostname update from hostinfo")
 
 		return
+	}
+
+	if hostInfo.Hostname != newHostname {
+		log.Info().
+			Str("node.id", node.ID.String()).
+			Str("raw_hostname", hostInfo.Hostname).
+			Str("normalised_hostname", newHostname).
+			Msg("Normalised hostname from hostinfo")
 	}
 
 	if node.Hostname != newHostname {

--- a/hscontrol/types/node_test.go
+++ b/hscontrol/types/node_test.go
@@ -393,11 +393,11 @@ func TestApplyHostnameFromHostInfo(t *testing.T) {
 				Hostname:  "valid-hostname",
 			},
 			change: &tailcfg.Hostinfo{
-				Hostname: "hostname-with-💩",
+				Hostname: "hostname-with-🎉",
 			},
 			want: Node{
 				GivenName: "valid-hostname",
-				Hostname:  "valid-hostname", // Should reject and keep old hostname
+				Hostname:  "valid-hostname",
 			},
 		},
 		{
@@ -411,11 +411,11 @@ func TestApplyHostnameFromHostInfo(t *testing.T) {
 			},
 			want: Node{
 				GivenName: "valid-hostname",
-				Hostname:  "valid-hostname", // Should keep old hostname
+				Hostname:  "valid-hostname",
 			},
 		},
 		{
-			name: "invalid-hostname-with-special-chars-rejected",
+			name: "hostname-with-special-chars-normalised",
 			nodeBefore: Node{
 				GivenName: "valid-hostname",
 				Hostname:  "valid-hostname",
@@ -424,8 +424,8 @@ func TestApplyHostnameFromHostInfo(t *testing.T) {
 				Hostname: "node-with-special!@#$%",
 			},
 			want: Node{
-				GivenName: "valid-hostname",
-				Hostname:  "valid-hostname", // Should reject and keep old hostname
+				GivenName: "node-with-special",
+				Hostname:  "node-with-special",
 			},
 		},
 		{
@@ -471,7 +471,7 @@ func TestApplyHostnameFromHostInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "at_sign_rejected",
+			name: "at_sign_normalised",
 			nodeBefore: Node{
 				GivenName: "valid-hostname",
 				Hostname:  "valid-hostname",
@@ -480,12 +480,12 @@ func TestApplyHostnameFromHostInfo(t *testing.T) {
 				Hostname: "Test@Host",
 			},
 			want: Node{
-				GivenName: "valid-hostname",
-				Hostname:  "valid-hostname",
+				GivenName: "testhost",
+				Hostname:  "testhost",
 			},
 		},
 		{
-			name: "chinese_chars_with_dash_rejected",
+			name: "chinese_chars_with_dash_normalised",
 			nodeBefore: Node{
 				GivenName: "valid-hostname",
 				Hostname:  "valid-hostname",
@@ -494,8 +494,8 @@ func TestApplyHostnameFromHostInfo(t *testing.T) {
 				Hostname: "server-北京-01", //nolint:gosmopolitan // intentional i18n test data
 			},
 			want: Node{
-				GivenName: "valid-hostname",
-				Hostname:  "valid-hostname",
+				GivenName: "server--01",
+				Hostname:  "server--01",
 			},
 		},
 		{
@@ -597,7 +597,7 @@ func TestApplyHostnameFromHostInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "too_long_hostname_rejected",
+			name: "too_long_hostname_truncated",
 			nodeBefore: Node{
 				GivenName: "valid-hostname",
 				Hostname:  "valid-hostname",
@@ -606,12 +606,12 @@ func TestApplyHostnameFromHostInfo(t *testing.T) {
 				Hostname: strings.Repeat("t", 65),
 			},
 			want: Node{
-				GivenName: "valid-hostname",
-				Hostname:  "valid-hostname",
+				GivenName: strings.Repeat("t", 63),
+				Hostname:  strings.Repeat("t", 63),
 			},
 		},
 		{
-			name: "underscore_rejected",
+			name: "underscore_normalised",
 			nodeBefore: Node{
 				GivenName: "valid-hostname",
 				Hostname:  "valid-hostname",
@@ -620,8 +620,24 @@ func TestApplyHostnameFromHostInfo(t *testing.T) {
 				Hostname: "test_node",
 			},
 			want: Node{
-				GivenName: "valid-hostname",
-				Hostname:  "valid-hostname",
+				GivenName: "testnode",
+				Hostname:  "testnode",
+			},
+		},
+		{
+			// Regression: hostnames like "Joe's Mac mini" were previously dropped
+			// with "Rejecting invalid hostname update from hostinfo".
+			name: "apostrophe_and_spaces_normalised",
+			nodeBefore: Node{
+				GivenName: "invalid-abc12345",
+				Hostname:  "invalid-abc12345",
+			},
+			change: &tailcfg.Hostinfo{
+				Hostname: "Joe's Mac mini",
+			},
+			want: Node{
+				GivenName: "joesmacmini",
+				Hostname:  "joesmacmini",
 			},
 		},
 	}

--- a/hscontrol/util/util.go
+++ b/hscontrol/util/util.go
@@ -312,9 +312,12 @@ func EnsureHostname(hostinfo tailcfg.HostinfoView, machineKey, nodeKey string) s
 
 	lowercased := strings.ToLower(hostinfo.Hostname())
 
-	err := ValidateHostname(lowercased)
-	if err == nil {
+	if err := ValidateHostname(lowercased); err == nil {
 		return lowercased
+	}
+
+	if normalised, err := NormaliseHostname(hostinfo.Hostname()); err == nil {
+		return normalised
 	}
 
 	return InvalidString()

--- a/hscontrol/util/util_test.go
+++ b/hscontrol/util/util_test.go
@@ -882,7 +882,7 @@ func TestEnsureHostname(t *testing.T) {
 			},
 			machineKey: "mkey12345678",
 			nodeKey:    "nkey12345678",
-			want:       "invalid-",
+			want:       "123456789012345678901234567890123456789012345678901234567890123",
 		},
 		{
 			name: "hostname_very_long_truncated",
@@ -891,7 +891,7 @@ func TestEnsureHostname(t *testing.T) {
 			},
 			machineKey: "mkey12345678",
 			nodeKey:    "nkey12345678",
-			want:       "invalid-",
+			want:       "test-node-with-very-long-hostname-that-exceeds-dns-label-limits",
 		},
 		{
 			name: "hostname_with_special_chars",
@@ -900,7 +900,7 @@ func TestEnsureHostname(t *testing.T) {
 			},
 			machineKey: "mkey12345678",
 			nodeKey:    "nkey12345678",
-			want:       "invalid-",
+			want:       "node-with-special",
 		},
 		{
 			name: "hostname_with_unicode",
@@ -954,7 +954,7 @@ func TestEnsureHostname(t *testing.T) {
 			},
 			machineKey: "mkey12345678",
 			nodeKey:    "nkey12345678",
-			want:       "invalid-",
+			want:       "node---test",
 		},
 		{
 			name: "uppercase_to_lowercase",
@@ -972,25 +972,35 @@ func TestEnsureHostname(t *testing.T) {
 			},
 			machineKey: "mkey12345678",
 			nodeKey:    "nkey12345678",
-			want:       "invalid-",
+			want:       "testnode",
 		},
 		{
-			name: "at_sign_invalid",
+			name: "at_sign_normalised",
 			hostinfo: &tailcfg.Hostinfo{
 				Hostname: "Test@Host",
 			},
 			machineKey: "mkey12345678",
 			nodeKey:    "nkey12345678",
-			want:       "invalid-",
+			want:       "testhost",
 		},
 		{
-			name: "chinese_chars_with_dash_invalid",
+			name: "chinese_chars_with_dash_normalised",
 			hostinfo: &tailcfg.Hostinfo{
 				Hostname: "server-北京-01", //nolint:gosmopolitan
 			},
 			machineKey: "mkey12345678",
 			nodeKey:    "nkey12345678",
-			want:       "invalid-",
+			want:       "server--01",
+		},
+		{
+			// Regression: "Joe's Mac mini" previously fell back to invalid-<random>.
+			name: "apostrophe_and_spaces_normalised",
+			hostinfo: &tailcfg.Hostinfo{
+				Hostname: "Joe's Mac mini",
+			},
+			machineKey: "mkey12345678",
+			nodeKey:    "nkey12345678",
+			want:       "joesmacmini",
 		},
 		{
 			name: "chinese_only_invalid",
@@ -1062,7 +1072,7 @@ func TestEnsureHostname(t *testing.T) {
 			},
 			machineKey: "mkey12345678",
 			nodeKey:    "nkey12345678",
-			want:       "invalid-",
+			want:       strings.Repeat("t", 63),
 		},
 	}
 
@@ -1135,13 +1145,13 @@ func TestEnsureHostnameWithHostinfo(t *testing.T) {
 			wantHostname: "node-mkey1234",
 		},
 		{
-			name: "long_hostname_rejected",
+			name: "long_hostname_truncated",
 			hostinfo: &tailcfg.Hostinfo{
 				Hostname: "test-node-with-very-long-hostname-that-exceeds-dns-label-limits-of-63-characters",
 			},
 			machineKey:   "mkey12345678",
 			nodeKey:      "nkey12345678",
-			wantHostname: "invalid-",
+			wantHostname: "test-node-with-very-long-hostname-that-exceeds-dns-label-limits",
 		},
 		{
 			name:         "nil_hostinfo_node_key_only",


### PR DESCRIPTION
Fixes #3188.

Hostnames like `Joe's Mac mini` were dropped on registration (falling back to `invalid-<random>`) and then rejected on every MapRequest with `WRN Rejecting invalid hostname update from hostinfo`. Both paths now route through `util.NormaliseHostname`, which lowercases, strips characters outside `[a-z0-9-.]`, and truncates to 63 chars. The update is dropped only if the normalised value is still invalid (empty, or starts/ends with a dash). Existing `invalid-*` nodes self-heal on the next MapRequest.

### Also changes

Other previously-rejected inputs now succeed (all strictly more permissive, none silently corrupting):

| Input | After |
|---|---|
| `> 63 chars` | truncated to 63 |
| `test_node` | `testnode` |
| `Test@Host` | `testhost` |
| `server-北京-01` | `server--01` |

Still rejected: empty-after-strip (`🎉`, `@@@`), leading/trailing dash (`-test`, `test-`), too short.

### Left for follow-up

- `node.Hostname` is normalised but `node.Hostinfo.Hostname` keeps the raw client string. Peers get the normalised value via `tailcfg.Node.Name` and the raw via `Hostinfo` — matches Tailscale's model.
- `GivenName` has a DB unique index. Two nodes across different users normalising to the same label will race; the losing MapRequest fails with a constraint error and the client retries. Rare and self-limiting. Wiring `EnsureUniqueGivenName` into the update path would fix it, at the cost of added complexity — happy to do it if wanted.

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md
