### PR TITLE
policy/v2: fix autogroup:internet via grants on exit nodes

### DIFF
--- a/hscontrol/policy/v2/compiled.go
+++ b/hscontrol/policy/v2/compiled.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 
 	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/juanfont/headscale/hscontrol/util"
 	"github.com/rs/zerolog/log"
 	"go4.org/netipx"
 	"tailscale.com/tailcfg"
@@ -671,11 +672,10 @@ func compileViaForNode(
 		return nil
 	}
 
-	// Find matching destination prefixes.
+	// Find matching destination prefixes. SubnetRoutes() excludes exit
+	// routes, so the *Prefix check below sees only subnet advertisements;
+	// the *AutoGroup AutoGroupInternet branch checks IsExitNode() instead.
 	nodeSubnetRoutes := node.SubnetRoutes()
-	if len(nodeSubnetRoutes) == 0 {
-		return nil
-	}
 
 	var viaDstPrefixes []netip.Prefix
 
@@ -689,8 +689,19 @@ func compileViaForNode(
 				)
 			}
 		case *AutoGroup:
-			// autogroup:internet via grants do not produce
-			// PacketFilter rules on exit nodes.
+			// autogroup:internet on a via-tagged exit advertiser
+			// becomes a rule whose DstPorts enumerate
+			// util.TheInternet(). The matchers derived from this
+			// rule let Node.CanAccess surface the exit node to the
+			// grant source via DestsIsTheInternet. ReduceFilterRules
+			// strips the rule from the wire format on non-exit
+			// advertisers, preserving SaaS PacketFilter encoding.
+			if d.Is(AutoGroupInternet) && node.IsExitNode() {
+				viaDstPrefixes = append(
+					viaDstPrefixes,
+					util.TheInternet().Prefixes()...,
+				)
+			}
 		}
 	}
 

--- a/hscontrol/policy/v2/filter_test.go
+++ b/hscontrol/policy/v2/filter_test.go
@@ -3668,6 +3668,27 @@ func TestCompileViaGrant(t *testing.T) {
 		Hostinfo: &tailcfg.Hostinfo{},
 	}
 
