### PR TITLE
policy: surface exit nodes via autogroup:internet

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -239,6 +239,7 @@ jobs:
           - TestHASubnetRouterFailover
           - TestSubnetRouteACL
           - TestEnablingExitRoutes
+          - TestExitRoutesWithAutogroupInternetACL
           - TestSubnetRouterMultiNetwork
           - TestSubnetRouterMultiNetworkExitNode
           - TestAutoApproveMultiNetwork/authkey-tag.*

--- a/hscontrol/policy/policy_test.go
+++ b/hscontrol/policy/policy_test.go
@@ -951,11 +951,13 @@ func TestReduceNodesFromPolicy(t *testing.T) {
   ]
 }`,
 			node: n(1, "100.64.0.1", "mobile", "mobile"),
-			// autogroup:internet does not generate packet filters - it's handled
-			// by exit node routing via AllowedIPs, not by packet filtering.
-			// Only server is visible through the mobile -> server:80 rule.
+			// autogroup:internet emits no client packet filter, but it
+			// must still produce a matcher: Node.CanAccess uses
+			// matcher.DestsIsTheInternet() + IsExitNode() to surface
+			// exit-node peers (juanfont/headscale#3212).
 			want: types.Nodes{
 				n(2, "100.64.0.2", "server", "server"),
+				n(3, "100.64.0.3", "exit", "server", "0.0.0.0/0", "::/0"),
 			},
 			wantMatchers: 1,
 		},

--- a/hscontrol/policy/policyutil/reduce.go
+++ b/hscontrol/policy/policyutil/reduce.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/util"
+	"go4.org/netipx"
 	"tailscale.com/tailcfg"
 )
 
@@ -18,6 +19,7 @@ import (
 func ReduceFilterRules(node types.NodeView, rules []tailcfg.FilterRule) []tailcfg.FilterRule {
 	ret := []tailcfg.FilterRule{}
 	subnetRoutes := node.SubnetRoutes()
+	hasExitRoutes := node.IsExitNode()
 
 	for _, rule := range rules {
 		// Handle CapGrant rules separately — they use CapGrant[].Dsts
@@ -56,6 +58,14 @@ func ReduceFilterRules(node types.NodeView, rules []tailcfg.FilterRule) []tailcf
 			// AllowedIPs/routing.
 			if slices.ContainsFunc(subnetRoutes, expanded.OverlapsPrefix) {
 				dests = append(dests, dest)
+				continue
+			}
+
+			// Exit-route advertisers need rules targeting the
+			// public internet so the kernel filter accepts
+			// traffic forwarded by autogroup:internet sources.
+			if hasExitRoutes && ipSetSubsetOf(expanded, util.TheInternet()) {
+				dests = append(dests, dest)
 			}
 		}
 
@@ -69,6 +79,20 @@ func ReduceFilterRules(node types.NodeView, rules []tailcfg.FilterRule) []tailcf
 	}
 
 	return ret
+}
+
+func ipSetSubsetOf(candidate, container *netipx.IPSet) bool {
+	if candidate == nil || container == nil {
+		return false
+	}
+
+	for _, pref := range candidate.Prefixes() {
+		if !container.ContainsPrefix(pref) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // reduceCapGrantRule filters a CapGrant rule to only include CapGrant

--- a/hscontrol/policy/v2/filter.go
+++ b/hscontrol/policy/v2/filter.go
@@ -166,12 +166,6 @@ func (pol *Policy) destinationsToNetPortRange(
 			continue
 		}
 
-		// autogroup:internet does not generate packet filters - it's handled
-		// by exit node routing via AllowedIPs, not by packet filtering.
-		if ag, isAutoGroup := dest.(*AutoGroup); isAutoGroup && ag.Is(AutoGroupInternet) {
-			continue
-		}
-
 		ips, err := dest.Resolve(pol, users, nodes)
 		if err != nil {
 			log.Trace().Caller().Err(err).Msgf("resolving destination ips")

--- a/hscontrol/policy/v2/filter_test.go
+++ b/hscontrol/policy/v2/filter_test.go
@@ -4101,6 +4101,14 @@ func TestDestinationsToNetPortRange_AutogroupInternet(t *testing.T) {
 	pol := &Policy{}
 	ports := []tailcfg.PortRange{tailcfg.PortRangeAny}
 
+	// autogroup:internet must surface as DstPorts (not be skipped at
+	// compile time). The matcher derived from these FilterRules is
+	// what makes Node.CanAccess return true for exit-node peers via
+	// DestsIsTheInternet (#3212). The wire format is currently the
+	// canonical CIDR breakdown of util.TheInternet(); aligning it to
+	// the SaaS range form is tracked separately.
+	internetPrefixCount := len(util.TheInternet().Prefixes())
+
 	tests := []struct {
 		name     string
 		dests    Aliases
@@ -4108,9 +4116,9 @@ func TestDestinationsToNetPortRange_AutogroupInternet(t *testing.T) {
 		wantStar bool
 	}{
 		{
-			name:    "autogroup:internet produces no DstPorts",
+			name:    "autogroup:internet produces TheInternet DstPorts",
 			dests:   Aliases{agp(string(AutoGroupInternet))},
-			wantLen: 0,
+			wantLen: internetPrefixCount,
 		},
 		{
 			name:     "wildcard produces DstPorts with star",

--- a/hscontrol/policy/v2/issue_3212_test.go
+++ b/hscontrol/policy/v2/issue_3212_test.go
@@ -1,0 +1,172 @@
+// Tests pinned against tscap captures for juanfont/headscale#3212.
+//
+// The captures were taken on 2026-04-28 against a live Tailscale SaaS
+// tailnet. They reproduce the literal #3212 setup: an ACL granting
+// access to autogroup:internet:* combined with autoApprovers.exitNode
+// approving exit routes on tagged exit nodes. SaaS surfaces those exit
+// nodes as peers in the ACL source's netmap with 0.0.0.0/0 and ::/0 in
+// AllowedIPs. Headscale must do the same — that is the user-visible UX
+// driving `tailscale exit-node list`.
+//
+// Captures live under testdata/issue_3212/ rather than testdata/
+// routes_results/ so the broader TestRoutesCompat / *PeerAllowedIPs /
+// *ReduceRoutes machinery does not pull them in. Those tests assume a
+// PacketFilterRules wire format (CIDR prefix per dest entry) that
+// differs from what SaaS emits for autogroup:internet (range form per
+// IPSet range — e.g. "0.0.0.0-9.255.255.255"). Aligning that wire
+// format is tracked separately; the #3212 fix is about peer
+// visibility, not packet-filter encoding.
+
+package v2
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/juanfont/headscale/hscontrol/types/testcapture"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"tailscale.com/net/tsaddr"
+)
+
+// TestIssue3212AutogroupInternetExitVisibility loads the b17/b18
+// SaaS captures and asserts headscale's BuildPeerMap surfaces every
+// exit-route advertiser to every ACL-source node — matching the peer
+// list in the captured netmap.
+//
+// The bug fixed by this PR (#3212) was that headscale skipped
+// autogroup:internet during FilterRule compilation, which silently
+// dropped the matchers that Node.CanAccess reads via DestsIsTheInternet.
+// The captures pin the SaaS-equivalent expectation as a regression
+// guard so the same skip cannot sneak back in unnoticed.
+func TestIssue3212AutogroupInternetExitVisibility(t *testing.T) {
+	t.Parallel()
+
+	files := []string{
+		"routes-b17-autogroup-internet-with-exit-autoapprover",
+		"routes-b18-autogroup-internet-wildcard-src-with-exit-autoapprover",
+	}
+
+	for _, testID := range files {
+		path := filepath.Join(
+			"testdata", "issue_3212", testID+".hujson",
+		)
+		tf := loadRoutesTestFile(t, path)
+
+		t.Run(tf.TestID, func(t *testing.T) {
+			t.Parallel()
+
+			users, nodes := buildRoutesUsersAndNodes(t, tf.Topology)
+			policyJSON := convertPolicyUserEmails(tf.Input.FullPolicy)
+
+			pm, err := NewPolicyManager(
+				policyJSON, users, nodes.ViewSlice(),
+			)
+			require.NoErrorf(t, err,
+				"%s: failed to create PolicyManager", tf.TestID,
+			)
+
+			peerMap := pm.BuildPeerMap(nodes.ViewSlice())
+
+			expected := expectedExitPeerVisibility(t, tf, nodes)
+			require.NotEmptyf(t, expected,
+				"%s: capture exposes no source→exit relationships — "+
+					"the test is meaningless if SaaS itself never "+
+					"surfaced an exit node to a source",
+				tf.TestID,
+			)
+
+			for srcName, exitNames := range expected {
+				srcNode := findNodeByGivenName(nodes, srcName)
+				require.NotNilf(t, srcNode,
+					"%s: src node %q missing from topology",
+					tf.TestID, srcName,
+				)
+
+				peerIDs := make(
+					map[types.NodeID]struct{},
+					len(peerMap[srcNode.ID]),
+				)
+				for _, p := range peerMap[srcNode.ID] {
+					peerIDs[p.ID()] = struct{}{}
+				}
+
+				for _, exitName := range exitNames {
+					exitNode := findNodeByGivenName(nodes, exitName)
+					require.NotNilf(t, exitNode,
+						"%s: exit node %q missing from topology",
+						tf.TestID, exitName,
+					)
+
+					_, found := peerIDs[exitNode.ID]
+					assert.Truef(t, found,
+						"%s: source %q must see exit node %q "+
+							"as a peer via the autogroup:internet "+
+							"ACL — Tailscale SaaS does (#3212)",
+						tf.TestID, srcName, exitName,
+					)
+				}
+			}
+		})
+	}
+}
+
+// expectedExitPeerVisibility extracts (source-node, exit-node) pairs
+// the capture's netmaps witness. A node is treated as an exit-route
+// advertiser when its ApprovedRoutes contain 0.0.0.0/0 or ::/0;
+// a (source, exit) pair is recorded when the source's captured netmap
+// lists the advertiser as a peer with 0.0.0.0/0 or ::/0 in AllowedIPs.
+func expectedExitPeerVisibility(
+	t *testing.T,
+	tf *testcapture.Capture,
+	nodes types.Nodes,
+) map[string][]string {
+	t.Helper()
+
+	v4Exit := tsaddr.AllIPv4()
+	v6Exit := tsaddr.AllIPv6()
+
+	exitAdvertisers := make(map[string]bool)
+
+	for _, n := range nodes {
+		if slices.Contains(n.ApprovedRoutes, v4Exit) ||
+			slices.Contains(n.ApprovedRoutes, v6Exit) {
+			exitAdvertisers[n.GivenName] = true
+		}
+	}
+
+	expected := make(map[string][]string)
+
+	for srcName, capture := range tf.Captures {
+		if capture.Netmap == nil {
+			continue
+		}
+
+		var seen []string
+
+		for _, peer := range capture.Netmap.Peers {
+			peerName := strings.Split(peer.Name(), ".")[0]
+
+			if !exitAdvertisers[peerName] {
+				continue
+			}
+
+			peerAllowed := peer.AllowedIPs().AsSlice()
+			if !slices.Contains(peerAllowed, v4Exit) &&
+				!slices.Contains(peerAllowed, v6Exit) {
+				continue
+			}
+
+			seen = append(seen, peerName)
+		}
+
+		if len(seen) > 0 {
+			expected[srcName] = seen
+		}
+	}
+
+	return expected
+}

--- a/hscontrol/policy/v2/policy_test.go
+++ b/hscontrol/policy/v2/policy_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
+	"tailscale.com/net/tsaddr"
 	"tailscale.com/tailcfg"
 )
 
@@ -1805,4 +1806,51 @@ func TestViaRoutesForPeer(t *testing.T) {
 			"client should NOT be able to access 10.0.0.0/24 via matchers alone; "+
 				"state.RoutesForPeer adds via routes after ReduceRoutes to fix this")
 	})
+}
+
+// TestBuildPeerMap_AutogroupInternetMakesExitNodeVisible reproduces
+// juanfont/headscale#3212. An ACL that grants access only via
+// `autogroup:internet` must keep the exit node visible to the source
+// in BuildPeerMap so the Tailscale client surfaces it in
+// `tailscale exit-node list`. Authoritative SaaS captures
+// (tscap routes-b17/b18, 2026-04-28) confirm SaaS includes the exit
+// node in the source's Peers with 0.0.0.0/0 and ::/0 in AllowedIPs.
+func TestBuildPeerMap_AutogroupInternetMakesExitNodeVisible(t *testing.T) {
+	t.Parallel()
+
+	users := types.Users{
+		{Model: gorm.Model{ID: 1}, Name: "alice", Email: "alice@headscale.net"},
+	}
+
+	aliceNode := node("alice-laptop", "100.64.0.10", "fd7a:115c:a1e0::a", users[0])
+	aliceNode.ID = 1
+
+	exitRoutes := []netip.Prefix{tsaddr.AllIPv4(), tsaddr.AllIPv6()}
+	exitNode := node("alice-exit", "100.64.0.1", "fd7a:115c:a1e0::1", users[0])
+	exitNode.ID = 2
+	exitNode.Hostinfo = &tailcfg.Hostinfo{RoutableIPs: exitRoutes}
+	exitNode.ApprovedRoutes = exitRoutes
+
+	nodes := types.Nodes{aliceNode, exitNode}
+
+	policy := `{
+		"acls": [
+			{"action": "accept", "src": ["alice@headscale.net"], "dst": ["autogroup:internet:*"]}
+		]
+	}`
+
+	pm, err := NewPolicyManager([]byte(policy), users, nodes.ViewSlice())
+	require.NoError(t, err)
+
+	peerMap := pm.BuildPeerMap(nodes.ViewSlice())
+
+	require.True(t,
+		slices.ContainsFunc(peerMap[aliceNode.ID], func(n types.NodeView) bool {
+			return n.ID() == exitNode.ID
+		}),
+		"alice should see the exit node as a peer when an ACL grants autogroup:internet (#3212)")
+
+	_, matchers := pm.Filter()
+	require.True(t, aliceNode.View().CanAccess(matchers, exitNode.View()),
+		"alice.CanAccess(exit) should be true via DestsIsTheInternet()+IsExitNode() (#3212)")
 }

--- a/hscontrol/policy/v2/testdata/issue_3212/routes-b17-autogroup-internet-with-exit-autoapprover.hujson
+++ b/hscontrol/policy/v2/testdata/issue_3212/routes-b17-autogroup-internet-with-exit-autoapprover.hujson
@@ -1,0 +1,10322 @@
+// routes-b17-autogroup-internet-with-exit-autoapprover
+//
+// routes b17 autogroup internet with exit autoapprover (#3212)
+//
+// Nodes with filter rules: 2 of 11
+// Captured at:    2026-04-28T09:34:11Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "routes-b17-autogroup-internet-with-exit-autoapprover",
+	"description":    "routes b17 autogroup internet with exit autoapprover (#3212)",
+	"category":       "routes",
+	"captured_at":    "2026-04-28T09:34:11.692495247Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                       \n  \n                                                                      \n                                                               \n                                                                  \n                                                                    \n                                                                 \n                     \n{\n\t\"category\":    \"routes\",\n\t\"description\": \"routes b17 autogroup internet with exit autoapprover (#3212)\",\n\t\"id\":          \"routes-b17-autogroup-internet-with-pidgeyutoapprover\",\n\t\"policy\": {\n\t\t\"acls\": [{\n\t\t\t\"action\": \"accept\",\n\t\t\t\"src\":    [\"odin@example.com\"],\n\t\t\t\"dst\":    [\"autogroup:internet:*\"]\n\t\t}],\n\t\t\"autoApprovers\": {\n\t\t\t\"exitNode\": [\"tag:exit\"],\n\t\t\t\"routes\": {\n\t\t\t\t\"10.0.0.0/8\":     [\"tag:router\"],\n\t\t\t\t\"172.16.0.0/12\":  [\"tag:router\"],\n\t\t\t\t\"192.168.0.0/16\": [\"tag:ha\"]\n\t\t\t}\n\t\t},\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.108.74.26\"\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t}\n\t},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/routes.hujson\"\n}\n",
+		"scenario_path":   "scenarios/routes/routes-b17-autogroup-internet-with-exit-autoapprover.hujson",
+		"full_policy": {"acls": [{
+			"action": "accept",
+			"dst":    ["autogroup:internet:*"],
+			"src":    ["odin@example.com"]
+		}], "autoApprovers": {"exitNode": ["tag:exit"], "routes": {
+			"10.0.0.0/8":     ["tag:router"],
+			"172.16.0.0/12":  ["tag:router"],
+			"192.168.0.0/16": ["tag:ha"]
+		}}, "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.108.74.26"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "butterfree": {
+		"hostname":        "butterfree",
+		"tags":            ["tag:ha"],
+		"ipv4":            "100.64.0.8",
+		"ipv6":            "fd7a:115c:a1e0::8",
+		"routable_ips":    ["192.168.1.0/24"],
+		"approved_routes": ["192.168.1.0/24"]
+	}, "caterpie": {
+		"hostname":        "caterpie",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.1",
+		"ipv6":            "fd7a:115c:a1e0::1",
+		"routable_ips":    ["10.0.0.0/8"],
+		"approved_routes": ["10.0.0.0/8"]
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": ["0.0.0.0/0", "::/0"]
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "metapod": {
+		"hostname":        "metapod",
+		"tags":            ["tag:ha"],
+		"ipv4":            "100.64.0.7",
+		"ipv6":            "fd7a:115c:a1e0::7",
+		"routable_ips":    ["192.168.1.0/24"],
+		"approved_routes": ["192.168.1.0/24"]
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": ["10.33.0.0/16"]
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "wartortle": {
+		"hostname":        "wartortle",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.10",
+		"ipv6":            "fd7a:115c:a1e0::a",
+		"routable_ips":    ["172.16.0.0/24", "0.0.0.0/0", "::/0"],
+		"approved_routes": ["0.0.0.0/0", "172.16.0.0/24", "::/0"]
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7179759577980688,
+			"StableID":   "nMKXyL7j4y11CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:f8be73c944bcf72fa79a5a644f7ab938a9620985d3fd22d8b6ed682098fbac4d",
+			"KeyExpiry":  "2026-10-25T09:34:23Z",
+			"DiscoKey":   "discokey:51c64f98eb647c86145367896a4fc5049150aff4a8287e42f07ed86b5663eb12",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints": [
+				"77.164.248.136:32821",
+				"10.65.0.27:32821",
+				"172.17.0.1:32821",
+				"172.18.0.1:32821",
+				"172.19.0.1:32821"
+			],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-28T09:34:23.636754249Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:f8be73c944bcf72fa79a5a644f7ab938a9620985d3fd22d8b6ed682098fbac4d",
+		"MachineKey": "mkey:d1d3dd0010bd62f599758e3c6c0d5ef5922783f728be9c4efc663db166775363",
+		"Peers": [{
+			"ID":         7841380667166350,
+			"StableID":   "nqcd1smNE421CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:374cd85425602623a32d98c5a9926f255173f1b1628ee00d81f3afd15109b117",
+			"DiscoKey":   "discokey:d3c505a32c3a2c94a18988790ae272095e7c3cc5c3875fbc8f168b0a0513086c",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:45326",
+				"10.65.0.27:45326",
+				"172.17.0.1:45326",
+				"172.18.0.1:45326",
+				"172.19.0.1:45326"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+				{"Proto": "peerapi4", "Port": 37067},
+				{"Proto": "peerapi6", "Port": 37067}
+			]},
+			"Created":              "2026-04-28T09:34:18.26768902Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		}, {
+			"ID":         6075243205977720,
+			"StableID":   "nFNKRZLVSp11CNTRL",
+			"Name":       "wartortle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:79a7691145e366e1251fd8d63184a148fa4c9fa0f28c38fe423bd807921db829",
+			"DiscoKey":   "discokey:65e81e82ee3843b83db606d4ae83eeb0a149a8a174747d255a50873dd899d21c",
+			"Addresses":  ["100.64.0.10/32", "fd7a:115c:a1e0::a/128"],
+			"AllowedIPs": ["100.64.0.10/32", "fd7a:115c:a1e0::a/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:51836",
+				"10.65.0.27:51836",
+				"172.17.0.1:51836",
+				"172.18.0.1:51836",
+				"172.19.0.1:51836"
+			],
+			"HomeDERP": 8,
+			"Hostinfo": {"OS": "linux", "Hostname": "wartortle", "Services": [
+				{"Proto": "peerapi4", "Port": 48588},
+				{"Proto": "peerapi6", "Port": 48588}
+			]},
+			"Created":              "2026-04-28T09:34:19.869827372Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "wartortle",
+			"ComputedNameWithHost": "wartortle"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "butterfree": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5685448030016382,
+			"StableID":   "nD4cWa5xPm11CNTRL",
+			"Name":       "butterfree.tail78f774.ts.net.",
+			"User":       5685448030016382,
+			"Key":        "nodekey:153a69ff5094ba0ce2fe8ed1b56ed9c88f2db49d36c895f75125d0344831ba7f",
+			"DiscoKey":   "discokey:299c16abc4d78a959192aa7813d84faa02bd58770d8af73d87fde212db66636d",
+			"Addresses":  ["100.64.0.8/32", "fd7a:115c:a1e0::8/128"],
+			"AllowedIPs": ["100.64.0.8/32", "fd7a:115c:a1e0::8/128", "192.168.1.0/24"],
+			"Endpoints": [
+				"77.164.248.136:60727",
+				"10.65.0.27:60727",
+				"172.17.0.1:60727",
+				"172.18.0.1:60727",
+				"172.19.0.1:60727"
+			],
+			"Hostinfo": {
+				"Hostname":    "butterfree",
+				"RoutableIPs": ["192.168.1.0/24"],
+				"RequestTags": ["tag:ha"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 56544},
+					{"Proto": "peerapi6", "Port": 56544},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-28T09:34:19.340118725Z",
+			"Tags":              ["tag:ha"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "butterfree",
+			"ComputedNameWithHost": "butterfree"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:153a69ff5094ba0ce2fe8ed1b56ed9c88f2db49d36c895f75125d0344831ba7f",
+		"MachineKey":        "mkey:9eb8e25ffb6bef36374e7f6fb96c34ce78fccda0c0152723b3a2d63067112840",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5685448030016382": {
+			"ID":          5685448030016382,
+			"LoginName":   "butterfree.tail78f774.ts.net",
+			"DisplayName": "butterfree"
+		}}
+	}}, "caterpie": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         471274098204411,
+			"StableID":   "nx9rF9aSg411CNTRL",
+			"Name":       "caterpie.tail78f774.ts.net.",
+			"User":       471274098204411,
+			"Key":        "nodekey:8777f0f36ae092eb0fd9d9b0948ba8a2e84f63dabbefebef8c6585fabdd90b47",
+			"DiscoKey":   "discokey:07ccfcac52f6eddf27093760b20895170c1ca888b8bb55c70faf96956dc0e14c",
+			"Addresses":  ["100.64.0.1/32", "fd7a:115c:a1e0::1/128"],
+			"AllowedIPs": ["100.64.0.1/32", "fd7a:115c:a1e0::1/128", "10.0.0.0/8"],
+			"Endpoints": [
+				"77.164.248.136:39792",
+				"10.65.0.27:39792",
+				"172.17.0.1:39792",
+				"172.18.0.1:39792",
+				"172.19.0.1:39792"
+			],
+			"Hostinfo": {
+				"Hostname":    "caterpie",
+				"RoutableIPs": ["10.0.0.0/8"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 58436},
+					{"Proto": "peerapi6", "Port": 58436},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-28T09:34:17.733868117Z",
+			"Tags":              ["tag:router"],
+			"PrimaryRoutes":     ["10.0.0.0/8"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "caterpie",
+			"ComputedNameWithHost": "caterpie"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:8777f0f36ae092eb0fd9d9b0948ba8a2e84f63dabbefebef8c6585fabdd90b47",
+		"MachineKey":        "mkey:39e604a175ff6b71295a58bc49b8a2abd500fedccc1c7fdeae07912caa5dac02",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"471274098204411": {
+			"ID":          471274098204411,
+			"LoginName":   "caterpie.tail78f774.ts.net",
+			"DisplayName": "caterpie"
+		}}
+	}}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": ["100.64.0.19", "fd7a:115c:a1e0::13"], "DstPorts": [
+			{"IP": "0.0.0.0-9.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "11.0.0.0-100.63.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "100.128.0.0-169.253.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "169.255.0.0-172.15.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "172.32.0.0-192.167.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "192.169.0.0-255.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{
+				"IP":    "2000::-3fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+				"Ports": {"First": 0, "Last": 65535}
+			}
+		]}],
+		"packet_filter_matches": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"SrcCaps": null,
+			"Dsts": [
+				{"Net": "0.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "8.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "11.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "12.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "16.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "32.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "64.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "96.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "100.0.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "100.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "101.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "102.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "104.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "112.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "128.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "160.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "168.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.128.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.192.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.224.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.240.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.248.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.252.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.255.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "170.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "172.0.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "172.32.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "172.64.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "172.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "173.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "174.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "176.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.128.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.160.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.169.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.170.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.172.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.176.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.192.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "193.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "194.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "196.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "200.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "208.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "224.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "2000::/3", "Ports": {"First": 0, "Last": 65535}}
+			],
+			"Caps": []
+		}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7841380667166350,
+				"StableID":   "nqcd1smNE421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7841380667166350,
+				"Key":        "nodekey:374cd85425602623a32d98c5a9926f255173f1b1628ee00d81f3afd15109b117",
+				"DiscoKey":   "discokey:d3c505a32c3a2c94a18988790ae272095e7c3cc5c3875fbc8f168b0a0513086c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128", "0.0.0.0/0", "::/0"],
+				"Endpoints": [
+					"77.164.248.136:45326",
+					"10.65.0.27:45326",
+					"172.17.0.1:45326",
+					"172.18.0.1:45326",
+					"172.19.0.1:45326"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-28T09:34:18.26768902Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:374cd85425602623a32d98c5a9926f255173f1b1628ee00d81f3afd15109b117",
+			"MachineKey": "mkey:b3326b3b2454185eb11a672981cf16816dc346e590ca7ac3fb21fd5194b67821",
+			"Peers": [{
+				"ID":         7179759577980688,
+				"StableID":   "nMKXyL7j4y11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f8be73c944bcf72fa79a5a644f7ab938a9620985d3fd22d8b6ed682098fbac4d",
+				"KeyExpiry":  "2026-10-25T09:34:23Z",
+				"DiscoKey":   "discokey:51c64f98eb647c86145367896a4fc5049150aff4a8287e42f07ed86b5663eb12",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32821",
+					"10.65.0.27:32821",
+					"172.17.0.1:32821",
+					"172.18.0.1:32821",
+					"172.19.0.1:32821"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-28T09:34:23.636754249Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{
+				"IPProto": [6, 17, 1, 58],
+				"Srcs":    ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"SrcCaps": null,
+				"Dsts": [
+					{"Net": "0.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "8.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "11.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "12.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "16.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "32.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "64.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "96.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "100.0.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "100.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "101.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "102.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "104.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "112.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "128.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "160.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "168.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.128.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.192.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.224.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.240.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.248.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.252.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.255.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "170.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "172.0.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "172.32.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "172.64.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "172.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "173.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "174.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "176.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.128.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.160.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.169.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.170.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.172.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.176.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.192.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "193.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "194.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "196.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "200.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "208.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "224.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "2000::/3", "Ports": {"First": 0, "Last": 65535}}
+				],
+				"Caps": []
+			}],
+			"PacketFilterRules": [{"SrcIPs": ["100.64.0.19", "fd7a:115c:a1e0::13"], "DstPorts": [
+				{"IP": "0.0.0.0-9.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+				{"IP": "11.0.0.0-100.63.255.255", "Ports": {"First": 0, "Last": 65535}},
+				{"IP": "100.128.0.0-169.253.255.255", "Ports": {"First": 0, "Last": 65535}},
+				{"IP": "169.255.0.0-172.15.255.255", "Ports": {"First": 0, "Last": 65535}},
+				{"IP": "172.32.0.0-192.167.255.255", "Ports": {"First": 0, "Last": 65535}},
+				{"IP": "192.169.0.0-255.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+				{
+					"IP":    "2000::-3fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+					"Ports": {"First": 0, "Last": 65535}
+				}
+			]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "7841380667166350": {
+				"ID":          7841380667166350,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7080689060507122,
+			"StableID":   "nTRbbJhrHx11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:f2cc08993d77f6181f7d42521679c359c65038e811028543cba4c57b657e297b",
+			"KeyExpiry":  "2026-10-25T09:34:22Z",
+			"DiscoKey":   "discokey:662bdb3235efc7e5e663369f65624b5c09a72b63ee165970cebaa5558b8f7900",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints": [
+				"77.164.248.136:39813",
+				"10.65.0.27:39813",
+				"172.17.0.1:39813",
+				"172.18.0.1:39813",
+				"172.19.0.1:39813"
+			],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-28T09:34:22.568293295Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:f2cc08993d77f6181f7d42521679c359c65038e811028543cba4c57b657e297b",
+		"MachineKey":        "mkey:e8172dcc6923b14860b558c9d970fce60d2964f34f5ec71c5735c9287d64f62f",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3637814452755361,
+			"StableID":   "ngtc5bDaQV11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       3637814452755361,
+			"Key":        "nodekey:ffecb8b7e133e7955868ae3a212c05838d4f11775de6e24e9a2fba57ff375a2e",
+			"DiscoKey":   "discokey:2fdef2e1c84cb41e095d00f66edc6c2efe5e72c75f938b9ca38bc458e227c147",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints": [
+				"77.164.248.136:53335",
+				"10.65.0.27:53335",
+				"172.17.0.1:53335",
+				"172.18.0.1:53335",
+				"172.19.0.1:53335"
+			],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-28T09:34:21.514177328Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:ffecb8b7e133e7955868ae3a212c05838d4f11775de6e24e9a2fba57ff375a2e",
+		"MachineKey":        "mkey:0dbd6512f02910b87707c15ea308ee8feeb83c85813b3bf320766cdefc61a755",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3637814452755361": {
+			"ID":          3637814452755361,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "metapod": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         6151538568832833,
+			"StableID":   "neffNFV33q11CNTRL",
+			"Name":       "metapod.tail78f774.ts.net.",
+			"User":       6151538568832833,
+			"Key":        "nodekey:b5c6f53aaacc5f15077bd90f58c6e840271f002f5ade997348786c5577759560",
+			"DiscoKey":   "discokey:98c134446df5637ecb1a014ace1797a6854048de1a993c3b3d85d0f4270fcc28",
+			"Addresses":  ["100.64.0.7/32", "fd7a:115c:a1e0::7/128"],
+			"AllowedIPs": ["100.64.0.7/32", "fd7a:115c:a1e0::7/128", "192.168.1.0/24"],
+			"Endpoints": [
+				"77.164.248.136:40792",
+				"10.65.0.27:40792",
+				"172.17.0.1:40792",
+				"172.18.0.1:40792",
+				"172.19.0.1:40792"
+			],
+			"Hostinfo": {
+				"Hostname":    "metapod",
+				"RoutableIPs": ["192.168.1.0/24"],
+				"RequestTags": ["tag:ha"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 49521},
+					{"Proto": "peerapi6", "Port": 49521},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-28T09:34:18.803482575Z",
+			"Tags":              ["tag:ha"],
+			"PrimaryRoutes":     ["192.168.1.0/24"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "metapod",
+			"ComputedNameWithHost": "metapod"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:b5c6f53aaacc5f15077bd90f58c6e840271f002f5ade997348786c5577759560",
+		"MachineKey":        "mkey:06c50d50a34e7ce12c862bb86668f74d4ef98ca6d9ccc0c8aadd32e016f05407",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"6151538568832833": {
+			"ID":          6151538568832833,
+			"LoginName":   "metapod.tail78f774.ts.net",
+			"DisplayName": "metapod"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1861170713005060,
+			"StableID":   "nBWTdKovXF11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       1861170713005060,
+			"Key":        "nodekey:dac2af1dc8a2fd2e56b84212a3c39916685d46b1e511b25fbb972bcdc93f6a0b",
+			"DiscoKey":   "discokey:c9e1b40ef29ce9ab009a83121ee64a959d7a14b0c681c577740e9c7321832340",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:33742",
+				"10.65.0.27:33742",
+				"172.17.0.1:33742",
+				"172.18.0.1:33742",
+				"172.19.0.1:33742"
+			],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-28T09:34:20.432190369Z",
+			"Tags":              ["tag:router"],
+			"PrimaryRoutes":     ["10.33.0.0/16"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:dac2af1dc8a2fd2e56b84212a3c39916685d46b1e511b25fbb972bcdc93f6a0b",
+		"MachineKey":        "mkey:28dca36dbe401748e06757083d21f1c8d39e88c8273390add2acaa5051b05f2c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1861170713005060": {
+			"ID":          1861170713005060,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         784641740483712,
+			"StableID":   "nq5Bj4DN8711CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:2a94015c8b72ef4405f7bc1755aa5ea5a68c55ced33786d53aa4ae88ca56e44d",
+			"KeyExpiry":  "2026-10-25T09:34:23Z",
+			"DiscoKey":   "discokey:18e1ff15f75e5c17ddfb6da7dfa8356b95cc92bf7eaaf1781084e2eab5160850",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints": [
+				"77.164.248.136:57315",
+				"10.65.0.27:57315",
+				"172.17.0.1:57315",
+				"172.18.0.1:57315",
+				"172.19.0.1:57315"
+			],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-28T09:34:23.091607447Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:2a94015c8b72ef4405f7bc1755aa5ea5a68c55ced33786d53aa4ae88ca56e44d",
+		"MachineKey":        "mkey:0c60955aea4c9ca6b397252bb7d2cc2991f268d74ba8805da634af246455c82d",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "wartortle": {
+		"packet_filter_rules": [{"SrcIPs": ["100.64.0.19", "fd7a:115c:a1e0::13"], "DstPorts": [
+			{"IP": "0.0.0.0-9.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "11.0.0.0-100.63.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "100.128.0.0-169.253.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "169.255.0.0-172.15.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "172.32.0.0-192.167.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "192.169.0.0-255.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{
+				"IP":    "2000::-3fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+				"Ports": {"First": 0, "Last": 65535}
+			}
+		]}],
+		"packet_filter_matches": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"SrcCaps": null,
+			"Dsts": [
+				{"Net": "0.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "8.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "11.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "12.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "16.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "32.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "64.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "96.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "100.0.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "100.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "101.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "102.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "104.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "112.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "128.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "160.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "168.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.128.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.192.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.224.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.240.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.248.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.252.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "169.255.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "170.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "172.0.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "172.32.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "172.64.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "172.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "173.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "174.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "176.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.128.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.160.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.169.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.170.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.172.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.176.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "192.192.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "193.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "194.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "196.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "200.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "208.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "224.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "2000::/3", "Ports": {"First": 0, "Last": 65535}}
+			],
+			"Caps": []
+		}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":        6075243205977720,
+				"StableID":  "nFNKRZLVSp11CNTRL",
+				"Name":      "wartortle.tail78f774.ts.net.",
+				"User":      6075243205977720,
+				"Key":       "nodekey:79a7691145e366e1251fd8d63184a148fa4c9fa0f28c38fe423bd807921db829",
+				"DiscoKey":  "discokey:65e81e82ee3843b83db606d4ae83eeb0a149a8a174747d255a50873dd899d21c",
+				"Addresses": ["100.64.0.10/32", "fd7a:115c:a1e0::a/128"],
+				"AllowedIPs": [
+					"100.64.0.10/32",
+					"fd7a:115c:a1e0::a/128",
+					"172.16.0.0/24",
+					"0.0.0.0/0",
+					"::/0"
+				],
+				"Endpoints": [
+					"77.164.248.136:51836",
+					"10.65.0.27:51836",
+					"172.17.0.1:51836",
+					"172.18.0.1:51836",
+					"172.19.0.1:51836"
+				],
+				"Hostinfo": {
+					"Hostname":    "wartortle",
+					"RoutableIPs": ["172.16.0.0/24", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 48588},
+						{"Proto": "peerapi6", "Port": 48588},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-28T09:34:19.869827372Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"PrimaryRoutes":     ["172.16.0.0/24"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "wartortle",
+				"ComputedNameWithHost": "wartortle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:79a7691145e366e1251fd8d63184a148fa4c9fa0f28c38fe423bd807921db829",
+			"MachineKey": "mkey:e17cd8afd3bf3dd562ff1de0f3195eb883907c89eae0f48444e7be24a014d827",
+			"Peers": [{
+				"ID":         7179759577980688,
+				"StableID":   "nMKXyL7j4y11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f8be73c944bcf72fa79a5a644f7ab938a9620985d3fd22d8b6ed682098fbac4d",
+				"KeyExpiry":  "2026-10-25T09:34:23Z",
+				"DiscoKey":   "discokey:51c64f98eb647c86145367896a4fc5049150aff4a8287e42f07ed86b5663eb12",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32821",
+					"10.65.0.27:32821",
+					"172.17.0.1:32821",
+					"172.18.0.1:32821",
+					"172.19.0.1:32821"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-28T09:34:23.636754249Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{
+				"IPProto": [6, 17, 1, 58],
+				"Srcs":    ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"SrcCaps": null,
+				"Dsts": [
+					{"Net": "0.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "8.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "11.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "12.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "16.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "32.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "64.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "96.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "100.0.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "100.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "101.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "102.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "104.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "112.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "128.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "160.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "168.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.128.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.192.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.224.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.240.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.248.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.252.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "169.255.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "170.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "172.0.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "172.32.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "172.64.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "172.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "173.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "174.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "176.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.128.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.160.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.169.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.170.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.172.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.176.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "192.192.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "193.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "194.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "196.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "200.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "208.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "224.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+					{"Net": "2000::/3", "Ports": {"First": 0, "Last": 65535}}
+				],
+				"Caps": []
+			}],
+			"PacketFilterRules": [{"SrcIPs": ["100.64.0.19", "fd7a:115c:a1e0::13"], "DstPorts": [
+				{"IP": "0.0.0.0-9.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+				{"IP": "11.0.0.0-100.63.255.255", "Ports": {"First": 0, "Last": 65535}},
+				{"IP": "100.128.0.0-169.253.255.255", "Ports": {"First": 0, "Last": 65535}},
+				{"IP": "169.255.0.0-172.15.255.255", "Ports": {"First": 0, "Last": 65535}},
+				{"IP": "172.32.0.0-192.167.255.255", "Ports": {"First": 0, "Last": 65535}},
+				{"IP": "192.169.0.0-255.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+				{
+					"IP":    "2000::-3fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+					"Ports": {"First": 0, "Last": 65535}
+				}
+			]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "6075243205977720": {
+				"ID":          6075243205977720,
+				"LoginName":   "wartortle.tail78f774.ts.net",
+				"DisplayName": "wartortle"
+			}}
+		}
+	}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3350520533595627,
+			"StableID":   "nAYeEbVTAT11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       3350520533595627,
+			"Key":        "nodekey:63c137bd0bdfff566fc06e3f961359b14d98225edb53d79d9e7e3429401b0e23",
+			"DiscoKey":   "discokey:1f6792ec95e917090fcb308b831c953b9a74a5119fd3172655905795475fee4a",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints": [
+				"77.164.248.136:46988",
+				"10.65.0.27:46988",
+				"172.17.0.1:46988",
+				"172.18.0.1:46988",
+				"172.19.0.1:46988"
+			],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-28T09:34:20.968284911Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:63c137bd0bdfff566fc06e3f961359b14d98225edb53d79d9e7e3429401b0e23",
+		"MachineKey":        "mkey:a1dfd3bd5a617bbb7324eaf6002817298e0deafaed922ad363b14ff0f7980f1c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3350520533595627": {
+			"ID":          3350520533595627,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/issue_3212/routes-b18-autogroup-internet-wildcard-src-with-exit-autoapprover.hujson
+++ b/hscontrol/policy/v2/testdata/issue_3212/routes-b18-autogroup-internet-wildcard-src-with-exit-autoapprover.hujson
@@ -1,0 +1,12404 @@
+// routes-b18-autogroup-internet-wildcard-src-with-exit-autoapprover
+//
+// routes b18 autogroup internet wildcard src with exit autoapprover (#3212)
+//
+// Nodes with filter rules: 2 of 12
+// Captured at:    2026-04-28T09:35:13Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "routes-b18-autogroup-internet-wildcard-src-with-exit-autoapprover",
+	"description":    "routes b18 autogroup internet wildcard src with exit autoapprover (#3212)",
+	"category":       "routes",
+	"captured_at":    "2026-04-28T09:35:13.435625043Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                                    \n  \n                                                                      \n                                                             \n                                                                        \n                                                                  \n                                                                     \n                                                    \n{\n\t\"category\":    \"routes\",\n\t\"description\": \"routes b18 autogroup internet wildcard src with exit autoapprover (#3212)\",\n\t\"id\":          \"routes-b18-autogroup-internet-wildcard-src-with-pidgeyutoapprover\",\n\t\"policy\": {\n\t\t\"acls\": [{\n\t\t\t\"action\": \"accept\",\n\t\t\t\"src\":    [\"*\"],\n\t\t\t\"dst\":    [\"autogroup:internet:*\"]\n\t\t}],\n\t\t\"autoApprovers\": {\n\t\t\t\"exitNode\": [\"tag:exit\"],\n\t\t\t\"routes\": {\n\t\t\t\t\"10.0.0.0/8\":     [\"tag:router\"],\n\t\t\t\t\"172.16.0.0/12\":  [\"tag:router\"],\n\t\t\t\t\"192.168.0.0/16\": [\"tag:ha\"]\n\t\t\t}\n\t\t},\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.108.74.26\"\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t}\n\t},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/routes.hujson\"\n}\n",
+		"scenario_path":   "scenarios/routes/routes-b18-autogroup-internet-wildcard-src-with-exit-autoapprover.hujson",
+		"full_policy": {
+			"acls": [{"action": "accept", "dst": ["autogroup:internet:*"], "src": ["*"]}],
+			"autoApprovers": {"exitNode": ["tag:exit"], "routes": {
+				"10.0.0.0/8":     ["tag:router"],
+				"172.16.0.0/12":  ["tag:router"],
+				"192.168.0.0/16": ["tag:ha"]
+			}},
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.108.74.26"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "butterfree": {
+		"hostname":        "butterfree",
+		"tags":            ["tag:ha"],
+		"ipv4":            "100.64.0.8",
+		"ipv6":            "fd7a:115c:a1e0::8",
+		"routable_ips":    ["192.168.1.0/24"],
+		"approved_routes": ["192.168.1.0/24"]
+	}, "caterpie": {
+		"hostname":        "caterpie",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.1",
+		"ipv6":            "fd7a:115c:a1e0::1",
+		"routable_ips":    ["10.0.0.0/8"],
+		"approved_routes": ["10.0.0.0/8"]
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": ["0.0.0.0/0", "::/0"]
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "metapod": {
+		"hostname":        "metapod",
+		"tags":            ["tag:ha"],
+		"ipv4":            "100.64.0.7",
+		"ipv6":            "fd7a:115c:a1e0::7",
+		"routable_ips":    ["192.168.1.0/24"],
+		"approved_routes": ["192.168.1.0/24"]
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": ["10.33.0.0/16"]
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "wartortle": {
+		"hostname":        "wartortle",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.10",
+		"ipv6":            "fd7a:115c:a1e0::a",
+		"routable_ips":    ["172.16.0.0/24", "0.0.0.0/0", "::/0"],
+		"approved_routes": ["0.0.0.0/0", "172.16.0.0/24", "::/0"]
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1809586025123150,
+			"StableID":   "nRkRQskZ8F11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1809586025123150,
+			"Key":        "nodekey:05f31eba5d7236418982c2989de166e49c9c8bc478a3633588739243aa2cc813",
+			"DiscoKey":   "discokey:4d646fbffbd97e374709eaf4770db2d1ac3f891b9e3524a65759b5b28af61157",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints": [
+				"77.164.248.136:45734",
+				"10.65.0.27:45734",
+				"172.17.0.1:45734",
+				"172.18.0.1:45734",
+				"172.19.0.1:45734"
+			],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-28T09:35:24.801792134Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:05f31eba5d7236418982c2989de166e49c9c8bc478a3633588739243aa2cc813",
+		"MachineKey": "mkey:5d492234f09c20713e57149b7da47fec8ce51a6e25cc33330ffba4ec0b2a4c26",
+		"Peers": [{
+			"ID":         8570706782030803,
+			"StableID":   "nzYeKAwgv921CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f787ded653faaea293f88b405ee7e577ca2e75d2a5ec98734bb09dcb27778b05",
+			"DiscoKey":   "discokey:5408541f0b405e2538274eac3bbf9b9ba9a69c294fc07682f6fc94a727626a49",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:45225",
+				"10.65.0.27:45225",
+				"172.17.0.1:45225",
+				"172.18.0.1:45225",
+				"172.19.0.1:45225"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+				{"Proto": "peerapi4", "Port": 37067},
+				{"Proto": "peerapi6", "Port": 37067}
+			]},
+			"Created":              "2026-04-28T09:35:20.022287593Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		}, {
+			"ID":         8303440479880363,
+			"StableID":   "n2NqQUJeq721CNTRL",
+			"Name":       "wartortle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:1f65840ce48362f83f50158e1c821b0aa3b83db29c2d6fa9555e8f1bae6ea65d",
+			"DiscoKey":   "discokey:be7c68968a9510fb0f34f4d2444b84badd7d21505904e885e1427208a73dac01",
+			"Addresses":  ["100.64.0.10/32", "fd7a:115c:a1e0::a/128"],
+			"AllowedIPs": ["100.64.0.10/32", "fd7a:115c:a1e0::a/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:44389",
+				"10.65.0.27:44389",
+				"172.17.0.1:44389",
+				"172.18.0.1:44389",
+				"172.19.0.1:44389"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "wartortle", "Services": [
+				{"Proto": "peerapi4", "Port": 48588},
+				{"Proto": "peerapi6", "Port": 48588}
+			]},
+			"Created":              "2026-04-28T09:35:22.630125333Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "wartortle",
+			"ComputedNameWithHost": "wartortle"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "1809586025123150": {
+			"ID":          1809586025123150,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8050234474581704,
+			"StableID":   "nfpanW1yr521CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:5269b163fde1e2e3a7046eed5f5a626886e90541e6fa72fb1550233682aec130",
+			"KeyExpiry":  "2026-10-25T09:35:26Z",
+			"DiscoKey":   "discokey:f2e8270a1a0871feac879b54cbb1a1848bdbe4ed1adb7283c2282b8445a2552f",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints": [
+				"77.164.248.136:34143",
+				"10.65.0.27:34143",
+				"172.17.0.1:34143",
+				"172.18.0.1:34143",
+				"172.19.0.1:34143"
+			],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-28T09:35:26.451181525Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:5269b163fde1e2e3a7046eed5f5a626886e90541e6fa72fb1550233682aec130",
+		"MachineKey": "mkey:6268061ae20bf9e0b9c26362962b8dec0d48b5a95073abaa232c4853a0dd8744",
+		"Peers": [{
+			"ID":         8570706782030803,
+			"StableID":   "nzYeKAwgv921CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f787ded653faaea293f88b405ee7e577ca2e75d2a5ec98734bb09dcb27778b05",
+			"DiscoKey":   "discokey:5408541f0b405e2538274eac3bbf9b9ba9a69c294fc07682f6fc94a727626a49",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:45225",
+				"10.65.0.27:45225",
+				"172.17.0.1:45225",
+				"172.18.0.1:45225",
+				"172.19.0.1:45225"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+				{"Proto": "peerapi4", "Port": 37067},
+				{"Proto": "peerapi6", "Port": 37067}
+			]},
+			"Created":              "2026-04-28T09:35:20.022287593Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		}, {
+			"ID":         8303440479880363,
+			"StableID":   "n2NqQUJeq721CNTRL",
+			"Name":       "wartortle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:1f65840ce48362f83f50158e1c821b0aa3b83db29c2d6fa9555e8f1bae6ea65d",
+			"DiscoKey":   "discokey:be7c68968a9510fb0f34f4d2444b84badd7d21505904e885e1427208a73dac01",
+			"Addresses":  ["100.64.0.10/32", "fd7a:115c:a1e0::a/128"],
+			"AllowedIPs": ["100.64.0.10/32", "fd7a:115c:a1e0::a/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:44389",
+				"10.65.0.27:44389",
+				"172.17.0.1:44389",
+				"172.18.0.1:44389",
+				"172.19.0.1:44389"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "wartortle", "Services": [
+				{"Proto": "peerapi4", "Port": 48588},
+				{"Proto": "peerapi6", "Port": 48588}
+			]},
+			"Created":              "2026-04-28T09:35:22.630125333Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "wartortle",
+			"ComputedNameWithHost": "wartortle"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "butterfree": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8066480792381647,
+			"StableID":   "ntXuFnmKz521CNTRL",
+			"Name":       "butterfree.tail78f774.ts.net.",
+			"User":       8066480792381647,
+			"Key":        "nodekey:0326235111f039e93cd7f43a04163595ce6848f0f5a25b17f379f5d1aaeb940f",
+			"DiscoKey":   "discokey:1f68f2e8eb4b81c13bac88c0cacfd3ddf3d959b573a2d078ce391a53b52f7f00",
+			"Addresses":  ["100.64.0.8/32", "fd7a:115c:a1e0::8/128"],
+			"AllowedIPs": ["100.64.0.8/32", "fd7a:115c:a1e0::8/128", "192.168.1.0/24"],
+			"Endpoints": [
+				"77.164.248.136:54832",
+				"10.65.0.27:54832",
+				"172.17.0.1:54832",
+				"172.18.0.1:54832",
+				"172.19.0.1:54832"
+			],
+			"Hostinfo": {
+				"Hostname":    "butterfree",
+				"RoutableIPs": ["192.168.1.0/24"],
+				"RequestTags": ["tag:ha"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 56544},
+					{"Proto": "peerapi6", "Port": 56544},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-28T09:35:21.101146722Z",
+			"Tags":              ["tag:ha"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "butterfree",
+			"ComputedNameWithHost": "butterfree"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:0326235111f039e93cd7f43a04163595ce6848f0f5a25b17f379f5d1aaeb940f",
+		"MachineKey": "mkey:70ade243bcfb64fa0c1cb9a4006de200a79d105557afe49c327e5a2d62640662",
+		"Peers": [{
+			"ID":         8570706782030803,
+			"StableID":   "nzYeKAwgv921CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f787ded653faaea293f88b405ee7e577ca2e75d2a5ec98734bb09dcb27778b05",
+			"DiscoKey":   "discokey:5408541f0b405e2538274eac3bbf9b9ba9a69c294fc07682f6fc94a727626a49",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:45225",
+				"10.65.0.27:45225",
+				"172.17.0.1:45225",
+				"172.18.0.1:45225",
+				"172.19.0.1:45225"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+				{"Proto": "peerapi4", "Port": 37067},
+				{"Proto": "peerapi6", "Port": 37067}
+			]},
+			"Created":              "2026-04-28T09:35:20.022287593Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		}, {
+			"ID":         8303440479880363,
+			"StableID":   "n2NqQUJeq721CNTRL",
+			"Name":       "wartortle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:1f65840ce48362f83f50158e1c821b0aa3b83db29c2d6fa9555e8f1bae6ea65d",
+			"DiscoKey":   "discokey:be7c68968a9510fb0f34f4d2444b84badd7d21505904e885e1427208a73dac01",
+			"Addresses":  ["100.64.0.10/32", "fd7a:115c:a1e0::a/128"],
+			"AllowedIPs": ["100.64.0.10/32", "fd7a:115c:a1e0::a/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:44389",
+				"10.65.0.27:44389",
+				"172.17.0.1:44389",
+				"172.18.0.1:44389",
+				"172.19.0.1:44389"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "wartortle", "Services": [
+				{"Proto": "peerapi4", "Port": 48588},
+				{"Proto": "peerapi6", "Port": 48588}
+			]},
+			"Created":              "2026-04-28T09:35:22.630125333Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "wartortle",
+			"ComputedNameWithHost": "wartortle"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "8066480792381647": {
+			"ID":          8066480792381647,
+			"LoginName":   "butterfree.tail78f774.ts.net",
+			"DisplayName": "butterfree"
+		}}
+	}}, "caterpie": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2172820536138461,
+			"StableID":   "n2HeJ3K5yH11CNTRL",
+			"Name":       "caterpie.tail78f774.ts.net.",
+			"User":       2172820536138461,
+			"Key":        "nodekey:f65d7b88e1f69c9560554b616ae0980de29e83439a2992bddfb9eaef05199c4c",
+			"DiscoKey":   "discokey:0c007afb8eb56e31af93dd5fa54c7df9a52a072f94d025d7e3830231837d0b32",
+			"Addresses":  ["100.64.0.1/32", "fd7a:115c:a1e0::1/128"],
+			"AllowedIPs": ["100.64.0.1/32", "fd7a:115c:a1e0::1/128", "10.0.0.0/8"],
+			"Endpoints": [
+				"77.164.248.136:38515",
+				"10.65.0.27:38515",
+				"172.17.0.1:38515",
+				"172.18.0.1:38515",
+				"172.19.0.1:38515"
+			],
+			"Hostinfo": {
+				"Hostname":    "caterpie",
+				"RoutableIPs": ["10.0.0.0/8"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 58436},
+					{"Proto": "peerapi6", "Port": 58436},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-28T09:35:19.476792842Z",
+			"Tags":              ["tag:router"],
+			"PrimaryRoutes":     ["10.0.0.0/8"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "caterpie",
+			"ComputedNameWithHost": "caterpie"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:f65d7b88e1f69c9560554b616ae0980de29e83439a2992bddfb9eaef05199c4c",
+		"MachineKey": "mkey:8b32c788cf4b8594d4a0c768dcf238178509110b751462f3d842e42e3e700f6e",
+		"Peers": [{
+			"ID":         8570706782030803,
+			"StableID":   "nzYeKAwgv921CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f787ded653faaea293f88b405ee7e577ca2e75d2a5ec98734bb09dcb27778b05",
+			"DiscoKey":   "discokey:5408541f0b405e2538274eac3bbf9b9ba9a69c294fc07682f6fc94a727626a49",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:45225",
+				"10.65.0.27:45225",
+				"172.17.0.1:45225",
+				"172.18.0.1:45225",
+				"172.19.0.1:45225"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+				{"Proto": "peerapi4", "Port": 37067},
+				{"Proto": "peerapi6", "Port": 37067}
+			]},
+			"Created":              "2026-04-28T09:35:20.022287593Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		}, {
+			"ID":         8303440479880363,
+			"StableID":   "n2NqQUJeq721CNTRL",
+			"Name":       "wartortle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:1f65840ce48362f83f50158e1c821b0aa3b83db29c2d6fa9555e8f1bae6ea65d",
+			"DiscoKey":   "discokey:be7c68968a9510fb0f34f4d2444b84badd7d21505904e885e1427208a73dac01",
+			"Addresses":  ["100.64.0.10/32", "fd7a:115c:a1e0::a/128"],
+			"AllowedIPs": ["100.64.0.10/32", "fd7a:115c:a1e0::a/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:44389",
+				"10.65.0.27:44389",
+				"172.17.0.1:44389",
+				"172.18.0.1:44389",
+				"172.19.0.1:44389"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "wartortle", "Services": [
+				{"Proto": "peerapi4", "Port": 48588},
+				{"Proto": "peerapi6", "Port": 48588}
+			]},
+			"Created":              "2026-04-28T09:35:22.630125333Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "wartortle",
+			"ComputedNameWithHost": "wartortle"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "2172820536138461": {
+			"ID":          2172820536138461,
+			"LoginName":   "caterpie.tail78f774.ts.net",
+			"DisplayName": "caterpie"
+		}}
+	}}, "charmander": {"packet_filter_rules": [{"SrcIPs": [
+		"10.0.0.0/8",
+		"10.33.0.0/16",
+		"100.115.94.0-100.127.255.255",
+		"100.64.0.0-100.115.91.255",
+		"172.16.0.0/24",
+		"192.168.1.0/24",
+		"fd7a:115c:a1e0::/48"
+	], "DstPorts": [
+		{"IP": "0.0.0.0-9.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+		{"IP": "11.0.0.0-100.63.255.255", "Ports": {"First": 0, "Last": 65535}},
+		{"IP": "100.128.0.0-169.253.255.255", "Ports": {"First": 0, "Last": 65535}},
+		{"IP": "169.255.0.0-172.15.255.255", "Ports": {"First": 0, "Last": 65535}},
+		{"IP": "172.32.0.0-192.167.255.255", "Ports": {"First": 0, "Last": 65535}},
+		{"IP": "192.169.0.0-255.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+		{
+			"IP":    "2000::-3fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+			"Ports": {"First": 0, "Last": 65535}
+		}
+	]}], "packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+		"10.0.0.0/8",
+		"10.33.0.0/16",
+		"100.115.94.0/23",
+		"100.115.96.0/19",
+		"100.115.128.0/17",
+		"100.116.0.0/14",
+		"100.120.0.0/13",
+		"100.64.0.0/11",
+		"100.96.0.0/12",
+		"100.112.0.0/15",
+		"100.114.0.0/16",
+		"100.115.0.0/18",
+		"100.115.64.0/20",
+		"100.115.80.0/21",
+		"100.115.88.0/22",
+		"172.16.0.0/24",
+		"192.168.1.0/24",
+		"fd7a:115c:a1e0::/48"
+	], "SrcCaps": null, "Dsts": [
+		{"Net": "0.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "8.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "11.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "12.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "16.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "32.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "64.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "96.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "100.0.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "100.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "101.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "102.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "104.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "112.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "128.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "160.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "168.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.128.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.192.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.224.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.240.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.248.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.252.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.255.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "170.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "172.0.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "172.32.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "172.64.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "172.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "173.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "174.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "176.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.128.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.160.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.169.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.170.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.172.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.176.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.192.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "193.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "194.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "196.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "200.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "208.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "224.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "2000::/3", "Ports": {"First": 0, "Last": 65535}}
+	], "Caps": []}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8570706782030803,
+			"StableID":   "nzYeKAwgv921CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       8570706782030803,
+			"Key":        "nodekey:f787ded653faaea293f88b405ee7e577ca2e75d2a5ec98734bb09dcb27778b05",
+			"DiscoKey":   "discokey:5408541f0b405e2538274eac3bbf9b9ba9a69c294fc07682f6fc94a727626a49",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:45225",
+				"10.65.0.27:45225",
+				"172.17.0.1:45225",
+				"172.18.0.1:45225",
+				"172.19.0.1:45225"
+			],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-28T09:35:20.022287593Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:f787ded653faaea293f88b405ee7e577ca2e75d2a5ec98734bb09dcb27778b05",
+		"MachineKey": "mkey:ed9f104a00b6f0ed0cc59bf7cb9ba42a2ef72ec40e0d73c67685c140840edb52",
+		"Peers": [{
+			"ID":         2172820536138461,
+			"StableID":   "n2HeJ3K5yH11CNTRL",
+			"Name":       "caterpie.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f65d7b88e1f69c9560554b616ae0980de29e83439a2992bddfb9eaef05199c4c",
+			"DiscoKey":   "discokey:0c007afb8eb56e31af93dd5fa54c7df9a52a072f94d025d7e3830231837d0b32",
+			"Addresses":  ["100.64.0.1/32", "fd7a:115c:a1e0::1/128"],
+			"AllowedIPs": ["100.64.0.1/32", "fd7a:115c:a1e0::1/128", "10.0.0.0/8"],
+			"Endpoints": [
+				"77.164.248.136:38515",
+				"10.65.0.27:38515",
+				"172.17.0.1:38515",
+				"172.18.0.1:38515",
+				"172.19.0.1:38515"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "caterpie", "Services": [
+				{"Proto": "peerapi4", "Port": 58436},
+				{"Proto": "peerapi6", "Port": 58436}
+			]},
+			"Created":              "2026-04-28T09:35:19.476792842Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:router"],
+			"PrimaryRoutes":        ["10.0.0.0/8"],
+			"Online":               true,
+			"ComputedName":         "caterpie",
+			"ComputedNameWithHost": "caterpie"
+		}, {
+			"ID":         4307869565917759,
+			"StableID":   "ncVAwrR3ea11CNTRL",
+			"Name":       "metapod.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:1b04bd2b29ff27ef223d9a5426a3db4fd83e0c5c09d43ea95f871b37dc82eb02",
+			"DiscoKey":   "discokey:ea257ab611fe5f0cb6adc5284befcfd7db6b1f76e96f64b9808331999ece6646",
+			"Addresses":  ["100.64.0.7/32", "fd7a:115c:a1e0::7/128"],
+			"AllowedIPs": ["100.64.0.7/32", "fd7a:115c:a1e0::7/128", "192.168.1.0/24"],
+			"Endpoints": [
+				"77.164.248.136:39030",
+				"10.65.0.27:39030",
+				"172.17.0.1:39030",
+				"172.18.0.1:39030",
+				"172.19.0.1:39030"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "metapod", "Services": [
+				{"Proto": "peerapi4", "Port": 49521},
+				{"Proto": "peerapi6", "Port": 49521}
+			]},
+			"Created":              "2026-04-28T09:35:20.563998974Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:ha"],
+			"PrimaryRoutes":        ["192.168.1.0/24"],
+			"Online":               true,
+			"ComputedName":         "metapod",
+			"ComputedNameWithHost": "metapod"
+		}, {
+			"ID":         8066480792381647,
+			"StableID":   "ntXuFnmKz521CNTRL",
+			"Name":       "butterfree.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:0326235111f039e93cd7f43a04163595ce6848f0f5a25b17f379f5d1aaeb940f",
+			"DiscoKey":   "discokey:1f68f2e8eb4b81c13bac88c0cacfd3ddf3d959b573a2d078ce391a53b52f7f00",
+			"Addresses":  ["100.64.0.8/32", "fd7a:115c:a1e0::8/128"],
+			"AllowedIPs": ["100.64.0.8/32", "fd7a:115c:a1e0::8/128"],
+			"Endpoints": [
+				"77.164.248.136:54832",
+				"10.65.0.27:54832",
+				"172.17.0.1:54832",
+				"172.18.0.1:54832",
+				"172.19.0.1:54832"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "butterfree", "Services": [
+				{"Proto": "peerapi4", "Port": 56544},
+				{"Proto": "peerapi6", "Port": 56544}
+			]},
+			"Created":              "2026-04-28T09:35:21.101146722Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:ha"],
+			"Online":               true,
+			"ComputedName":         "butterfree",
+			"ComputedNameWithHost": "butterfree"
+		}, {
+			"ID":        8303440479880363,
+			"StableID":  "n2NqQUJeq721CNTRL",
+			"Name":      "wartortle.tail78f774.ts.net.",
+			"User":      1260082990019555,
+			"Key":       "nodekey:1f65840ce48362f83f50158e1c821b0aa3b83db29c2d6fa9555e8f1bae6ea65d",
+			"DiscoKey":  "discokey:be7c68968a9510fb0f34f4d2444b84badd7d21505904e885e1427208a73dac01",
+			"Addresses": ["100.64.0.10/32", "fd7a:115c:a1e0::a/128"],
+			"AllowedIPs": [
+				"100.64.0.10/32",
+				"fd7a:115c:a1e0::a/128",
+				"172.16.0.0/24",
+				"0.0.0.0/0",
+				"::/0"
+			],
+			"Endpoints": [
+				"77.164.248.136:44389",
+				"10.65.0.27:44389",
+				"172.17.0.1:44389",
+				"172.18.0.1:44389",
+				"172.19.0.1:44389"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "wartortle", "Services": [
+				{"Proto": "peerapi4", "Port": 48588},
+				{"Proto": "peerapi6", "Port": 48588}
+			]},
+			"Created":              "2026-04-28T09:35:22.630125333Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"PrimaryRoutes":        ["172.16.0.0/24"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "wartortle",
+			"ComputedNameWithHost": "wartortle"
+		}, {
+			"ID":         8268221412476602,
+			"StableID":   "nB7Y24AhZ721CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:bb34390789ef85622abfc877a87726d43b040cbc43c96a5715f27062da434c4e",
+			"DiscoKey":   "discokey:4676a3a130a8008f1f4757009b933d82a66342a91ad5ccb1cd8ef5b01381a262",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:35230",
+				"10.65.0.27:35230",
+				"172.17.0.1:35230",
+				"172.18.0.1:35230",
+				"172.19.0.1:35230"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+				{"Proto": "peerapi4", "Port": 43119},
+				{"Proto": "peerapi6", "Port": 43119}
+			]},
+			"Created":              "2026-04-28T09:35:23.198045969Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:router"],
+			"PrimaryRoutes":        ["10.33.0.0/16"],
+			"Online":               true,
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		}, {
+			"ID":         4968751853700144,
+			"StableID":   "nB4ycmgMof11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f08982b72a06dba7d86f84c91a4f74be77929752240e71c9947388a38a81ab5d",
+			"DiscoKey":   "discokey:6df42e0d4453c00f04727dd93c88286309f550a706b975e4612264934a586417",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints": [
+				"77.164.248.136:47867",
+				"10.65.0.27:47867",
+				"172.17.0.1:47867",
+				"172.18.0.1:47867",
+				"172.19.0.1:47867"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957}
+			]},
+			"Created":              "2026-04-28T09:35:23.732395651Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:client"],
+			"Online":               true,
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		}, {
+			"ID":         1274609663418738,
+			"StableID":   "nRa7GQqGxA11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:8a46cd15b955d8454fa933484dffc41c4e8a5c37007c07ce9d8ce43f3cb36d7f",
+			"DiscoKey":   "discokey:309db9a093b89fc82820382ffaac372852ab479005eac163ad66242c4d511128",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints": [
+				"77.164.248.136:35029",
+				"10.65.0.27:35029",
+				"172.17.0.1:35029",
+				"172.18.0.1:35029",
+				"172.19.0.1:35029"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523}
+			]},
+			"Created":              "2026-04-28T09:35:24.26321868Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:prod"],
+			"Online":               true,
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		}, {
+			"ID":         1809586025123150,
+			"StableID":   "nRkRQskZ8F11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:05f31eba5d7236418982c2989de166e49c9c8bc478a3633588739243aa2cc813",
+			"DiscoKey":   "discokey:4d646fbffbd97e374709eaf4770db2d1ac3f891b9e3524a65759b5b28af61157",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints": [
+				"77.164.248.136:45734",
+				"10.65.0.27:45734",
+				"172.17.0.1:45734",
+				"172.18.0.1:45734",
+				"172.19.0.1:45734"
+			],
+			"HomeDERP": 18,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-04-28T09:35:24.801792134Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}, {
+			"ID":         3815257184602448,
+			"StableID":   "n76ofXLwnW11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:cf8081e0fdf9f8d5754a88d441d58803ad4e5c2e98025b9936d52e223802b06c",
+			"KeyExpiry":  "2026-10-25T09:35:25Z",
+			"DiscoKey":   "discokey:360319ff7727b29dabf262d64617c5a6a6f89fe27abfa01400954ead09f0f84b",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints": [
+				"77.164.248.136:35733",
+				"10.65.0.27:35733",
+				"172.17.0.1:35733",
+				"172.18.0.1:35733",
+				"172.19.0.1:35733"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496}
+			]},
+			"Created":              "2026-04-28T09:35:25.343648615Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		}, {
+			"ID":         4438416858511854,
+			"StableID":   "nyLF9igAfb11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:607b9cbaec5806a225f4164f9da71882b1b3b896f407641a305a8331fd2bbd5d",
+			"KeyExpiry":  "2026-10-25T09:35:25Z",
+			"DiscoKey":   "discokey:a52e2b3164119872316cbf9525042ba342fd561a08cec03979da1014e9de1c0f",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints": [
+				"77.164.248.136:52610",
+				"10.65.0.27:52610",
+				"172.17.0.1:52610",
+				"172.18.0.1:52610",
+				"172.19.0.1:52610"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394}
+			]},
+			"Created":              "2026-04-28T09:35:25.957039359Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		}, {
+			"ID":         8050234474581704,
+			"StableID":   "nfpanW1yr521CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:5269b163fde1e2e3a7046eed5f5a626886e90541e6fa72fb1550233682aec130",
+			"KeyExpiry":  "2026-10-25T09:35:26Z",
+			"DiscoKey":   "discokey:f2e8270a1a0871feac879b54cbb1a1848bdbe4ed1adb7283c2282b8445a2552f",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints": [
+				"77.164.248.136:34143",
+				"10.65.0.27:34143",
+				"172.17.0.1:34143",
+				"172.18.0.1:34143",
+				"172.19.0.1:34143"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156}
+			]},
+			"Created":              "2026-04-28T09:35:26.451181525Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"10.0.0.0/8",
+			"10.33.0.0/16",
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"172.16.0.0/24",
+			"192.168.1.0/24",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "8.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "11.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "12.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "16.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "32.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "64.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "96.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "100.0.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "100.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "101.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "102.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "104.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "112.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "128.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "160.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "168.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.128.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.192.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.224.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.240.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.248.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.252.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.255.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "170.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "172.0.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "172.32.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "172.64.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "172.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "173.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "174.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "176.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.128.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.160.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.169.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.170.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.172.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.176.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.192.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "193.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "194.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "196.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "200.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "208.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "224.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "2000::/3", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"PacketFilterRules": [{"SrcIPs": [
+			"10.0.0.0/8",
+			"10.33.0.0/16",
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"172.16.0.0/24",
+			"192.168.1.0/24",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [
+			{"IP": "0.0.0.0-9.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "11.0.0.0-100.63.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "100.128.0.0-169.253.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "169.255.0.0-172.15.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "172.32.0.0-192.167.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "192.169.0.0-255.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{
+				"IP":    "2000::-3fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+				"Ports": {"First": 0, "Last": 65535}
+			}
+		]}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}, "4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}, "8570706782030803": {
+			"ID":          8570706782030803,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3815257184602448,
+			"StableID":   "n76ofXLwnW11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:cf8081e0fdf9f8d5754a88d441d58803ad4e5c2e98025b9936d52e223802b06c",
+			"KeyExpiry":  "2026-10-25T09:35:25Z",
+			"DiscoKey":   "discokey:360319ff7727b29dabf262d64617c5a6a6f89fe27abfa01400954ead09f0f84b",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints": [
+				"77.164.248.136:35733",
+				"10.65.0.27:35733",
+				"172.17.0.1:35733",
+				"172.18.0.1:35733",
+				"172.19.0.1:35733"
+			],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-28T09:35:25.343648615Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:cf8081e0fdf9f8d5754a88d441d58803ad4e5c2e98025b9936d52e223802b06c",
+		"MachineKey": "mkey:7cdb10547311344bcb2eb618a768537f4eeaf9c752ebf13b4e3d1b419c48164e",
+		"Peers": [{
+			"ID":         8570706782030803,
+			"StableID":   "nzYeKAwgv921CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f787ded653faaea293f88b405ee7e577ca2e75d2a5ec98734bb09dcb27778b05",
+			"DiscoKey":   "discokey:5408541f0b405e2538274eac3bbf9b9ba9a69c294fc07682f6fc94a727626a49",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:45225",
+				"10.65.0.27:45225",
+				"172.17.0.1:45225",
+				"172.18.0.1:45225",
+				"172.19.0.1:45225"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+				{"Proto": "peerapi4", "Port": 37067},
+				{"Proto": "peerapi6", "Port": 37067}
+			]},
+			"Created":              "2026-04-28T09:35:20.022287593Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		}, {
+			"ID":         8303440479880363,
+			"StableID":   "n2NqQUJeq721CNTRL",
+			"Name":       "wartortle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:1f65840ce48362f83f50158e1c821b0aa3b83db29c2d6fa9555e8f1bae6ea65d",
+			"DiscoKey":   "discokey:be7c68968a9510fb0f34f4d2444b84badd7d21505904e885e1427208a73dac01",
+			"Addresses":  ["100.64.0.10/32", "fd7a:115c:a1e0::a/128"],
+			"AllowedIPs": ["100.64.0.10/32", "fd7a:115c:a1e0::a/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:44389",
+				"10.65.0.27:44389",
+				"172.17.0.1:44389",
+				"172.18.0.1:44389",
+				"172.19.0.1:44389"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "wartortle", "Services": [
+				{"Proto": "peerapi4", "Port": 48588},
+				{"Proto": "peerapi6", "Port": 48588}
+			]},
+			"Created":              "2026-04-28T09:35:22.630125333Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "wartortle",
+			"ComputedNameWithHost": "wartortle"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1274609663418738,
+			"StableID":   "nRa7GQqGxA11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       1274609663418738,
+			"Key":        "nodekey:8a46cd15b955d8454fa933484dffc41c4e8a5c37007c07ce9d8ce43f3cb36d7f",
+			"DiscoKey":   "discokey:309db9a093b89fc82820382ffaac372852ab479005eac163ad66242c4d511128",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints": [
+				"77.164.248.136:35029",
+				"10.65.0.27:35029",
+				"172.17.0.1:35029",
+				"172.18.0.1:35029",
+				"172.19.0.1:35029"
+			],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-28T09:35:24.26321868Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:8a46cd15b955d8454fa933484dffc41c4e8a5c37007c07ce9d8ce43f3cb36d7f",
+		"MachineKey": "mkey:eaf0c6db69908d303010df4da1d8ede65e7d9d8ec88af5ff065bb46b0002d754",
+		"Peers": [{
+			"ID":         8570706782030803,
+			"StableID":   "nzYeKAwgv921CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f787ded653faaea293f88b405ee7e577ca2e75d2a5ec98734bb09dcb27778b05",
+			"DiscoKey":   "discokey:5408541f0b405e2538274eac3bbf9b9ba9a69c294fc07682f6fc94a727626a49",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:45225",
+				"10.65.0.27:45225",
+				"172.17.0.1:45225",
+				"172.18.0.1:45225",
+				"172.19.0.1:45225"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+				{"Proto": "peerapi4", "Port": 37067},
+				{"Proto": "peerapi6", "Port": 37067}
+			]},
+			"Created":              "2026-04-28T09:35:20.022287593Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		}, {
+			"ID":         8303440479880363,
+			"StableID":   "n2NqQUJeq721CNTRL",
+			"Name":       "wartortle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:1f65840ce48362f83f50158e1c821b0aa3b83db29c2d6fa9555e8f1bae6ea65d",
+			"DiscoKey":   "discokey:be7c68968a9510fb0f34f4d2444b84badd7d21505904e885e1427208a73dac01",
+			"Addresses":  ["100.64.0.10/32", "fd7a:115c:a1e0::a/128"],
+			"AllowedIPs": ["100.64.0.10/32", "fd7a:115c:a1e0::a/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:44389",
+				"10.65.0.27:44389",
+				"172.17.0.1:44389",
+				"172.18.0.1:44389",
+				"172.19.0.1:44389"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "wartortle", "Services": [
+				{"Proto": "peerapi4", "Port": 48588},
+				{"Proto": "peerapi6", "Port": 48588}
+			]},
+			"Created":              "2026-04-28T09:35:22.630125333Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "wartortle",
+			"ComputedNameWithHost": "wartortle"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "1274609663418738": {
+			"ID":          1274609663418738,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "metapod": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4307869565917759,
+			"StableID":   "ncVAwrR3ea11CNTRL",
+			"Name":       "metapod.tail78f774.ts.net.",
+			"User":       4307869565917759,
+			"Key":        "nodekey:1b04bd2b29ff27ef223d9a5426a3db4fd83e0c5c09d43ea95f871b37dc82eb02",
+			"DiscoKey":   "discokey:ea257ab611fe5f0cb6adc5284befcfd7db6b1f76e96f64b9808331999ece6646",
+			"Addresses":  ["100.64.0.7/32", "fd7a:115c:a1e0::7/128"],
+			"AllowedIPs": ["100.64.0.7/32", "fd7a:115c:a1e0::7/128", "192.168.1.0/24"],
+			"Endpoints": [
+				"77.164.248.136:39030",
+				"10.65.0.27:39030",
+				"172.17.0.1:39030",
+				"172.18.0.1:39030",
+				"172.19.0.1:39030"
+			],
+			"Hostinfo": {
+				"Hostname":    "metapod",
+				"RoutableIPs": ["192.168.1.0/24"],
+				"RequestTags": ["tag:ha"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 49521},
+					{"Proto": "peerapi6", "Port": 49521},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-28T09:35:20.563998974Z",
+			"Tags":              ["tag:ha"],
+			"PrimaryRoutes":     ["192.168.1.0/24"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "metapod",
+			"ComputedNameWithHost": "metapod"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:1b04bd2b29ff27ef223d9a5426a3db4fd83e0c5c09d43ea95f871b37dc82eb02",
+		"MachineKey": "mkey:2abab0bc53d4061202f2f0dfc167deb107f513ed9028f0c97cbd138add2f8529",
+		"Peers": [{
+			"ID":         8570706782030803,
+			"StableID":   "nzYeKAwgv921CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f787ded653faaea293f88b405ee7e577ca2e75d2a5ec98734bb09dcb27778b05",
+			"DiscoKey":   "discokey:5408541f0b405e2538274eac3bbf9b9ba9a69c294fc07682f6fc94a727626a49",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:45225",
+				"10.65.0.27:45225",
+				"172.17.0.1:45225",
+				"172.18.0.1:45225",
+				"172.19.0.1:45225"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+				{"Proto": "peerapi4", "Port": 37067},
+				{"Proto": "peerapi6", "Port": 37067}
+			]},
+			"Created":              "2026-04-28T09:35:20.022287593Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		}, {
+			"ID":         8303440479880363,
+			"StableID":   "n2NqQUJeq721CNTRL",
+			"Name":       "wartortle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:1f65840ce48362f83f50158e1c821b0aa3b83db29c2d6fa9555e8f1bae6ea65d",
+			"DiscoKey":   "discokey:be7c68968a9510fb0f34f4d2444b84badd7d21505904e885e1427208a73dac01",
+			"Addresses":  ["100.64.0.10/32", "fd7a:115c:a1e0::a/128"],
+			"AllowedIPs": ["100.64.0.10/32", "fd7a:115c:a1e0::a/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:44389",
+				"10.65.0.27:44389",
+				"172.17.0.1:44389",
+				"172.18.0.1:44389",
+				"172.19.0.1:44389"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "wartortle", "Services": [
+				{"Proto": "peerapi4", "Port": 48588},
+				{"Proto": "peerapi6", "Port": 48588}
+			]},
+			"Created":              "2026-04-28T09:35:22.630125333Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "wartortle",
+			"ComputedNameWithHost": "wartortle"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4307869565917759": {
+			"ID":          4307869565917759,
+			"LoginName":   "metapod.tail78f774.ts.net",
+			"DisplayName": "metapod"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8268221412476602,
+			"StableID":   "nB7Y24AhZ721CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       8268221412476602,
+			"Key":        "nodekey:bb34390789ef85622abfc877a87726d43b040cbc43c96a5715f27062da434c4e",
+			"DiscoKey":   "discokey:4676a3a130a8008f1f4757009b933d82a66342a91ad5ccb1cd8ef5b01381a262",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:35230",
+				"10.65.0.27:35230",
+				"172.17.0.1:35230",
+				"172.18.0.1:35230",
+				"172.19.0.1:35230"
+			],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-28T09:35:23.198045969Z",
+			"Tags":              ["tag:router"],
+			"PrimaryRoutes":     ["10.33.0.0/16"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:bb34390789ef85622abfc877a87726d43b040cbc43c96a5715f27062da434c4e",
+		"MachineKey": "mkey:cade09d695937972aa4f5ab8e974d94db86c666397b1b7c8f21ff3422f905c28",
+		"Peers": [{
+			"ID":         8570706782030803,
+			"StableID":   "nzYeKAwgv921CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f787ded653faaea293f88b405ee7e577ca2e75d2a5ec98734bb09dcb27778b05",
+			"DiscoKey":   "discokey:5408541f0b405e2538274eac3bbf9b9ba9a69c294fc07682f6fc94a727626a49",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:45225",
+				"10.65.0.27:45225",
+				"172.17.0.1:45225",
+				"172.18.0.1:45225",
+				"172.19.0.1:45225"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+				{"Proto": "peerapi4", "Port": 37067},
+				{"Proto": "peerapi6", "Port": 37067}
+			]},
+			"Created":              "2026-04-28T09:35:20.022287593Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		}, {
+			"ID":         8303440479880363,
+			"StableID":   "n2NqQUJeq721CNTRL",
+			"Name":       "wartortle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:1f65840ce48362f83f50158e1c821b0aa3b83db29c2d6fa9555e8f1bae6ea65d",
+			"DiscoKey":   "discokey:be7c68968a9510fb0f34f4d2444b84badd7d21505904e885e1427208a73dac01",
+			"Addresses":  ["100.64.0.10/32", "fd7a:115c:a1e0::a/128"],
+			"AllowedIPs": ["100.64.0.10/32", "fd7a:115c:a1e0::a/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:44389",
+				"10.65.0.27:44389",
+				"172.17.0.1:44389",
+				"172.18.0.1:44389",
+				"172.19.0.1:44389"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "wartortle", "Services": [
+				{"Proto": "peerapi4", "Port": 48588},
+				{"Proto": "peerapi6", "Port": 48588}
+			]},
+			"Created":              "2026-04-28T09:35:22.630125333Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "wartortle",
+			"ComputedNameWithHost": "wartortle"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "8268221412476602": {
+			"ID":          8268221412476602,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4438416858511854,
+			"StableID":   "nyLF9igAfb11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:607b9cbaec5806a225f4164f9da71882b1b3b896f407641a305a8331fd2bbd5d",
+			"KeyExpiry":  "2026-10-25T09:35:25Z",
+			"DiscoKey":   "discokey:a52e2b3164119872316cbf9525042ba342fd561a08cec03979da1014e9de1c0f",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints": [
+				"77.164.248.136:52610",
+				"10.65.0.27:52610",
+				"172.17.0.1:52610",
+				"172.18.0.1:52610",
+				"172.19.0.1:52610"
+			],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-28T09:35:25.957039359Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:607b9cbaec5806a225f4164f9da71882b1b3b896f407641a305a8331fd2bbd5d",
+		"MachineKey": "mkey:f0fd0e920ab947250ee505bfc07bfb447a4abc6806928dfb0794c395a7af785d",
+		"Peers": [{
+			"ID":         8570706782030803,
+			"StableID":   "nzYeKAwgv921CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f787ded653faaea293f88b405ee7e577ca2e75d2a5ec98734bb09dcb27778b05",
+			"DiscoKey":   "discokey:5408541f0b405e2538274eac3bbf9b9ba9a69c294fc07682f6fc94a727626a49",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:45225",
+				"10.65.0.27:45225",
+				"172.17.0.1:45225",
+				"172.18.0.1:45225",
+				"172.19.0.1:45225"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+				{"Proto": "peerapi4", "Port": 37067},
+				{"Proto": "peerapi6", "Port": 37067}
+			]},
+			"Created":              "2026-04-28T09:35:20.022287593Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		}, {
+			"ID":         8303440479880363,
+			"StableID":   "n2NqQUJeq721CNTRL",
+			"Name":       "wartortle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:1f65840ce48362f83f50158e1c821b0aa3b83db29c2d6fa9555e8f1bae6ea65d",
+			"DiscoKey":   "discokey:be7c68968a9510fb0f34f4d2444b84badd7d21505904e885e1427208a73dac01",
+			"Addresses":  ["100.64.0.10/32", "fd7a:115c:a1e0::a/128"],
+			"AllowedIPs": ["100.64.0.10/32", "fd7a:115c:a1e0::a/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:44389",
+				"10.65.0.27:44389",
+				"172.17.0.1:44389",
+				"172.18.0.1:44389",
+				"172.19.0.1:44389"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "wartortle", "Services": [
+				{"Proto": "peerapi4", "Port": 48588},
+				{"Proto": "peerapi6", "Port": 48588}
+			]},
+			"Created":              "2026-04-28T09:35:22.630125333Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "wartortle",
+			"ComputedNameWithHost": "wartortle"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "wartortle": {"packet_filter_rules": [{"SrcIPs": [
+		"10.0.0.0/8",
+		"10.33.0.0/16",
+		"100.115.94.0-100.127.255.255",
+		"100.64.0.0-100.115.91.255",
+		"172.16.0.0/24",
+		"192.168.1.0/24",
+		"fd7a:115c:a1e0::/48"
+	], "DstPorts": [
+		{"IP": "0.0.0.0-9.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+		{"IP": "11.0.0.0-100.63.255.255", "Ports": {"First": 0, "Last": 65535}},
+		{"IP": "100.128.0.0-169.253.255.255", "Ports": {"First": 0, "Last": 65535}},
+		{"IP": "169.255.0.0-172.15.255.255", "Ports": {"First": 0, "Last": 65535}},
+		{"IP": "172.32.0.0-192.167.255.255", "Ports": {"First": 0, "Last": 65535}},
+		{"IP": "192.169.0.0-255.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+		{
+			"IP":    "2000::-3fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+			"Ports": {"First": 0, "Last": 65535}
+		}
+	]}], "packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+		"10.0.0.0/8",
+		"10.33.0.0/16",
+		"100.115.94.0/23",
+		"100.115.96.0/19",
+		"100.115.128.0/17",
+		"100.116.0.0/14",
+		"100.120.0.0/13",
+		"100.64.0.0/11",
+		"100.96.0.0/12",
+		"100.112.0.0/15",
+		"100.114.0.0/16",
+		"100.115.0.0/18",
+		"100.115.64.0/20",
+		"100.115.80.0/21",
+		"100.115.88.0/22",
+		"172.16.0.0/24",
+		"192.168.1.0/24",
+		"fd7a:115c:a1e0::/48"
+	], "SrcCaps": null, "Dsts": [
+		{"Net": "0.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "8.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "11.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "12.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "16.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "32.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "64.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "96.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "100.0.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "100.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "101.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "102.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "104.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "112.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "128.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "160.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "168.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.128.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.192.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.224.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.240.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.248.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.252.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "169.255.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "170.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "172.0.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "172.32.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "172.64.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "172.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "173.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "174.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "176.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.128.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.160.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.169.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.170.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.172.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.176.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "192.192.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "193.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "194.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "196.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "200.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "208.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "224.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+		{"Net": "2000::/3", "Ports": {"First": 0, "Last": 65535}}
+	], "Caps": []}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":        8303440479880363,
+			"StableID":  "n2NqQUJeq721CNTRL",
+			"Name":      "wartortle.tail78f774.ts.net.",
+			"User":      8303440479880363,
+			"Key":       "nodekey:1f65840ce48362f83f50158e1c821b0aa3b83db29c2d6fa9555e8f1bae6ea65d",
+			"DiscoKey":  "discokey:be7c68968a9510fb0f34f4d2444b84badd7d21505904e885e1427208a73dac01",
+			"Addresses": ["100.64.0.10/32", "fd7a:115c:a1e0::a/128"],
+			"AllowedIPs": [
+				"100.64.0.10/32",
+				"fd7a:115c:a1e0::a/128",
+				"172.16.0.0/24",
+				"0.0.0.0/0",
+				"::/0"
+			],
+			"Endpoints": [
+				"77.164.248.136:44389",
+				"10.65.0.27:44389",
+				"172.17.0.1:44389",
+				"172.18.0.1:44389",
+				"172.19.0.1:44389"
+			],
+			"Hostinfo": {
+				"Hostname":    "wartortle",
+				"RoutableIPs": ["172.16.0.0/24", "0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit", "tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 48588},
+					{"Proto": "peerapi6", "Port": 48588},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-28T09:35:22.630125333Z",
+			"Tags":              ["tag:exit", "tag:router"],
+			"PrimaryRoutes":     ["172.16.0.0/24"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "wartortle",
+			"ComputedNameWithHost": "wartortle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:1f65840ce48362f83f50158e1c821b0aa3b83db29c2d6fa9555e8f1bae6ea65d",
+		"MachineKey": "mkey:ce84b49de656e71703e430c3f1a0596d78b83765d54a4deb6a75bb96e1f43809",
+		"Peers": [{
+			"ID":         2172820536138461,
+			"StableID":   "n2HeJ3K5yH11CNTRL",
+			"Name":       "caterpie.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f65d7b88e1f69c9560554b616ae0980de29e83439a2992bddfb9eaef05199c4c",
+			"DiscoKey":   "discokey:0c007afb8eb56e31af93dd5fa54c7df9a52a072f94d025d7e3830231837d0b32",
+			"Addresses":  ["100.64.0.1/32", "fd7a:115c:a1e0::1/128"],
+			"AllowedIPs": ["100.64.0.1/32", "fd7a:115c:a1e0::1/128", "10.0.0.0/8"],
+			"Endpoints": [
+				"77.164.248.136:38515",
+				"10.65.0.27:38515",
+				"172.17.0.1:38515",
+				"172.18.0.1:38515",
+				"172.19.0.1:38515"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "caterpie", "Services": [
+				{"Proto": "peerapi4", "Port": 58436},
+				{"Proto": "peerapi6", "Port": 58436}
+			]},
+			"Created":              "2026-04-28T09:35:19.476792842Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:router"],
+			"PrimaryRoutes":        ["10.0.0.0/8"],
+			"Online":               true,
+			"ComputedName":         "caterpie",
+			"ComputedNameWithHost": "caterpie"
+		}, {
+			"ID":         8570706782030803,
+			"StableID":   "nzYeKAwgv921CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f787ded653faaea293f88b405ee7e577ca2e75d2a5ec98734bb09dcb27778b05",
+			"DiscoKey":   "discokey:5408541f0b405e2538274eac3bbf9b9ba9a69c294fc07682f6fc94a727626a49",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:45225",
+				"10.65.0.27:45225",
+				"172.17.0.1:45225",
+				"172.18.0.1:45225",
+				"172.19.0.1:45225"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+				{"Proto": "peerapi4", "Port": 37067},
+				{"Proto": "peerapi6", "Port": 37067}
+			]},
+			"Created":              "2026-04-28T09:35:20.022287593Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		}, {
+			"ID":         4307869565917759,
+			"StableID":   "ncVAwrR3ea11CNTRL",
+			"Name":       "metapod.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:1b04bd2b29ff27ef223d9a5426a3db4fd83e0c5c09d43ea95f871b37dc82eb02",
+			"DiscoKey":   "discokey:ea257ab611fe5f0cb6adc5284befcfd7db6b1f76e96f64b9808331999ece6646",
+			"Addresses":  ["100.64.0.7/32", "fd7a:115c:a1e0::7/128"],
+			"AllowedIPs": ["100.64.0.7/32", "fd7a:115c:a1e0::7/128", "192.168.1.0/24"],
+			"Endpoints": [
+				"77.164.248.136:39030",
+				"10.65.0.27:39030",
+				"172.17.0.1:39030",
+				"172.18.0.1:39030",
+				"172.19.0.1:39030"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "metapod", "Services": [
+				{"Proto": "peerapi4", "Port": 49521},
+				{"Proto": "peerapi6", "Port": 49521}
+			]},
+			"Created":              "2026-04-28T09:35:20.563998974Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:ha"],
+			"PrimaryRoutes":        ["192.168.1.0/24"],
+			"Online":               true,
+			"ComputedName":         "metapod",
+			"ComputedNameWithHost": "metapod"
+		}, {
+			"ID":         8066480792381647,
+			"StableID":   "ntXuFnmKz521CNTRL",
+			"Name":       "butterfree.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:0326235111f039e93cd7f43a04163595ce6848f0f5a25b17f379f5d1aaeb940f",
+			"DiscoKey":   "discokey:1f68f2e8eb4b81c13bac88c0cacfd3ddf3d959b573a2d078ce391a53b52f7f00",
+			"Addresses":  ["100.64.0.8/32", "fd7a:115c:a1e0::8/128"],
+			"AllowedIPs": ["100.64.0.8/32", "fd7a:115c:a1e0::8/128"],
+			"Endpoints": [
+				"77.164.248.136:54832",
+				"10.65.0.27:54832",
+				"172.17.0.1:54832",
+				"172.18.0.1:54832",
+				"172.19.0.1:54832"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "butterfree", "Services": [
+				{"Proto": "peerapi4", "Port": 56544},
+				{"Proto": "peerapi6", "Port": 56544}
+			]},
+			"Created":              "2026-04-28T09:35:21.101146722Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:ha"],
+			"Online":               true,
+			"ComputedName":         "butterfree",
+			"ComputedNameWithHost": "butterfree"
+		}, {
+			"ID":         8268221412476602,
+			"StableID":   "nB7Y24AhZ721CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:bb34390789ef85622abfc877a87726d43b040cbc43c96a5715f27062da434c4e",
+			"DiscoKey":   "discokey:4676a3a130a8008f1f4757009b933d82a66342a91ad5ccb1cd8ef5b01381a262",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:35230",
+				"10.65.0.27:35230",
+				"172.17.0.1:35230",
+				"172.18.0.1:35230",
+				"172.19.0.1:35230"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+				{"Proto": "peerapi4", "Port": 43119},
+				{"Proto": "peerapi6", "Port": 43119}
+			]},
+			"Created":              "2026-04-28T09:35:23.198045969Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:router"],
+			"PrimaryRoutes":        ["10.33.0.0/16"],
+			"Online":               true,
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		}, {
+			"ID":         4968751853700144,
+			"StableID":   "nB4ycmgMof11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f08982b72a06dba7d86f84c91a4f74be77929752240e71c9947388a38a81ab5d",
+			"DiscoKey":   "discokey:6df42e0d4453c00f04727dd93c88286309f550a706b975e4612264934a586417",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints": [
+				"77.164.248.136:47867",
+				"10.65.0.27:47867",
+				"172.17.0.1:47867",
+				"172.18.0.1:47867",
+				"172.19.0.1:47867"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957}
+			]},
+			"Created":              "2026-04-28T09:35:23.732395651Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:client"],
+			"Online":               true,
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		}, {
+			"ID":         1274609663418738,
+			"StableID":   "nRa7GQqGxA11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:8a46cd15b955d8454fa933484dffc41c4e8a5c37007c07ce9d8ce43f3cb36d7f",
+			"DiscoKey":   "discokey:309db9a093b89fc82820382ffaac372852ab479005eac163ad66242c4d511128",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints": [
+				"77.164.248.136:35029",
+				"10.65.0.27:35029",
+				"172.17.0.1:35029",
+				"172.18.0.1:35029",
+				"172.19.0.1:35029"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523}
+			]},
+			"Created":              "2026-04-28T09:35:24.26321868Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:prod"],
+			"Online":               true,
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		}, {
+			"ID":         1809586025123150,
+			"StableID":   "nRkRQskZ8F11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:05f31eba5d7236418982c2989de166e49c9c8bc478a3633588739243aa2cc813",
+			"DiscoKey":   "discokey:4d646fbffbd97e374709eaf4770db2d1ac3f891b9e3524a65759b5b28af61157",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints": [
+				"77.164.248.136:45734",
+				"10.65.0.27:45734",
+				"172.17.0.1:45734",
+				"172.18.0.1:45734",
+				"172.19.0.1:45734"
+			],
+			"HomeDERP": 18,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-04-28T09:35:24.801792134Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}, {
+			"ID":         3815257184602448,
+			"StableID":   "n76ofXLwnW11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:cf8081e0fdf9f8d5754a88d441d58803ad4e5c2e98025b9936d52e223802b06c",
+			"KeyExpiry":  "2026-10-25T09:35:25Z",
+			"DiscoKey":   "discokey:360319ff7727b29dabf262d64617c5a6a6f89fe27abfa01400954ead09f0f84b",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints": [
+				"77.164.248.136:35733",
+				"10.65.0.27:35733",
+				"172.17.0.1:35733",
+				"172.18.0.1:35733",
+				"172.19.0.1:35733"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496}
+			]},
+			"Created":              "2026-04-28T09:35:25.343648615Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		}, {
+			"ID":         4438416858511854,
+			"StableID":   "nyLF9igAfb11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:607b9cbaec5806a225f4164f9da71882b1b3b896f407641a305a8331fd2bbd5d",
+			"KeyExpiry":  "2026-10-25T09:35:25Z",
+			"DiscoKey":   "discokey:a52e2b3164119872316cbf9525042ba342fd561a08cec03979da1014e9de1c0f",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints": [
+				"77.164.248.136:52610",
+				"10.65.0.27:52610",
+				"172.17.0.1:52610",
+				"172.18.0.1:52610",
+				"172.19.0.1:52610"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394}
+			]},
+			"Created":              "2026-04-28T09:35:25.957039359Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		}, {
+			"ID":         8050234474581704,
+			"StableID":   "nfpanW1yr521CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:5269b163fde1e2e3a7046eed5f5a626886e90541e6fa72fb1550233682aec130",
+			"KeyExpiry":  "2026-10-25T09:35:26Z",
+			"DiscoKey":   "discokey:f2e8270a1a0871feac879b54cbb1a1848bdbe4ed1adb7283c2282b8445a2552f",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints": [
+				"77.164.248.136:34143",
+				"10.65.0.27:34143",
+				"172.17.0.1:34143",
+				"172.18.0.1:34143",
+				"172.19.0.1:34143"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156}
+			]},
+			"Created":              "2026-04-28T09:35:26.451181525Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"10.0.0.0/8",
+			"10.33.0.0/16",
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"172.16.0.0/24",
+			"192.168.1.0/24",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "8.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "11.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "12.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "16.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "32.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "64.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "96.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "100.0.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "100.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "101.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "102.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "104.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "112.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "128.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "160.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "168.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.128.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.192.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.224.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.240.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.248.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.252.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "169.255.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "170.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "172.0.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "172.32.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "172.64.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "172.128.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "173.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "174.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "176.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.0.0.0/9", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.128.0.0/11", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.160.0.0/13", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.169.0.0/16", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.170.0.0/15", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.172.0.0/14", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.176.0.0/12", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "192.192.0.0/10", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "193.0.0.0/8", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "194.0.0.0/7", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "196.0.0.0/6", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "200.0.0.0/5", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "208.0.0.0/4", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "224.0.0.0/3", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "2000::/3", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"PacketFilterRules": [{"SrcIPs": [
+			"10.0.0.0/8",
+			"10.33.0.0/16",
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"172.16.0.0/24",
+			"192.168.1.0/24",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [
+			{"IP": "0.0.0.0-9.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "11.0.0.0-100.63.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "100.128.0.0-169.253.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "169.255.0.0-172.15.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "172.32.0.0-192.167.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{"IP": "192.169.0.0-255.255.255.255", "Ports": {"First": 0, "Last": 65535}},
+			{
+				"IP":    "2000::-3fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+				"Ports": {"First": 0, "Last": 65535}
+			}
+		]}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}, "4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}, "8303440479880363": {
+			"ID":          8303440479880363,
+			"LoginName":   "wartortle.tail78f774.ts.net",
+			"DisplayName": "wartortle"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4968751853700144,
+			"StableID":   "nB4ycmgMof11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       4968751853700144,
+			"Key":        "nodekey:f08982b72a06dba7d86f84c91a4f74be77929752240e71c9947388a38a81ab5d",
+			"DiscoKey":   "discokey:6df42e0d4453c00f04727dd93c88286309f550a706b975e4612264934a586417",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints": [
+				"77.164.248.136:47867",
+				"10.65.0.27:47867",
+				"172.17.0.1:47867",
+				"172.18.0.1:47867",
+				"172.19.0.1:47867"
+			],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-28T09:35:23.732395651Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:f08982b72a06dba7d86f84c91a4f74be77929752240e71c9947388a38a81ab5d",
+		"MachineKey": "mkey:6b7baab21109713ccdc87c5d0185696b330c1df084d3a6c6d7e7b74569f6c50a",
+		"Peers": [{
+			"ID":         8570706782030803,
+			"StableID":   "nzYeKAwgv921CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f787ded653faaea293f88b405ee7e577ca2e75d2a5ec98734bb09dcb27778b05",
+			"DiscoKey":   "discokey:5408541f0b405e2538274eac3bbf9b9ba9a69c294fc07682f6fc94a727626a49",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:45225",
+				"10.65.0.27:45225",
+				"172.17.0.1:45225",
+				"172.18.0.1:45225",
+				"172.19.0.1:45225"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+				{"Proto": "peerapi4", "Port": 37067},
+				{"Proto": "peerapi6", "Port": 37067}
+			]},
+			"Created":              "2026-04-28T09:35:20.022287593Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		}, {
+			"ID":         8303440479880363,
+			"StableID":   "n2NqQUJeq721CNTRL",
+			"Name":       "wartortle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:1f65840ce48362f83f50158e1c821b0aa3b83db29c2d6fa9555e8f1bae6ea65d",
+			"DiscoKey":   "discokey:be7c68968a9510fb0f34f4d2444b84badd7d21505904e885e1427208a73dac01",
+			"Addresses":  ["100.64.0.10/32", "fd7a:115c:a1e0::a/128"],
+			"AllowedIPs": ["100.64.0.10/32", "fd7a:115c:a1e0::a/128", "0.0.0.0/0", "::/0"],
+			"Endpoints": [
+				"77.164.248.136:44389",
+				"10.65.0.27:44389",
+				"172.17.0.1:44389",
+				"172.18.0.1:44389",
+				"172.19.0.1:44389"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "wartortle", "Services": [
+				{"Proto": "peerapi4", "Port": 48588},
+				{"Proto": "peerapi6", "Port": 48588}
+			]},
+			"Created":              "2026-04-28T09:35:22.630125333Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"Online":               true,
+			"CapMap":               {"suggest-charmander": null},
+			"ComputedName":         "wartortle",
+			"ComputedNameWithHost": "wartortle"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4968751853700144": {
+			"ID":          4968751853700144,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/integration/route_test.go
+++ b/integration/route_test.go
@@ -1702,6 +1702,145 @@ func TestEnablingExitRoutes(t *testing.T) {
 	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "clients should see new routes")
 }
 
+// TestExitRoutesWithAutogroupInternetACL reproduces juanfont/headscale#3212.
+// When an ACL grants access via autogroup:internet, the source nodes must
+// still see approved exit nodes as peers with 0.0.0.0/0 and ::/0 in their
+// AllowedIPs — that visibility is what drives `tailscale exit-node list`.
+//
+// Tailscale SaaS surfaces exit nodes on the autogroup:internet path
+// (verified against a live tailnet on 2026-04-28; see captures
+// routes-b17/b18 in tscap). The bug was that headscale stripped
+// autogroup:internet rules from both the client packet filter AND the
+// matcher source used by Node.CanAccess, breaking exit-node visibility.
+func TestExitRoutesWithAutogroupInternetACL(t *testing.T) {
+	IntegrationSkip(t)
+
+	user := "user2"
+
+	spec := ScenarioSpec{
+		NodesPerUser: 2,
+		Users:        []string{user},
+	}
+
+	scenario, err := NewScenario(spec)
+	require.NoErrorf(t, err, "failed to create scenario")
+
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv(
+		[]tsic.Option{
+			tsic.WithExtraLoginArgs([]string{"--advertise-exit-node"}),
+		},
+		hsic.WithTestName("rt-exit-aginternet"),
+		hsic.WithACLPolicy(&policyv2.Policy{
+			ACLs: []policyv2.ACL{
+				{
+					Action:  "accept",
+					Sources: []policyv2.Alias{usernamep(user + "@")},
+					Destinations: []policyv2.AliasWithPorts{
+						aliasWithPorts(
+							new(policyv2.AutoGroupInternet),
+							tailcfg.PortRangeAny,
+						),
+					},
+				},
+			},
+		}),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	allClients, err := scenario.ListTailscaleClients()
+	requireNoErrListClients(t, err)
+
+	headscale, err := scenario.Headscale()
+	requireNoErrGetHeadscale(t, err)
+
+	// The autogroup:internet ACL grants no peer visibility until the
+	// exit routes are approved (Node.IsExitNode() flips on approval),
+	// so the standard WaitForTailscaleSync wait would deadlock here —
+	// the post-approval EventuallyWithT block below covers the peer
+	// state we actually care about.
+	var nodes []*v1.Node
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err = headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 2)
+
+		requireNodeRouteCountWithCollect(c, nodes[0], 2, 0, 0)
+		requireNodeRouteCountWithCollect(c, nodes[1], 2, 0, 0)
+	}, integrationutil.ScaledTimeout(20*time.Second), 200*time.Millisecond,
+		"Waiting for exit-route advertisements to propagate")
+
+	// Approve exit routes on both nodes so either could serve as
+	// alice's exit. The bug fix is about visibility, not which node
+	// is chosen.
+	_, err = headscale.ApproveRoutes(
+		nodes[0].GetId(),
+		[]netip.Prefix{tsaddr.AllIPv4(), tsaddr.AllIPv6()},
+	)
+	require.NoError(t, err)
+	_, err = headscale.ApproveRoutes(
+		nodes[1].GetId(),
+		[]netip.Prefix{tsaddr.AllIPv4(), tsaddr.AllIPv6()},
+	)
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err = headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 2)
+
+		requireNodeRouteCountWithCollect(c, nodes[0], 2, 2, 2)
+		requireNodeRouteCountWithCollect(c, nodes[1], 2, 2, 2)
+	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond,
+		"approved exit routes should propagate to nodes")
+
+	// The end-to-end UX assertion: every client must see the OTHER
+	// node as a peer carrying both default-route prefixes in
+	// AllowedIPs. Tailscale derives PeerStatus.ExitNodeOption from
+	// those AllowedIPs, which is what `tailscale exit-node list`
+	// reads (see tailscale.com/ipn/ipnlocal/local.go).
+	for _, client := range allClients {
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			status, err := client.Status()
+			assert.NoError(c, err)
+
+			peerCount := 0
+
+			for _, peerKey := range status.Peers() {
+				peerStatus := status.Peer[peerKey]
+				peerCount++
+
+				assert.NotNilf(c, peerStatus.AllowedIPs,
+					"peer %s has nil AllowedIPs", peerStatus.HostName)
+
+				if peerStatus.AllowedIPs != nil {
+					ips := peerStatus.AllowedIPs.AsSlice()
+					assert.Containsf(c, ips, tsaddr.AllIPv4(),
+						"peer %s lacks 0.0.0.0/0 in AllowedIPs",
+						peerStatus.HostName)
+					assert.Containsf(c, ips, tsaddr.AllIPv6(),
+						"peer %s lacks ::/0 in AllowedIPs",
+						peerStatus.HostName)
+				}
+
+				assert.Truef(c, peerStatus.ExitNodeOption,
+					"peer %s should be exposed as an exit-node "+
+						"option (autogroup:internet ACL must "+
+						"keep exit-node visibility — #3212)",
+					peerStatus.HostName)
+			}
+
+			assert.Equalf(c, 1, peerCount,
+				"client %s should see the other node as a peer "+
+					"via the autogroup:internet ACL",
+				status.Self.HostName)
+		}, integrationutil.ScaledTimeout(15*time.Second), 500*time.Millisecond,
+			"client should see exit nodes as peers via autogroup:internet ACL")
+	}
+}
+
 // TestSubnetRouterMultiNetwork is an evolution of the subnet router test.
 // This test will set up multiple docker networks and use two isolated tailscale
 // clients and a service available in one of the networks to validate that a


### PR DESCRIPTION
`compileFilterRules` skipped `autogroup:internet` destinations to keep them out of the wire-format `PacketFilter`, but those compiled rules also feed `pm.matchers`. `Node.CanAccess` looks at a matcher whose `DestsIsTheInternet` covers the public internet to surface exit-node peers to ACL sources — with the skip in place no such matcher existed, exit nodes silently dropped out of the source's peer list, and the `ref/routes/#setup-an-exit-node` walkthrough stopped working: `tailscale exit-node list` returned `no exit nodes found` and `tailscale set --exit-node=<ip>` returned `no node found in netmap with IP`.

The skip lands in `filter.go`. Removing it lets `autogroup:internet` flow through normal matcher derivation. To keep the wire-format PacketFilter correct on advertisers, `ReduceFilterRules` now keeps a destination on exit-route advertisers when every prefix sits inside `util.TheInternet()` — Tailscale SaaS sends those rules to exit nodes so the advertiser's kernel filter accepts traffic forwarded by `autogroup:internet` sources.

Verified against a live Tailscale SaaS tailnet on 2026-04-28 via `tscap`. The b17/b18 captures land under `testdata/issue_3212/` as a regression guard. They are isolated from `testdata/routes_results/` because the broader `TestRoutesCompat` machinery assumes a CIDR-prefix wire format that differs from the IPSet-range form SaaS emits for `autogroup:internet`; aligning that wire format is tracked separately.

Fixes #3212

> Generated with the help of an AI assistant