### PR TITLE
config: move randomize_client_port to policy file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,10 @@ Examples that previously regressed and now work:
   - Downgrading to a previous minor version is blocked
   - Patch version changes within the same minor are always allowed
 
+#### Configuration
+
+- The global `randomize_client_port` option has been removed from `config.yaml`. Set `"randomizeClientPort": true` at the root of the ACL policy file instead. Headscale refuses to start if the old key is present.
+
 #### CLI
 
 - `headscale nodes register` is deprecated in favour of `headscale auth register --auth-id <id> --user <user>` [#1850](https://github.com/juanfont/headscale/pull/1850)

--- a/cmd/headscale/headscale_test.go
+++ b/cmd/headscale/headscale_test.go
@@ -73,5 +73,4 @@ func TestConfigLoading(t *testing.T) {
 	assert.Equal(t, "HTTP-01", viper.GetString("tls_letsencrypt_challenge_type"))
 	assert.Equal(t, fs.FileMode(0o770), util.GetFileMode("unix_socket_permission"))
 	assert.False(t, viper.GetBool("logtail.enabled"))
-	assert.False(t, viper.GetBool("randomize_client_port"))
 }

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -452,11 +452,6 @@ logtail:
   # disabled by default. Enabling this will make your clients send logs to Tailscale Inc.
   enabled: false
 
-# Enabling this option makes devices prefer a random port for WireGuard traffic over the
-# default static port 41641. This option is intended as a workaround for some buggy
-# firewall devices. See https://tailscale.com/docs/integrations/firewalls for more information.
-randomize_client_port: false
-
 # Taildrop configuration
 # Taildrop is the file sharing feature of Tailscale, allowing nodes to send files to each other.
 # https://tailscale.com/docs/features/taildrop

--- a/hscontrol/mapper/builder.go
+++ b/hscontrol/mapper/builder.go
@@ -90,6 +90,14 @@ func (b *MapResponseBuilder) WithSelfNode() *MapResponseBuilder {
 		return b
 	}
 
+	if b.mapper.state.RandomizeClientPort() {
+		if tailnode.CapMap == nil {
+			tailnode.CapMap = make(tailcfg.NodeCapMap)
+		}
+
+		tailnode.CapMap[tailcfg.NodeAttrRandomizeClientPort] = []tailcfg.RawMessage{}
+	}
+
 	b.resp.Node = tailnode
 
 	return b
@@ -264,6 +272,14 @@ func (b *MapResponseBuilder) buildTailPeers(peers views.Slice[types.NodeView]) (
 		}, b.mapper.cfg)
 		if err != nil {
 			return nil, err
+		}
+
+		if b.mapper.state.RandomizeClientPort() {
+			if tn.CapMap == nil {
+				tn.CapMap = make(tailcfg.NodeCapMap)
+			}
+
+			tn.CapMap[tailcfg.NodeAttrRandomizeClientPort] = []tailcfg.RawMessage{}
 		}
 
 		tailPeers = append(tailPeers, tn)

--- a/hscontrol/mapper/tail_test.go
+++ b/hscontrol/mapper/tail_test.go
@@ -209,10 +209,9 @@ func TestTailNode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &types.Config{
-				BaseDomain:          tt.baseDomain,
-				TailcfgDNSConfig:    tt.dnsConfig,
-				RandomizeClientPort: false,
-				Taildrop:            types.TaildropConfig{Enabled: true},
+				BaseDomain:       tt.baseDomain,
+				TailcfgDNSConfig: tt.dnsConfig,
+				Taildrop:         types.TaildropConfig{Enabled: true},
 			}
 
 			// Stub primary-route lookup: tt.node owns its SubnetRoutes,

