### PR TITLE
policy: include CapGrant destinations for peer relay capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ traffic through specific tagged subnet routers or exit nodes. The `ip` field wor
 Grants can be mixed with ACLs in the same policy file.
 [#2180](https://github.com/juanfont/headscale/pull/2180)
 
+Fix: `CapGrant` destinations are now included in the peer map matcher, ensuring that grant-only
+relay policies correctly establish peer visibility between the grant issuer and recipient.
+[#3192](https://github.com/juanfont/headscale/pull/3192)
+
 As part of this, we added `autogroup:danger-all`. It resolves to `0.0.0.0/0` and `::/0` — all IP
 addresses, including those outside the tailnet. This replaces the old behaviour where `*` matched
 all IPs (see BREAKING below). The name is intentionally scary: accepting traffic from the entire

--- a/hscontrol/policy/matcher/matcher.go
+++ b/hscontrol/policy/matcher/matcher.go
@@ -49,6 +49,11 @@ func MatchFromFilterRule(rule tailcfg.FilterRule) Match {
 	for _, dest := range rule.DstPorts {
 		dests = append(dests, dest.IP)
 	}
+	for _, grant := range rule.CapGrant {
+		for _, dst := range grant.Dsts {
+			dests = append(dests, dst.String())
+		}
+	}
 
 	return MatchFromStrings(rule.SrcIPs, dests)
 }

--- a/hscontrol/policy/matcher/matcher_test.go
+++ b/hscontrol/policy/matcher/matcher_test.go
@@ -1,1 +1,41 @@
 package matcher
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"tailscale.com/tailcfg"
+)
+
+func TestMatchFromFilterRuleIncludesCapGrantDests(t *testing.T) {
+	rule := tailcfg.FilterRule{
+		SrcIPs: []string{"100.64.0.1/32"},
+		DstPorts: []tailcfg.NetPortRange{
+			{
+				IP:    "100.64.0.2",
+				Ports: tailcfg.PortRangeAny,
+			},
+		},
+		CapGrant: []tailcfg.CapGrant{
+			{
+				Dsts: []netip.Prefix{
+					netip.MustParsePrefix("100.64.0.3/32"),
+					netip.MustParsePrefix("100.64.0.0/24"),
+				},
+			},
+		},
+	}
+
+	got := MatchFromFilterRule(rule)
+
+	require.True(t, got.SrcsContainsIPs(netip.MustParseAddr("100.64.0.1")))
+	require.True(
+		t,
+		got.DestsContainsIP(
+			netip.MustParseAddr("100.64.0.2"),
+			netip.MustParseAddr("100.64.0.3"),
+			netip.MustParseAddr("100.64.0.77"),
+		),
+	)
+}

--- a/hscontrol/policy/v2/policy_test.go
+++ b/hscontrol/policy/v2/policy_test.go
@@ -69,6 +69,46 @@ func TestPolicyManager(t *testing.T) {
 	}
 }
 
