### PR TITLE
all: add HA subnet router health probing

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -249,6 +249,7 @@ jobs:
           - TestAutoApproveMultiNetwork/webauth-group.*
           - TestSubnetRouteACLFiltering
           - TestGrantViaSubnetSteering
+          - TestHASubnetRouterPingFailover
           - TestHeadscale
           - TestTailscaleNodesJoiningHeadcale
           - TestSSHOneUserToAll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,8 +60,19 @@ internet is a security-sensitive choice. `autogroup:danger-all` can only be used
 - **CLI**: `headscale nodes register` is deprecated in favour of `headscale auth register --auth-id <id> --user <user>` [#1850](https://github.com/juanfont/headscale/pull/1850)
   - The old command continues to work but will be removed in a future release
 
+### HA subnet router health probing
+
+Headscale now actively probes HA subnet routers to detect nodes that are connected but not
+forwarding traffic. The control plane periodically pings HA subnet routers via the Noise
+control channel and fails over to a healthy standby if the primary stops responding. This is
+enabled by default (`node.routes.ha.probe_interval: 10s`, `probe_timeout: 5s`) and only
+active when HA routes exist (2+ nodes advertising the same prefix). Set `probe_interval` to
+`0` to disable. This complements the existing disconnect-based failover, catching "zombie
+connected" routers that maintain their control session but cannot route packets.
+
 ### Changes
 
+- **Debug endpoints**: Add node connectivity ping page for verifying control-plane reachability [#3183](https://github.com/juanfont/headscale/pull/3183)
 - **OIDC registration**: Add a confirmation page before completing node registration, showing the device hostname and machine key fingerprint [#3180](https://github.com/juanfont/headscale/pull/3180)
 - **Debug endpoints**: Omit secret fields (`Pass`, `ClientSecret`, `APIKey`) from `/debug/config` JSON output [#3180](https://github.com/juanfont/headscale/pull/3180)
 - **Debug endpoints**: Route `statsviz` through `tsweb.Protected` [#3180](https://github.com/juanfont/headscale/pull/3180)

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -165,6 +165,31 @@ node:
     # Time before an inactive ephemeral node is deleted.
     inactivity_timeout: 30m
 
+  # HA subnet router health probing.
+  #
+  # A subnet router can hold its control-plane session open yet be unable to
+  # forward traffic ("zombie connected"). The normal disconnect-based failover
+  # never fires because the Noise session is still alive.
+  #
+  # When HA routes exist (2+ nodes advertising the same prefix), headscale
+  # pings each HA node every probe_interval via the Noise channel. If a node
+  # fails to respond within probe_timeout it is marked unhealthy and the
+  # primary role moves to the next healthy node. A node that later responds
+  # is marked healthy again but does NOT reclaim primary (avoids flapping).
+  #
+  # Worst-case detection time is probe_interval + probe_timeout (15s default).
+  # No-op when no HA routes exist. Set probe_interval to 0 to disable.
+  # probe_timeout must be less than probe_interval.
+  routes:
+    ha:
+      # How often to ping HA subnet routers. Set to 0 to disable probing.
+      # Must be >= 2s when enabled.
+      probe_interval: 10s
+
+      # How long to wait for a ping response before marking a node unhealthy.
+      # Must be >= 1s and less than probe_interval.
+      probe_timeout: 5s
+
 database:
   # Database type. Available options: sqlite, postgres
   # Please note that using Postgres is highly discouraged as it is only supported for legacy reasons.

--- a/hscontrol/app.go
+++ b/hscontrol/app.go
@@ -276,6 +276,31 @@ func (h *Headscale) scheduledTasks(ctx context.Context) {
 		extraRecordsUpdate = make(chan []tailcfg.DNSRecord)
 	}
 
+	var (
+		haProber     *state.HAHealthProber
+		haHealthChan <-chan time.Time
+	)
+	if h.cfg.Node.Routes.HA.ProbeInterval > 0 {
+		haProber = state.NewHAHealthProber(
+			h.state,
+			h.cfg.Node.Routes.HA,
+			h.cfg.ServerURL,
+			h.mapBatcher.IsConnected,
+		)
+
+		haTicker := time.NewTicker(h.cfg.Node.Routes.HA.ProbeInterval)
+		defer haTicker.Stop()
+
+		haHealthChan = haTicker.C
+
+		log.Info().
+			Dur("interval", h.cfg.Node.Routes.HA.ProbeInterval).
+			Dur("timeout", h.cfg.Node.Routes.HA.ProbeTimeout).
+			Msg("HA subnet router health probing enabled")
+	} else {
+		haHealthChan = make(<-chan time.Time)
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -332,6 +357,9 @@ func (h *Headscale) scheduledTasks(ctx context.Context) {
 			h.cfg.TailcfgDNSConfig.ExtraRecords = records
 
 			h.Change(change.ExtraRecords())
+
+		case <-haHealthChan:
+			haProber.ProbeOnce(ctx, h.Change)
 		}
 	}
 }
@@ -1111,6 +1139,11 @@ func (h *Headscale) StartBatcherForTest(tb testing.TB) {
 	h.mapBatcher = mapper.NewBatcherAndMapper(h.cfg, h.state)
 	h.mapBatcher.Start()
 	tb.Cleanup(func() { h.mapBatcher.Close() })
+}
+
+// MapBatcher returns the map response batcher (for test use).
+func (h *Headscale) MapBatcher() *mapper.Batcher {
+	return h.mapBatcher
 }
 
 // StartEphemeralGCForTest starts the ephemeral node garbage collector.

--- a/hscontrol/routes/primary.go
+++ b/hscontrol/routes/primary.go
@@ -27,6 +27,10 @@ type PrimaryRoutes struct {
 	// primaries is a map of prefixes to the node that is the primary for that prefix.
 	primaries map[netip.Prefix]types.NodeID
 	isPrimary map[types.NodeID]bool
+
+	// unhealthy tracks nodes that failed health probes. Unhealthy nodes
+	// are skipped during primary selection but remain in the routes map.
+	unhealthy set.Set[types.NodeID]
 }
 
 func New() *PrimaryRoutes {
@@ -34,6 +38,7 @@ func New() *PrimaryRoutes {
 		routes:    make(map[types.NodeID]set.Set[netip.Prefix]),
 		primaries: make(map[netip.Prefix]types.NodeID),
 		isPrimary: make(map[types.NodeID]bool),
+		unhealthy: make(set.Set[types.NodeID]),
 	}
 }
 
@@ -92,13 +97,13 @@ func (pr *PrimaryRoutes) updatePrimaryLocked() bool {
 			Msg("processing prefix for primary route selection")
 
 		if node, ok := pr.primaries[prefix]; ok {
-			// If the current primary is still available, continue.
-			if slices.Contains(nodes, node) {
+			// If the current primary is still available and healthy, continue.
+			if slices.Contains(nodes, node) && !pr.unhealthy.Contains(node) {
 				log.Debug().
 					Caller().
 					Str(zf.Prefix, prefix.String()).
 					Uint64("currentPrimary", node.Uint64()).
-					Msg("current primary still available, keeping it")
+					Msg("current primary still available and healthy, keeping it")
 
 				continue
 			} else {
@@ -106,18 +111,46 @@ func (pr *PrimaryRoutes) updatePrimaryLocked() bool {
 					Caller().
 					Str(zf.Prefix, prefix.String()).
 					Uint64("oldPrimary", node.Uint64()).
-					Msg("current primary no longer available")
+					Bool("unhealthy", pr.unhealthy.Contains(node)).
+					Msg("current primary no longer available or unhealthy")
 			}
 		}
 
-		if len(nodes) >= 1 {
-			pr.primaries[prefix] = nodes[0]
+		// Select the first healthy node as primary.
+		// If all nodes are unhealthy, fall back to the first node
+		// (degraded service is better than no service).
+		var selected types.NodeID
+
+		found := false
+
+		for _, n := range nodes {
+			if !pr.unhealthy.Contains(n) {
+				selected = n
+				found = true
+
+				break
+			}
+		}
+
+		if !found && len(nodes) >= 1 {
+			selected = nodes[0]
+			found = true
+
+			log.Warn().
+				Caller().
+				Str(zf.Prefix, prefix.String()).
+				Uint64("fallbackPrimary", selected.Uint64()).
+				Msg("all nodes unhealthy for prefix, keeping first as degraded primary")
+		}
+
+		if found {
+			pr.primaries[prefix] = selected
 			changed = true
 
 			log.Debug().
 				Caller().
 				Str(zf.Prefix, prefix.String()).
-				Uint64("newPrimary", nodes[0].Uint64()).
+				Uint64("newPrimary", selected.Uint64()).
 				Msg("selected new primary for prefix")
 		}
 	}
@@ -164,12 +197,14 @@ func (pr *PrimaryRoutes) SetRoutes(node types.NodeID, prefixes ...netip.Prefix) 
 		Strs("prefixes", util.PrefixesToString(prefixes)).
 		Msg("PrimaryRoutes.SetRoutes called")
 
-	// If no routes are being set, remove the node from the routes map.
+	// If no routes are being set, remove the node from the routes map
+	// and clear any unhealthy state.
 	if len(prefixes) == 0 {
 		wasPresent := false
 
 		if _, ok := pr.routes[node]; ok {
 			delete(pr.routes, node)
+			pr.unhealthy.Delete(node)
 
 			wasPresent = true
 
@@ -245,6 +280,99 @@ func (pr *PrimaryRoutes) PrimaryRoutes(id types.NodeID) []netip.Prefix {
 	return routes
 }
 
+// SetNodeHealthy marks a node as healthy or unhealthy and recalculates
+// primary routes. Returns true if primaries changed.
+func (pr *PrimaryRoutes) SetNodeHealthy(
+	node types.NodeID,
+	healthy bool,
+) bool {
+	pr.mu.Lock()
+	defer pr.mu.Unlock()
+
+	if healthy {
+		if !pr.unhealthy.Contains(node) {
+			return false
+		}
+
+		pr.unhealthy.Delete(node)
+
+		log.Debug().
+			Caller().
+			Uint64(zf.NodeID, node.Uint64()).
+			Msg("node marked healthy")
+	} else {
+		if pr.unhealthy.Contains(node) {
+			return false
+		}
+
+		pr.unhealthy.Add(node)
+
+		log.Info().
+			Caller().
+			Uint64(zf.NodeID, node.Uint64()).
+			Msg("node marked unhealthy")
+	}
+
+	return pr.updatePrimaryLocked()
+}
+
+// ClearUnhealthy removes a node from the unhealthy set without
+// recalculating primaries. Used when a node reconnects to give
+// it a fresh start.
+func (pr *PrimaryRoutes) ClearUnhealthy(node types.NodeID) {
+	pr.mu.Lock()
+	defer pr.mu.Unlock()
+
+	if pr.unhealthy.Contains(node) {
+		pr.unhealthy.Delete(node)
+
+		log.Debug().
+			Caller().
+			Uint64(zf.NodeID, node.Uint64()).
+			Msg("cleared unhealthy state on reconnect")
+	}
+}
+
+// HANodes returns a snapshot of prefixes that have 2+ nodes
+// advertising them (HA configurations), mapped to the node IDs.
+// Node IDs are sorted deterministically.
+func (pr *PrimaryRoutes) HANodes() map[netip.Prefix][]types.NodeID {
+	pr.mu.Lock()
+	defer pr.mu.Unlock()
+
+	// Build prefix → nodes map.
+	prefixNodes := make(map[netip.Prefix][]types.NodeID)
+
+	ids := types.NodeIDs(xmaps.Keys(pr.routes))
+	sort.Sort(ids)
+
+	for _, id := range ids {
+		routes := pr.routes[id]
+		for route := range routes {
+			prefixNodes[route] = append(prefixNodes[route], id)
+		}
+	}
+
+	// Keep only prefixes with 2+ advertisers.
+	result := make(map[netip.Prefix][]types.NodeID)
+
+	for prefix, nodes := range prefixNodes {
+		if len(nodes) >= 2 {
+			result[prefix] = nodes
+		}
+	}
+
+	return result
+}
+
+// IsNodeHealthy returns whether the node is currently considered healthy.
+func (pr *PrimaryRoutes) IsNodeHealthy(node types.NodeID) bool {
+	pr.mu.Lock()
+	defer pr.mu.Unlock()
+
+	return !pr.unhealthy.Contains(node)
+}
+
 func (pr *PrimaryRoutes) String() string {
 	pr.mu.Lock()
 	defer pr.mu.Unlock()
@@ -285,6 +413,9 @@ type DebugRoutes struct {
 
 	// PrimaryRoutes maps route prefixes to the primary node serving them
 	PrimaryRoutes map[string]types.NodeID `json:"primary_routes"`
+
+	// UnhealthyNodes lists nodes that have failed health probes.
+	UnhealthyNodes []types.NodeID `json:"unhealthy_nodes,omitempty"`
 }
 
 // DebugJSON returns a structured representation of the primary routes state suitable for JSON serialization.
@@ -307,6 +438,23 @@ func (pr *PrimaryRoutes) DebugJSON() DebugRoutes {
 	// Populate primary routes
 	for prefix, nodeID := range pr.primaries {
 		debug.PrimaryRoutes[prefix.String()] = nodeID
+	}
+
+	// Populate unhealthy nodes
+	if pr.unhealthy.Len() > 0 {
+		nodes := pr.unhealthy.Slice()
+		slices.SortFunc(nodes, func(a, b types.NodeID) int {
+			if a < b {
+				return -1
+			}
+
+			if a > b {
+				return 1
+			}
+
+			return 0
+		})
+		debug.UnhealthyNodes = nodes
 	}
 
 	return debug

--- a/hscontrol/routes/primary_test.go
+++ b/hscontrol/routes/primary_test.go
@@ -24,6 +24,7 @@ func TestPrimaryRoutes(t *testing.T) {
 		expectedRoutes    map[types.NodeID]set.Set[netip.Prefix]
 		expectedPrimaries map[netip.Prefix]types.NodeID
 		expectedIsPrimary map[types.NodeID]bool
+		expectedUnhealthy set.Set[types.NodeID]
 		expectedChange    bool
 
 		// primaries is a map of prefixes to the node that is the primary for that prefix.
@@ -413,6 +414,161 @@ func TestPrimaryRoutes(t *testing.T) {
 			expectedChange: false,
 		},
 		{
+			name: "unhealthy-primary-fails-over",
+			operations: func(pr *PrimaryRoutes) bool {
+				pr.SetRoutes(1, mp("192.168.1.0/24"))
+				pr.SetRoutes(2, mp("192.168.1.0/24"))
+
+				return pr.SetNodeHealthy(1, false)
+			},
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {mp("192.168.1.0/24"): {}},
+				2: {mp("192.168.1.0/24"): {}},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 2,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				2: true,
+			},
+			expectedUnhealthy: set.Set[types.NodeID]{1: {}},
+			expectedChange:    true,
+		},
+		{
+			name: "unhealthy-non-primary-no-change",
+			operations: func(pr *PrimaryRoutes) bool {
+				pr.SetRoutes(1, mp("192.168.1.0/24"))
+				pr.SetRoutes(2, mp("192.168.1.0/24"))
+
+				return pr.SetNodeHealthy(2, false)
+			},
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {mp("192.168.1.0/24"): {}},
+				2: {mp("192.168.1.0/24"): {}},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 1,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				1: true,
+			},
+			expectedUnhealthy: set.Set[types.NodeID]{2: {}},
+			expectedChange:    false,
+		},
+		{
+			name: "all-unhealthy-keeps-current-primary",
+			operations: func(pr *PrimaryRoutes) bool {
+				pr.SetRoutes(1, mp("192.168.1.0/24"))
+				pr.SetRoutes(2, mp("192.168.1.0/24"))
+				pr.SetNodeHealthy(1, false) // failover to 2
+
+				return pr.SetNodeHealthy(2, false) // both unhealthy, falls back to first sorted (1)
+			},
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {mp("192.168.1.0/24"): {}},
+				2: {mp("192.168.1.0/24"): {}},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 1,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				1: true,
+			},
+			expectedUnhealthy: set.Set[types.NodeID]{1: {}, 2: {}},
+			expectedChange:    true,
+		},
+		{
+			name: "recovery-marks-healthy-no-flap",
+			operations: func(pr *PrimaryRoutes) bool {
+				pr.SetRoutes(1, mp("192.168.1.0/24"))
+				pr.SetRoutes(2, mp("192.168.1.0/24"))
+				pr.SetRoutes(3, mp("192.168.1.0/24"))
+				pr.SetNodeHealthy(1, false) // failover to 2
+
+				return pr.SetNodeHealthy(1, true) // recovered, but 2 stays primary
+			},
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {mp("192.168.1.0/24"): {}},
+				2: {mp("192.168.1.0/24"): {}},
+				3: {mp("192.168.1.0/24"): {}},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 2,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				2: true,
+			},
+			expectedChange: false,
+		},
+		{
+			name: "clear-unhealthy-on-reconnect",
+			operations: func(pr *PrimaryRoutes) bool {
+				pr.SetRoutes(1, mp("192.168.1.0/24"))
+				pr.SetRoutes(2, mp("192.168.1.0/24"))
+				pr.SetNodeHealthy(1, false) // failover to 2
+				pr.ClearUnhealthy(1)        // reconnect clears unhealthy
+
+				// 2 stays primary (stability), but 1 is healthy again
+				return pr.SetNodeHealthy(1, false) // can be marked unhealthy again
+			},
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {mp("192.168.1.0/24"): {}},
+				2: {mp("192.168.1.0/24"): {}},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 2,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				2: true,
+			},
+			expectedUnhealthy: set.Set[types.NodeID]{1: {}},
+			expectedChange:    false,
+		},
+		{
+			name: "unhealthy-then-deregister",
+			operations: func(pr *PrimaryRoutes) bool {
+				pr.SetRoutes(1, mp("192.168.1.0/24"))
+				pr.SetRoutes(2, mp("192.168.1.0/24"))
+				pr.SetNodeHealthy(1, false)
+
+				return pr.SetRoutes(1) // deregister clears routes and unhealthy
+			},
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				2: {mp("192.168.1.0/24"): {}},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 2,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				2: true,
+			},
+			expectedChange: false,
+		},
+		{
+			name: "unhealthy-primary-three-nodes-cascade",
+			operations: func(pr *PrimaryRoutes) bool {
+				pr.SetRoutes(1, mp("192.168.1.0/24"))
+				pr.SetRoutes(2, mp("192.168.1.0/24"))
+				pr.SetRoutes(3, mp("192.168.1.0/24"))
+				pr.SetNodeHealthy(1, false) // failover to 2
+
+				return pr.SetNodeHealthy(2, false) // failover to 3
+			},
+			expectedRoutes: map[types.NodeID]set.Set[netip.Prefix]{
+				1: {mp("192.168.1.0/24"): {}},
+				2: {mp("192.168.1.0/24"): {}},
+				3: {mp("192.168.1.0/24"): {}},
+			},
+			expectedPrimaries: map[netip.Prefix]types.NodeID{
+				mp("192.168.1.0/24"): 3,
+			},
+			expectedIsPrimary: map[types.NodeID]bool{
+				3: true,
+			},
+			expectedUnhealthy: set.Set[types.NodeID]{1: {}, 2: {}},
+			expectedChange:    true,
+		},
+		{
 			name: "concurrent-access",
 			operations: func(pr *PrimaryRoutes) bool {
 				var wg sync.WaitGroup
@@ -475,6 +631,86 @@ func TestPrimaryRoutes(t *testing.T) {
 
 			if diff := cmp.Diff(tt.expectedIsPrimary, pr.isPrimary, comps...); diff != "" {
 				t.Errorf("isPrimary mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tt.expectedUnhealthy, pr.unhealthy, comps...); diff != "" {
+				t.Errorf("unhealthy mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestHANodes(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(pr *PrimaryRoutes)
+		expected map[netip.Prefix][]types.NodeID
+	}{
+		{
+			name: "single-node-not-ha",
+			setup: func(pr *PrimaryRoutes) {
+				pr.SetRoutes(1, mp("192.168.1.0/24"))
+			},
+			expected: nil,
+		},
+		{
+			name: "two-nodes-same-prefix-is-ha",
+			setup: func(pr *PrimaryRoutes) {
+				pr.SetRoutes(1, mp("192.168.1.0/24"))
+				pr.SetRoutes(2, mp("192.168.1.0/24"))
+			},
+			expected: map[netip.Prefix][]types.NodeID{
+				mp("192.168.1.0/24"): {1, 2},
+			},
+		},
+		{
+			name: "two-nodes-different-prefixes-not-ha",
+			setup: func(pr *PrimaryRoutes) {
+				pr.SetRoutes(1, mp("192.168.1.0/24"))
+				pr.SetRoutes(2, mp("192.168.2.0/24"))
+			},
+			expected: nil,
+		},
+		{
+			name: "three-nodes-two-share-prefix",
+			setup: func(pr *PrimaryRoutes) {
+				pr.SetRoutes(1, mp("192.168.1.0/24"))
+				pr.SetRoutes(2, mp("192.168.1.0/24"))
+				pr.SetRoutes(3, mp("10.0.0.0/8"))
+			},
+			expected: map[netip.Prefix][]types.NodeID{
+				mp("192.168.1.0/24"): {1, 2},
+			},
+		},
+		{
+			name: "three-nodes-all-share",
+			setup: func(pr *PrimaryRoutes) {
+				pr.SetRoutes(1, mp("192.168.1.0/24"))
+				pr.SetRoutes(2, mp("192.168.1.0/24"))
+				pr.SetRoutes(3, mp("192.168.1.0/24"))
+			},
+			expected: map[netip.Prefix][]types.NodeID{
+				mp("192.168.1.0/24"): {1, 2, 3},
+			},
+		},
+		{
+			name: "empty",
+			setup: func(_ *PrimaryRoutes) {
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pr := New()
+			tt.setup(pr)
+
+			got := pr.HANodes()
+
+			comps := append(util.Comparers, cmpopts.EquateEmpty())
+			if diff := cmp.Diff(tt.expected, got, comps...); diff != "" {
+				t.Errorf("HANodes mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/hscontrol/servertest/ha_health_test.go
+++ b/hscontrol/servertest/ha_health_test.go
@@ -1,0 +1,226 @@
+package servertest_test
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/juanfont/headscale/hscontrol/servertest"
+	"github.com/juanfont/headscale/hscontrol/state"
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/juanfont/headscale/hscontrol/types/change"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"tailscale.com/tailcfg"
+)
+
+// advertiseAndApproveRoute sets RoutableIPs on a client and approves
+// the route on the server. Returns the node ID.
+func advertiseAndApproveRoute(
+	t *testing.T,
+	srv *servertest.TestServer,
+	c *servertest.TestClient,
+	route netip.Prefix,
+) types.NodeID {
+	t.Helper()
+
+	c.Direct().SetHostinfo(&tailcfg.Hostinfo{
+		BackendLogID: "servertest-" + c.Name,
+		Hostname:     c.Name,
+		RoutableIPs:  []netip.Prefix{route},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_ = c.Direct().SendUpdate(ctx)
+
+	nodeID := findNodeID(t, srv, c.Name)
+
+	_, rc, err := srv.State().SetApprovedRoutes(nodeID, []netip.Prefix{route})
+	require.NoError(t, err)
+	srv.App.Change(rc)
+
+	return nodeID
+}
+
+// TestHAHealthProbe_HealthyNodes verifies that the prober correctly
+// pings HA nodes and they all respond healthy.
+func TestHAHealthProbe_HealthyNodes(t *testing.T) {
+	t.Parallel()
+
+	srv := servertest.NewServer(t)
+	user := srv.CreateUser(t, "ha-healthy")
+
+	route := netip.MustParsePrefix("10.50.0.0/24")
+
+	c1 := servertest.NewClient(t, srv, "ha-router1", servertest.WithUser(user))
+	c2 := servertest.NewClient(t, srv, "ha-router2", servertest.WithUser(user))
+
+	c1.WaitForPeers(t, 1, 10*time.Second)
+	c2.WaitForPeers(t, 1, 10*time.Second)
+
+	nodeID1 := advertiseAndApproveRoute(t, srv, c1, route)
+	advertiseAndApproveRoute(t, srv, c2, route)
+
+	prober := state.NewHAHealthProber(
+		srv.State(),
+		types.HARouteConfig{
+			ProbeInterval: 30 * time.Second,
+			ProbeTimeout:  5 * time.Second,
+		},
+		srv.URL,
+		srv.App.MapBatcher().IsConnected,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	prober.ProbeOnce(ctx, srv.App.Change)
+
+	// Both nodes should be healthy, primary unchanged (node 1).
+	assert.True(t, srv.State().PrimaryRoutes().IsNodeHealthy(nodeID1))
+
+	primaries := srv.State().GetNodePrimaryRoutes(nodeID1)
+	assert.Contains(t, primaries, route)
+}
+
+// TestHAHealthProbe_UnhealthyFailover verifies that marking a primary
+// node unhealthy via the PrimaryRoutes API triggers failover to the
+// standby.
+func TestHAHealthProbe_UnhealthyFailover(t *testing.T) {
+	t.Parallel()
+
+	srv := servertest.NewServer(t)
+	user := srv.CreateUser(t, "ha-failover")
+
+	route := netip.MustParsePrefix("10.60.0.0/24")
+
+	c1 := servertest.NewClient(t, srv, "ha-fail-r1", servertest.WithUser(user))
+	c2 := servertest.NewClient(t, srv, "ha-fail-r2", servertest.WithUser(user))
+
+	c1.WaitForPeers(t, 1, 10*time.Second)
+	c2.WaitForPeers(t, 1, 10*time.Second)
+
+	nodeID1 := advertiseAndApproveRoute(t, srv, c1, route)
+	nodeID2 := advertiseAndApproveRoute(t, srv, c2, route)
+
+	// Node 1 should be primary (lower ID).
+	primaries := srv.State().GetNodePrimaryRoutes(nodeID1)
+	require.Contains(t, primaries, route, "node 1 should be primary initially")
+
+	// Mark node 1 unhealthy — should failover to node 2.
+	changed := srv.State().PrimaryRoutes().SetNodeHealthy(nodeID1, false)
+	assert.True(t, changed, "marking primary unhealthy should change primaries")
+
+	primaries2 := srv.State().GetNodePrimaryRoutes(nodeID2)
+	assert.Contains(t, primaries2, route, "node 2 should be primary after failover")
+
+	primaries1 := srv.State().GetNodePrimaryRoutes(nodeID1)
+	assert.NotContains(t, primaries1, route, "node 1 should not be primary")
+}
+
+// TestHAHealthProbe_RecoveryNoFlap verifies that marking an unhealthy
+// node healthy again does NOT cause it to reclaim primary (stability).
+func TestHAHealthProbe_RecoveryNoFlap(t *testing.T) {
+	t.Parallel()
+
+	srv := servertest.NewServer(t)
+	user := srv.CreateUser(t, "ha-noflap")
+
+	route := netip.MustParsePrefix("10.70.0.0/24")
+
+	c1 := servertest.NewClient(t, srv, "ha-nf-r1", servertest.WithUser(user))
+	c2 := servertest.NewClient(t, srv, "ha-nf-r2", servertest.WithUser(user))
+
+	c1.WaitForPeers(t, 1, 10*time.Second)
+	c2.WaitForPeers(t, 1, 10*time.Second)
+
+	nodeID1 := advertiseAndApproveRoute(t, srv, c1, route)
+	nodeID2 := advertiseAndApproveRoute(t, srv, c2, route)
+
+	// Failover: node 1 → node 2.
+	srv.State().PrimaryRoutes().SetNodeHealthy(nodeID1, false)
+	primaries := srv.State().GetNodePrimaryRoutes(nodeID2)
+	require.Contains(t, primaries, route, "node 2 should be primary")
+
+	// Recovery: node 1 healthy again. Node 2 should STAY primary.
+	changed := srv.State().PrimaryRoutes().SetNodeHealthy(nodeID1, true)
+	assert.False(t, changed, "recovery should not change primaries (no flap)")
+
+	primaries = srv.State().GetNodePrimaryRoutes(nodeID2)
+	assert.Contains(t, primaries, route, "node 2 should remain primary after recovery")
+}
+
+// TestHAHealthProbe_ConnectClearsUnhealthy verifies that reconnecting
+// a node clears its unhealthy state.
+func TestHAHealthProbe_ConnectClearsUnhealthy(t *testing.T) {
+	t.Parallel()
+
+	srv := servertest.NewServer(t)
+	user := srv.CreateUser(t, "ha-reconnect")
+
+	route := netip.MustParsePrefix("10.80.0.0/24")
+
+	c1 := servertest.NewClient(t, srv, "ha-rc-r1", servertest.WithUser(user))
+	c2 := servertest.NewClient(t, srv, "ha-rc-r2", servertest.WithUser(user))
+
+	c1.WaitForPeers(t, 1, 10*time.Second)
+	c2.WaitForPeers(t, 1, 10*time.Second)
+
+	nodeID1 := advertiseAndApproveRoute(t, srv, c1, route)
+	advertiseAndApproveRoute(t, srv, c2, route)
+
+	// Mark unhealthy.
+	srv.State().PrimaryRoutes().SetNodeHealthy(nodeID1, false)
+	assert.False(t, srv.State().PrimaryRoutes().IsNodeHealthy(nodeID1))
+
+	// Reconnect clears unhealthy via State.Connect → ClearUnhealthy.
+	c1.Disconnect(t)
+	c1.Reconnect(t)
+
+	c1.WaitForPeers(t, 1, 10*time.Second)
+
+	assert.True(t, srv.State().PrimaryRoutes().IsNodeHealthy(nodeID1),
+		"reconnect should clear unhealthy state")
+}
+
+// TestHAHealthProbe_NoHARoutes verifies that the prober is a no-op
+// when no HA configuration exists.
+func TestHAHealthProbe_NoHARoutes(t *testing.T) {
+	t.Parallel()
+
+	srv := servertest.NewServer(t)
+	user := srv.CreateUser(t, "ha-noha")
+
+	c1 := servertest.NewClient(t, srv, "noha-r1", servertest.WithUser(user))
+	c2 := servertest.NewClient(t, srv, "noha-r2", servertest.WithUser(user))
+
+	c1.WaitForPeers(t, 1, 10*time.Second)
+	c2.WaitForPeers(t, 1, 10*time.Second)
+
+	// Different routes — not HA.
+	advertiseAndApproveRoute(t, srv, c1, netip.MustParsePrefix("10.90.0.0/24"))
+	advertiseAndApproveRoute(t, srv, c2, netip.MustParsePrefix("10.91.0.0/24"))
+
+	prober := state.NewHAHealthProber(
+		srv.State(),
+		types.HARouteConfig{
+			ProbeInterval: 30 * time.Second,
+			ProbeTimeout:  5 * time.Second,
+		},
+		srv.URL,
+		srv.App.MapBatcher().IsConnected,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var dispatched bool
+
+	prober.ProbeOnce(ctx, func(_ ...change.Change) {
+		dispatched = true
+	})
+	assert.False(t, dispatched, "no HA routes should produce no changes")
+}

--- a/hscontrol/state/ha_health.go
+++ b/hscontrol/state/ha_health.go
@@ -1,0 +1,139 @@
+package state
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/juanfont/headscale/hscontrol/types/change"
+	"github.com/juanfont/headscale/hscontrol/util/zlog/zf"
+	"github.com/rs/zerolog/log"
+	"tailscale.com/tailcfg"
+	"tailscale.com/util/set"
+)
+
+// HAHealthProber periodically pings HA subnet router nodes and
+// triggers failover when a primary stops responding.
+type HAHealthProber struct {
+	state       *State
+	cfg         types.HARouteConfig
+	serverURL   string
+	isConnected func(types.NodeID) bool
+}
+
+// NewHAHealthProber creates a prober that uses the given State for
+// ping tracking and primary route management.
+// isConnected should return true if a node has an active map session.
+func NewHAHealthProber(
+	s *State,
+	cfg types.HARouteConfig,
+	serverURL string,
+	isConnected func(types.NodeID) bool,
+) *HAHealthProber {
+	return &HAHealthProber{
+		state:       s,
+		cfg:         cfg,
+		serverURL:   serverURL,
+		isConnected: isConnected,
+	}
+}
+
+// ProbeOnce pings all HA subnet router nodes. PingNode changes are
+// dispatched immediately via dispatch so nodes can respond before the
+// timeout. Health-related policy changes are also dispatched inline.
+func (p *HAHealthProber) ProbeOnce(
+	ctx context.Context,
+	dispatch func(...change.Change),
+) {
+	haNodes := p.state.primaryRoutes.HANodes()
+	if len(haNodes) == 0 {
+		return
+	}
+
+	// Deduplicate node IDs across prefixes.
+	seen := make(set.Set[types.NodeID])
+
+	var nodeIDs []types.NodeID
+
+	for _, nodes := range haNodes {
+		for _, id := range nodes {
+			if !seen.Contains(id) {
+				seen.Add(id)
+				nodeIDs = append(nodeIDs, id)
+			}
+		}
+	}
+
+	log.Debug().
+		Int("haNodes", len(nodeIDs)).
+		Msg("HA health prober starting probe cycle")
+
+	var wg sync.WaitGroup
+
+	deadline := time.After(p.cfg.ProbeTimeout)
+
+	for _, id := range nodeIDs {
+		if !p.isConnected(id) {
+			log.Debug().
+				Uint64(zf.NodeID, id.Uint64()).
+				Msg("HA probe: skipping offline node")
+
+			continue
+		}
+
+		pingID, responseCh := p.state.RegisterPing(id)
+		callbackURL := p.serverURL + "/machine/ping-response?id=" + pingID
+
+		dispatch(change.PingNode(id, &tailcfg.PingRequest{
+			URL: callbackURL,
+		}))
+
+		wg.Go(func() {
+			select {
+			case latency := <-responseCh:
+				log.Debug().
+					Uint64(zf.NodeID, id.Uint64()).
+					Dur("latency", latency).
+					Msg("HA probe: node responded")
+
+				if p.state.primaryRoutes.SetNodeHealthy(id, true) {
+					dispatch(change.PolicyChange())
+
+					log.Info().
+						Uint64(zf.NodeID, id.Uint64()).
+						Msg("HA probe: node recovered, recalculating primaries")
+				}
+
+			case <-deadline:
+				p.state.CancelPing(pingID)
+
+				if !p.isConnected(id) {
+					log.Debug().
+						Uint64(zf.NodeID, id.Uint64()).
+						Msg("HA probe: node went offline during probe, skipping")
+
+					return
+				}
+
+				log.Warn().
+					Uint64(zf.NodeID, id.Uint64()).
+					Dur("timeout", p.cfg.ProbeTimeout).
+					Msg("HA probe: node did not respond")
+
+				if p.state.primaryRoutes.SetNodeHealthy(id, false) {
+					dispatch(change.PolicyChange())
+
+					log.Info().
+						Uint64(zf.NodeID, id.Uint64()).
+						Msg("HA probe: node unhealthy, triggering failover")
+				}
+
+			case <-ctx.Done():
+				p.state.CancelPing(pingID)
+			}
+		})
+	}
+
+	wg.Wait()
+}

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -574,6 +574,10 @@ func (s *State) Connect(id types.NodeID) ([]change.Change, uint64) {
 
 	log.Info().EmbedObject(node).Msg("node connected")
 
+	// Reconnecting clears any prior unhealthy state — the node proved
+	// basic connectivity by establishing the Noise session.
+	s.primaryRoutes.ClearUnhealthy(id)
+
 	// Use the node's current routes for primary route update.
 	// AllApprovedRoutes() returns only the intersection of announced and approved routes.
 	routeChange := s.primaryRoutes.SetRoutes(id, node.AllApprovedRoutes()...)
@@ -1182,6 +1186,11 @@ func (s *State) RoutesForPeer(
 	}
 
 	return reduced
+}
+
+// PrimaryRoutes returns the primary routes tracker.
+func (s *State) PrimaryRoutes() *routes.PrimaryRoutes {
+	return s.primaryRoutes
 }
 
 // PrimaryRoutesString returns a string representation of all primary routes.

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -60,6 +60,22 @@ type EphemeralConfig struct {
 	InactivityTimeout time.Duration
 }
 
+// HARouteConfig contains configuration for HA subnet router health probing.
+type HARouteConfig struct {
+	// ProbeInterval is how often HA subnet routers are probed.
+	// A zero or negative duration disables probing.
+	ProbeInterval time.Duration
+
+	// ProbeTimeout is the maximum time to wait for a probe response
+	// before declaring a node unhealthy. Must be less than ProbeInterval.
+	ProbeTimeout time.Duration
+}
+
+// RouteConfig contains configuration for route behaviour.
+type RouteConfig struct {
+	HA HARouteConfig
+}
+
 // NodeConfig contains configuration for node lifecycle and expiry.
 type NodeConfig struct {
 	// Expiry is the default key expiry duration for non-tagged nodes.
@@ -70,6 +86,9 @@ type NodeConfig struct {
 
 	// Ephemeral contains configuration for ephemeral node lifecycle.
 	Ephemeral EphemeralConfig
+
+	// Routes contains configuration for route behaviour.
+	Routes RouteConfig
 }
 
 // Config contains the initial Headscale configuration.
@@ -414,6 +433,8 @@ func LoadConfig(path string, isFile bool) error {
 
 	viper.SetDefault("node.expiry", "0")
 	viper.SetDefault("node.ephemeral.inactivity_timeout", "120s")
+	viper.SetDefault("node.routes.ha.probe_interval", "10s")
+	viper.SetDefault("node.routes.ha.probe_timeout", "5s")
 
 	viper.SetDefault("tuning.notifier_send_timeout", "800ms")
 	viper.SetDefault("tuning.batch_change_delay", "800ms")
@@ -573,6 +594,34 @@ func validateServerConfig() error {
 	if viper.GetBool("dns.override_local_dns") {
 		if global := viper.GetStringSlice("dns.nameservers.global"); len(global) == 0 {
 			errorText += "Fatal config error: dns.nameservers.global must be set when dns.override_local_dns is true\n"
+		}
+	}
+
+	// Validate HA health probing parameters
+	if haInterval := viper.GetDuration(
+		"node.routes.ha.probe_interval",
+	); haInterval > 0 {
+		if haInterval < 2*time.Second {
+			errorText += fmt.Sprintf(
+				"Fatal config error: node.routes.ha.probe_interval (%s) must be >= 2s\n",
+				haInterval,
+			)
+		}
+
+		haTimeout := viper.GetDuration("node.routes.ha.probe_timeout")
+		if haTimeout < 1*time.Second {
+			errorText += fmt.Sprintf(
+				"Fatal config error: node.routes.ha.probe_timeout (%s) must be >= 1s\n",
+				haTimeout,
+			)
+		}
+
+		if haTimeout >= haInterval {
+			errorText += fmt.Sprintf(
+				"Fatal config error: node.routes.ha.probe_timeout (%s) must be less than node.routes.ha.probe_interval (%s)\n",
+				haTimeout,
+				haInterval,
+			)
 		}
 	}
 
@@ -1128,6 +1177,12 @@ func LoadServerConfig() (*Config, error) {
 			Expiry: resolveNodeExpiry(),
 			Ephemeral: EphemeralConfig{
 				InactivityTimeout: resolveEphemeralInactivityTimeout(),
+			},
+			Routes: RouteConfig{
+				HA: HARouteConfig{
+					ProbeInterval: viper.GetDuration("node.routes.ha.probe_interval"),
+					ProbeTimeout:  viper.GetDuration("node.routes.ha.probe_timeout"),
+				},
 			},
 		},
 

--- a/integration/hsic/hsic.go
+++ b/integration/hsic/hsic.go
@@ -273,6 +273,13 @@ func WithTuning(batchTimeout time.Duration, mapSessionChanSize int) Option {
 	}
 }
 
+func WithHAProbing(interval, timeout time.Duration) Option {
+	return func(hsic *HeadscaleInContainer) {
+		hsic.env["HEADSCALE_NODE_ROUTES_HA_PROBE_INTERVAL"] = interval.String()
+		hsic.env["HEADSCALE_NODE_ROUTES_HA_PROBE_TIMEOUT"] = timeout.String()
+	}
+}
+
 func WithTimezone(timezone string) Option {
 	return func(hsic *HeadscaleInContainer) {
 		hsic.env["TZ"] = timezone

--- a/integration/route_test.go
+++ b/integration/route_test.go
@@ -3493,3 +3493,241 @@ func TestGrantViaSubnetSteering(t *testing.T) {
 		assertTracerouteViaIPWithCollect(c, tr, ip)
 	}, assertTimeout, 200*time.Millisecond, "Client B traceroute should go through Router B")
 }
+
+// TestHASubnetRouterPingFailover tests HA failover triggered by the
+// health prober rather than by a full disconnect. The primary router
+// stays connected (Noise session alive) but its ping callback is
+// blocked via iptables, so the prober marks it unhealthy and fails
+// over to the next available router.
+func TestHASubnetRouterPingFailover(t *testing.T) {
+	IntegrationSkip(t)
+
+	propagationTime := integrationutil.ScaledTimeout(60 * time.Second)
+
+	spec := ScenarioSpec{
+		NodesPerUser: 2,
+		Users:        []string{"user1", "user2"},
+		Networks: map[string]NetworkSpec{
+			"usernet1": {Users: []string{"user1"}},
+			"usernet2": {Users: []string{"user2"}},
+		},
+		ExtraService: map[string][]extraServiceFunc{
+			"usernet1": {Webservice},
+		},
+		Versions: []string{"head"},
+	}
+
+	scenario, err := NewScenario(spec)
+	require.NoErrorf(t, err, "failed to create scenario: %s", err)
+
+	err = scenario.CreateHeadscaleEnv(
+		[]tsic.Option{
+			tsic.WithAcceptRoutes(),
+			tsic.WithPackages("iptables"),
+		},
+		hsic.WithTestName("rt-hapingfail"),
+		hsic.WithHAProbing(10*time.Second, 5*time.Second),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	allClients, err := scenario.ListTailscaleClients()
+	requireNoErrListClients(t, err)
+
+	err = scenario.WaitForTailscaleSync()
+	requireNoErrSync(t, err)
+
+	headscale, err := scenario.Headscale()
+	requireNoErrGetHeadscale(t, err)
+
+	prefp, err := scenario.SubnetOfNetwork("usernet1")
+	require.NoError(t, err)
+
+	pref := *prefp
+	t.Logf("usernet1 prefix: %s", pref.String())
+
+	usernet1, err := scenario.Network("usernet1")
+	require.NoError(t, err)
+
+	services, err := scenario.Services("usernet1")
+	require.NoError(t, err)
+	require.Len(t, services, 1)
+
+	web := services[0]
+	webip := netip.MustParseAddr(web.GetIPInNetwork(usernet1))
+	weburl := fmt.Sprintf("http://%s/etc/hostname", webip)
+
+	sort.SliceStable(allClients, func(i, j int) bool {
+		return allClients[i].MustStatus().Self.ID < allClients[j].MustStatus().Self.ID
+	})
+
+	subRouter1 := allClients[0]
+	subRouter2 := allClients[1]
+	client := allClients[2]
+
+	t.Logf("Router 1: %s, Router 2: %s, Client: %s",
+		subRouter1.Hostname(), subRouter2.Hostname(), client.Hostname())
+
+	// Advertise same route on both routers.
+	for _, r := range []TailscaleClient{subRouter1, subRouter2} {
+		_, _, err = r.Execute([]string{
+			"tailscale", "set", "--advertise-routes=" + pref.String(),
+		})
+		require.NoError(t, err)
+	}
+
+	err = scenario.WaitForTailscaleSync()
+	requireNoErrSync(t, err)
+
+	var nodes []*v1.Node
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err = headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 4)
+	}, propagationTime, 200*time.Millisecond)
+
+	// Approve routes on both routers.
+	_, err = headscale.ApproveRoutes(
+		MustFindNode(subRouter1.Hostname(), nodes).GetId(),
+		[]netip.Prefix{pref},
+	)
+	require.NoError(t, err)
+
+	_, err = headscale.ApproveRoutes(
+		MustFindNode(subRouter2.Hostname(), nodes).GetId(),
+		[]netip.Prefix{pref},
+	)
+	require.NoError(t, err)
+
+	nodeID1 := types.NodeID(MustFindNode(subRouter1.Hostname(), nodes).GetId())
+	nodeID2 := types.NodeID(MustFindNode(subRouter2.Hostname(), nodes).GetId())
+
+	// Wait for HA to be set up: router 1 primary, router 2 standby.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		pr, err := headscale.PrimaryRoutes()
+		assert.NoError(c, err)
+
+		assert.Equal(c, map[string]types.NodeID{
+			pref.String(): nodeID1,
+		}, pr.PrimaryRoutes, "router 1 should be primary")
+
+		assert.Contains(c, pr.AvailableRoutes, nodeID1)
+		assert.Contains(c, pr.AvailableRoutes, nodeID2)
+	}, propagationTime, 200*time.Millisecond, "waiting for HA setup")
+
+	// Verify connectivity through router 1.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		result, err := client.Curl(weburl)
+		assert.NoError(c, err)
+		assert.Len(c, result, 13)
+	}, propagationTime, 200*time.Millisecond, "client should reach webservice through router 1")
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		tr, err := client.Traceroute(webip)
+		assert.NoError(c, err)
+
+		ip, err := subRouter1.IPv4()
+		if !assert.NoError(c, err) {
+			return
+		}
+
+		assertTracerouteViaIPWithCollect(c, tr, ip)
+	}, propagationTime, 200*time.Millisecond, "traceroute should go through router 1")
+
+	t.Log("=== HA setup verified. Blocking ping callbacks on router 1 via iptables ===")
+
+	// Block NEW outbound TCP from router 1 to headscale.
+	// Preserves the existing Noise HTTP/2 long-poll (ESTABLISHED).
+	hsIP := headscale.GetIPInNetwork(usernet1)
+	iptablesAdd := []string{
+		"iptables", "-A", "OUTPUT",
+		"-d", hsIP,
+		"-p", "tcp", "--dport", "8080",
+		"-m", "state", "--state", "NEW",
+		"-j", "DROP",
+	}
+
+	_, _, err = subRouter1.Execute(iptablesAdd)
+	require.NoError(t, err, "failed to add iptables rule")
+
+	t.Logf("Blocked new TCP connections from %s to headscale at %s:8080",
+		subRouter1.Hostname(), hsIP)
+
+	// Wait for the prober to detect the failure and trigger failover.
+	// Probe interval=10s, timeout=5s → failover within ~15s.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		pr, err := headscale.PrimaryRoutes()
+		assert.NoError(c, err)
+
+		assert.Equal(c, map[string]types.NodeID{
+			pref.String(): nodeID2,
+		}, pr.PrimaryRoutes, "router 2 should be primary after ping failover")
+
+		assert.Contains(c, pr.UnhealthyNodes, nodeID1,
+			"router 1 should be marked unhealthy")
+
+		// Router 1 still in available routes (still connected, just unhealthy).
+		assert.Contains(c, pr.AvailableRoutes, nodeID1)
+		assert.Contains(c, pr.AvailableRoutes, nodeID2)
+	}, propagationTime, 1*time.Second, "waiting for ping-based failover")
+
+	t.Log("Failover detected. Verifying connectivity through router 2.")
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		result, err := client.Curl(weburl)
+		assert.NoError(c, err)
+		assert.Len(c, result, 13)
+	}, propagationTime, 200*time.Millisecond, "client should reach webservice through router 2")
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		tr, err := client.Traceroute(webip)
+		assert.NoError(c, err)
+
+		ip, err := subRouter2.IPv4()
+		if !assert.NoError(c, err) {
+			return
+		}
+
+		assertTracerouteViaIPWithCollect(c, tr, ip)
+	}, propagationTime, 200*time.Millisecond, "traceroute should go through router 2")
+
+	t.Log("=== Recovery: removing iptables block on router 1 ===")
+
+	iptablesDel := []string{
+		"iptables", "-D", "OUTPUT",
+		"-d", hsIP,
+		"-p", "tcp", "--dport", "8080",
+		"-m", "state", "--state", "NEW",
+		"-j", "DROP",
+	}
+
+	_, _, err = subRouter1.Execute(iptablesDel)
+	require.NoError(t, err, "failed to remove iptables rule")
+
+	// Wait for the prober to detect recovery.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		pr, err := headscale.PrimaryRoutes()
+		assert.NoError(c, err)
+
+		// Router 1 should be healthy again but NOT primary (no flapping).
+		assert.Equal(c, map[string]types.NodeID{
+			pref.String(): nodeID2,
+		}, pr.PrimaryRoutes, "router 2 should remain primary (no flapping)")
+
+		assert.Empty(c, pr.UnhealthyNodes,
+			"no nodes should be unhealthy after recovery")
+	}, propagationTime, 1*time.Second, "waiting for recovery without flapping")
+
+	// Traffic should still go through router 2 (stability).
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		tr, err := client.Traceroute(webip)
+		assert.NoError(c, err)
+
+		ip, err := subRouter2.IPv4()
+		if !assert.NoError(c, err) {
+			return
+		}
+
+		assertTracerouteViaIPWithCollect(c, tr, ip)
+	}, propagationTime, 200*time.Millisecond, "traceroute should still go through router 2 after recovery")
+}


### PR DESCRIPTION
Periodically ping HA subnet routers via the Noise control channel and fail over to a healthy standby when the primary stops responding. This catches "zombie connected" nodes that hold their control session open but cannot forward traffic — the existing disconnect-based failover never fires because the Noise session is still alive.

Enabled by default (probe_interval: 10s, probe_timeout: 5s). Only active when HA routes exist (2+ nodes advertising the same prefix). Set node.routes.ha.probe_interval to 0 to disable. A node that recovers is marked healthy but does not reclaim primary to avoid flapping.

Fixes #2129
Fixes #2902

Generated with the help of an AI assistant