+	// Expected rule for autogroup:internet on a via-tagged exit
+	// advertiser: SrcIPs scoped to the grant source, DstPorts
+	// enumerating util.TheInternet() prefixes.
+	internetDstPorts := make(
+		[]tailcfg.NetPortRange, 0, len(util.TheInternet().Prefixes()),
+	)
+
+	for _, p := range util.TheInternet().Prefixes() {
+		internetDstPorts = append(internetDstPorts, tailcfg.NetPortRange{
+			IP:    p.String(),
+			Ports: tailcfg.PortRangeAny,
+		})
+	}
+
+	internetWant := []tailcfg.FilterRule{
+		{
+			SrcIPs:   []string{"100.64.0.10"},
+			DstPorts: internetDstPorts,
+		},
+	}
+
 	tests := []struct {
 		name    string
 		grant   Grant
@@ -3724,11 +3745,12 @@ func TestCompileViaGrant(t *testing.T) {
 			},
 		},
 		{
-			// autogroup:internet via grants do NOT produce PacketFilter rules
-			// on exit nodes. Tailscale SaaS handles exit traffic forwarding
-			// through the client's exit node mechanism, not PacketFilter.
-			// Verified by golden captures GRANT-V14 through GRANT-V36.
-			name: "autogroup:internet with exit routes produces no rules",
+			// autogroup:internet on a via-tagged exit advertiser
+			// produces a rule with DstPorts enumerating
+			// util.TheInternet(). The matchers derived from this
+			// rule let Node.CanAccess surface the exit node to
+			// grant sources via DestsIsTheInternet.
+			name: "autogroup:internet with exit routes produces TheInternet rule",
 			grant: Grant{
 				Sources:           Aliases{up("testuser@")},
 				Destinations:      Aliases{agp(string(AutoGroupInternet))},
@@ -3738,7 +3760,7 @@ func TestCompileViaGrant(t *testing.T) {
 			node:  exitNode,
 			nodes: types.Nodes{exitNode, srcNode},
 			pol:   &Policy{},
-			want:  nil,
+			want:  internetWant,
 		},
 		{
 			name: "autogroup:internet without exit routes returns nil",

--- a/hscontrol/policy/v2/issue_3233_test.go
+++ b/hscontrol/policy/v2/issue_3233_test.go
@@ -1,0 +1,106 @@
+// A via grant scoping autogroup:internet to a tag must surface only
+// the matching exit node to the source — not strip every exit node
+// from the source's view.
+//
+// Spec: https://tailscale.com/docs/features/access-control/grants/grants-via#route-users-through-exit-nodes-based-on-location
+package v2
+
+import (
+	"net/netip"
+	"slices"
+	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"tailscale.com/net/tsaddr"
+	"tailscale.com/tailcfg"
+)
+
+// TestIssue3233ViaInternetExitVisibility loads a policy where alice's
+// only access to autogroup:internet is via tag:exit1. Alice sees her
+// tag:exit1 exit node as a peer with 0.0.0.0/0 + ::/0 in AllowedIPs,
+// and does not see bob's tag:exit2 exit node.
+func TestIssue3233ViaInternetExitVisibility(t *testing.T) {
+	t.Parallel()
+
+	users := types.Users{
+		{Model: gorm.Model{ID: 1}, Name: "alice", Email: "alice@headscale.net"},
+		{Model: gorm.Model{ID: 2}, Name: "bob", Email: "bob@headscale.net"},
+	}
+
+	exitRoutes := []netip.Prefix{tsaddr.AllIPv4(), tsaddr.AllIPv6()}
+
+	aliceLaptop := node("alice-laptop", "100.64.0.10", "fd7a:115c:a1e0::a", users[0])
+	aliceLaptop.ID = 1
+
+	aliceExit := node("alice-exit", "100.64.0.11", "fd7a:115c:a1e0::b", users[0])
+	aliceExit.ID = 2
+	aliceExit.Tags = []string{"tag:exit1"}
+	aliceExit.Hostinfo = &tailcfg.Hostinfo{RoutableIPs: exitRoutes}
+	aliceExit.ApprovedRoutes = exitRoutes
+
+	bobExit := node("bob-exit", "100.64.0.21", "fd7a:115c:a1e0::15", users[1])
+	bobExit.ID = 3
+	bobExit.Tags = []string{"tag:exit2"}
+	bobExit.Hostinfo = &tailcfg.Hostinfo{RoutableIPs: exitRoutes}
+	bobExit.ApprovedRoutes = exitRoutes
+
+	nodes := types.Nodes{aliceLaptop, aliceExit, bobExit}
+
+	policy := `{
+		"tagOwners": {
+			"tag:exit1": ["alice@headscale.net"],
+			"tag:exit2": ["bob@headscale.net"]
+		},
+		"grants": [
+			{
+				"src": ["alice@headscale.net"],
+				"dst": ["autogroup:internet"],
+				"via": ["tag:exit1"],
+				"ip": ["*"]
+			}
+		]
+	}`
+
+	pm, err := NewPolicyManager([]byte(policy), users, nodes.ViewSlice())
+	require.NoError(t, err)
+
+	t.Run("BuildPeerMap_includes_via_tagged_exit", func(t *testing.T) {
+		t.Parallel()
+
+		peerMap := pm.BuildPeerMap(nodes.ViewSlice())
+
+		require.True(t,
+			slices.ContainsFunc(peerMap[aliceLaptop.ID], func(n types.NodeView) bool {
+				return n.ID() == aliceExit.ID
+			}),
+			"alice must see her tag:exit1 exit node as a peer")
+
+		require.False(t,
+			slices.ContainsFunc(peerMap[aliceLaptop.ID], func(n types.NodeView) bool {
+				return n.ID() == bobExit.ID
+			}),
+			"alice must not see bob's tag:exit2 exit node — via grant scopes to tag:exit1")
+	})
+
+	t.Run("ViaRoutesForPeer_includes_exit_for_matching_tag", func(t *testing.T) {
+		t.Parallel()
+
+		result := pm.ViaRoutesForPeer(aliceLaptop.View(), aliceExit.View())
+		require.Contains(t, result.Include, tsaddr.AllIPv4(),
+			"alice viewing tag:exit1 exit must Include 0.0.0.0/0 — drives AllowedIPs in state.RoutesForPeer")
+		require.Contains(t, result.Include, tsaddr.AllIPv6(),
+			"alice viewing tag:exit1 exit must Include ::/0 — drives AllowedIPs in state.RoutesForPeer")
+	})
+
+	t.Run("ViaRoutesForPeer_excludes_exit_for_other_tag", func(t *testing.T) {
+		t.Parallel()
+
+		result := pm.ViaRoutesForPeer(aliceLaptop.View(), bobExit.View())
+		require.Contains(t, result.Exclude, tsaddr.AllIPv4(),
+			"alice viewing tag:exit2 exit must Exclude 0.0.0.0/0 — strips it from AllowedIPs")
+		require.Contains(t, result.Exclude, tsaddr.AllIPv6(),
+			"alice viewing tag:exit2 exit must Exclude ::/0 — strips it from AllowedIPs")
+	})
+}

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -903,10 +903,16 @@ func (pm *PolicyManager) ViaRoutesForPeer(viewer, peer types.NodeView) types.Via
 					matchedPrefixes = append(matchedPrefixes, dstPrefix)
 				}
 			case *AutoGroup:
-				// autogroup:internet via grants do NOT affect AllowedIPs or
-				// route steering for exit nodes. Tailscale SaaS handles exit
-				// traffic forwarding through the client's exit node selection
-				// mechanism, not through AllowedIPs.
+				// Per-viewer steering for autogroup:internet: a peer
+				// advertising approved exit routes is the via-tagged
+				// node's analogue of "advertises the destination".
+				// The downstream Include/Exclude split below restricts
+				// alice to exit nodes carrying the via tag.
+				if d.Is(AutoGroupInternet) && peer.IsExitNode() {
+					matchedPrefixes = append(
+						matchedPrefixes, peer.ExitRoutes()...,
+					)
+				}
 			}
 		}
 

