### PR TITLE
github: split nu where in needs-more-info timer

### DIFF
--- a/.github/workflows/needs-more-info-timer.yml
+++ b/.github/workflows/needs-more-info-timer.yml
@@ -60,7 +60,8 @@ jobs:
             let events = (gh api $"repos/($env.GH_REPO)/issues/($number)/events"
               --paginate | from json | flatten)
             let label_event = ($events
-              | where event == "labeled" and label.name == "needs-more-info"
+              | where event == "labeled"
+              | where label.name == "needs-more-info"
               | last)
             let label_added_at = ($label_event.created_at | into datetime)
 


### PR DESCRIPTION
The scheduled `needs-more-info-timer` job has failed every night since
2026-04-13, the first run where any issue actually carried the
`needs-more-info` label. As a result no issue has been auto-closed.

Root cause is a Nu script column dereference. GitHub's
`/issues/:n/events` endpoint returns a mixed-schema table and only
`labeled`/`unlabeled` rows carry a `label` column. Nu's `where` does
not short-circuit, so the combined predicate
`event == "labeled" and label.name == "needs-more-info"` dereferences
`label.name` on every row and crashes on the first non-labelled event
with `nu::shell::column_not_found`.

Splitting into two sequential `where` filters isolates the `label.name`
access to rows that have the column.

Generated with the help of an AI assistant