### PR TITLE
ci: add rolling development tag to container builds

### DIFF
--- a/.github/workflows/container-main.yml
+++ b/.github/workflows/container-main.yml
@@ -59,7 +59,7 @@ jobs:
           nix develop --command -- ko build \
             --bare \
             --platform=linux/amd64,linux/arm64 \
-            --tags=main-${GITHUB_SHA::7} \
+            --tags=main-${GITHUB_SHA::7},development \
             ./cmd/headscale
 
       - name: Push to Docker Hub
@@ -71,7 +71,7 @@ jobs:
           nix develop --command -- ko build \
             --bare \
             --platform=linux/amd64,linux/arm64 \
-            --tags=main-${GITHUB_SHA::7} \
+            --tags=main-${GITHUB_SHA::7},development \
             ./cmd/headscale
 
   binaries:


### PR DESCRIPTION
Adds a rolling `development` tag alongside the existing `main-<sha>` tag for container images pushed to both GHCR and Docker Hub. This gives users a stable reference to track the latest main build without needing to look up commit SHAs.

Generated with the help of an AI assistant