--- a/hscontrol/policy/pm.go
+++ b/hscontrol/policy/pm.go
@@ -44,6 +44,7 @@ type PolicyManager interface {
 
 	Version() int
 	DebugString() string
+	RandomizeClientPort() bool
 }
 
 // NewPolicyManager returns a new policy manager.

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -1449,3 +1449,14 @@ func resolveTagOwners(p *Policy, users types.Users, nodes views.Slice[types.Node
 
 	return ret, nil
 }
+
+func (pm *PolicyManager) RandomizeClientPort() bool {
+	if pm == nil || pm.pol == nil {
+		return false
+	}
+
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	return pm.pol.RandomizeClientPort
+}

--- a/hscontrol/policy/v2/types.go
+++ b/hscontrol/policy/v2/types.go
@@ -1985,7 +1985,9 @@ type Policy struct {
 	ACLs          []ACL              `json:"acls,omitempty"`
 	Grants        []Grant            `json:"grants,omitempty"`
 	AutoApprovers AutoApproverPolicy `json:"autoApprovers"`
-	SSHs          []SSH              `json:"ssh,omitempty"`
+
+	RandomizeClientPort bool  `json:"randomizeClientPort,omitempty"`
+	SSHs                []SSH `json:"ssh,omitempty"`
 }
 
 // MarshalJSON is deliberately not implemented for Policy.

--- a/hscontrol/policy/v2/types_test.go
+++ b/hscontrol/policy/v2/types_test.go
@@ -2051,6 +2051,11 @@ func TestUnmarshalPolicy(t *testing.T) {
 `,
 			wantErr: "invalid localpart format",
 		},
+		{
+			name:  "randomize-client-port",
+			input: `{"randomizeClientPort": true}`,
+			want:  &Policy{RandomizeClientPort: true},
+		},
 	}
 
 	cmps := append(util.Comparers,

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -2712,3 +2712,12 @@ func peerChangeEmpty(peerChange tailcfg.PeerChange) bool {
 		peerChange.LastSeen == nil &&
 		peerChange.KeyExpiry == nil
 }
+
+// RandomizeClientPort returns whether the randomizeClientPort setting is enabled in the current policy.
+func (s *State) RandomizeClientPort() bool {
+	if s.polMan == nil {
+		return false
+	}
+
+	return s.polMan.RandomizeClientPort()
+}

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -130,9 +130,8 @@ type Config struct {
 
 	OIDC OIDCConfig
 
-	LogTail             LogTailConfig
-	RandomizeClientPort bool
-	Taildrop            TaildropConfig
+	LogTail  LogTailConfig
+	Taildrop TaildropConfig
 
 	CLI CLIConfig
 
@@ -428,7 +427,6 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("oidc.email_verified_required", true)
 
 	viper.SetDefault("logtail.enabled", false)
-	viper.SetDefault("randomize_client_port", false)
 	viper.SetDefault("taildrop.enabled", true)
 
 	viper.SetDefault("node.expiry", "0")
@@ -535,6 +533,8 @@ func validateServerConfig() error {
 
 	// Removed: oidc.expiry -> node.expiry
 	depr.fatalIfSet("oidc.expiry", "node.expiry")
+
+	depr.fatalIfSet("randomize_client_port", "policy file: randomizeClientPort")
 
 	if viper.GetBool("oidc.enabled") {
 		err := validatePKCEMethod(viper.GetString("oidc.pkce.method"))
@@ -1120,7 +1120,6 @@ func LoadServerConfig() (*Config, error) {
 
 	derpConfig := derpConfig()
 	logTailConfig := logtailConfig()
-	randomizeClientPort := viper.GetBool("randomize_client_port")
 
 	oidcClientSecret := viper.GetString("oidc.client_secret")
 
@@ -1219,8 +1218,7 @@ func LoadServerConfig() (*Config, error) {
 			},
 		},
 
-		LogTail:             logTailConfig,
-		RandomizeClientPort: randomizeClientPort,
+		LogTail: logTailConfig,
 		Taildrop: TaildropConfig{
 			Enabled: viper.GetBool("taildrop.enabled"),
 		},

--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -1185,9 +1185,6 @@ func (nv NodeView) TailNode(
 		tailcfg.CapabilityAdmin: []tailcfg.RawMessage{},
 		tailcfg.CapabilitySSH:   []tailcfg.RawMessage{},
 	}
-	if cfg.RandomizeClientPort {
-		capMap[tailcfg.NodeAttrRandomizeClientPort] = []tailcfg.RawMessage{}
-	}
 
 	if cfg.Taildrop.Enabled {
 		capMap[tailcfg.CapabilityFileSharing] = []tailcfg.RawMessage{}


### PR DESCRIPTION
Tailscale models randomize-client-port as a per-tailnet node capability (`tailcfg.NodeAttrRandomizeClientPort`); headscale carried it as a global server flag. Move it to where Tailscale puts it: a `randomizeClientPort: true` field at the ACL policy root.

The mapper injects the capability into self and peer `CapMap`s when the policy enables it. Operators with the old `randomize_client_port` key in `config.yaml` get a fatal startup error pointing at the new location, surfaced via the existing deprecation path in `validateServerConfig()`.

Breaking change for anyone using the flag — flagged in `CHANGELOG.md` under the `0.29.0` `BREAKING` block.

Generated with the help of an AI assistant