### PR TITLE
.github: enforce issue references in PR commit messages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,5 +18,4 @@ If you find mistakes in the documentation, please submit a fix to the documentat
 - [ ] added integration tests
 - [ ] updated documentation if needed
 - [ ] updated CHANGELOG.md
-
-<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
+- [ ] referenced an issue in every commit message (e.g. `Fixes #N` or `Updates #N`) — see [CONTRIBUTING.md](./CONTRIBUTING.md#commit-messages)

--- a/.github/scripts/commit-lint.nu
+++ b/.github/scripts/commit-lint.nu
@@ -1,0 +1,83 @@
+# Commit message linter for headscale.
+#
+# Mirrors the rule in tailscale/issuebot (cmd/issuebot/issuebot.go:107-145):
+# every non-trivial commit in a pull request must reference an issue.
+#
+# A commit passes if any of the following hold:
+#
+#   - The author name or email contains "[bot]" (dependabot, renovate, etc.).
+#   - The subject starts with "Revert " (revert inherits context).
+#   - A line in the body equals "#cleanup" (trivial cleanup escape hatch).
+#   - The token "skip-issuebot" appears anywhere in the body.
+#   - At least one line in subject or body matches:
+#       (?i)^\s*(close[ds]?|fix(es|ed)?|resolve[ds]?|updates|for)\b.*(#|github.com)
+#
+# Cross-repo refs (org/repo#N) and full GitHub issue URLs are accepted because
+# the rule only requires the literal "#" or substring "github.com" on the
+# matching line.
+
+const ISSUE_REF_PATTERN = '(?im)^\s*(close[ds]?|fix(es|ed)?|resolve[ds]?|updates|for)\b.*(#|github\.com)'
+
+# Pure rule check. Returns {ok: bool, reason: string}.
+export def check-commit-message [
+    author: string,
+    subject: string,
+    body: string,
+] {
+    if ($author | str contains '[bot]') {
+        return {ok: true, reason: "skip:bot-author"}
+    }
+
+    if ($subject | str starts-with 'Revert ') {
+        return {ok: true, reason: "skip:revert"}
+    }
+
+    let lines = ($body | lines)
+
+    if ($lines | any {|l| ($l | str trim) == '#cleanup' }) {
+        return {ok: true, reason: "skip:cleanup"}
+    }
+
+    if ($lines | any {|l| $l | str contains 'skip-issuebot' }) {
+        return {ok: true, reason: "skip:skip-issuebot"}
+    }
+
+    if ($body =~ $ISSUE_REF_PATTERN) {
+        return {ok: true, reason: "ref:matched"}
+    }
+
+    {ok: false, reason: "no issue reference"}
+}
+
+# Walk `git rev-list $base..$head` and lint each commit. Emits GitHub
+# workflow annotations on failure and exits 1 if any commit fails.
+export def lint-range [base: string, head: string] {
+    let raw = (git rev-list $"($base)..($head)" | str trim)
+    if ($raw | is-empty) {
+        print "No commits to lint."
+        return
+    }
+    let shas = ($raw | lines)
+
+    mut failed = 0
+    for sha in $shas {
+        let author = (git log -1 --format='%an <%ae>' $sha | str trim)
+        let subject = (git log -1 --format='%s' $sha | str trim)
+        let body = (git log -1 --format='%B' $sha)
+        let result = (check-commit-message $author $subject $body)
+        let short = ($sha | str substring 0..7)
+        if $result.ok {
+            print $"ok    ($short)  ($result.reason)  ($subject)"
+        } else {
+            print $"::error::Commit ($sha) does not reference an issue. Add 'Fixes #N' or 'Updates #N', or use a skip token."
+            print $"  subject: ($subject)"
+            print $"  author:  ($author)"
+            $failed = $failed + 1
+        }
+    }
+
+    if $failed > 0 {
+        print $"::error::($failed) commits missing issue reference."
+        exit 1
+    }
+}

--- a/.github/scripts/commit-lint.test.nu
+++ b/.github/scripts/commit-lint.test.nu
@@ -1,0 +1,63 @@
+# Unit tests for commit-lint.nu.
+#
+# Drives the pure rule with fixture records (no git, no I/O). Run with:
+#
+#     nu .github/scripts/commit-lint.test.nu
+#
+# Exits non-zero on the first failing case.
+
+use std/assert
+use commit-lint.nu *
+
+def cases [] {
+    [
+        # [label, author, subject, body, expect_ok]
+
+        # Accepted refs.
+        ["fixes #N",         "user <u@e>",         "feat: x",            "feat: x\n\nFixes #1",                              true],
+        ["updates #N",       "user <u@e>",         "feat: x",            "feat: x\n\nUpdates #1",                            true],
+        ["closes #N",        "user <u@e>",         "feat: x",            "feat: x\n\nCloses #1",                             true],
+        ["resolves #N",      "user <u@e>",         "feat: x",            "feat: x\n\nResolves #1",                           true],
+        ["for #N",           "user <u@e>",         "feat: x",            "feat: x\n\nFor #1",                                true],
+        ["lowercase fixes",  "user <u@e>",         "feat: x",            "feat: x\n\nfixes #1",                              true],
+        ["closed past",      "user <u@e>",         "feat: x",            "feat: x\n\nclosed #1",                             true],
+        ["fixed past",       "user <u@e>",         "feat: x",            "feat: x\n\nfixed #1",                              true],
+        ["resolved past",    "user <u@e>",         "feat: x",            "feat: x\n\nresolved #1",                           true],
+        ["cross-repo",       "user <u@e>",         "feat: x",            "feat: x\n\nUpdates juanfont/headscale#1",          true],
+        ["url form",         "user <u@e>",         "feat: x",            "feat: x\n\nFixes https://github.com/o/r/issues/1", true],
+        ["leading whitespace","user <u@e>",        "feat: x",            "feat: x\n\n  Fixes #1",                            true],
+
+        # Skip tokens.
+        ["bot author",       "dependabot[bot] <>", "bump deps",          "bump deps",                                        true],
+        ["renovate bot",     "renovate[bot] <>",   "deps",               "deps",                                             true],
+        ["bot author email", "ci <bot@example>",   "feat: x",            "feat: x",                                          false],
+        ["revert subject",   "user <u@e>",         "Revert \"feat: x\"", "Revert \"feat: x\"",                               true],
+        ["#cleanup token",   "user <u@e>",         "fmt",                "fmt\n\n#cleanup",                                  true],
+        ["#cleanup w space", "user <u@e>",         "fmt",                "fmt\n\n  #cleanup  ",                              true],
+        ["skip-issuebot",    "user <u@e>",         "wip",                "wip\n\nskip-issuebot",                             true],
+
+        # Rejected.
+        ["no ref",           "user <u@e>",         "feat: x",            "feat: x",                                          false],
+        ["verb without #",   "user <u@e>",         "feat: x",            "feat: x\n\nFixes the parser",                      false],
+        ["# without verb",   "user <u@e>",         "feat: x",            "feat: x\n\nrelated to bug #1",                     false],
+        ["fake bot in body", "user <u@e>",         "feat: x",            "feat: x\n\nlooks like a [bot]",                    false],
+        ["fake revert body", "user <u@e>",         "feat: x",            "feat: x\n\nRevert this later",                     false],
+        ["#cleanup not alone","user <u@e>",        "feat: x",            "feat: x\n\nstart #cleanup end",                    false],
+    ]
+}
+
+def main [] {
+    let rows = (cases)
+    mut passed = 0
+    for row in $rows {
+        let label = ($row | get 0)
+        let author = ($row | get 1)
+        let subject = ($row | get 2)
+        let body = ($row | get 3)
+        let expected = ($row | get 4)
+        let result = (check-commit-message $author $subject $body)
+        assert ($result.ok == $expected) $"case '($label)': expected ok=($expected), got ($result)"
+        $passed = $passed + 1
+    }
+    print $"all ($passed) cases passed"
+}

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,39 @@
+name: Commit Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Rule unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: hustcer/setup-nu@920172d92eb04671776f3ba69d605d3b09351c30 # v3.22
+        with:
+          version: "*"
+      - name: Run rule unit tests
+        run: nu commit-lint.test.nu
+        working-directory: .github/scripts
+
+  check:
+    name: Issue references in commits
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+      - uses: hustcer/setup-nu@920172d92eb04671776f3ba69d605d3b09351c30 # v3.22
+        with:
+          version: "*"
+      - name: Check that PR commits reference an issue
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          nu -c 'use .github/scripts/commit-lint.nu *; lint-range $env.BASE_SHA $env.HEAD_SHA'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,3 +32,27 @@ Headscale is open to code contributions for bug fixes without discussion.
 ## Documentation
 
 If you find mistakes in the documentation, please submit a fix to the documentation.
+
+## Commit messages
+
+Every commit in a pull request must reference a GitHub issue. CI enforces this via `.github/scripts/commit-lint.nu`.
+
+Use one of the following at the start of a line in the commit body:
+
+- `Fixes #N` — closes issue N when the PR merges.
+- `Updates #N` — references issue N without closing it.
+
+Cross-repo references (`Updates juanfont/headscale#N`) and full GitHub issue URLs are accepted.
+
+The full set of accepted verbs (case-insensitive) is: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`, `updates`, `for`.
+
+### Skip tokens
+
+Some commits do not need an issue reference:
+
+- Authors containing `[bot]` (e.g. `dependabot[bot]`, `renovate[bot]`) are skipped.
+- Subjects starting with `Revert ` are skipped (the original commit carries the reference).
+- A line equal to `#cleanup` skips trivial cleanups.
+- The token `skip-issuebot` anywhere in the body skips a commit.
+
+This rule is modelled after [tailscale/issuebot](https://github.com/tailscale/issuebot).


### PR DESCRIPTION
Adds a per-commit lint that requires every commit in a pull request to reference a GitHub issue, modelled after [`tailscale/issuebot`](https://github.com/tailscale/issuebot) but implemented as a self-contained GitHub Action. No hosted daemon, no GitHub App, no new toolchain — it reuses the nushell setup already present in `.github/workflows/needs-more-info-timer.yml`.

The rule is a pure function in `.github/scripts/commit-lint.nu`, exercised by a 25-case fixture suite that runs without git. The workflow has two jobs: `test` runs the fixtures, `check` runs `lint-range` over the PR commit range. `test` gates `check` so a broken rule never lands silently.

Accepted forms: `Fixes #N`, `Updates #N`, cross-repo refs (`org/repo#N`), full GitHub issue URLs, plus the full `tailscale/issuebot` verb set. Skip tokens: `[bot]` authors, `Revert` subjects, `#cleanup` lines, `skip-issuebot`. All documented in `CONTRIBUTING.md`.

Branch protection on `main` needs a manual flip to require `Commit Lint / check` once this lands.

> Generated with the help of an AI assistant