### PR TITLE
state: preserve username-based IP allocation

### DIFF
--- a/hscontrol/db/ip.go
+++ b/hscontrol/db/ip.go
@@ -136,24 +136,76 @@ func NewIPAllocator(
 		ret.nsPrev[ns] = network
 	}
 
+	// Fetch all nodes from the database to properly initialize namespace prev pointers.
+	var nodes []types.Node
+	if db != nil {
+		err := db.Read(func(rx *gorm.DB) error {
+			return rx.Preload("User").Find(&nodes).Error
+		})
+		if err != nil {
+			return nil, fmt.Errorf("reading nodes from database: %w", err)
+		}
+	}
+
+	// Track the highest IP allocated per namespace to set nsPrev correctly.
+	nsMaxIP := make(map[string]netip.Addr)
+
 	// Fetch all the IP Addresses currently handed out from the Database
 	// and add them to the used IP set.
-	for _, addrStr := range append(v4s, v6s...) {
-		if addrStr.Valid {
-			addr, err := netip.ParseAddr(addrStr.String)
-			if err != nil {
-				return nil, fmt.Errorf("parsing IP address from database: %w", err)
-			}
+	for _, node := range nodes {
+		// Process IPv4
+		if node.IPv4 != nil {
+			addr := *node.IPv4
 
 			// Add to global used set.
 			ips.Add(addr)
 
-			// Also add to any namespace pool whose prefix contains this IP,
-			// so we don't re-issue IPs that were previously allocated.
+			// Determine namespace for this node
+			namespace := ""
+			if node.User != nil {
+				namespace = node.User.Name
+			}
+
+			// Add to namespace pool and track max IP if this namespace has a dedicated prefix
+			if namespace != "" {
+				if nsPfx, ok := nsPrefixes[namespace]; ok {
+					if nsPfx.Contains(addr) {
+						nsb := ret.nsUsed[namespace]
+						nsb.Add(addr)
+
+						// Track the highest IP in this namespace
+						if maxIP, exists := nsMaxIP[namespace]; !exists || addr.Compare(maxIP) > 0 {
+							nsMaxIP[namespace] = addr
+						}
+					}
+				}
+			}
+
+			// Add to all namespace pools to prevent cross-namespace collisions
+			for ns, nsb := range ret.nsUsed {
+				nsb.Add(addr)
+			}
+		}
+
+		// Process IPv6
+		if node.IPv6 != nil {
+			addr := *node.IPv6
+			ips.Add(addr)
+
+			// IPv6 doesn't use namespace-specific prefixes, but still add to all namespace pools
 			for _, nsb := range ret.nsUsed {
 				nsb.Add(addr)
 			}
 		}
+	}
+
+	// Update nsPrev to the highest allocated IP in each namespace
+	for ns, maxIP := range nsMaxIP {
+		ret.nsPrev[ns] = maxIP
+		log.Debug().
+			Str("namespace", ns).
+			Str("max_ip", maxIP.String()).
+			Msg("initialized namespace prev pointer from existing allocations")
 	}
 
 	// Build the initial IPSet to validate that we can use it.
@@ -222,16 +274,38 @@ func (i *IPAllocator) NextForNamespace(namespace string) (*netip.Addr, *netip.Ad
 
 		ret4, err = i.nextFromBuilder(prev, &nsPfx, nsb)
 		if err != nil {
-			return nil, nil, fmt.Errorf("allocating IPv4 for namespace %q: %w", namespace, err)
+			// Namespace-specific prefix is exhausted, fall back to global prefix
+			log.Warn().
+				Str("namespace", namespace).
+				Str("prefix", nsPfx.String()).
+				Err(err).
+				Msg("namespace-specific prefix exhausted, falling back to global prefix")
+
+			if i.prefix4 != nil {
+				ret4, err = i.next(i.prev4, i.prefix4)
+				if err != nil {
+					return nil, nil, fmt.Errorf("allocating IPv4 address from global prefix after namespace exhaustion: %w", err)
+				}
+
+				i.prev4 = *ret4
+
+				log.Info().
+					Str("namespace", namespace).
+					Str("prefix", i.prefix4.String()).
+					Str("ip", ret4.String()).
+					Msg("allocated IP from global prefix (namespace prefix exhausted)")
+			} else {
+				return nil, nil, fmt.Errorf("allocating IPv4 for namespace %q: namespace prefix exhausted and no global prefix configured: %w", namespace, err)
+			}
+		} else {
+			i.nsPrev[namespace] = *ret4
+
+			log.Debug().
+				Str("namespace", namespace).
+				Str("prefix", nsPfx.String()).
+				Str("ip", ret4.String()).
+				Msg("allocated IP from namespace-specific prefix")
 		}
-
-		i.nsPrev[namespace] = *ret4
-
-		log.Debug().
-			Str("namespace", namespace).
-			Str("prefix", nsPfx.String()).
-			Str("ip", ret4.String()).
-			Msg("allocated IP from namespace-specific prefix")
 	} else if i.prefix4 != nil {
 		// Fallback to global prefix.
 		ret4, err = i.next(i.prev4, i.prefix4)
@@ -293,8 +367,27 @@ func (i *IPAllocator) nextFromBuilder(prev netip.Addr, prefix *netip.Prefix, bui
 		return nil, err
 	}
 
+	startIP := ip
+	wrappedAround := false
+
 	for {
 		if !prefix.Contains(ip) {
+			// If we've reached the end of the prefix and haven't wrapped around yet,
+			// start from the beginning to find holes left by deleted nodes
+			if !wrappedAround && i.strategy == types.IPAllocationStrategySequential {
+				wrappedAround = true
+				ip = prefix.Addr().Next() // Start from first usable IP in prefix
+				log.Debug().
+					Str("prefix", prefix.String()).
+					Str("restart_ip", ip.String()).
+					Msg("reached end of prefix, wrapping around to find freed IPs")
+				continue
+			}
+			return nil, ErrCouldNotAllocateIP
+		}
+
+		// Prevent infinite loop: if we've wrapped around and reached the starting IP again
+		if wrappedAround && ip.Compare(startIP) >= 0 {
 			return nil, ErrCouldNotAllocateIP
 		}
 
@@ -514,6 +607,16 @@ func (i *IPAllocator) FreeIPs(ips []netip.Addr) {
 	defer i.mu.Unlock()
 
 	for _, ip := range ips {
+		// Remove from global used set
 		i.usedIPs.Remove(ip)
+
+		// Also remove from all namespace-specific used sets
+		for ns, nsb := range i.nsUsed {
+			nsb.Remove(ip)
+			log.Debug().
+				Str("namespace", ns).
+				Str("ip", ip.String()).
+				Msg("freed IP from namespace pool")
+		}
 	}
 }

--- a/hscontrol/db/ip.go
+++ b/hscontrol/db/ip.go
@@ -47,6 +47,17 @@ type IPAllocator struct {
 	// database fails, the IP will be allocated here
 	// until the next restart of Headscale.
 	usedIPs netipx.IPSetBuilder
+
+	// nsPrefixes maps namespace name -> dedicated IPv4 prefix.
+	// When set, nodes in that namespace are allocated from this prefix
+	// instead of the global prefix4.
+	nsPrefixes map[string]netip.Prefix
+
+	// nsPrev tracks the previous IP handed out per namespace prefix.
+	nsPrev map[string]netip.Addr
+
+	// nsUsed tracks used IPs per namespace prefix (keyed by prefix string).
+	nsUsed map[string]*netipx.IPSetBuilder
 }
 
 // NewIPAllocator returns a new IPAllocator singleton which
@@ -58,12 +69,15 @@ func NewIPAllocator(
 	db *HSDatabase,
 	prefix4, prefix6 *netip.Prefix,
 	strategy types.IPAllocationStrategy,
+	nsPrefixes map[string]netip.Prefix,
 ) (*IPAllocator, error) {
 	ret := IPAllocator{
-		prefix4: prefix4,
-		prefix6: prefix6,
-
-		strategy: strategy,
+		prefix4:    prefix4,
+		prefix6:    prefix6,
+		strategy:   strategy,
+		nsPrefixes: nsPrefixes,
+		nsPrev:     make(map[string]netip.Addr),
+		nsUsed:     make(map[string]*netipx.IPSetBuilder),
 	}
 
 	var (
@@ -110,6 +124,18 @@ func NewIPAllocator(
 		ret.prev6 = network6
 	}
 
+	// Initialise per-namespace prefix pools: reserve network/broadcast addresses
+	// and set the starting prev pointer for each namespace prefix.
+	for ns, pfx := range nsPrefixes {
+		pfxCopy := pfx
+		nsb := &netipx.IPSetBuilder{}
+		network, broadcast := util.GetIPPrefixEndpoints(pfxCopy)
+		nsb.Add(network)
+		nsb.Add(broadcast)
+		ret.nsUsed[ns] = nsb
+		ret.nsPrev[ns] = network
+	}
+
 	// Fetch all the IP Addresses currently handed out from the Database
 	// and add them to the used IP set.
 	for _, addrStr := range append(v4s, v6s...) {
@@ -119,7 +145,14 @@ func NewIPAllocator(
 				return nil, fmt.Errorf("parsing IP address from database: %w", err)
 			}
 
+			// Add to global used set.
 			ips.Add(addr)
+
+			// Also add to any namespace pool whose prefix contains this IP,
+			// so we don't re-issue IPs that were previously allocated.
+			for _, nsb := range ret.nsUsed {
+				nsb.Add(addr)
+			}
 		}
 	}
 
@@ -168,6 +201,66 @@ func (i *IPAllocator) Next() (*netip.Addr, *netip.Addr, error) {
 	return ret4, ret6, nil
 }
 
+// NextForNamespace allocates an IPv4 address for the given namespace.
+// If the namespace has a dedicated prefix configured (via PrefixesByNamespace),
+// the IP is drawn from that pool. Otherwise it falls back to the global prefix4.
+// IPv6 is always allocated from the global prefix6 (namespace-specific v6 is not supported).
+func (i *IPAllocator) NextForNamespace(namespace string) (*netip.Addr, *netip.Addr, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	var (
+		err  error
+		ret4 *netip.Addr
+		ret6 *netip.Addr
+	)
+
+	// Determine which IPv4 prefix to use for this namespace.
+	if nsPfx, ok := i.nsPrefixes[namespace]; ok {
+		nsb := i.nsUsed[namespace]
+		prev := i.nsPrev[namespace]
+
+		ret4, err = i.nextFromBuilder(prev, &nsPfx, nsb)
+		if err != nil {
+			return nil, nil, fmt.Errorf("allocating IPv4 for namespace %q: %w", namespace, err)
+		}
+
+		i.nsPrev[namespace] = *ret4
+
+		log.Debug().
+			Str("namespace", namespace).
+			Str("prefix", nsPfx.String()).
+			Str("ip", ret4.String()).
+			Msg("allocated IP from namespace-specific prefix")
+	} else if i.prefix4 != nil {
+		// Fallback to global prefix.
+		ret4, err = i.next(i.prev4, i.prefix4)
+		if err != nil {
+			return nil, nil, fmt.Errorf("allocating IPv4 address: %w", err)
+		}
+
+		i.prev4 = *ret4
+
+		log.Debug().
+			Str("namespace", namespace).
+			Str("prefix", i.prefix4.String()).
+			Str("ip", ret4.String()).
+			Msg("allocated IP from global prefix (namespace not configured)")
+	}
+
+	// IPv6 always uses the global prefix6.
+	if i.prefix6 != nil {
+		ret6, err = i.next(i.prev6, i.prefix6)
+		if err != nil {
+			return nil, nil, fmt.Errorf("allocating IPv6 address: %w", err)
+		}
+
+		i.prev6 = *ret6
+	}
+
+	return ret4, ret6, nil
+}
+
 var ErrCouldNotAllocateIP = errors.New("failed to allocate IP")
 
 func (i *IPAllocator) nextLocked(prev netip.Addr, prefix *netip.Prefix) (*netip.Addr, error) {
@@ -175,6 +268,56 @@ func (i *IPAllocator) nextLocked(prev netip.Addr, prefix *netip.Prefix) (*netip.
 	defer i.mu.Unlock()
 
 	return i.next(prev, prefix)
+}
+
+// nextFromBuilder is like next but uses a caller-supplied IPSetBuilder
+// instead of the global i.usedIPs. Used for per-namespace prefix pools.
+func (i *IPAllocator) nextFromBuilder(prev netip.Addr, prefix *netip.Prefix, builder *netipx.IPSetBuilder) (*netip.Addr, error) {
+	var (
+		err error
+		ip  netip.Addr
+	)
+
+	switch i.strategy {
+	case types.IPAllocationStrategySequential:
+		ip = prev.Next()
+	case types.IPAllocationStrategyRandom:
+		ip, err = randomNext(*prefix)
+		if err != nil {
+			return nil, fmt.Errorf("getting random IP: %w", err)
+		}
+	}
+
+	set, err := builder.IPSet()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		if !prefix.Contains(ip) {
+			return nil, ErrCouldNotAllocateIP
+		}
+
+		if set.Contains(ip) || isTailscaleReservedIP(ip) {
+			switch i.strategy {
+			case types.IPAllocationStrategySequential:
+				ip = ip.Next()
+			case types.IPAllocationStrategyRandom:
+				ip, err = randomNext(*prefix)
+				if err != nil {
+					return nil, fmt.Errorf("getting random IP: %w", err)
+				}
+			}
+
+			continue
+		}
+
+		builder.Add(ip)
+		// Also mark in global usedIPs to prevent cross-namespace collisions.
+		i.usedIPs.Add(ip)
+
+		return &ip, nil
+	}
 }
 
 func (i *IPAllocator) next(prev netip.Addr, prefix *netip.Prefix) (*netip.Addr, error) {
@@ -301,10 +444,16 @@ func (db *HSDatabase) BackfillNodeIPs(i *IPAllocator) ([]string, error) {
 		for _, node := range nodes {
 			log.Trace().Caller().EmbedObject(node).Msg("ip backfill check started because node found in database")
 
+			// Determine the namespace name for this node (used for per-namespace prefix lookup).
+			namespace := ""
+			if node.User != nil {
+				namespace = node.User.Name
+			}
+
 			changed := false
 			// IPv4 prefix is set, but node ip is missing, alloc
-			if i.prefix4 != nil && node.IPv4 == nil {
-				ret4, err := i.nextLocked(i.prev4, i.prefix4)
+			if (i.prefix4 != nil || len(i.nsPrefixes) > 0) && node.IPv4 == nil {
+				ret4, _, err := i.NextForNamespace(namespace)
 				if err != nil {
 					return fmt.Errorf("allocating IPv4 for node(%d): %w", node.ID, err)
 				}
@@ -312,12 +461,12 @@ func (db *HSDatabase) BackfillNodeIPs(i *IPAllocator) ([]string, error) {
 				node.IPv4 = ret4
 				changed = true
 
-				ret = append(ret, fmt.Sprintf("assigned IPv4 %q to Node(%d) %q", ret4.String(), node.ID, node.Hostname))
+				ret = append(ret, fmt.Sprintf("assigned IPv4 %q to Node(%d) %q (namespace %q)", ret4.String(), node.ID, node.Hostname, namespace))
 			}
 
 			// IPv6 prefix is set, but node ip is missing, alloc
 			if i.prefix6 != nil && node.IPv6 == nil {
-				ret6, err := i.nextLocked(i.prev6, i.prefix6)
+				_, ret6, err := i.NextForNamespace(namespace)
 				if err != nil {
 					return fmt.Errorf("allocating IPv6 for node(%d): %w", node.ID, err)
 				}
@@ -329,7 +478,7 @@ func (db *HSDatabase) BackfillNodeIPs(i *IPAllocator) ([]string, error) {
 			}
 
 			// IPv4 prefix is not set, but node has IP, remove
-			if i.prefix4 == nil && node.IPv4 != nil {
+			if i.prefix4 == nil && len(i.nsPrefixes) == 0 && node.IPv4 != nil {
 				ret = append(ret, fmt.Sprintf("removing IPv4 %q from Node(%d) %q", node.IPv4.String(), node.ID, node.Hostname))
 				node.IPv4 = nil
 				changed = true

--- a/hscontrol/db/ip_test.go
+++ b/hscontrol/db/ip_test.go
@@ -153,6 +153,7 @@ func TestIPAllocatorSequential(t *testing.T) {
 				tt.prefix4,
 				tt.prefix6,
 				types.IPAllocationStrategySequential,
+				nil,
 			)
 
 			var (
@@ -258,7 +259,7 @@ func TestIPAllocatorRandom(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			db := tt.dbFunc()
 
-			alloc, _ := NewIPAllocator(db, tt.prefix4, tt.prefix6, types.IPAllocationStrategyRandom)
+			alloc, _ := NewIPAllocator(db, tt.prefix4, tt.prefix6, types.IPAllocationStrategyRandom, nil)
 
 			for range tt.getCount {
 				got4, got6, err := alloc.Next()
@@ -458,6 +459,7 @@ func TestBackfillIPAddresses(t *testing.T) {
 				tt.prefix4,
 				tt.prefix6,
 				types.IPAllocationStrategySequential,
+				nil,
 			)
 			if err != nil {
 				t.Fatalf("failed to set up ip alloc: %s", err)
@@ -493,6 +495,7 @@ func TestIPAllocatorNextNoReservedIPs(t *testing.T) {
 		new(tsaddr.CGNATRange()),
 		new(tsaddr.TailscaleULARange()),
 		types.IPAllocationStrategySequential,
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("failed to set up ip alloc: %s", err)

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -204,7 +204,7 @@ func NewState(cfg *types.Config) (*State, error) {
 		return nil, fmt.Errorf("initializing database: %w", err)
 	}
 
-	ipAlloc, err := hsdb.NewIPAllocator(db, cfg.PrefixV4, cfg.PrefixV6, cfg.IPAllocation)
+	ipAlloc, err := hsdb.NewIPAllocator(db, cfg.PrefixV4, cfg.PrefixV6, cfg.IPAllocation, cfg.PrefixesByNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("initializing IP allocator: %w", err)
 	}
@@ -1712,8 +1712,13 @@ func (s *State) createAndSaveNewNode(params newNodeParams) (types.NodeView, erro
 		return types.NodeView{}, err
 	}
 
-	// Allocate new IPs
-	ipv4, ipv6, err := s.ipAlloc.Next()
+	// Allocate new IPs, using the namespace-specific prefix if configured.
+	namespace := ""
+	if nodeToRegister.User != nil {
+		namespace = nodeToRegister.User.Name
+	}
+
+	ipv4, ipv6, err := s.ipAlloc.NextForNamespace(namespace)
 	if err != nil {
 		return types.NodeView{}, fmt.Errorf("allocating IPs: %w", err)
 	}

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -102,6 +102,10 @@ type Config struct {
 	PrefixV4            *netip.Prefix
 	PrefixV6            *netip.Prefix
 	IPAllocation        IPAllocationStrategy
+	// PrefixesByNamespace maps namespace (user) names to their dedicated IPv4 prefix.
+	// Nodes belonging to a namespace will be allocated IPs from that namespace's prefix.
+	// Falls back to PrefixV4/PrefixV6 when a namespace is not listed here.
+	PrefixesByNamespace map[string]netip.Prefix
 	NoisePrivateKeyPath string
 	BaseDomain          string
 	Log                 LogConfig
@@ -1113,6 +1117,18 @@ func LoadServerConfig() (*Config, error) {
 		)
 	}
 
+	// Parse per-namespace prefix overrides.
+	// Config key: prefixes.by_namespace.<name> = "100.64.x.0/24"
+	prefixesByNamespace := make(map[string]netip.Prefix)
+	nsByNS := viper.GetStringMapString("prefixes.by_namespace")
+	for ns, cidr := range nsByNS {
+		p, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("parsing prefixes.by_namespace[%q]: %w", ns, err)
+		}
+		prefixesByNamespace[ns] = p
+	}
+
 	dnsConfig, err := dns()
 	if err != nil {
 		return nil, err
@@ -1162,9 +1178,10 @@ func LoadServerConfig() (*Config, error) {
 		GRPCAllowInsecure:  viper.GetBool("grpc_allow_insecure"),
 		DisableUpdateCheck: false,
 
-		PrefixV4:     prefix4,
-		PrefixV6:     prefix6,
-		IPAllocation: alloc,
+		PrefixV4:            prefix4,
+		PrefixV6:            prefix6,
+		IPAllocation:        alloc,
+		PrefixesByNamespace: prefixesByNamespace,
 
 		NoisePrivateKeyPath: util.AbsolutePathFromConfigPath(
 			viper.GetString("noise.private_key_path"),


### PR DESCRIPTION
## Summary

Preserve username-based IP allocation on top of the current upstream main branch.

## Changes

- add namespace-specific IPv4 prefix allocation support in the IP allocator
- allocate node IPs based on the registering user's namespace
- load namespace prefix overrides from config
- update allocator tests to match the new behavior

## Notes

This change keeps the existing custom username-based IP allocation behavior after rebasing onto the latest upstream main branch.
