### PR TITLE
hscontrol/policy: reject ambiguous user references at policy load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ connected" routers that maintain their control session but cannot route packets.
 - Fix non-wildcard source IPs being dropped when combined with wildcard `*` in the same ACL rule [#2180](https://github.com/juanfont/headscale/pull/2180)
 - Fix exit node approval not triggering filter rule recalculation for peers [#2180](https://github.com/juanfont/headscale/pull/2180)
 - Policy validation error messages now include field context (e.g., `src=`, `dst=`) and are more descriptive [#2180](https://github.com/juanfont/headscale/pull/2180)
+- Reject policies whose `user@` tokens match multiple DB users; rename the duplicate via `headscale users rename` to load [#3160](https://github.com/juanfont/headscale/issues/3160)
 
 #### Grants
 
@@ -151,6 +152,7 @@ connected" routers that maintain their control session but cannot route packets.
 
 - Add `headscale auth register`, `headscale auth approve`, and `headscale auth reject` CLI commands [#1850](https://github.com/juanfont/headscale/pull/1850)
 - Deprecate `headscale nodes register --key` in favour of `headscale auth register --auth-id` [#1850](https://github.com/juanfont/headscale/pull/1850)
+- `headscale policy check --bypass-grpc-and-access-database-directly` validates `user@` tokens against the live user database [#3160](https://github.com/juanfont/headscale/issues/3160)
 - Remove deprecated `--namespace` flag from `nodes list`, `nodes register`, and `debug create-node` commands (use `--user` instead) [#3093](https://github.com/juanfont/headscale/pull/3093)
 - Remove deprecated `namespace`/`ns` command aliases for `users` and `machine`/`machines` aliases for `nodes` [#3093](https://github.com/juanfont/headscale/pull/3093)
 - **User deletion**: Fix `DestroyUser` deleting all pre-auth keys in the database instead of only the target user's keys [#3155](https://github.com/juanfont/headscale/pull/3155)

--- a/cmd/headscale/cli/policy.go
+++ b/cmd/headscale/cli/policy.go
@@ -48,6 +48,7 @@ func init() {
 	policyCmd.AddCommand(setPolicy)
 
 	checkPolicy.Flags().StringP("file", "f", "", "Path to a policy file in HuJSON format")
+	checkPolicy.Flags().BoolP(bypassFlag, "", false, "Uses the headscale config to directly access the database, bypassing gRPC and does not require the server to be running. Required to validate that user@ tokens resolve against the user database; without it, the check is syntax-only.")
 	mustMarkRequired(checkPolicy, "file")
 	policyCmd.AddCommand(checkPolicy)
 }
@@ -178,12 +179,35 @@ var checkPolicy = &cobra.Command{
 			return fmt.Errorf("reading policy file: %w", err)
 		}
 
-		_, err = policy.NewPolicyManager(policyBytes, nil, views.Slice[types.NodeView]{})
+		var users []types.User
+
+		if bypass, _ := cmd.Flags().GetBool(bypassFlag); bypass {
+			if !confirmAction(cmd, "DO NOT run this command if an instance of headscale is running, are you sure headscale is not running?") {
+				return errAborted
+			}
+
+			d, err := bypassDatabase()
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+
+			users, err = d.ListUsers()
+			if err != nil {
+				return fmt.Errorf("loading users for policy validation: %w", err)
+			}
+		}
+
+		_, err = policy.NewPolicyManager(policyBytes, users, views.Slice[types.NodeView]{})
 		if err != nil {
 			return fmt.Errorf("parsing policy file: %w", err)
 		}
 
-		fmt.Println("Policy is valid")
+		if users == nil {
+			fmt.Println("Policy syntax is valid (run with --" + bypassFlag + " to also validate user references against the database)")
+		} else {
+			fmt.Println("Policy is valid")
+		}
 
 		return nil
 	},

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -20,6 +20,7 @@ import (
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/views"
 	"tailscale.com/util/deephash"
+	"tailscale.com/util/multierr"
 )
 
 // ErrInvalidTagOwner is returned when a tag owner is not an Alias type.
@@ -73,6 +74,91 @@ type filterAndPolicy struct {
 	Policy *Policy
 }
 
+// validateUserReferences surfaces ambiguous user@ tokens at policy load so
+// duplicate DB rows fail loudly instead of silently dropping rules (#3160).
+// Missing-user tokens stay tolerant (#2863). Empty users → no-op for
+// syntax-only checks.
+func validateUserReferences(pol *Policy, users types.Users) error {
+	if pol == nil || len(users) == 0 {
+		return nil
+	}
+
+	var errs []error
+
+	check := func(u *Username) {
+		if u == nil {
+			return
+		}
+
+		_, err := u.resolveUser(users)
+		if err != nil && errors.Is(err, ErrMultipleUsersFound) {
+			errs = append(errs, err)
+		}
+	}
+
+	checkAlias := func(a Alias) {
+		if u, ok := a.(*Username); ok {
+			check(u)
+		}
+	}
+
+	checkOwner := func(o Owner) {
+		if u, ok := o.(*Username); ok {
+			check(u)
+		}
+	}
+
+	checkAutoApprover := func(aa AutoApprover) {
+		if u, ok := aa.(*Username); ok {
+			check(u)
+		}
+	}
+
+	for _, usernames := range pol.Groups {
+		for i := range usernames {
+			check(&usernames[i])
+		}
+	}
+
+	for _, owners := range pol.TagOwners {
+		for _, o := range owners {
+			checkOwner(o)
+		}
+	}
+
+	for _, approvers := range pol.AutoApprovers.Routes {
+		for _, aa := range approvers {
+			checkAutoApprover(aa)
+		}
+	}
+
+	for _, aa := range pol.AutoApprovers.ExitNode {
+		checkAutoApprover(aa)
+	}
+
+	for _, acl := range pol.ACLs {
+		for _, src := range acl.Sources {
+			checkAlias(src)
+		}
+
+		for _, dst := range acl.Destinations {
+			checkAlias(dst.Alias)
+		}
+	}
+
+	for _, ssh := range pol.SSHs {
+		for _, src := range ssh.Sources {
+			checkAlias(src)
+		}
+
+		for _, dst := range ssh.Destinations {
+			checkAlias(dst)
+		}
+	}
+
+	return multierr.New(errs...)
+}
+
 // NewPolicyManager creates a new PolicyManager from a policy file and a list of users and nodes.
 // It returns an error if the policy file is invalid.
 // The policy manager will update the filter rules based on the users and nodes.
@@ -80,6 +166,11 @@ func NewPolicyManager(b []byte, users []types.User, nodes views.Slice[types.Node
 	policy, err := unmarshalPolicy(b)
 	if err != nil {
 		return nil, fmt.Errorf("parsing policy: %w", err)
+	}
+
+	err = validateUserReferences(policy, users)
+	if err != nil {
+		return nil, fmt.Errorf("validating policy user references: %w", err)
 	}
 
 	pm := PolicyManager{
@@ -350,6 +441,11 @@ func (pm *PolicyManager) SetPolicy(polB []byte) (bool, error) {
 
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
+
+	err = validateUserReferences(pol, pm.users)
+	if err != nil {
+		return false, fmt.Errorf("validating policy user references: %w", err)
+	}
 
 	// Log policy metadata for debugging
 	log.Debug().

--- a/hscontrol/policy/v2/policy_test.go
+++ b/hscontrol/policy/v2/policy_test.go
@@ -1854,3 +1854,164 @@ func TestBuildPeerMap_AutogroupInternetMakesExitNodeVisible(t *testing.T) {
 	require.True(t, aliceNode.View().CanAccess(matchers, exitNode.View()),
 		"alice.CanAccess(exit) should be true via DestsIsTheInternet()+IsExitNode() (#3212)")
 }
+
+// Reproduction for #3160: ambiguous user@ used to silently drop rules.
+func TestNewPolicyManager_DuplicateUsername(t *testing.T) {
+	users := types.Users{
+		{Model: gorm.Model{ID: 2}, Name: "yala"},
+		{Model: gorm.Model{ID: 7}, Name: "yala", Email: "yala@yala.yala"},
+	}
+
+	polB := []byte(`{
+  "groups":    {"group:admins": ["yala@"]},
+  "tagOwners": {"tag:ssh": ["group:admins"]},
+  "acls":      [{"action":"accept","src":["*"],"dst":["*:*"]}],
+  "ssh": [
+    {"action":"accept","src":["group:admins"],"dst":["tag:ssh"],"users":["root"]}
+  ]
+}`)
+
+	_, err := NewPolicyManager(polB, users, types.Nodes{}.ViewSlice())
+	require.Error(t, err, "NewPolicyManager must reject policy with ambiguous username")
+	require.ErrorIs(t, err, ErrMultipleUsersFound)
+	require.Contains(t, err.Error(), "yala@",
+		"error must name the offending token")
+}
+
+// Missing-user tokens stay tolerant per #2863; only multi-match blocks load.
+func TestNewPolicyManager_UnknownUsernameTolerant(t *testing.T) {
+	users := types.Users{
+		{Model: gorm.Model{ID: 1}, Name: "alice"},
+	}
+
+	polB := []byte(`{
+  "acls": [{"action":"accept","src":["ghost@"],"dst":["*:*"]}]
+}`)
+
+	_, err := NewPolicyManager(polB, users, types.Nodes{}.ViewSlice())
+	require.NoError(t, err, "missing-user references must not block policy load (#2863)")
+}
+
+// Rejected SetPolicy must keep the previous policy intact.
+func TestSetPolicy_DuplicateUsername(t *testing.T) {
+	users := types.Users{
+		{Model: gorm.Model{ID: 2}, Name: "yala"},
+		{Model: gorm.Model{ID: 7}, Name: "yala", Email: "yala@yala.yala"},
+	}
+
+	good := []byte(`{
+  "acls": [{"action":"accept","src":["*"],"dst":["*:*"]}]
+}`)
+
+	pm, err := NewPolicyManager(good, users, types.Nodes{}.ViewSlice())
+	require.NoError(t, err)
+
+	bad := []byte(`{
+  "groups": {"group:admins": ["yala@"]},
+  "acls":   [{"action":"accept","src":["group:admins"],"dst":["*:*"]}]
+}`)
+
+	_, err = pm.SetPolicy(bad)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrMultipleUsersFound)
+
+	filter, _ := pm.Filter()
+	require.NotNil(t, filter, "filter must remain populated after rejected SetPolicy")
+}
+
+// Empty users → syntax-only check, used by `headscale policy check`.
+func TestValidateUserReferences_EmptyUsersTolerant(t *testing.T) {
+	polB := []byte(`{
+  "groups":    {"group:admins": ["yala@"]},
+  "tagOwners": {"tag:ssh": ["group:admins"]},
+  "acls":      [{"action":"accept","src":["yala@"],"dst":["*:*"]}],
+  "ssh": [
+    {"action":"accept","src":["yala@"],"dst":["tag:ssh"],"users":["root"]}
+  ]
+}`)
+
+	_, err := NewPolicyManager(polB, nil, types.Nodes{}.ViewSlice())
+	require.NoError(t, err, "nil users must skip user-reference validation")
+
+	_, err = NewPolicyManager(polB, types.Users{}, types.Nodes{}.ViewSlice())
+	require.NoError(t, err, "empty users must skip user-reference validation")
+}
+
+// One case per AST site so a dropped walk fails the matching subtest.
+func TestValidateUserReferences_AllSites(t *testing.T) {
+	users := types.Users{
+		{Model: gorm.Model{ID: 1}, Name: "alice"},
+		{Model: gorm.Model{ID: 2}, Name: "dup"},
+		{Model: gorm.Model{ID: 3}, Name: "dup"},
+	}
+
+	tests := []struct {
+		name string
+		pol  string
+	}{
+		{
+			name: "groups",
+			pol: `{
+  "groups": {"group:admins": ["dup@"]},
+  "acls":   [{"action":"accept","src":["group:admins"],"dst":["*:*"]}]
+}`,
+		},
+		{
+			name: "tagOwners",
+			pol: `{
+  "tagOwners": {"tag:ssh": ["dup@"]},
+  "acls":      [{"action":"accept","src":["*"],"dst":["*:*"]}]
+}`,
+		},
+		{
+			name: "autoApprovers.routes",
+			pol: `{
+  "autoApprovers": {"routes": {"10.0.0.0/8": ["dup@"]}},
+  "acls":          [{"action":"accept","src":["*"],"dst":["*:*"]}]
+}`,
+		},
+		{
+			name: "autoApprovers.exitNode",
+			pol: `{
+  "autoApprovers": {"exitNode": ["dup@"]},
+  "acls":          [{"action":"accept","src":["*"],"dst":["*:*"]}]
+}`,
+		},
+		{
+			name: "acls.src",
+			pol: `{
+  "acls": [{"action":"accept","src":["dup@"],"dst":["*:*"]}]
+}`,
+		},
+		{
+			name: "acls.dst",
+			pol: `{
+  "acls": [{"action":"accept","src":["alice@"],"dst":["dup@:*"]}]
+}`,
+		},
+		{
+			name: "ssh.src",
+			pol: `{
+  "tagOwners": {"tag:ssh": ["alice@"]},
+  "acls":      [{"action":"accept","src":["*"],"dst":["*:*"]}],
+  "ssh": [{"action":"accept","src":["dup@"],"dst":["tag:ssh"],"users":["root"]}]
+}`,
+		},
+		{
+			// ErrSSHUserDestRequiresSameUser forces src==dst when dst is a user.
+			name: "ssh.dst",
+			pol: `{
+  "acls": [{"action":"accept","src":["*"],"dst":["*:*"]}],
+  "ssh": [{"action":"accept","src":["dup@"],"dst":["dup@"],"users":["root"]}]
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewPolicyManager([]byte(tt.pol), users, types.Nodes{}.ViewSlice())
+			require.Error(t, err, "site %q must surface duplicate-user errors", tt.name)
+			require.ErrorIs(t, err, ErrMultipleUsersFound)
+		})
+	}
+}


### PR DESCRIPTION
Two DB rows sharing a username (typically the legacy + OIDC-created pair from #2785) made every `user@` token in the policy ambiguous. The resolver returned `ErrMultipleUsersFound`, but every caller — `compileFilterRules`, `compileSSHPolicy`, `resolveTagOwners`, `resolveAutoApprovers` — silently dropped the affected rule. The client saw `SSHPolicy={"rules": null}` and `tailscale ssh` failed with `tailnet policy does not permit you to SSH to this node`, with no signal to the admin that the policy was broken.

This adds a load-time pass that walks every `Username` reference in groups, tagOwners, autoApprovers, ACLs, and SSH rules and surfaces `ErrMultipleUsersFound` from `NewPolicyManager` and `(*PolicyManager).SetPolicy`. Server startup, file reload, and gRPC `SetPolicy` all share that path. Missing-user references stay tolerant per #2863 — only the duplicate-row ambiguity is blocking.

`headscale policy check` gets `--bypass-grpc-and-access-database-directly` so admins can run the same validation against the live user list without starting the server. Without the flag the command remains a syntax-only check and the success message now says so.

Fix-side for affected admins is `headscale users rename` on the duplicate, as walked through in the issue thread.

Fixes #3160

Generated with the help of an AI assistant