### PR TITLE
api/v1: persist omitted key expiration as NULL, not zero time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ HTTP API directly.
 ### Changes
 
 - Expiring or deleting a non-existent pre-auth key now returns an error instead of silently succeeding [#3324](https://github.com/juanfont/headscale/pull/3324)
+- Fix API keys and pre-auth keys created without an expiration being stored as `0001-01-01` instead of NULL, which made them immediately rejected as expired [#3254](https://github.com/juanfont/headscale/pull/3254)
 
 ## 0.29.1 (2026-06-18)
 

--- a/hscontrol/api/v1/apikeys.go
+++ b/hscontrol/api/v1/apikeys.go
@@ -85,14 +85,10 @@ func registerApiKeys(api huma.API, b Backend) {
 		Tags:        []string{"ApiKeys"},
 		Security:    bearerAuth,
 	}, func(ctx context.Context, in *createApiKeyInput) (*createApiKeyOutput, error) {
-		// CreateAPIKey requires a non-nil pointer; default a missing expiration
-		// to the zero time as the gRPC handler does.
-		var expiration time.Time
-		if in.Body.Expiration != nil {
-			expiration = *in.Body.Expiration
-		}
-
-		keyStr, _, err := b.State.CreateAPIKey(&expiration)
+		// A missing expiration must persist as NULL, not the zero time, or the
+		// key is rejected as already-expired on first use. Body.Expiration is
+		// already *time.Time (nil when omitted), so pass it straight through.
+		keyStr, _, err := b.State.CreateAPIKey(in.Body.Expiration)
 		if err != nil {
 			return nil, huma.Error500InternalServerError("creating api key", err)
 		}

--- a/hscontrol/api/v1/preauthkeys.go
+++ b/hscontrol/api/v1/preauthkeys.go
@@ -102,12 +102,6 @@ func registerPreAuthKeys(api huma.API, b Backend) {
 			}
 		}
 
-		// CreatePreAuthKey requires a non-nil pointer; zero-stamp when unset.
-		var expiration time.Time
-		if in.Body.Expiration != nil {
-			expiration = *in.Body.Expiration
-		}
-
 		var userID *types.UserID
 
 		if user != 0 {
@@ -119,11 +113,14 @@ func registerPreAuthKeys(api huma.API, b Backend) {
 			userID = u.TypedID()
 		}
 
+		// A missing expiration must persist as NULL, not the zero time, or the
+		// key is rejected as already-expired on first use. Body.Expiration is
+		// already *time.Time (nil when omitted), so pass it straight through.
 		preAuthKey, err := b.State.CreatePreAuthKey(
 			userID,
 			in.Body.Reusable,
 			in.Body.Ephemeral,
-			&expiration,
+			in.Body.Expiration,
 			in.Body.ACLTags,
 		)
 		if err != nil {

--- a/hscontrol/apiv1_apikeys_test.go
+++ b/hscontrol/apiv1_apikeys_test.go
@@ -54,6 +54,26 @@ func TestAPIV1ApiKeyCreate(t *testing.T) {
 		require.NoError(t, json.Unmarshal(hum.body, &humBody))
 		assert.NotEmpty(t, humBody.APIKey)
 	})
+
+	t.Run("no expiration is not immediately expired", func(t *testing.T) {
+		h := newAPIV1Harness(t)
+
+		res := h.callHuma(http.MethodPost, "/api/v1/apikey", []byte(`{}`))
+		require.Equal(t, http.StatusOK, res.status)
+
+		var got struct {
+			APIKey string `json:"apiKey"`
+		}
+		require.NoError(t, json.Unmarshal(res.body, &got))
+		require.NotEmpty(t, got.APIKey)
+
+		// A missing expiration must persist as NULL, not the zero time, or the
+		// key is rejected as already-expired on first use (regression for the
+		// fix that the gRPC handler received in #3254).
+		valid, err := h.app.state.ValidateAPIKey(got.APIKey)
+		require.NoError(t, err)
+		assert.True(t, valid, "api key created without expiration must not be expired")
+	})
 }
 
 func TestAPIV1ApiKeyList(t *testing.T) {

--- a/hscontrol/apiv1_preauthkeys_test.go
+++ b/hscontrol/apiv1_preauthkeys_test.go
@@ -76,6 +76,28 @@ func TestAPIV1CreatePreAuthKey(t *testing.T) {
 		assert.Equal(t, []any{"tag:test"}, got.PreAuthKey["aclTags"])
 	})
 
+	t.Run("no expiration persists as NULL not zero-time", func(t *testing.T) {
+		h := newAPIV1Harness(t)
+
+		// No expiration field in the body. The JSON response can't distinguish
+		// NULL from the zero time (both render as 0001-01-01), so inspect the
+		// stored key directly.
+		res := h.callHuma(http.MethodPost, "/api/v1/preauthkey",
+			[]byte(`{"aclTags":["tag:test"]}`))
+		require.Equal(t, http.StatusOK, res.status)
+
+		keys, err := h.app.state.ListPreAuthKeys()
+		require.NoError(t, err)
+		require.Len(t, keys, 1)
+
+		// A missing expiration must persist as NULL, not the zero time, or the
+		// key is rejected as already-expired on first use (regression for the
+		// fix that the gRPC handler received in #3254).
+		assert.Nil(t, keys[0].Expiration, "expiration must be NULL when omitted")
+		assert.NoError(t, keys[0].Validate(),
+			"key created without expiration must be valid")
+	})
+
 	t.Run("invalid tag parity", func(t *testing.T) {
 		h := newAPIV1Harness(t)
 		h.app.state.CreateUserForTest("alice")


### PR DESCRIPTION
CreateAPIKey and CreatePreAuthKey declared a zero-valued time.Time and passed its address to the state layer, so a request that omitted the expiration persisted 0001-01-01 instead of NULL. Both key types were then rejected as already-expired on first use. Pass the request body's *time.Time straight through (nil when omitted).

Fixes: https://github.com/infradohq/headscale-operator/issues/92

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [x] updated CHANGELOG.md