### PR TITLE
state: preserve nil expiry on user owned registration when no default is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@ connected" routers that maintain their control session but cannot route packets.
 
 - Remove old migrations for the debian package [#3185](https://github.com/juanfont/headscale/pull/3185)
 - Install `config-example.yaml` as example for the debian package [#3186](https://github.com/juanfont/headscale/pull/3186)
+- **Node Expiry**: Fix user owned re registration with zero client expiry and no default storing `0001-01-01 00:00:00` in the database instead of NULL [#3199](https://github.com/juanfont/headscale/pull/3199)
 
 ## 0.28.0 (2026-02-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,7 @@ connected" routers that maintain their control session but cannot route packets.
 - Remove old migrations for the debian package [#3185](https://github.com/juanfont/headscale/pull/3185)
 - Install `config-example.yaml` as example for the debian package [#3186](https://github.com/juanfont/headscale/pull/3186)
 - **Node Expiry**: Fix user owned re registration with zero client expiry and no default storing `0001-01-01 00:00:00` in the database instead of NULL [#3199](https://github.com/juanfont/headscale/pull/3199)
+  - Pre-existing rows with `0001-01-01 00:00:00` are not backfilled; they clear themselves the next time the node re-registers
 
 ## 0.28.0 (2026-02-04)
 

--- a/hscontrol/auth_tags_test.go
+++ b/hscontrol/auth_tags_test.go
@@ -1119,3 +1119,67 @@ func TestReregistrationAppliesDefaultExpiry(t *testing.T) {
 	assert.True(t, node2.Expiry().Get().After(firstExpiry),
 		"re-registration expiry should be later than initial registration expiry")
 }
+
+// TestReregistrationZeroExpiryStaysNil tests that when a user-owned node
+// re-registers with zero client expiry and node.expiry is disabled (0),
+// the node's expiry stays nil rather than being set to a pointer to zero
+// time. Regression test for the else branch introduced in commit 6337a3db
+// which assigned `&regReq.Expiry` (pointer to time.Time{}) instead of nil,
+// causing the database row to hold `0001-01-01 00:00:00` instead of NULL.
+func TestReregistrationZeroExpiryStaysNil(t *testing.T) {
+	t.Parallel()
+
+	// node.expiry = 0 means "no default expiry"
+	app := createTestAppWithNodeExpiry(t, 0)
+
+	user := app.state.CreateUserForTest("node-owner")
+
+	pak, err := app.state.CreatePreAuthKey(user.TypedID(), true, false, nil, nil)
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	nodeKey := key.NewNode()
+
+	// Initial registration with zero client expiry
+	regReq := tailcfg.RegisterRequest{
+		Auth: &tailcfg.RegisterResponseAuth{
+			AuthKey: pak.Key,
+		},
+		NodeKey: nodeKey.Public(),
+		Hostinfo: &tailcfg.Hostinfo{
+			Hostname: "reregister-zero-expiry",
+		},
+		Expiry: time.Time{},
+	}
+
+	resp, err := app.handleRegisterWithAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err)
+	require.True(t, resp.MachineAuthorized)
+
+	node, found := app.state.GetNodeByNodeKey(nodeKey.Public())
+	require.True(t, found)
+	assert.False(t, node.Expiry().Valid(),
+		"initial registration with zero expiry and no default should leave expiry nil")
+
+	// Re-register with a new node key but same machine key + user
+	nodeKey2 := key.NewNode()
+	regReq2 := tailcfg.RegisterRequest{
+		Auth: &tailcfg.RegisterResponseAuth{
+			AuthKey: pak.Key,
+		},
+		NodeKey: nodeKey2.Public(),
+		Hostinfo: &tailcfg.Hostinfo{
+			Hostname: "reregister-zero-expiry",
+		},
+		Expiry: time.Time{}, // still zero
+	}
+
+	resp2, err := app.handleRegisterWithAuthKey(regReq2, machineKey.Public())
+	require.NoError(t, err)
+	require.True(t, resp2.MachineAuthorized)
+
+	node2, found := app.state.GetNodeByNodeKey(nodeKey2.Public())
+	require.True(t, found)
+	assert.False(t, node2.Expiry().Valid(),
+		"re-registration with zero client expiry and no default should leave expiry nil, not pointer to zero time")
+}

--- a/hscontrol/auth_tags_test.go
+++ b/hscontrol/auth_tags_test.go
@@ -1126,6 +1126,11 @@ func TestReregistrationAppliesDefaultExpiry(t *testing.T) {
 // time. Regression test for the else branch introduced in commit 6337a3db
 // which assigned `&regReq.Expiry` (pointer to time.Time{}) instead of nil,
 // causing the database row to hold `0001-01-01 00:00:00` instead of NULL.
+//
+// The same !regReq.Expiry.IsZero() gate at state.go:2221-2228 is shared by
+// the tags-only PreAuthKey path (createAndSaveNewNode also receives nil
+// when the client sends zero expiry), so this regression is covered for
+// tagged nodes by inspection.
 func TestReregistrationZeroExpiryStaysNil(t *testing.T) {
 	t.Parallel()
 

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -2176,7 +2176,9 @@ func (s *State) HandleNodeFromPreAuthKey(
 			// Tagged nodes keep their existing expiry (disabled).
 			// User-owned nodes update expiry from the client request,
 			// falling back to the configured default if the client
-			// did not request a specific expiry.
+			// did not request a specific expiry. If neither is set,
+			// clear the expiry so the database holds NULL instead of
+			// a pointer to zero time.
 			if !node.IsTagged() {
 				if !regReq.Expiry.IsZero() {
 					node.Expiry = &regReq.Expiry
@@ -2184,7 +2186,7 @@ func (s *State) HandleNodeFromPreAuthKey(
 					exp := time.Now().Add(s.cfg.Node.Expiry)
 					node.Expiry = &exp
 				} else {
-					node.Expiry = &regReq.Expiry
+					node.Expiry = nil
 				}
 			}
 		})
@@ -2271,6 +2273,15 @@ func (s *State) HandleNodeFromPreAuthKey(
 			pakUser = *pak.User
 		}
 
+		// Only pass the client-requested expiry when it is actually set.
+		// A pointer to a zero time.Time gets persisted as "0001-01-01 00:00:00"
+		// rather than NULL, which breaks downstream consumers that distinguish
+		// "no expiry" from "expires at year 1".
+		var reqExpiry *time.Time
+		if !regReq.Expiry.IsZero() {
+			reqExpiry = &regReq.Expiry
+		}
+
 		var err error
 
 		finalNode, err = s.createAndSaveNewNode(newNodeParams{
@@ -2281,7 +2292,7 @@ func (s *State) HandleNodeFromPreAuthKey(
 			Hostname:               hostname,
 			Hostinfo:               validHostinfo,
 			Endpoints:              nil, // Endpoints not available in RegisterRequest
-			Expiry:                 &regReq.Expiry,
+			Expiry:                 reqExpiry,
 			RegisterMethod:         util.RegisterMethodAuthKey,
 			PreAuthKey:             pak,
 			ExistingNodeForNetinfo: cmp.Or(existingNodeAnyUser, types.NodeView{}),


### PR DESCRIPTION
<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md

When a user owned node registers or re registers with a PreAuthKey and the client sends zero expiry while `node.expiry` is set to `0`, the node's `expiry` column ends up as `0001-01-01 00:00:00` instead of NULL. `hscontrol/state/state.go` builds a pointer to `regReq.Expiry` unconditionally at two sites, even when the value is zero time. Downstream consumers that distinguish "no expiry" from "expired at year 1" (the headplane "no expiry" badge checks `=== null`) see the wrong state.

This change converts an unset `regReq.Expiry` to nil before handing it off, so the `needsDefaultExpiry` guard at `state.go:1644` is the only place that assigns a non nil pointer.

Added a regression test `TestReregistrationZeroExpiryStaysNil` that covers both initial and re registration paths with `node.expiry=0` and zero client expiry. It fails on master and passes with this change. Full `go test ./hscontrol/...` passes.

This is a narrower sibling of #3170 (tagged node on tailscaled restart) on the user owned PreAuthKey path. The regression was introduced alongside the fix for #3111 in commit 6337a3db.

Fixes #3198
