### PR TITLE
ci, Dockerfile: bump golang to 1.26.3 and fetch full history in lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Get changed files
         id: changed-files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/Dockerfile.derper
+++ b/Dockerfile.derper
@@ -1,6 +1,6 @@
 # For testing purposes only
 
-FROM golang:1.26.2-alpine AS build-env
+FROM golang:1.26.3-alpine AS build-env
 
 WORKDIR /go/src
 

--- a/Dockerfile.tailscale-HEAD
+++ b/Dockerfile.tailscale-HEAD
@@ -4,7 +4,7 @@
 # This Dockerfile is more or less lifted from tailscale/tailscale
 # to ensure a similar build process when testing the HEAD of tailscale.
 
-FROM golang:1.26.2-alpine AS build-env
+FROM golang:1.26.3-alpine AS build-env
 
 WORKDIR /go/src
 


### PR DESCRIPTION
Two unrelated build/CI fixes split out of #3251.

**Dockerfile.tailscale-HEAD, Dockerfile.derper: bump golang to 1.26.3**

Tailscale upstream `go.mod` now requires 1.26.3. Headscale's tailscale-HEAD and DERPer builder images still pin 1.26.2, so the HEAD build fails on the toolchain check.

**ci: fetch full history in golangci-lint job**

`revgrep` needs `pull_request.base.sha` reachable in the local clone to compute the diff against new code. With `fetch-depth: 2` only HEAD and one parent are fetched, so a stale base SHA (when main moves between PR syncs) is not reachable, revgrep falls through, and pre-existing issues outside the PR scope get surfaced as lint failures.