### PR TITLE
.github: gate PRs via mitchellh/vouch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,1 @@
-* @juanfont @kradalby
-
-*.md @ohdearaugustin @nblock
-*.yml @ohdearaugustin @nblock
-*.yaml @ohdearaugustin @nblock
-Dockerfile* @ohdearaugustin @nblock
-.goreleaser.yaml @ohdearaugustin @nblock
-/docs/ @ohdearaugustin @nblock
-/.github/workflows/ @ohdearaugustin @nblock
-/.github/renovate.json @ohdearaugustin @nblock
+* @juanfont @kradalby @nblock

--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -1,0 +1,119 @@
+# Vouched (or actively denounced) users for this repository.
+#
+# Headscale gates pull requests to vouched contributors only. Issues
+# remain open to everyone — see CONTRIBUTING.md for the rationale and
+# the process for getting vouched.
+#
+# A denounced user (prefix `-`) is explicitly blocked from contributing.
+#
+# Syntax:
+#  - One handle per line (without @). Sorted alphabetically.
+#  - Optionally specify platform: `platform:username` (e.g., `github:nblock`).
+#  - To denounce, prefix with minus: `-username` or `-platform:username`.
+#  - Optionally, add a comment after a space following the handle.
+#
+# Maintainers can vouch for new contributors by commenting `!vouch` (or
+# `!vouch @username`) on any issue or PR by the author. `!denounce` blocks.
+
+aalmenar
+adoolaard
+adriangoransson
+Aluxima
+AlynxZhou
+apollo13
+aradng
+ArcticLampyrid
+bobelev
+ChibangLW
+christian-heusel
+ckiee
+codethief
+cure
+dmeremyanin
+dotlambda
+dragetd
+e-zk
+edvardvb
+enoperm
+EtaoinWu
+evenh
+eyJhb
+felixscheinost
+FlorinPeter
+fredrikekre
+griffer
+GrigoriyMikhalkin
+gymnae
+huskyii
+igrikus
+ImpostorKeanu
+isaac-mcfadyen
+iSchluff
+ItalyPaleAle
+ItsShadowCone
+jdewinne
+joachimtingvold
+jonathanspw
+juanfont
+kazauwa
+korfuri
+kradalby
+linsomniac
+lyc8503
+madjam002
+majst01
+maprambo
+marcelmindemann
+maxpain
+mevansam
+mike-lloyd03
+motiejus
+mpldr
+nblock
+negbie
+Nemo157
+nicka101
+Niek
+nielscil
+NoelGisler
+noseshimself
+ohdearaugustin
+oplik0
+Orhideous
+pallabpain
+philippderdiedas
+Polsaker
+PowershellScripter
+ptman
+puzpuzpuz
+pvinis
+qbit
+QEDeD
+qoke
+Qup42
+redstonekasi
+restanrm
+reynico
+Riezebos
+samson4649
+SlackingVeteran
+spymobilfon
+stavros-k
+stblassitude
+SuperSandro2000
+SysAdminSmith
+sysvinit
+teleclimber
+tgrushka
+thebigbone
+tianon
+TotoTheDragon
+tsujamin
+unreality
+vbrandl
+vdovhanych
+victorhooi
+vsychov
+yaneony
+yaroslavkasatikov
+Zottelchen

--- a/.github/pr-unvouched-message
+++ b/.github/pr-unvouched-message
@@ -1,0 +1,25 @@
+Hi @{author}, thanks for your interest in headscale.
+
+Headscale gates pull requests to vouched contributors only. Your account
+isn't on the list yet, so this PR has been auto-closed. This is **not** a
+judgment of you or this change.
+
+Headscale is an "Open Source, acknowledged contribution" project: every
+contribution starts with a discussion on the issue tracker, **before** any
+code is written. See [`CONTRIBUTING.md`](https://github.com/juanfont/headscale/blob/main/CONTRIBUTING.md)
+for the full policy and the rationale.
+
+To get vouched:
+
+1. Open an issue describing the change you'd like to make (use case,
+   implementation sketch, who will maintain it). For bug fixes, a clear
+   reproduction is enough.
+2. Engage with maintainers on the issue. Once we've agreed on scope and
+   approach, a maintainer will `!vouch @{author}`.
+3. You can then reopen this PR (or open a new one) and it will pass the
+   gate.
+
+Issues remain open to everyone — no vouching needed there, and that's the
+intended starting point for any contribution.
+
+The vouched list: [`.github/VOUCHED.td`](https://github.com/juanfont/headscale/blob/main/.github/VOUCHED.td).

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -1,0 +1,30 @@
+name: "Vouch - Check PR"
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.VOUCH_APP_ID }}
+          private-key: ${{ secrets.VOUCH_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          sparse-checkout: .github/pr-unvouched-message
+
+      - uses: mitchellh/vouch/action/check-pr@c6d80ead49839655b61b422700b7a3bc9d0804a9 # v1.4.2
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          auto-close: true
+          template-file: .github/pr-unvouched-message
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -1,0 +1,36 @@
+name: "Vouch - Manage by Issue"
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: false
+
+jobs:
+  manage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.VOUCH_APP_ID }}
+          private-key: ${{ secrets.VOUCH_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: mitchellh/vouch/action/manage-by-issue@c6d80ead49839655b61b422700b7a3bc9d0804a9 # v1.4.2
+        with:
+          repo: ${{ github.repository }}
+          issue-id: ${{ github.event.issue.number }}
+          comment-id: ${{ github.event.comment.id }}
+          vouch-keyword: "!vouch"
+          denounce-keyword: "!denounce"
+          unvouch-keyword: "!unvouch"
+          pull-request: "true"
+          merge-immediately: "true"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/vouch-sync-codeowners.yml
+++ b/.github/workflows/vouch-sync-codeowners.yml
@@ -1,0 +1,32 @@
+name: "Vouch - Sync CODEOWNERS"
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: vouch-manage
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          app-id: ${{ secrets.VOUCH_APP_ID }}
+          private-key: ${{ secrets.VOUCH_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: mitchellh/vouch/action/sync-codeowners@c6d80ead49839655b61b422700b7a3bc9d0804a9 # v1.4.2
+        with:
+          repo: ${{ github.repository }}
+          pull-request: "true"
+          merge-immediately: "true"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
PRs keep arriving without the prior discussion `CONTRIBUTING.md` asks
for. We are not able to review or triage PRs fast enough, specially now that everyone has super human code generation capabilities.

Adopt [mitchellh/vouch](https://github.com/mitchellh/vouch) to
auto-close PRs from authors not on `.github/VOUCHED.td`. Issues stay
open to everyone — the close message points contributors back at
`CONTRIBUTING.md` to start that discussion.

Less aggressive than ghostty, which gates issues too.

Seed list is past PR contributors with merged code plus authors of
detailed issues; bots and CODEOWNERS are auto-vouched. Anyone with an
open PR that hasn't been through review yet was left off — `!vouch`
later if it lands.

`!vouch @user` / `!denounce @user` / `!unvouch @user` on any issue or PR
comment from a maintainer manages the list. Weekly cron resyncs
CODEOWNERS.

Workflows need a GitHub App with Contents/Issues/PRs write installed on
the repo, plus `VOUCH_APP_ID` and `VOUCH_APP_PRIVATE_KEY` secrets. Until
those exist nothing is gated (fail-open).

> Generated with the help of an AI assistant