### PR TITLE
ci: fetch full history in lint workflow for --new-from-rev

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Get changed files
         id: changed-files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2


### PR DESCRIPTION
- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

The `golangci-lint` job in `.github/workflows/lint.yml` runs with `--new-from-rev=${{ github.event.pull_request.base.sha }}` to filter reported issues to lines added by the PR. The checkout step uses `fetch-depth: 2`, which is only enough for single-commit PRs. For PRs with N > 1 commits, base.sha lives at HEAD~N and is not in the fetched history, so revgrep fails:

```
fatal: bad object <base-sha>
[runner] Can't process results by diff processor
```

When the diff processor fails open, golangci-lint reports every existing issue in the repo, drowning out anything actually new in the PR and forcing maintainers to ignore the check.

Reproduction:

```
git clone --depth 2 --branch <multi-commit-pr-branch> ...
cd ...
git cat-file -e <base-sha>; echo $?  # => 1
```

Fix: `fetch-depth: 0` (full history). Matches the pattern already in `release.yml:18` and `docs-deploy.yml:26`. Only the `golangci-lint` job changes; `prettier-lint` and `proto-lint` do not use `--new-from-rev`.