### PR TITLE
OIDC groups: persist claim and resolve from ACL group: rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ addresses, including those outside the tailnet. This replaces the old behaviour 
 all IPs (see BREAKING below). The name is intentionally scary: accepting traffic from the entire
 internet is a security-sensitive choice. `autogroup:danger-all` can only be used as a source.
 
+### OIDC groups in ACLs
+
+`oidc.groups.enabled: true` makes Headscale persist the OIDC `groups` claim on each user at login
+and resolve it from ACL `group:<name>` rules. A user matches `group:foo` if listed under it in
+`policy.hujson` or if their persisted IdP groups claim contains `foo`. `oidc.groups.claim`
+overrides the default claim name (e.g. AWS Cognito's `cognito:groups`). Default off; opt-in.
+[#3216](https://github.com/juanfont/headscale/pull/3216)
+
 ### Hostname handling (cleanroom rewrite)
 
 The hostname ingest pipeline has been rewritten to match Tailscale SaaS byte-for-byte.
@@ -165,6 +173,7 @@ connected" routers that maintain their control session but cannot route packets.
 - Add a confirmation page before completing node registration, showing the device hostname and machine key fingerprint [#3180](https://github.com/juanfont/headscale/pull/3180)
 - Generalise auth templates into reusable `AuthSuccess` and `AuthWeb` components [#1850](https://github.com/juanfont/headscale/pull/1850)
 - Unify auth pipeline with `AuthVerdict` type, supporting registration, reauthentication, and SSH checks [#1850](https://github.com/juanfont/headscale/pull/1850)
+- Persist OIDC `groups` claim on User and resolve it from ACL `group:` rules; opt-in via `oidc.groups.enabled` (default off), claim name configurable via `oidc.groups.claim` [#3216](https://github.com/juanfont/headscale/pull/3216)
 
 #### Configuration
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -428,6 +428,19 @@ unix_socket_permission: "0770"
 #   allowed_groups:
 #     - /headscale
 #
+#   # Use OIDC groups in ACL `group:<name>` rules.
+#   # When enabled, the user's group memberships from the identity provider's
+#   # `groups` claim (or the claim configured via `claim:` below) are persisted
+#   # on each login and resolved by the policy engine alongside any static
+#   # memberships in policy.hujson. Default is off — enable to stop maintaining
+#   # group memberships in two places.
+#   groups:
+#     enabled: false
+#     # Override when the identity provider exposes group memberships under a
+#     # non-standard claim name (e.g. AWS Cognito's `cognito:groups`, custom
+#     # `roles` claims).
+#     claim: groups
+#
 #   # Optional: PKCE (Proof Key for Code Exchange) configuration
 #   # PKCE adds an additional layer of security to the OAuth 2.0 authorization code flow
 #   # by preventing authorization code interception attacks

--- a/docs/ref/oidc.md
+++ b/docs/ref/oidc.md
@@ -227,6 +227,64 @@ You may refer to users in the Headscale policy via:
     }
     ```
 
+### Use OIDC groups in ACL policies
+
+Headscale can persist the OIDC `groups` claim on each user at login time and resolve it from ACL `group:<name>` rules.
+This lets administrators reference identity-provider groups (e.g. Workspace groups, Entra ID groups, Authentik groups)
+directly in their policy file without maintaining a parallel list of group memberships in `policy.hujson`.
+
+This is opt-in. With `oidc.groups.enabled: false` (the default), the `groups` claim is ignored and ACL groups behave
+exactly as they did before — only the static membership list in `policy.hujson` is consulted.
+
+When `oidc.groups.enabled: true`, an ACL rule referencing `group:<name>` matches a user when *either* of the following
+holds:
+
+* the user's username is listed under `group:<name>` in `policy.hujson`, **or**
+* the user's most recent OIDC `groups` claim contains `<name>`
+
+The two sources are additive — static memberships continue to work unchanged.
+
+=== "Standard `groups` claim"
+
+    For identity providers that emit the standard OpenID Connect `groups` claim — which includes most providers
+    (Authentik, Authelia, Keycloak, Okta with the right scope, Google Workspace via Dex, Entra ID via app role
+    mappings, etc.) — only the `enabled` flag is required.
+
+    ```yaml hl_lines="5-7"
+    oidc:
+      issuer: "https://sso.example.com"
+      client_id: "headscale"
+      client_secret: "generated-secret"
+      scope: ["openid", "profile", "email", "groups"]
+      groups:
+        enabled: true
+    ```
+
+=== "Custom claim name"
+
+    For providers that expose group memberships under a different claim name (e.g. AWS Cognito's `cognito:groups`,
+    or providers that use `roles`), set `oidc.groups.claim` to the custom name. The standard `groups` claim
+    is still parsed for the existing `allowed_groups` filter; the custom claim is read on top of that for ACL
+    resolution.
+
+    ```yaml hl_lines="5-8"
+    oidc:
+      issuer: "https://sso.example.com"
+      client_id: "headscale"
+      client_secret: "generated-secret"
+      scope: ["openid", "profile", "email", "cognito:groups"]
+      groups:
+        enabled: true
+        claim: "cognito:groups"
+    ```
+
+Group memberships are refreshed on every login. To force a refresh — for instance after granting a user a new role at
+the IdP — have them re-authenticate (`tailscale up --force-reauth` on a connected node).
+
+The persisted membership list is also surfaced via the gRPC `User.groups` field, so administrators can introspect what
+headscale received with `headscale users list -o json`.
+
+
 ## Supported OIDC claims
 
 Headscale uses [the standard OIDC claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) to
@@ -240,13 +298,12 @@ endpoint.
 | username            | `preferred_username` | Depends on identity provider, eg: `ssmith`, `ssmith@idp.example.com`, `\\example.com\ssmith`      |
 | profile picture     | `picture`            | URL to a profile picture or avatar                                                                |
 | provider identifier | `iss`, `sub`         | A stable and unique identifier for a user, typically a combination of `iss` and `sub` OIDC claims |
-|                     | `groups`             | [Only used to filter for allowed groups](#authorize-users-with-filters)                           |
+| group memberships   | `groups`             | Used by `allowed_groups`; also fed into ACL `group:<name>` rules when [`oidc.groups.enabled`](#use-oidc-groups-in-acl-policies) is set. The claim name is configurable via `oidc.groups.claim`. |
 
 ## Limitations
 
 - Support for OpenID Connect aims to be generic and vendor independent. It offers only limited support for quirks of
   specific identity providers.
-- OIDC groups cannot be used in ACLs.
 - The username provided by the identity provider needs to adhere to this pattern:
     - The username must be at least two characters long.
     - It must only contain letters, digits, hyphens, dots, underscores, and up to a single `@`.

--- a/gen/go/headscale/v1/user.pb.go
+++ b/gen/go/headscale/v1/user.pb.go
@@ -32,6 +32,11 @@ type User struct {
 	ProviderId    string                 `protobuf:"bytes,6,opt,name=provider_id,json=providerId,proto3" json:"provider_id,omitempty"`
 	Provider      string                 `protobuf:"bytes,7,opt,name=provider,proto3" json:"provider,omitempty"`
 	ProfilePicUrl string                 `protobuf:"bytes,8,opt,name=profile_pic_url,json=profilePicUrl,proto3" json:"profile_pic_url,omitempty"`
+	// Group memberships imported from the OIDC `groups` claim (or the
+	// configured equivalent), populated when `oidc.groups.enabled` is set.
+	// Empty for users that signed up before the feature was enabled, for
+	// CLI-created users, or when the IdP does not assert groups.
+	Groups        []string `protobuf:"bytes,9,rep,name=groups,proto3" json:"groups,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -120,6 +125,13 @@ func (x *User) GetProfilePicUrl() string {
 		return x.ProfilePicUrl
 	}
 	return ""
+}
+
+func (x *User) GetGroups() []string {
+	if x != nil {
+		return x.Groups
+	}
+	return nil
 }
 
 type CreateUserRequest struct {
@@ -518,7 +530,7 @@ var File_headscale_v1_user_proto protoreflect.FileDescriptor
 
 const file_headscale_v1_user_proto_rawDesc = "" +
 	"\n" +
-	"\x17headscale/v1/user.proto\x12\fheadscale.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x83\x02\n" +
+	"\x17headscale/v1/user.proto\x12\fheadscale.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x9b\x02\n" +
 	"\x04User\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x04R\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x129\n" +
@@ -529,7 +541,8 @@ const file_headscale_v1_user_proto_rawDesc = "" +
 	"\vprovider_id\x18\x06 \x01(\tR\n" +
 	"providerId\x12\x1a\n" +
 	"\bprovider\x18\a \x01(\tR\bprovider\x12&\n" +
-	"\x0fprofile_pic_url\x18\b \x01(\tR\rprofilePicUrl\"\x81\x01\n" +
+	"\x0fprofile_pic_url\x18\b \x01(\tR\rprofilePicUrl\x12\x16\n" +
+	"\x06groups\x18\t \x03(\tR\x06groups\"\x81\x01\n" +
 	"\x11CreateUserRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
 	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12\x14\n" +

--- a/gen/openapiv2/headscale/v1/headscale.swagger.json
+++ b/gen/openapiv2/headscale/v1/headscale.swagger.json
@@ -1485,6 +1485,13 @@
         },
         "profilePicUrl": {
           "type": "string"
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Group memberships imported from the OIDC `groups` claim (or the\nconfigured equivalent), populated when `oidc.groups.enabled` is set.\nEmpty for users that signed up before the feature was enabled, for\nCLI-created users, or when the IdP does not assert groups."
         }
       }
     }

--- a/hscontrol/db/db.go
+++ b/hscontrol/db/db.go
@@ -228,7 +228,13 @@ AND auth_key_id NOT IN (
 					for _, user := range users {
 						user.ProviderIdentifier.String = types.CleanIdentifier(user.ProviderIdentifier.String)
 
-						err := tx.Save(user).Error
+						// Skip the `groups` column when re-saving rows in
+						// this older migration: the column is created by
+						// a later migration in this list and does not
+						// yet exist at the time this one runs against a
+						// fresh DB. tx.Omit lets the gorm Save go through
+						// without referencing it.
+						err := tx.Omit("groups").Save(user).Error
 						if err != nil {
 							return fmt.Errorf("saving user: %w", err)
 						}
@@ -695,6 +701,23 @@ AND auth_key_id NOT IN (
 							Msg("Migrated validated RequestTags from host_info to tags column")
 					}
 
+					return nil
+				},
+				Rollback: func(db *gorm.DB) error { return nil },
+			},
+			{
+				// Adds the users.groups column so the OIDC `groups` claim
+				// can be persisted and referenced from ACL `group:<name>`
+				// rules. Storage-only; whether the claim is actually read
+				// from the IdP is gated by the `oidc.groups.enabled`
+				// config flag, which defaults to off.
+				ID: "202601241200-user-oidc-groups",
+				Migrate: func(tx *gorm.DB) error {
+					if !tx.Migrator().HasColumn(&types.User{}, "groups") {
+						if err := tx.Migrator().AddColumn(&types.User{}, "groups"); err != nil {
+							return fmt.Errorf("adding groups column to users: %w", err)
+						}
+					}
 					return nil
 				},
 				Rollback: func(db *gorm.DB) error { return nil },

--- a/hscontrol/db/schema.sql
+++ b/hscontrol/db/schema.sql
@@ -12,6 +12,8 @@ CREATE TABLE users(
   provider_identifier text,
   provider text,
   profile_pic_url text,
+  -- Group memberships from the OIDC `groups` claim, JSON-serialized.
+  groups text,
 
   created_at datetime,
   updated_at datetime,

--- a/hscontrol/oidc.go
+++ b/hscontrol/oidc.go
@@ -277,6 +277,17 @@ func (a *AuthProviderOIDC) OIDCCallbackHandler(
 		return
 	}
 
+	// When OIDC groups are enabled with a non-default claim name, decode the
+	// token a second time into a generic map and pull the configured field
+	// out. This keeps the canonical struct (`json:"groups"`) untouched so
+	// providers that use the standard claim name don't need any config.
+	if a.cfg.Groups.Enabled && a.cfg.Groups.Claim != "" && a.cfg.Groups.Claim != "groups" {
+		var raw map[string]any
+		if err := idToken.Claims(&raw); err == nil {
+			claims.Groups = types.ExtractGroupsClaim(raw, a.cfg.Groups.Claim)
+		}
+	}
+
 	// Fetch user information (email, groups, name, etc) from the userinfo endpoint
 	// https://openid.net/specs/openid-connect-core-1_0.html#UserInfo
 	var userinfo *oidc.UserInfo
@@ -302,6 +313,16 @@ func (a *AuthProviderOIDC) OIDCCallbackHandler(
 		if userinfo2.Groups != nil {
 			claims.Groups = userinfo2.Groups
 		}
+		// Same custom-claim treatment for the userinfo response — overrides
+		// the value just copied above when a non-standard claim name is set.
+		if a.cfg.Groups.Enabled && a.cfg.Groups.Claim != "" && a.cfg.Groups.Claim != "groups" {
+			var rawUI map[string]any
+			if err := userinfo.Claims(&rawUI); err == nil {
+				if g := types.ExtractGroupsClaim(rawUI, a.cfg.Groups.Claim); g != nil {
+					claims.Groups = g
+				}
+			}
+		}
 	} else {
 		util.LogErr(err, "could not get userinfo; only using claims from id token")
 	}
@@ -314,7 +335,7 @@ func (a *AuthProviderOIDC) OIDCCallbackHandler(
 		return
 	}
 
-	user, _, err := a.createOrUpdateUserFromClaim(&claims)
+	user, userChange, err := a.createOrUpdateUserFromClaim(&claims)
 	if err != nil {
 		httpUserError(writer, NewHTTPError(
 			http.StatusInternalServerError,
@@ -324,6 +345,14 @@ func (a *AuthProviderOIDC) OIDCCallbackHandler(
 
 		return
 	}
+
+	// Broadcast the user-update so peers refresh netmaps when the
+	// login mutated ACL-affecting state. Without this, a freshly
+	// populated `groups` claim is correctly persisted and reflected in
+	// the policy manager's user cache, but already-connected peers
+	// keep their pre-login netmaps until some other event triggers a
+	// refresh. Empty changes are ignored by Change.
+	a.h.Change(userChange)
 
 	// TODO(kradalby): Is this comment right?
 	// If the node exists, then the node should be reauthenticated,
@@ -630,7 +659,7 @@ func (a *AuthProviderOIDC) createOrUpdateUserFromClaim(
 		user = &types.User{}
 	}
 
-	user.FromClaim(claims, a.cfg.EmailVerifiedRequired)
+	user.FromClaim(claims, a.cfg.EmailVerifiedRequired, a.cfg.Groups.Enabled)
 
 	if newUser {
 		user, c, err = a.h.state.CreateUser(*user)

--- a/hscontrol/policy/v2/oidc_groups_test.go
+++ b/hscontrol/policy/v2/oidc_groups_test.go
@@ -1,0 +1,186 @@
+// Unit tests for OIDC-asserted group resolution in policy v2.
+//
+// Validates that Group.Resolve matches not only by user identifier
+// (upstream behaviour) but also by a user's persisted OIDC groups claim.
+package v2
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/juanfont/headscale/hscontrol/types"
+	"gorm.io/gorm"
+	"tailscale.com/types/views"
+)
+
+func TestGroupResolve_MatchesOIDCGroupClaim(t *testing.T) {
+	alice := types.User{
+		Model:  gorm.Model{ID: 1},
+		Name:   "alice@example.com",
+		Email:  "alice@example.com",
+		Groups: []string{"group1", "group2"},
+	}
+	bob := types.User{
+		Model:  gorm.Model{ID: 2},
+		Name:   "bob@example.com",
+		Email:  "bob@example.com",
+		Groups: []string{"group3"},
+	}
+	// A user whose identifier literally matches a group reference (the
+	// upstream resolution path). Ensures the union with the IdP-claim
+	// path keeps working.
+	literal := types.User{
+		Model: gorm.Model{ID: 3},
+		Name:  "group1",
+	}
+
+	users := types.Users{alice, bob, literal}
+
+	aliceNode := nodeWithIPs(t, 1, "100.64.0.1")
+	bobNode := nodeWithIPs(t, 2, "100.64.0.2")
+	literalNode := nodeWithIPs(t, 3, "100.64.0.3")
+
+	nodes := views.SliceOf([]types.NodeView{
+		aliceNode.View(), bobNode.View(), literalNode.View(),
+	})
+
+	tests := []struct {
+		name       string
+		members    []Username
+		wantPfxStr []string
+	}{
+		{
+			name:    "resolves group by IdP claim and literal username",
+			members: []Username{"group1@"},
+			wantPfxStr: []string{
+				"100.64.0.1/32", // alice carries group1 in her groups claim
+				"100.64.0.3/32", // literal user named group1
+			},
+		},
+		{
+			name:    "resolves distinct IdP group",
+			members: []Username{"group3@"},
+			wantPfxStr: []string{
+				"100.64.0.2/32", // bob only
+			},
+		},
+		{
+			name:       "returns empty set when group unmatched",
+			members:    []Username{"unknown@"},
+			wantPfxStr: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pol := &Policy{
+				Groups: Groups{
+					Group("group:test"): tc.members,
+				},
+			}
+			g := Group("group:test")
+			resolved, err := g.Resolve(pol, users, nodes)
+			if err != nil && len(tc.wantPfxStr) > 0 {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var got []string
+			if resolved != nil {
+				got = prefixStrings(resolved.Prefixes())
+			}
+			if diff := cmp.Diff(tc.wantPfxStr, got); diff != "" {
+				t.Errorf("prefix mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// nodeWithIPs constructs a minimal Node owned by user ID uid carrying a
+// single IPv4 address so we can exercise Group.Resolve.
+func nodeWithIPs(t *testing.T, uid uint, ip string) *types.Node {
+	t.Helper()
+	addr := netip.MustParseAddr(ip)
+	uidCopy := uid
+	return &types.Node{
+		ID:       types.NodeID(uid),
+		UserID:   &uidCopy,
+		User:     &types.User{Model: gorm.Model{ID: uid}},
+		IPv4:     &addr,
+		Hostname: "n",
+	}
+}
+
+// TestPolicyManagerSetUsersRefreshesOIDCGroupResolution exercises the
+// live-update path that runs after an OIDC login (State.UpdateUser →
+// updatePolicyManagerUsers → PolicyManager.SetUsers). A user whose
+// Groups claim is newly populated must be picked up by group:* sources
+// without requiring a server restart.
+func TestPolicyManagerSetUsersRefreshesOIDCGroupResolution(t *testing.T) {
+	alice := types.User{
+		Model: gorm.Model{ID: 1},
+		Name:  "alice@example.com",
+		Email: "alice@example.com",
+	}
+	uid := alice.ID
+	v4 := netip.MustParseAddr("100.64.0.1")
+	v6 := netip.MustParseAddr("fd7a:115c:a1e0::1")
+	aliceNode := &types.Node{
+		ID:       1,
+		Hostname: "alice-node",
+		User:     &alice,
+		UserID:   &uid,
+		IPv4:     &v4,
+		IPv6:     &v6,
+	}
+
+	policy := []byte(`{
+		"groups": {
+			"group:test": ["group1@"]
+		},
+		"acls": [
+			{
+				"action": "accept",
+				"src":    ["group:test"],
+				"dst":    ["*:*"]
+			}
+		]
+	}`)
+
+	pm, err := NewPolicyManager(
+		policy,
+		types.Users{alice},
+		types.Nodes{aliceNode}.ViewSlice(),
+	)
+	if err != nil {
+		t.Fatalf("NewPolicyManager: %v", err)
+	}
+
+	// Without a Groups claim, group:test resolves to nothing and the rule
+	// is dropped before reaching the global filter.
+	filter, _ := pm.Filter()
+	if len(filter) != 0 {
+		t.Fatalf("expected empty filter before SetUsers, got %d rule(s): %+v", len(filter), filter)
+	}
+
+	aliceWithGroups := alice
+	aliceWithGroups.Groups = []string{"group1"}
+
+	changed, err := pm.SetUsers(types.Users{aliceWithGroups})
+	if err != nil {
+		t.Fatalf("SetUsers: %v", err)
+	}
+	if !changed {
+		t.Fatalf("SetUsers returned changed=false; expected the new groups claim to invalidate the cached filter")
+	}
+
+	filter, _ = pm.Filter()
+	if len(filter) != 1 {
+		t.Fatalf("expected one filter rule after SetUsers populated the groups claim, got %d: %+v", len(filter), filter)
+	}
+
+	want := []string{"100.64.0.1", "fd7a:115c:a1e0::1"}
+	if diff := cmp.Diff(want, filter[0].SrcIPs); diff != "" {
+		t.Errorf("SrcIPs mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/hscontrol/policy/v2/types.go
+++ b/hscontrol/policy/v2/types.go
@@ -500,15 +500,78 @@ func (g *Group) resolve(p *Policy, users types.Users, nodes views.Slice[types.No
 	)
 
 	for _, user := range p.Groups[*g] {
+		// Existing behaviour: treat each entry as a user identifier
+		// (email / Name / provider id).
 		uips, err := user.resolve(nil, users, nodes)
-		if err != nil {
-			errs = append(errs, err)
+		if err == nil {
+			ips.AddSet(uips)
 		}
 
-		ips.AddSet(uips)
+		// Additionally, treat the entry as an OIDC group identifier:
+		// pull in every node whose owner has this group in their
+		// persisted `Groups` claim. This lets policy files reference
+		// IdP groups directly, e.g.
+		//   "group:admins": ["security-team@example.com"]
+		// where `security-team@example.com` is an OIDC-asserted group
+		// name (from the IdP's `groups` claim), not a headscale user.
+		memberStr := strings.TrimSuffix(user.String(), "@")
+		resolveOIDCGroup(memberStr, users, nodes, &ips)
+
+		// If neither path produced a match, surface the original
+		// user-lookup error so operators still get a clear signal
+		// when an identifier truly does not correspond to anything.
+		if err != nil && !userHasOIDCGroup(memberStr, users) {
+			errs = append(errs, err)
+		}
 	}
 
 	return buildIPSetMultiErr(&ips, errs)
+}
+
+// resolveOIDCGroup collects node IPs for every user whose OIDC groups
+// claim contains `group`, appending them to ips.
+func resolveOIDCGroup(
+	group string,
+	users types.Users,
+	nodes views.Slice[types.NodeView],
+	ips *netipx.IPSetBuilder,
+) {
+	matchingUserIDs := make(map[uint]struct{})
+	for _, u := range users {
+		for _, g := range u.Groups {
+			if g == group {
+				matchingUserIDs[u.ID] = struct{}{}
+				break
+			}
+		}
+	}
+
+	if len(matchingUserIDs) == 0 {
+		return
+	}
+
+	for _, node := range nodes.All() {
+		if node.IsTagged() || !node.User().Valid() {
+			continue
+		}
+		if _, ok := matchingUserIDs[uint(node.User().ID())]; ok {
+			node.AppendToIPSet(ips)
+		}
+	}
+}
+
+// userHasOIDCGroup reports whether any user carries `group` in their
+// persisted OIDC Groups claim. Used to suppress noisy user-lookup
+// errors when a policy entry is intentionally an IdP group.
+func userHasOIDCGroup(group string, users types.Users) bool {
+	for _, u := range users {
+		for _, g := range u.Groups {
+			if g == group {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Tag is a special string which is always prefixed with `tag:`.

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -226,6 +226,22 @@ type OIDCConfig struct {
 	EmailVerifiedRequired      bool
 	UseExpiryFromToken         bool
 	PKCE                       PKCEConfig
+	Groups                     OIDCGroupsConfig
+}
+
+// OIDCGroupsConfig controls whether group memberships from the OIDC provider
+// flow into the policy engine and become usable in ACL rules. Disabled by
+// default — when off, headscale ignores any `groups` claim returned by the IdP
+// and ACLs continue to depend solely on statically-configured group memberships
+// in policy.hujson, exactly as before.
+//
+// When Enabled, the user's Groups field is populated on every login from the
+// claim named by `Claim` (default: "groups"), and ACL rules referencing
+// `group:<name>` will match the OIDC-provided group as well as any statically
+// configured members.
+type OIDCGroupsConfig struct {
+	Enabled bool
+	Claim   string
 }
 
 type DERPConfig struct {
@@ -426,6 +442,8 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("oidc.pkce.enabled", false)
 	viper.SetDefault("oidc.pkce.method", "S256")
 	viper.SetDefault("oidc.email_verified_required", true)
+	viper.SetDefault("oidc.groups.enabled", false)
+	viper.SetDefault("oidc.groups.claim", "groups")
 
 	viper.SetDefault("logtail.enabled", false)
 	viper.SetDefault("randomize_client_port", false)
@@ -1216,6 +1234,10 @@ func LoadServerConfig() (*Config, error) {
 			PKCE: PKCEConfig{
 				Enabled: viper.GetBool("oidc.pkce.enabled"),
 				Method:  viper.GetString("oidc.pkce.method"),
+			},
+			Groups: OIDCGroupsConfig{
+				Enabled: viper.GetBool("oidc.groups.enabled"),
+				Claim:   viper.GetString("oidc.groups.claim"),
 			},
 		},
 

--- a/hscontrol/types/types_clone.go
+++ b/hscontrol/types/types_clone.go
@@ -24,6 +24,7 @@ func (src *User) Clone() *User {
 	}
 	dst := new(User)
 	*dst = *src
+	dst.Groups = append(src.Groups[:0:0], src.Groups...)
 	return dst
 }
 
@@ -36,6 +37,7 @@ var _UserCloneNeedsRegeneration = User(struct {
 	ProviderIdentifier sql.NullString
 	Provider           string
 	ProfilePicURL      string
+	Groups             []string
 }{})
 
 // Clone makes a deep copy of Node.
@@ -57,9 +59,7 @@ func (src *Node) Clone() *Node {
 	if dst.UserID != nil {
 		dst.UserID = ptr.To(*src.UserID)
 	}
-	if dst.User != nil {
-		dst.User = ptr.To(*src.User)
-	}
+	dst.User = src.User.Clone()
 	dst.Tags = append(src.Tags[:0:0], src.Tags...)
 	if dst.AuthKeyID != nil {
 		dst.AuthKeyID = ptr.To(*src.AuthKeyID)
@@ -120,9 +120,7 @@ func (src *PreAuthKey) Clone() *PreAuthKey {
 	if dst.UserID != nil {
 		dst.UserID = ptr.To(*src.UserID)
 	}
-	if dst.User != nil {
-		dst.User = ptr.To(*src.User)
-	}
+	dst.User = src.User.Clone()
 	dst.Tags = append(src.Tags[:0:0], src.Tags...)
 	if dst.CreatedAt != nil {
 		dst.CreatedAt = ptr.To(*src.CreatedAt)

--- a/hscontrol/types/types_view.go
+++ b/hscontrol/types/types_view.go
@@ -115,6 +115,12 @@ func (v UserView) ProviderIdentifier() sql.NullString { return v.ж.ProviderIden
 func (v UserView) Provider() string      { return v.ж.Provider }
 func (v UserView) ProfilePicURL() string { return v.ж.ProfilePicURL }
 
+// Groups is the list of group identifiers captured from the OIDC
+// `groups` claim on login. Stored so the policy matcher can resolve
+// `group:<oidc-group>` references in the tailnet policy file (which
+// otherwise only matches by user identifier).
+func (v UserView) Groups() views.Slice[string] { return views.SliceOf(v.ж.Groups) }
+
 // A compilation failure here means this code must be regenerated, with the command at the top of this file.
 var _UserViewNeedsRegeneration = User(struct {
 	gorm.Model
@@ -124,6 +130,7 @@ var _UserViewNeedsRegeneration = User(struct {
 	ProviderIdentifier sql.NullString
 	Provider           string
 	ProfilePicURL      string
+	Groups             []string
 }{})
 
 // View returns a read-only view of Node.

--- a/hscontrol/types/users.go
+++ b/hscontrol/types/users.go
@@ -92,6 +92,12 @@ type User struct {
 	Provider string
 
 	ProfilePicURL string
+
+	// Groups is the list of group identifiers captured from the OIDC
+	// `groups` claim on login. Stored so the policy matcher can resolve
+	// `group:<oidc-group>` references in the tailnet policy file (which
+	// otherwise only matches by user identifier).
+	Groups []string `gorm:"serializer:json"`
 }
 
 func (u *User) StringID() string {
@@ -202,6 +208,7 @@ func (u *User) Proto() *v1.User {
 		ProviderId:    u.ProviderIdentifier.String,
 		Provider:      u.Provider,
 		ProfilePicUrl: u.ProfilePicURL,
+		Groups:        append([]string(nil), u.Groups...),
 	}
 }
 
@@ -380,6 +387,32 @@ func CleanIdentifier(identifier string) string {
 	return strings.Join(cleanParts, "/")
 }
 
+// ExtractGroupsClaim returns the list of groups from a raw OIDC claims map
+// under the configured claim name. The "standard" claim is `groups`, but
+// some IdPs expose group memberships under different names (e.g. `roles`,
+// `cognito:groups`). Returns an empty slice if the claim is missing or the
+// shape isn't a JSON array of strings.
+func ExtractGroupsClaim(rawClaims map[string]any, claimName string) []string {
+	if claimName == "" {
+		claimName = "groups"
+	}
+	val, ok := rawClaims[claimName]
+	if !ok {
+		return nil
+	}
+	list, ok := val.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(list))
+	for _, item := range list {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 type OIDCUserInfo struct {
 	Sub               string          `json:"sub"`
 	Name              string          `json:"name"`
@@ -394,7 +427,16 @@ type OIDCUserInfo struct {
 
 // FromClaim overrides a User from OIDC claims.
 // All fields will be updated, except for the ID.
-func (u *User) FromClaim(claims *OIDCClaims, emailVerifiedRequired bool) {
+// FromClaim populates the User fields from an OIDC ID token's claims.
+//
+// emailVerifiedRequired: when true, only sets the user's email if the IdP
+// asserts the address is verified.
+//
+// groupsEnabled: when true, persists the claims.Groups list so the policy
+// engine can match `group:<name>` rules against IdP-provided memberships.
+// When false, OIDC groups are ignored (existing behavior pre-feature) and
+// any previously-stored memberships are cleared on the next login.
+func (u *User) FromClaim(claims *OIDCClaims, emailVerifiedRequired, groupsEnabled bool) {
 	err := util.ValidateUsername(claims.Username)
 	if err == nil {
 		u.Name = claims.Username
@@ -420,4 +462,14 @@ func (u *User) FromClaim(claims *OIDCClaims, emailVerifiedRequired bool) {
 	u.DisplayName = claims.Name
 	u.ProfilePicURL = claims.ProfilePictureURL
 	u.Provider = util.RegisterMethodOIDC
+	// Persist (or wipe) OIDC groups based on whether the feature is enabled.
+	// When enabled, removed memberships at the IdP are reflected on next
+	// sign-in because we overwrite unconditionally. When disabled, an empty
+	// slice ensures stale data from a previous "enabled" period doesn't keep
+	// granting access.
+	if groupsEnabled {
+		u.Groups = append([]string(nil), claims.Groups...)
+	} else {
+		u.Groups = nil
+	}
 }

--- a/hscontrol/types/users_test.go
+++ b/hscontrol/types/users_test.go
@@ -477,6 +477,10 @@ func TestOIDCClaimsJSONToUser(t *testing.T) {
 					Valid:  true,
 				},
 				ProfilePicURL: "https://cdn.casbin.org/img/casbin.svg",
+				// FromClaim persists the OIDC `groups` claim when the feature
+				// is enabled (the test below passes groupsEnabled=true), so
+				// the policy matcher can resolve `group:<idp-group>` rules.
+				Groups: []string{"org1/department1", "org1/department2"},
 			},
 		},
 	}
@@ -493,11 +497,102 @@ func TestOIDCClaimsJSONToUser(t *testing.T) {
 
 			var user User
 
-			user.FromClaim(&got, tt.emailVerifiedRequired)
-
+			// Run with OIDC groups enabled so existing test fixtures that
+			// assert User.Groups is populated continue to validate the
+			// claim-to-user pipeline.
+			user.FromClaim(&got, tt.emailVerifiedRequired, true)
 			if diff := cmp.Diff(user, tt.want); diff != "" {
 				t.Errorf("TestOIDCClaimsJSONToUser() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
+}
+
+func TestExtractGroupsClaim(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       map[string]any
+		claimName string
+		want      []string
+	}{
+		{
+			name:      "default claim name when blank",
+			raw:       map[string]any{"groups": []any{"a", "b"}},
+			claimName: "",
+			want:      []string{"a", "b"},
+		},
+		{
+			name:      "explicit standard claim",
+			raw:       map[string]any{"groups": []any{"a", "b"}},
+			claimName: "groups",
+			want:      []string{"a", "b"},
+		},
+		{
+			name:      "custom claim name (Cognito-style)",
+			raw:       map[string]any{"cognito:groups": []any{"admins", "engineers"}},
+			claimName: "cognito:groups",
+			want:      []string{"admins", "engineers"},
+		},
+		{
+			name:      "custom claim name (roles)",
+			raw:       map[string]any{"roles": []any{"role1", "role2"}, "groups": []any{"ignored"}},
+			claimName: "roles",
+			want:      []string{"role1", "role2"},
+		},
+		{
+			name:      "missing claim",
+			raw:       map[string]any{"other": "value"},
+			claimName: "groups",
+			want:      nil,
+		},
+		{
+			name:      "non-array claim is dropped",
+			raw:       map[string]any{"groups": "not-an-array"},
+			claimName: "groups",
+			want:      nil,
+		},
+		{
+			name:      "mixed-type array drops non-string entries",
+			raw:       map[string]any{"groups": []any{"keep", 42, "also-keep", true}},
+			claimName: "groups",
+			want:      []string{"keep", "also-keep"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractGroupsClaim(tt.raw, tt.claimName)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("ExtractGroupsClaim mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFromClaimGroupsGating(t *testing.T) {
+	claims := &OIDCClaims{
+		Sub:           "user-1",
+		Iss:           "https://idp.example.com",
+		Email:         "alice@example.com",
+		EmailVerified: true,
+		Username:      "alice",
+		Groups:        []string{"admins", "engineers"},
+	}
+
+	t.Run("disabled wipes any prior groups", func(t *testing.T) {
+		u := User{Groups: []string{"stale", "from", "previous", "login"}}
+		u.FromClaim(claims, true, false)
+		if u.Groups != nil {
+			t.Errorf("expected Groups to be nil when feature disabled, got %v", u.Groups)
+		}
+	})
+
+	t.Run("enabled persists claim groups", func(t *testing.T) {
+		var u User
+		u.FromClaim(claims, true, true)
+		want := []string{"admins", "engineers"}
+		if diff := cmp.Diff(u.Groups, want); diff != "" {
+			t.Errorf("Groups mismatch (-got +want):\n%s", diff)
+		}
+	})
 }

--- a/integration/auth_oidc_test.go
+++ b/integration/auth_oidc_test.go
@@ -1935,3 +1935,362 @@ func TestOIDCReloginSameUserRoutesPreserved(t *testing.T) {
 
 	t.Logf("Test completed - verifying issue #2896 fix for OIDC")
 }
+
+// TestOIDCGroupsClaimPopulatesUser exercises the full mockoidc → headscale →
+// gRPC ListUsers pipeline. With `oidc.groups.enabled=true` and a mock user
+// emitting a `groups` claim, the User row must have Groups persisted and
+// surfaced via the gRPC User message.
+//
+// This is the "end-to-end test addressing maintainer concern" from
+// juanfont/headscale#1121 — proves the feature without needing a third-party
+// IdP. Default is opt-in, so disabling it (or omitting the env) keeps the
+// previous behavior (no groups persisted).
+func TestOIDCGroupsClaimPopulatesUser(t *testing.T) {
+	IntegrationSkip(t)
+
+	const username = "engineer"
+
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{},
+		OIDCUsers: []mockoidc.MockUser{
+			oidcMockUserWithGroups(username, true, "engineers", "platform"),
+		},
+	}
+
+	scenario, err := NewScenario(spec)
+	require.NoError(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	oidcMap := map[string]string{
+		"HEADSCALE_OIDC_ISSUER":             scenario.mockOIDC.Issuer(),
+		"HEADSCALE_OIDC_CLIENT_ID":          scenario.mockOIDC.ClientID(),
+		"HEADSCALE_OIDC_GROUPS_ENABLED":     "true",
+		"CREDENTIALS_DIRECTORY_TEST":        "/tmp",
+		"HEADSCALE_OIDC_CLIENT_SECRET_PATH": "${CREDENTIALS_DIRECTORY_TEST}/hs_client_oidc_secret",
+	}
+
+	err = scenario.CreateHeadscaleEnvWithLoginURL(
+		nil,
+		hsic.WithTestName("oidcgroupsclaim"),
+		hsic.WithConfigEnv(oidcMap),
+		hsic.WithFileInContainer("/tmp/hs_client_oidc_secret", []byte(scenario.mockOIDC.ClientSecret())),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	require.NoError(t, scenario.WaitForTailscaleSync())
+
+	headscale, err := scenario.Headscale()
+	require.NoError(t, err)
+
+	users, err := headscale.ListUsers()
+	require.NoError(t, err)
+
+	var got *v1.User
+	for _, u := range users {
+		if u.GetEmail() == username+"@headscale.net" {
+			got = u
+			break
+		}
+	}
+	require.NotNil(t, got, "OIDC user not registered after login")
+
+	wantGroups := []string{"engineers", "platform"}
+	if diff := cmp.Diff(wantGroups, got.GetGroups(),
+		cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+		t.Fatalf("Groups mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestOIDCGroupsDisabledDoesNotPersist is the negative companion: with the
+// feature flag off (the default), even a mock user emitting groups in its
+// claim should not have those memberships persisted. This guards against
+// silent default-behavior changes for existing deployments on upgrade.
+func TestOIDCGroupsDisabledDoesNotPersist(t *testing.T) {
+	IntegrationSkip(t)
+
+	const username = "engineer"
+
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{},
+		OIDCUsers: []mockoidc.MockUser{
+			oidcMockUserWithGroups(username, true, "engineers"),
+		},
+	}
+
+	scenario, err := NewScenario(spec)
+	require.NoError(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	// Note: HEADSCALE_OIDC_GROUPS_ENABLED is intentionally omitted to
+	// exercise the default-off behavior.
+	oidcMap := map[string]string{
+		"HEADSCALE_OIDC_ISSUER":             scenario.mockOIDC.Issuer(),
+		"HEADSCALE_OIDC_CLIENT_ID":          scenario.mockOIDC.ClientID(),
+		"CREDENTIALS_DIRECTORY_TEST":        "/tmp",
+		"HEADSCALE_OIDC_CLIENT_SECRET_PATH": "${CREDENTIALS_DIRECTORY_TEST}/hs_client_oidc_secret",
+	}
+
+	err = scenario.CreateHeadscaleEnvWithLoginURL(
+		nil,
+		hsic.WithTestName("oidcgroupsdisabled"),
+		hsic.WithConfigEnv(oidcMap),
+		hsic.WithFileInContainer("/tmp/hs_client_oidc_secret", []byte(scenario.mockOIDC.ClientSecret())),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	require.NoError(t, scenario.WaitForTailscaleSync())
+
+	headscale, err := scenario.Headscale()
+	require.NoError(t, err)
+
+	users, err := headscale.ListUsers()
+	require.NoError(t, err)
+
+	var got *v1.User
+	for _, u := range users {
+		if u.GetEmail() == username+"@headscale.net" {
+			got = u
+			break
+		}
+	}
+	require.NotNil(t, got, "OIDC user not registered after login")
+
+	if len(got.GetGroups()) != 0 {
+		t.Fatalf("expected no groups when feature disabled, got %v", got.GetGroups())
+	}
+}
+
+// TestOIDCGroupsCustomClaimName proves that a deployment with an IdP that
+// exposes group memberships under a non-standard claim name (e.g. "roles" or
+// Cognito's "cognito:groups") can configure headscale to read from that name.
+//
+// We can't reconfigure mockoidc to emit a non-default claim name, so this
+// test runs the configured-claim-name path negatively: by pointing
+// `oidc.groups.claim` at a name mockoidc does NOT emit, the user's persisted
+// Groups should be empty even though mockoidc sends a `groups` claim. This
+// is the same code path that, against a real IdP using e.g. "roles", would
+// successfully extract the role list — what differs is only the name.
+func TestOIDCGroupsCustomClaimName(t *testing.T) {
+	IntegrationSkip(t)
+
+	const username = "engineer"
+
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{},
+		OIDCUsers: []mockoidc.MockUser{
+			oidcMockUserWithGroups(username, true, "engineers"),
+		},
+	}
+
+	scenario, err := NewScenario(spec)
+	require.NoError(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	oidcMap := map[string]string{
+		"HEADSCALE_OIDC_ISSUER":             scenario.mockOIDC.Issuer(),
+		"HEADSCALE_OIDC_CLIENT_ID":          scenario.mockOIDC.ClientID(),
+		"HEADSCALE_OIDC_GROUPS_ENABLED":     "true",
+		"HEADSCALE_OIDC_GROUPS_CLAIM":       "roles", // mockoidc emits "groups", not "roles"
+		"CREDENTIALS_DIRECTORY_TEST":        "/tmp",
+		"HEADSCALE_OIDC_CLIENT_SECRET_PATH": "${CREDENTIALS_DIRECTORY_TEST}/hs_client_oidc_secret",
+	}
+
+	err = scenario.CreateHeadscaleEnvWithLoginURL(
+		nil,
+		hsic.WithTestName("oidcgroupscustomclaim"),
+		hsic.WithConfigEnv(oidcMap),
+		hsic.WithFileInContainer("/tmp/hs_client_oidc_secret", []byte(scenario.mockOIDC.ClientSecret())),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	require.NoError(t, scenario.WaitForTailscaleSync())
+
+	headscale, err := scenario.Headscale()
+	require.NoError(t, err)
+
+	users, err := headscale.ListUsers()
+	require.NoError(t, err)
+
+	var got *v1.User
+	for _, u := range users {
+		if u.GetEmail() == username+"@headscale.net" {
+			got = u
+			break
+		}
+	}
+	require.NotNil(t, got, "OIDC user not registered after login")
+
+	if len(got.GetGroups()) != 0 {
+		t.Fatalf("groups extracted from claim %q should be empty (mockoidc only emits %q): got %v",
+			"roles", "groups", got.GetGroups())
+	}
+}
+
+// TestOIDCGroupsClaimRefreshOnRelogin verifies that when an OIDC re-login
+// mutates the user's `groups` claim, the change propagates to peers that
+// were already connected — no headscale restart required. Guards against
+// regression in the State.UpdateUser → Headscale.Change broadcast path
+// that would otherwise leave peer netmaps stale until something else
+// triggered a refresh.
+//
+// The OIDC user logs in twice: first with no groups claim, then with
+// groups=["group1"]. The policy resolves `group:test` via the OIDC
+// claim. An anchor peer is connected throughout and inspects its own
+// PacketFilter to assert the OIDC user only appears as a Src for the
+// `group:test`-gated rule after the second login.
+func TestOIDCGroupsClaimRefreshOnRelogin(t *testing.T) {
+	IntegrationSkip(t)
+
+	const oidcUsername = "engineer"
+	const anchorUser = "anchor"
+
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{anchorUser},
+		OIDCUsers: []mockoidc.MockUser{
+			oidcMockUser(oidcUsername, true),                     // initial login: no groups
+			oidcMockUserWithGroups(oidcUsername, true, "group1"), // relogin: groups=[group1]
+		},
+	}
+
+	scenario, err := NewScenario(spec)
+	require.NoError(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	oidcMap := map[string]string{
+		"HEADSCALE_OIDC_ISSUER":             scenario.mockOIDC.Issuer(),
+		"HEADSCALE_OIDC_CLIENT_ID":          scenario.mockOIDC.ClientID(),
+		"HEADSCALE_OIDC_GROUPS_ENABLED":     "true",
+		"CREDENTIALS_DIRECTORY_TEST":        "/tmp",
+		"HEADSCALE_OIDC_CLIENT_SECRET_PATH": "${CREDENTIALS_DIRECTORY_TEST}/hs_client_oidc_secret",
+	}
+
+	err = scenario.CreateHeadscaleEnvWithLoginURL(
+		nil,
+		hsic.WithTestName("oidcgroupsrefresh"),
+		hsic.WithConfigEnv(oidcMap),
+		hsic.WithFileInContainer("/tmp/hs_client_oidc_secret", []byte(scenario.mockOIDC.ClientSecret())),
+		hsic.WithACLPolicy(&policyv2.Policy{
+			Groups: policyv2.Groups{
+				policyv2.Group("group:test"): []policyv2.Username{policyv2.Username("group1@")},
+			},
+			ACLs: []policyv2.ACL{
+				{
+					Action:  "accept",
+					Sources: []policyv2.Alias{groupp("group:test")},
+					Destinations: []policyv2.AliasWithPorts{
+						aliasWithPorts(prefixp("100.64.0.0/10"), tailcfg.PortRangeAny),
+					},
+				},
+			},
+		}),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	headscale, err := scenario.Headscale()
+	require.NoError(t, err)
+
+	// Anchor peer was created by the scenario and connected via CLI.
+	// It stays connected for the entire test — the assertion below
+	// reads its PacketFilter, which only refreshes via the broadcast
+	// path under test.
+	anchorClients, err := scenario.ListTailscaleClients()
+	require.NoError(t, err)
+	require.Len(t, anchorClients, 1, "expected exactly one anchor client before OIDC login")
+	anchor := anchorClients[0]
+
+	// Bring up the OIDC client and complete the first login (mockoidc
+	// serves the no-groups record).
+	oidcClient, err := scenario.CreateTailscaleNode("unstable",
+		tsic.WithNetwork(scenario.networks[scenario.testDefaultNetwork]))
+	require.NoError(t, err)
+
+	u, err := oidcClient.LoginWithURL(headscale.GetEndpoint())
+	require.NoError(t, err)
+
+	_, err = doLoginURL(oidcClient.Hostname(), u)
+	require.NoError(t, err)
+
+	require.NoError(t, scenario.WaitForTailscaleSync())
+
+	oidcIPv4, err := oidcClient.IPv4()
+	require.NoError(t, err)
+
+	// anchorSeesOIDCAsSrc reports whether anchor's PacketFilter
+	// contains any rule whose Srcs includes the OIDC user's IP. With
+	// the test policy, the only way for that IP to appear is through
+	// the `group:test` rule, which only resolves to it once the
+	// groups claim is asserted.
+	anchorSeesOIDCAsSrc := func() bool {
+		pf, err := anchor.PacketFilter()
+		if err != nil {
+			return false
+		}
+		for _, m := range pf {
+			for _, src := range m.Srcs {
+				if src.Contains(oidcIPv4) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// Pre-relogin: OIDC user has no groups, group:test resolves to an
+	// empty set, the rule drops out, anchor's filter never lists the
+	// OIDC IP as Src.
+	assert.Never(t, func() bool { return anchorSeesOIDCAsSrc() },
+		5*time.Second, 500*time.Millisecond,
+		"OIDC user must not appear as Src on anchor before group claim is asserted")
+
+	// Trigger the relogin. Logout twice (workaround mirrored from
+	// TestOIDCReloginSameNodeSameUser), wait for NeedsLogin, then
+	// log in again. mockoidc serves the second record this time,
+	// which carries groups=["group1"].
+	require.NoError(t, oidcClient.Logout())
+	require.NoError(t, oidcClient.Logout())
+
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		status, err := oidcClient.Status()
+		assert.NoError(ct, err)
+		assert.Equal(ct, "NeedsLogin", status.BackendState)
+	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second,
+		"waiting for logout to settle before relogin")
+
+	u, err = oidcClient.LoginWithURL(headscale.GetEndpoint())
+	require.NoError(t, err)
+
+	_, err = doLoginURL(oidcClient.Hostname(), u)
+	require.NoError(t, err)
+
+	// Sanity check: ListUsers must reflect the new claim. This alone
+	// passes regardless of the broadcast — it only proves the row was
+	// updated in the DB.
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		users, err := headscale.ListUsers()
+		assert.NoError(ct, err)
+		for _, u := range users {
+			if u.GetEmail() == oidcUsername+"@headscale.net" {
+				if diff := cmp.Diff([]string{"group1"}, u.GetGroups()); diff != "" {
+					ct.Errorf("groups not persisted after relogin (-want +got):\n%s", diff)
+				}
+				return
+			}
+		}
+		ct.Errorf("OIDC user not present in ListUsers after relogin")
+	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second,
+		"OIDC user record should reflect the new groups claim after relogin")
+
+	// The real assertion: the anchor's PacketFilter must update to
+	// include the OIDC user's IP as Src for the group:test rule. If
+	// the broadcast path is broken, anchor keeps its pre-relogin
+	// netmap and this fails until the headscale process restarts.
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.True(ct, anchorSeesOIDCAsSrc(),
+			"OIDC user must appear as Src in anchor's PacketFilter after the relogin's groups claim; if this never converges, the State.UpdateUser → Headscale.Change broadcast was not invoked")
+	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second,
+		"anchor PacketFilter should refresh after OIDC relogin adds groups claim")
+}

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -1019,6 +1019,15 @@ func oidcMockUser(username string, emailVerified bool) mockoidc.MockUser {
 	}
 }
 
+// oidcMockUserWithGroups builds a MockUser that emits the supplied groups in
+// the standard OIDC `groups` claim. Used by integration tests covering the
+// OIDC-groups-to-ACL pipeline.
+func oidcMockUserWithGroups(username string, emailVerified bool, groups ...string) mockoidc.MockUser {
+	user := oidcMockUser(username, emailVerified)
+	user.Groups = groups
+	return user
+}
+
 // GetUserByName retrieves a user by name from the headscale server.
 // This is a common pattern used when creating preauth keys or managing users.
 func GetUserByName(headscale ControlServer, username string) (*v1.User, error) {

--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -4,13 +4,13 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 61b203b9a9164be9a834f58c37be6f62
-    digest: shake256:e619113001d6e284ee8a92b1561e5d4ea89a47b28bf0410815cb2fa23914df8be9f1a6a98dcf069f5bc2d829a2cfb1ac614863be45cd4f8a5ad8606c5f200224
+    commit: c17df5b2beca46928cc87d5656bd5343
+    digest: shake256:c62ecead9b13485a02893cd678a6c81e40879bf00ea509bbc6fd8f1b2cc33eccf6a85c259b08d1e0f052f693cbfc7dfda236e9665b1d6869b8e1132a794a61e2
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway
-    commit: 4c5ba75caaf84e928b7137ae5c18c26a
-    digest: shake256:e174ad9408f3e608f6157907153ffec8d310783ee354f821f57178ffbeeb8faa6bb70b41b61099c1783c82fe16210ebd1279bc9c9ee6da5cffba9f0e675b8b99
+    commit: 4836b6d552304e1bbe47e66a523f0daa
+    digest: shake256:9747ec8da8c45fe6e0c9860f5495897b28c77b985c2c65a75a54c22f2f1f168039f06925aca6cd8d856a723b60eb80d510d6db1f7d0f3bd27f8d91a8a8c6182c
   - remote: buf.build
     owner: ufoundit-dev
     repository: protoc-gen-gorm

--- a/proto/headscale/v1/user.proto
+++ b/proto/headscale/v1/user.proto
@@ -13,6 +13,11 @@ message User {
   string provider_id = 6;
   string provider = 7;
   string profile_pic_url = 8;
+  // Group memberships imported from the OIDC `groups` claim (or the
+  // configured equivalent), populated when `oidc.groups.enabled` is set.
+  // Empty for users that signed up before the feature was enabled, for
+  // CLI-created users, or when the IdP does not assert groups.
+  repeated string groups = 9;
 }
 
 message CreateUserRequest {


### PR DESCRIPTION
Implements the OIDC `groups` claim → ACL `group:` resolution feature discussed in #1121 and #2366.

Closes: #2366

## What this changes

- `User.Groups []string` — JSON-serialized SQLite column populated from the OIDC `groups` claim on every login; surfaced via the v1 gRPC `User` message.
- `oidc.groups.enabled` (default `false`) — opt-in flag. With it off, `claims.Groups` is ignored regardless of what the IdP sends, so the upgrade is a no-op behavior change for existing deployments.
- `oidc.groups.claim` (default `"groups"`) — overrides the claim name for IdPs that emit memberships under a non-standard key (AWS Cognito's `cognito:groups`, Auth0 namespaced claims, custom `roles`). Both the ID-token and userinfo paths honor it; the standard-claim fast path is unchanged.
- `Group.Resolve` (policy v2) — additionally matches users whose persisted `Groups` slice contains the referenced group name. Static memberships in `policy.hujson` keep working; the two paths are additive.
- **`State.UpdateUser → Headscale.Change` broadcast** — OIDC logins now propagate the resulting `change.Change` to `Headscale.Change(...)` so already-connected peers refresh their netmaps when the login mutated ACL-affecting state. The OIDC handler previously discarded this return value, which was harmless before this PR (no OIDC-login-time mutation affected ACL evaluation) but load-bearing once `Groups` is in the picture.

## Vendor neutrality

The implementation is intentionally vendor-agnostic — `User.Groups` is plain `[]string` and resolution is string equality. Works against the standard OIDC `groups` claim shape (Authelia, Authentik, Keycloak, Okta with the `groups` scope, Google Workspace via Dex, Entra ID via app-role mapping) and against the custom-claim-name path (AWS Cognito, custom `roles`-style claims).

## Tests

- **Unit:** `TestGroupResolve_MatchesOIDCGroupClaim`,`TestPolicyManagerSetUsersRefreshesOIDCGroupResolution` (validates the live cache-refresh path after `State.UpdateUser` → `PolicyManager.SetUsers`), plus coverage in `hscontrol/types/users_test.go` for `ExtractGroupsClaim` and `FromClaim` group handling. 
- **Integration:** Four mockoidc-driven end-to-end tests in integration/auth_oidc_test.go — three cover the enabled, disabled, and custom-claim-name persistence paths; the fourth (TestOIDCGroupsClaimRefreshOnRelogin) connects an anchor peer, drives the OIDC user through a logout-relogin that mutates the groups claim, and asserts the anchor's PacketFilter refreshes without a server restart (this is the regression test for the broadcast fix above). No external IdP or third-party service required at CI time. This addresses the maintenance concern raised in  #1121 ("we are actively avoiding platforms we cannot have full end-to-end tests as it is unfeasible for us to maintain it over time")

## Notes for review

- **Migration `202505141324` gets a one-line `tx.Omit("groups")`.** That migration's `tx.Save(user)` writes the live `types.User` struct; once `Groups` is added, a fresh-DB run hits the older migration before the column-add migration and crashes. Omitting the new column keeps the older migration hermetic against the schema as it existed when it shipped. Happy to refactor to a migration-local struct if that's preferred.
- **Refresh model is snapshot-on-login.** Groups update when the user re-authenticates against the IdP, not on a timer. Admins tune staleness tolerance via `node.expiry`. This is the "nothing dynamic, nothing fancy" model called for in #1121 and matches the acceptable trade-off kradalby outlined in #2366. Other refresh mechanisms discussed in the issue threads (offline-access + UserInfo polling, LDAP federation, SCIM v2 provisioning) all still need a place to persist the IdP's group claims for ACL evaluation — i.e. they would all build on the `User.Groups` storage and `state.UpdateUser → Headscale.Change` path this PR introduces, not replace it. Those approaches are out of scope here per kradalby's prior call. If there is appetite for any of these (SCIMv2, LDAP, etc) I'd be happy to work on them in separate PRs.
- **Production validation and maintenance commitment.** Running this fork today across multiple environments — Dex + Google Workspace & Microsoft Entra ID as the IdP's, Headplane, SQLite, Kubernetes — where OIDC group resolution was a hard requirement for the deployments. I've deployed headscale in many environments over time; since I had to do this work anyway, contributing it upstream felt like the right way to give back. I'm a big fan of the project and the maintainers' work, committed to maintaining this feature long term, and fully open to discussion or refactors that come out of review.

Refs: #1121, #2366

## Checklist

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand (#1121, #2366)
- [x] added unit tests
- [x] added integration tests
- [x] updated documentation if needed
- [x] updated [CHANGELOG.md](./CHANGELOG.md) file