### PR TITLE
mapper bug fix: include UserProfiles in policy-change MapResponses

### DIFF
--- a/hscontrol/mapper/mapper.go
+++ b/hscontrol/mapper/mapper.go
@@ -239,7 +239,10 @@ func (m *mapper) policyChangeResponse(
 
 	// Send remaining peers in PeersChanged - their AllowedIPs may have
 	// changed due to the policy update (e.g., different routes allowed).
+	// Cross-user peers must also carry their user profile, otherwise the
+	// client's netmap shows the peer without a UserProfiles[user] entry.
 	if currentPeers.Len() > 0 {
+		builder.WithUserProfiles(currentPeers)
 		builder.WithPeerChanges(currentPeers)
 	}
 

--- a/hscontrol/servertest/issues_test.go
+++ b/hscontrol/servertest/issues_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juanfont/headscale/hscontrol/servertest"
 	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/juanfont/headscale/hscontrol/types/change"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"tailscale.com/tailcfg"
@@ -130,6 +131,39 @@ func TestIssuesMapContent(t *testing.T) {
 			assert.NotEmpty(t, peerProfile.DisplayName(),
 				"peer user profile should have a display name")
 		}
+	})
+
+	// When a new cross-user peer first becomes visible via a policy change,
+	// MapResponse should carry that peer's UserProfile alongside it.
+	// Otherwise the netmap has a peer whose owner is unknown and code
+	// reading nm.UserProfiles[peer.User()] sees a zero UserProfileView.
+	t.Run("policy_change_carries_user_profile_for_new_peer", func(t *testing.T) {
+		t.Parallel()
+
+		srv := servertest.NewServer(t)
+		user1 := srv.CreateUser(t, "pc-user1")
+		c1 := servertest.NewClient(t, srv, "pc-node1", servertest.WithUser(user1))
+
+		c1.WaitForCondition(t, "c1 has its initial netmap",
+			5*time.Second,
+			func(nm *netmap.NetworkMap) bool { return nm.SelfNode.Valid() })
+
+		// Pre-register node2 directly so c1's first view of it arrives
+		// via the policy-change broadcast, not via a per-node NodeAdded.
+		user2 := srv.CreateUser(t, "pc-user2")
+		node2 := srv.State().CreateRegisteredNodeForTest(user2, "pc-node2")
+		node2.User = user2
+		srv.State().PutNodeInStoreForTest(*node2)
+
+		srv.App.Change(change.PolicyChange())
+		c1.WaitForPeers(t, 1, 5*time.Second)
+
+		nm := c1.Netmap()
+		peer := nm.Peers[0]
+		profile, ok := nm.UserProfiles[peer.User()]
+		require.True(t, ok,
+			"peer is visible but nm.UserProfiles[%d] is missing", peer.User())
+		assert.Equal(t, "pc-user2", profile.LoginName())
 	})
 }
 


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

 ### Summary                                                                                                                                                                                                                  
   
  `policyChangeResponse` sends `PeersChanged` for current peers but never calls `WithUserProfiles(currentPeers)`. When a policy change fires alongside a new cross-user peer joining (i.e. user list grows), the resulting     
  `MapResponse` carries the new peer in `PeersChanged` but no entry in `UserProfiles` for that peer's owner. On the client, `mapSession.addUserProfile` silently skips users it has never seen in `lastUserProfile`, so the
  netmap ends up with `len(Peers) == n` but `nm.UserProfiles[peer.User()]` missing.                                                                                                                                            
                                                         
  The non-policy path (`buildFromChange`, `mapper.go:298`) already does this correctly:                                                                                                                                        
   
  ```go                                                                                                                                                                                                                        
  if len(resp.PeersChanged) > 0 {                        
      peers := m.state.ListPeers(nodeID, resp.PeersChanged...)
      builder.WithUserProfiles(peers)   // ← present
      builder.WithPeerChanges(peers)                                                                                                                                                                                           
  }
  ```                                                                                                                                                                                                                          
                                                         
  `policyChangeResponse` is missing the same call.

  ### Reproducer                                                                                                                                                                                                               
   
 This PR adds `TestIssuesMapContent/policy_change_carries_user_profile_for_new_peer` in `hscontrol/servertest/issues_test.go`, which deterministically exercises the buggy path by inserting `node2` straight into `NodeStore` and firing an explicit `change.PolicyChange()`. This test guarantees that `c1`'s first view of the peer arrives via `policyChangeResponse` — independent of registration      
  timing.                                                
                                                                                                                                                                                                                               
  The same bug also surfaces in the existing `TestIssuesMapContent/all_peers_have_user_profiles`, but only as a flaky failure: when registration is fast, the per-peer `NodeAdded` change wins the race against the user-list  
  policy change and delivers `UserProfiles[user2]` via `buildFromChange`. When registration is even ~1–2s slower, the policy-change update lands first or
  coalesces with the peer-added one inside `policyChangeResponse`, and the profile is dropped.                                                                                                                                 
                                                         
  The bug is latent in `master` — it surfaces deterministically as soon as anything stretches registration timing.