+func TestBuildPeerMapFromAppOnlyRelayGrant(t *testing.T) {
+	users := types.Users{
+		{Model: gorm.Model{ID: 1}, Name: "alice", Email: "alice@headscale.net"},
+		{Model: gorm.Model{ID: 2}, Name: "bob", Email: "bob@headscale.net"},
+	}
+
+	relay := node("relay", "100.64.0.3", "fd7a:115c:a1e0::3", users[0])
+	relay.ID = 1
+	relay.Tags = []string{"tag:relay"}
+
+	client := node("client", "100.64.0.2", "fd7a:115c:a1e0::2", users[1])
+	client.ID = 2
+
+	nodes := types.Nodes{relay, client}
+
+	policy := `{
+		"tagOwners": {
+			"tag:relay": ["alice@"]
+		},
+		"grants": [
+			{
+				"src": ["bob@"],
+				"dst": ["tag:relay"],
+				"app": {
+					"tailscale.com/cap/relay": [{}]
+				}
+			}
+		]
+	}`
+
+	pm, err := NewPolicyManager([]byte(policy), users, nodes.ViewSlice())
+	require.NoError(t, err)
+
+	peerMap := pm.BuildPeerMap(nodes.ViewSlice())
+	require.Len(t, peerMap[relay.ID], 1)
+	require.Len(t, peerMap[client.ID], 1)
+	require.Equal(t, client.ID, peerMap[relay.ID][0].ID())
+	require.Equal(t, relay.ID, peerMap[client.ID][0].ID())
+}
+
 func TestInvalidateAutogroupSelfCache(t *testing.T) {
 	users := types.Users{
 		{Model: gorm.Model{ID: 1}, Name: "user1", Email: "user1@headscale.net"},

--- a/integration/grant_cap_test.go
+++ b/integration/grant_cap_test.go
@@ -64,6 +64,159 @@ func parsePeerRelay(pr string) (netip.AddrPort, string, bool) {
 	return ap, vni, true
 }
 
+// TestGrantCapRelayAppOnly validates that a grant with only the app
+// field (cap/relay, no IP connectivity grant) is sufficient for peer
+// visibility and correct cap routing. This is the integration-level
+// regression test for the MatchFromFilterRule fix that includes
+// CapGrant.Dsts in the peer map.
+//
+// Without the fix, nodes connected only by a CapGrant would not appear
+// in each other's peer lists because CapGrant destinations were not
+// included in the matcher's destination set.
+//
+//  1. Only a relay cap grant exists (no ACL rules, no IP grants)
+//  2. All nodes see each other as peers (peer map includes CapGrant.Dsts)
+//  3. Cap grants compile correctly (cap/relay on relay, cap/relay-target on clients)
+//  4. Wrong caps must NOT be present (negative checks)
+func TestGrantCapRelayAppOnly(t *testing.T) {
+	IntegrationSkip(t)
+
+	assertTimeout := 120 * time.Second
+
+	spec := ScenarioSpec{
+		NodesPerUser: 0,
+		Users:        []string{"relay", "client"},
+		Networks: map[string]NetworkSpec{
+			"usernet1": {Users: []string{"relay", "client"}},
+		},
+		Versions: []string{"head"},
+	}
+
+	scenario, err := NewScenario(spec)
+	require.NoErrorf(t, err, "failed to create scenario: %s", err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	// Policy has ONLY a relay cap grant — no IP connectivity.
+	// Without the CapGrant.Dsts fix, this grant alone would not
+	// establish peer visibility between relay and client.
+	pol := &policyv2.Policy{
+		TagOwners: policyv2.TagOwners{
+			policyv2.Tag("tag:relay"): policyv2.Owners{usernameOwner("relay@")},
+		},
+		Grants: []policyv2.Grant{
+			{
+				Sources:      policyv2.Aliases{usernamep("client@")},
+				Destinations: policyv2.Aliases{tagp("tag:relay")},
+				App: tailcfg.PeerCapMap{
+					tailcfg.PeerCapabilityRelay: {tailcfg.RawMessage("{}")},
+				},
+			},
+		},
+	}
+
+	headscale, err := scenario.Headscale(
+		hsic.WithTestName("grant-cap-relay-app-only"),
+		hsic.WithACLPolicy(pol),
+		hsic.WithPolicyMode(types.PolicyModeDB),
+	)
+	requireNoErrGetHeadscale(t, err)
+
+	usernet1, err := scenario.Network("usernet1")
+	require.NoError(t, err)
+
+	_, err = scenario.CreateUser("relay")
+	require.NoError(t, err)
+	_, err = scenario.CreateUser("client")
+	require.NoError(t, err)
+
+	userMap, err := headscale.MapUsers()
+	require.NoError(t, err)
+
+	// --- Create relay node (tagged) ---
+	relayR, err := scenario.CreateTailscaleNode("head",
+		tsic.WithNetwork(usernet1),
+	)
+	require.NoError(t, err)
+	defer func() { _, _, _ = relayR.Shutdown() }()
+
+	pakRelay, err := scenario.CreatePreAuthKeyWithTags(
+		userMap["relay"].GetId(), false, false, []string{"tag:relay"},
+	)
+	require.NoError(t, err)
+	err = relayR.Login(headscale.GetEndpoint(), pakRelay.GetKey())
+	require.NoError(t, err)
+	err = relayR.WaitForRunning(30 * time.Second)
+	require.NoError(t, err)
+
+	// --- Create client node (user-owned, no tags) ---
+	clientN, err := scenario.CreateTailscaleNode("head",
+		tsic.WithNetwork(usernet1),
+	)
+	require.NoError(t, err)
+	defer func() { _, _, _ = clientN.Shutdown() }()
+
+	pakClient, err := scenario.CreatePreAuthKey(
+		userMap["client"].GetId(), false, false,
+	)
+	require.NoError(t, err)
+	err = clientN.Login(headscale.GetEndpoint(), pakClient.GetKey())
+	require.NoError(t, err)
+	err = clientN.WaitForRunning(30 * time.Second)
+	require.NoError(t, err)
+
+	// ===== Phase 1: Validate peer visibility =====
+	// This is the core assertion: with only a CapGrant (no IP grant),
+	// both nodes must still appear in each other's peer list.
+	t.Log("Phase 1: Validate peer visibility with app-only grant")
+
+	allNodes := []TailscaleClient{relayR, clientN}
+	for _, node := range allNodes {
+		err = node.WaitForPeers(1, 60*time.Second, 1*time.Second)
+		require.NoErrorf(t, err, "node %s failed to see its peer", node.Hostname())
+	}
+
+	relayIPv4 := relayR.MustIPv4()
+	clientIPv4 := clientN.MustIPv4()
+
+	// ===== Phase 2: Validate cap grants in packet filters =====
+	t.Log("Phase 2: Validate cap grants in packet filters")
+
+	// Relay should have cap/relay targeting its own IP.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		pf, err := relayR.PacketFilter()
+		assert.NoError(c, err)
+		assert.True(c, hasCapMatchForIP(pf, tailcfg.PeerCapabilityRelay, relayIPv4),
+			"Relay should have cap/relay with Dst matching relay's IP %s", relayIPv4)
+	}, assertTimeout, 500*time.Millisecond, "relay should have cap/relay targeting its own IP")
+
+	// Client should have cap/relay-target targeting client's IP.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		pf, err := clientN.PacketFilter()
+		assert.NoError(c, err)
+		assert.True(c, hasCapMatchForIP(pf, tailcfg.PeerCapabilityRelayTarget, clientIPv4),
+			"Client should have cap/relay-target with Dst matching client's IP %s", clientIPv4)
+	}, assertTimeout, 500*time.Millisecond, "client should have cap/relay-target")
+
+	// ===== Phase 3: Negative checks =====
+	t.Log("Phase 3: Negative cap checks")
+
+	// Relay should NOT have cap/relay-target.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		pf, err := relayR.PacketFilter()
+		assert.NoError(c, err)
+		assert.False(c, hasCapMatchInPacketFilter(pf, tailcfg.PeerCapabilityRelayTarget),
+			"Relay should NOT have cap/relay-target")
+	}, 10*time.Second, 500*time.Millisecond, "relay should not have cap/relay-target")
+
+	// Client should NOT have cap/relay.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		pf, err := clientN.PacketFilter()
+		assert.NoError(c, err)
+		assert.False(c, hasCapMatchInPacketFilter(pf, tailcfg.PeerCapabilityRelay),
+			"Client should NOT have cap/relay")
+	}, 10*time.Second, 500*time.Millisecond, "client should not have cap/relay")
+}
+
 // TestGrantCapRelay validates the full peer relay lifecycle:
 //  1. No direct connection between isolated clients
 //  2. Cap grants compile correctly (relay + relay-target in packet filters)