--- a/hscontrol/policy/v2/policy_test.go
+++ b/hscontrol/policy/v2/policy_test.go
@@ -1640,10 +1640,14 @@ func TestViaRoutesForPeer(t *testing.T) {
 		require.NoError(t, err)
 
 		result := pm.ViaRoutesForPeer(nodes[0].View(), nodes[1].View())
-		// Include should have only the subnet route.
-		// autogroup:internet does not produce via route effects.
+		// Include contains the subnet route plus the peer's approved
+		// exit routes — the peer holds tag:router and advertises exit
+		// routes, so autogroup:internet steering applies alongside the
+		// explicit prefix.
 		require.Contains(t, result.Include, mp("10.0.0.0/24"))
-		require.Len(t, result.Include, 1)
+		require.Contains(t, result.Include, mp("0.0.0.0/0"))
+		require.Contains(t, result.Include, mp("::/0"))
+		require.Len(t, result.Include, 3)
 		require.Empty(t, result.Exclude)
 	})
 
@@ -1713,17 +1717,20 @@ func TestViaRoutesForPeer(t *testing.T) {
 		pm, err := NewPolicyManager([]byte(pol), users, nodes.ViewSlice())
 		require.NoError(t, err)
 
-		// autogroup:internet via grants do NOT affect AllowedIPs or
-		// route steering. Tailscale SaaS handles exit traffic through
-		// the client's exit node mechanism, not ViaRoutesForPeer.
-		// Verified by golden captures GRANT-V14 through GRANT-V36.
+		// autogroup:internet via grants surface the peer's approved
+		// exit routes when the peer carries the via tag, and exclude
+		// them when it does not — restricting which exit nodes the
+		// viewer may use, per Tailscale's grants-via spec for
+		// autogroup:internet.
 		resultExit := pm.ViaRoutesForPeer(nodes[0].View(), nodes[1].View())
-		require.Empty(t, resultExit.Include)
+		require.Contains(t, resultExit.Include, mp("0.0.0.0/0"))
+		require.Contains(t, resultExit.Include, mp("::/0"))
 		require.Empty(t, resultExit.Exclude)
 
 		resultOther := pm.ViaRoutesForPeer(nodes[0].View(), nodes[2].View())
 		require.Empty(t, resultOther.Include)
-		require.Empty(t, resultOther.Exclude)
+		require.Contains(t, resultOther.Exclude, mp("0.0.0.0/0"))
+		require.Contains(t, resultOther.Exclude, mp("::/0"))
 	})
 
 	t.Run("via_routes_survive_reduce_routes", func(t *testing.T) {

--- a/hscontrol/servertest/grants_test.go
+++ b/hscontrol/servertest/grants_test.go
@@ -772,11 +772,12 @@ func TestGrantViaSubnetFilterRules(t *testing.T) {
 			"without per-node filter compilation for via grants, these rules are missing")
 }
 
-// TestGrantViaExitNodeNoFilterRules verifies that exit nodes with via grants
-// for autogroup:internet do NOT receive PacketFilter rules for exit traffic.
-// Tailscale SaaS handles exit traffic forwarding through the client's exit
-// node selection mechanism, not through PacketFilter rules. Verified by
-// golden captures GRANT-V14 through GRANT-V36.
+// TestGrantViaExitNodeNoFilterRules verifies wire-format SaaS compat:
+// the exit node's PacketFilter must not contain literal 0.0.0.0/0 or
+// ::/0 destinations. Internally, autogroup:internet via grants emit a
+// rule whose DstPorts enumerate util.TheInternet() prefixes;
+// ReduceFilterRules preserves it on exit-route advertisers but it
+// never surfaces as the literal /0 form.
 func TestGrantViaExitNodeNoFilterRules(t *testing.T) {
 	t.Parallel()
 
@@ -852,9 +853,11 @@ func TestGrantViaExitNodeNoFilterRules(t *testing.T) {
 			return nm != nil
 		})
 
-	// The exit node's PacketFilter must NOT contain rules for exit traffic.
-	// The only rules should be from the peer connectivity grant (tag:exit-a
-	// and tag:group-a can talk to each other at their Tailscale IPs).
+	// The exit node's PacketFilter must not surface exit-route
+	// destinations as the literal /0 form. The autogroup:internet via
+	// grant emits a rule with DstPorts enumerating util.TheInternet()
+	// prefixes; literal /0 would diverge from SaaS PacketFilter
+	// encoding.
 	exitNM := exitA.Netmap()
 	require.NotNil(t, exitNM)
 
@@ -862,10 +865,111 @@ func TestGrantViaExitNodeNoFilterRules(t *testing.T) {
 		for _, dst := range m.Dsts {
 			dstPrefix := netip.PrefixFrom(dst.Net.Addr(), dst.Net.Bits())
 			assert.Falsef(t, dstPrefix == exitRouteV4 || dstPrefix == exitRouteV6,
-				"exit node PacketFilter should NOT contain exit route destinations (0.0.0.0/0 or ::/0); "+
-					"autogroup:internet via grants do not produce filter rules on exit nodes (verified against Tailscale SaaS)")
+				"exit node PacketFilter must not contain literal 0.0.0.0/0 or ::/0; "+
+					"autogroup:internet via rules use util.TheInternet() prefixes")
 		}
 	}
