### PR TITLE
github: drop nu flatten in needs-more-info timer

### DIFF
--- a/.github/workflows/needs-more-info-timer.yml
+++ b/.github/workflows/needs-more-info-timer.yml
@@ -58,7 +58,7 @@ jobs:
 
             # Find when needs-more-info was last added
             let events = (gh api $"repos/($env.GH_REPO)/issues/($number)/events"
-              --paginate | from json | flatten)
+              --paginate | from json)
             let label_event = ($events
               | where event == "labeled"
               | where label.name == "needs-more-info"
@@ -67,7 +67,7 @@ jobs:
 
             # Check for non-bot comments after the label was added
             let comments = (gh api $"repos/($env.GH_REPO)/issues/($number)/comments"
-              --paginate | from json | flatten)
+              --paginate | from json)
             let human_responses = ($comments
               | where user.type != "Bot"
               | where { ($in.created_at | into datetime) > $label_added_at })


### PR DESCRIPTION
Scheduled job has failed every night since 2026-04-13. Prior fixes (#3200 split the `where`, earlier commits guarded the label race) missed the cause: `flatten` lifts nested record fields to the parent row, deleting `label` and `user` columns. `where label.name == ...` and `where user.type != "Bot"` then reference columns that no longer exist.

`gh api --paginate` already concatenates pages into one JSON array, so `from json` yields a list of records directly. Drop both `| flatten` calls.

Verified locally with nu 0.108 against issue 3178's events: without `flatten`, `where event == "labeled" | where label.name == "needs-more-info" | last` returns the labeled event row with its `label` record intact.

> Generated with the help of an AI assistant