### PR DESCRIPTION
# Changes
Extend MatchFromFilterRule in hscontrol/policy/matcher/matcher.go to union CapGrant[].Dsts into the rule's destination set. Without this, a node that only receives capabilities (e.g. cap/relay, cap/relay-target) through a CapGrant is excluded from the grant issuer's peer map, which breaks peer relay on grant-only policies.
Close: https://github.com/juanfont/headscale/issues/2841  

# Peer Relay Test Method and Results
## Method
  - Objective: verify in a real environment that 100.64.0.2 and 100.64.0.4 can use peer relay through 100.64.0.3 when direct UDP connectivity is
    blocked.
  - Environment:
      - 100.64.0.2: headscale-server on 107.150.110.155
      - 100.64.0.3: relay node on 123.58.213.16 / 10-7-54-172
      - 100.64.0.4: client node on 10-60-53-172
      - Headscale was upgraded to the current branch build before testing.
  - Method:
      - Verified the baseline path was direct.
      - Added temporary iptables rules on both ends to block UDP 41641 between 0.2 and 0.4.
      - Configured the relay node to listen on 40000 and advertise 123.58.213.16:40000.
      - Re-tested with tailscale ping, tailscale status, and tailscale debug peer-relay-sessions.
      - Removed the temporary firewall rules after the test.

## Result

  - Direct connectivity was successfully forced off.
  - Both directions switched to peer relay:
      - 0.2 -> 0.4: via peer-relay(123.58.213.16:40000:vni:1)
      - 0.4 -> 0.2: via peer-relay(10.7.54.172:40000:vni:1)
  - On the relay node, tailscale debug peer-relay-sessions showed an active session and increasing packet counts.
  - After removing the temporary blocks, the nodes returned to direct connectivity.

  Conclusion

  - Real-world end-to-end peer relay is working.

# Check List
- [x] have read the [CONTRIBUTING.md](https://github.com/juanfont/headscale/pull/CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [x] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md
 