+}
+
+// TestGrantViaExitNodeInternetVisibility verifies that a via grant
+// scoping autogroup:internet to a tag surfaces the via-tagged exit
+// node as a peer in the source client's netmap with 0.0.0.0/0 and
+// ::/0 in its AllowedIPs — the substrate the Tailscale client reads
+// to populate `tailscale exit-node list`.
+func TestGrantViaExitNodeInternetVisibility(t *testing.T) {
+	t.Parallel()
+
+	srv := servertest.NewServer(t)
+	exitUser := srv.CreateUser(t, "exit-user")
+	clientUser := srv.CreateUser(t, "cl-user")
+
+	exitRouteV4 := netip.MustParsePrefix("0.0.0.0/0")
+	exitRouteV6 := netip.MustParsePrefix("::/0")
+
+	changed, err := srv.State().SetPolicy([]byte(`{
+		"tagOwners": {
+			"tag:exit-a":  ["exit-user@"],
+			"tag:group-a": ["cl-user@"]
+		},
+		"grants": [
+			{
+				"src": ["tag:exit-a", "tag:group-a"],
+				"dst": ["tag:exit-a", "tag:group-a"],
+				"ip": ["*"]
+			},
+			{
+				"src": ["tag:group-a"],
+				"dst": ["autogroup:internet"],
+				"ip": ["*"],
+				"via": ["tag:exit-a"]
+			}
+		],
+		"autoApprovers": {
+			"exitNode": ["tag:exit-a"]
+		}
+	}`))
+	require.NoError(t, err)
+
+	if changed {
+		changes, err := srv.State().ReloadPolicy()
+		require.NoError(t, err)
+		srv.App.Change(changes...)
+	}
+
+	exitA := servertest.NewClient(t, srv, "exit-a",
+		servertest.WithUser(exitUser),
+		servertest.WithTags("tag:exit-a"))
+	clientA := servertest.NewClient(t, srv, "client-a",
+		servertest.WithUser(clientUser),
+		servertest.WithTags("tag:group-a"))
+
+	exitA.WaitForPeers(t, 1, 15*time.Second)
+	clientA.WaitForPeers(t, 1, 15*time.Second)
+
+	exitA.Direct().SetHostinfo(&tailcfg.Hostinfo{
+		BackendLogID: "servertest-exit-a-internet",
+		Hostname:     "exit-a",
+		RoutableIPs:  []netip.Prefix{exitRouteV4, exitRouteV6},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_ = exitA.Direct().SendUpdate(ctx)
+
+	exitAID := findNodeID(t, srv, "exit-a")
+	_, routeChange, err := srv.State().SetApprovedRoutes(
+		exitAID, []netip.Prefix{exitRouteV4, exitRouteV6})
+	require.NoError(t, err)
+	srv.App.Change(routeChange)
+
+	clientA.WaitForCondition(t, "client-a sees exit-a with exit AllowedIPs",
+		15*time.Second,
+		func(nm *netmap.NetworkMap) bool {
+			for _, p := range nm.Peers {
+				hi := p.Hostinfo()
+				if !hi.Valid() || hi.Hostname() != "exit-a" {
+					continue
+				}
+
+				var sawV4, sawV6 bool
+
+				for i := range p.AllowedIPs().Len() {
+					switch p.AllowedIPs().At(i) {
+					case exitRouteV4:
+						sawV4 = true
+					case exitRouteV6:
+						sawV6 = true
+					}
+				}
+
+				if sawV4 && sawV6 {
+					return true
+				}
+			}
+
+			return false
+		})
 }
 
 // hasCapMatches returns true if any Match in the slice contains a


### PR DESCRIPTION
A grant of the form `{src: alice, dst: autogroup:internet, via: tag:exit1}` was loading without error but stripping every exit node from alice's view — `tailscale exit-node list` returned "no exit nodes found".

Two sites in `policy/v2` skipped `autogroup:internet` at the compile / steering layer: `compileViaForNode`'s `*AutoGroup` arm produced no `FilterRule` for the via-tagged exit node, and `ViaRoutesForPeer`'s `*AutoGroup` arm produced no `Include`/`Exclude`. With `pm.needsPerNodeFilter` true, the exit node's matchers were empty, `BuildPeerMap` could not link source to exit, and `RoutesForPeer`'s `ReduceRoutes` stripped `0.0.0.0/0` and `::/0` from `AllowedIPs`.

The skip belongs at the wire-format layer (`ReduceFilterRules`), not at the compile layer that also feeds internal matchers. This PR lifts `autogroup:internet` handling into both `*AutoGroup` arms with the same shape used for `*Prefix` destinations: emit a `TheInternet` rule on via-tagged exit advertisers; surface `peer.ExitRoutes()` in `Include` when the peer carries the via tag, `Exclude` otherwise. `ReduceFilterRules` continues to keep the rule on exit-route advertisers' wire output and strip it elsewhere, preserving the SaaS PacketFilter encoding.

Reproduction lives in `hscontrol/policy/v2/issue_3233_test.go` (unit) and `TestGrantViaExitNodeInternetVisibility` in `hscontrol/servertest/grants_test.go` (end-to-end via netmap).

Fixes #3233

> Generated with the help of an AI assistant