### PR TITLE
integration: retry transient docker network ops

### DIFF
--- a/.github/workflows/gh-action-integration-generator.go
+++ b/.github/workflows/gh-action-integration-generator.go
@@ -68,6 +68,7 @@ func findTests() []string {
 	args := []string{
 		"--type", "go",
 		"--regexp", "func (Test.+)\\(.*",
+		"--max-depth", "1",
 		"../../integration/",
 		"--replace", "$1",
 		"--sort", "path",

--- a/hscontrol/state/ha_health.go
+++ b/hscontrol/state/ha_health.go
@@ -71,8 +71,6 @@ func (p *HAHealthProber) ProbeOnce(
 
 	var wg sync.WaitGroup
 
-	deadline := time.After(p.cfg.ProbeTimeout)
-
 	for _, id := range nodeIDs {
 		if !p.isConnected(id) {
 			log.Debug().
@@ -90,6 +88,9 @@ func (p *HAHealthProber) ProbeOnce(
 		}))
 
 		wg.Go(func() {
+			timer := time.NewTimer(p.cfg.ProbeTimeout)
+			defer timer.Stop()
+
 			select {
 			case latency := <-responseCh:
 				log.Debug().
@@ -105,7 +106,7 @@ func (p *HAHealthProber) ProbeOnce(
 						Msg("HA probe: node recovered, recalculating primaries")
 				}
 
-			case <-deadline:
+			case <-timer.C:
 				p.state.CancelPing(pingID)
 
 				if !p.isConnected(id) {

--- a/integration/dockertestutil/network.go
+++ b/integration/dockertestutil/network.go
@@ -132,7 +132,6 @@ func DisconnectContainerFromNetwork(
 	return retryDockerOp(context.Background(), func() error {
 		return pool.Client.DisconnectNetwork(network.Network.ID, docker.NetworkConnectionOptions{
 			Container: containers[0].ID,
-			Force:     true,
 		})
 	})
 }

--- a/integration/dockertestutil/network.go
+++ b/integration/dockertestutil/network.go
@@ -1,17 +1,34 @@
 package dockertestutil
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
 	"net"
+	"time"
 
+	"github.com/cenkalti/backoff/v5"
 	"github.com/juanfont/headscale/hscontrol/util"
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
 )
 
 var ErrContainerNotFound = errors.New("container not found")
+
+// retryDockerOp absorbs eventual-consistency races in libnetwork endpoint cleanup.
+func retryDockerOp(ctx context.Context, op func() error) error {
+	_, err := backoff.Retry(ctx, func() (struct{}, error) {
+		err := op()
+		if err != nil {
+			return struct{}{}, err
+		}
+
+		return struct{}{}, nil
+	}, backoff.WithBackOff(backoff.NewExponentialBackOff()), backoff.WithMaxElapsedTime(30*time.Second))
+
+	return err
+}
 
 func GetFirstOrCreateNetwork(pool *dockertest.Pool, name string) (*dockertest.Network, error) {
 	return GetFirstOrCreateNetworkWithSubnet(pool, name, "")
@@ -72,13 +89,6 @@ func AddContainerToNetwork(
 		return err
 	}
 
-	err = pool.Client.ConnectNetwork(network.Network.ID, docker.NetworkConnectionOptions{
-		Container: containers[0].ID,
-	})
-	if err != nil {
-		return err
-	}
-
 	// TODO(kradalby): This doesn't work reliably, but calling the exact same functions
 	// seem to work fine...
 	// if container, ok := pool.ContainerByName("/" + testContainer); ok {
@@ -88,7 +98,11 @@ func AddContainerToNetwork(
 	// 	}
 	// }
 
-	return nil
+	return retryDockerOp(context.Background(), func() error {
+		return pool.Client.ConnectNetwork(network.Network.ID, docker.NetworkConnectionOptions{
+			Container: containers[0].ID,
+		})
+	})
 }
 
 // DisconnectContainerFromNetwork removes the container from network at
@@ -115,9 +129,11 @@ func DisconnectContainerFromNetwork(
 		return fmt.Errorf("%w: %s", ErrContainerNotFound, testContainer)
 	}
 
-	return pool.Client.DisconnectNetwork(network.Network.ID, docker.NetworkConnectionOptions{
-		Container: containers[0].ID,
-		Force:     true,
+	return retryDockerOp(context.Background(), func() error {
+		return pool.Client.DisconnectNetwork(network.Network.ID, docker.NetworkConnectionOptions{
+			Container: containers[0].ID,
+			Force:     true,
+		})
 	})
 }
 

--- a/integration/dockertestutil/network_test.go
+++ b/integration/dockertestutil/network_test.go
@@ -1,0 +1,56 @@
+package dockertestutil
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+var (
+	errTransientEndpointExists = errors.New("endpoint with name foo already exists in network bar")
+	errPermanent               = errors.New("permanent error")
+)
+
+func TestRetryDockerOp_RecoversFromTransient(t *testing.T) {
+	var attempts atomic.Int32
+
+	op := func() error {
+		if attempts.Add(1) < 3 {
+			return errTransientEndpointExists
+		}
+
+		return nil
+	}
+
+	err := retryDockerOp(context.Background(), op)
+	if err != nil {
+		t.Fatalf("retryDockerOp should recover from 2 transient errors, got: %v", err)
+	}
+
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("expected 3 attempts, got %d", got)
+	}
+}
+
+func TestRetryDockerOp_RespectsContextCancellation(t *testing.T) {
+	op := func() error {
+		return errPermanent
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := retryDockerOp(ctx, op)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("retryDockerOp should fail when op always errors")
+	}
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("retryDockerOp should honour ctx deadline (~200ms), took %s", elapsed)
+	}
+}


### PR DESCRIPTION
`TestHASubnetRouterFailoverDockerDisconnect` flaked on phase 4c reconnect (5/6 attempts on [#3226](https://github.com/juanfont/headscale/pull/3226) CI). Debugging surfaced three independent bugs:

**Docker daemon eventual-consistency on connect.** `ConnectNetwork` right after a matching `DisconnectNetwork` returns transient errors like `endpoint with name X already exists`. `dockertestutil` now wraps the daemon calls in `backoff.Retry` with 30s `MaxElapsedTime`.

**Force-disconnect leaks routes.** `DisconnectNetwork(Force=true)` left stale entries in the container's namespace route table; the next `ConnectNetwork` failed with `cannot program address ... conflicts with existing route` and never recovered on its own, so the retry above exhausted instead of absorbing. Drop `Force`. Cable-pull semantic preserved — paired probe timeouts on both routers are visible in prober logs while they are physically disconnected.

**HA prober deadlocks when two or more nodes time out in one cycle.** `time.After(ProbeTimeout)` returned a single channel shared by every probe goroutine. The first goroutine to receive drains it; others park on `responseCh` forever, `wg.Wait()` never returns, the scheduler loop in `app.go` stops ticking. Per-goroutine timer fixes it.

Plus: `gh-action-integration-generator.go` no longer recurses into `integration/` subpackages, so the new `dockertestutil` unit tests stay as plain `go test` jobs rather than being promoted to Docker-based integration matrix entries.

Three consecutive local runs of the test pass cleanly. Unit tests for `retryDockerOp` lock recovery and context-bound behaviour.

Fixes #3234

Generated with the help of an AI assistant