### PR TITLE
integration: harden suite against Docker Hub 429s and timing flakes

### DIFF
--- a/.github/workflows/integration-test-template.yml
+++ b/.github/workflows/integration-test-template.yml
@@ -67,22 +67,10 @@ jobs:
         with:
           name: postgres-image
           path: /tmp/artifacts
-      - name: Pin Docker to v28 (avoid v29 breaking changes)
+      - name: Force overlay2 storage driver
         run: |
-          # Docker 29 breaks docker build via Go client libraries and
-          # docker load/save with certain tarball formats.
-          # Pin to Docker 28.x until our tooling is updated.
-          # https://github.com/actions/runner-images/issues/13474
-          sudo install -m 0755 -d /etc/apt/keyrings
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
-            | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
-            https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
-            | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update -qq
-          VERSION=$(apt-cache madison docker-ce | grep '28\.5' | head -1 | awk '{print $3}')
-          sudo apt-get install -y --allow-downgrades \
-            "docker-ce=${VERSION}" "docker-ce-cli=${VERSION}"
+          sudo mkdir -p /etc/docker
+          echo '{"storage-driver":"overlay2"}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker version
       - name: Load Docker images, Go cache, and prepare binary

--- a/.github/workflows/integration-test-template.yml
+++ b/.github/workflows/integration-test-template.yml
@@ -73,6 +73,15 @@ jobs:
           echo '{"storage-driver":"overlay2"}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker version
+      - name: Login to Docker Hub
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_CI_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_CI_TOKEN }}
+        if: env.DOCKERHUB_USERNAME != ''
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: Load Docker images, Go cache, and prepare binary
         run: |
           gunzip -c /tmp/artifacts/headscale-image.tar.gz | docker load
@@ -93,6 +102,12 @@ jobs:
           HEADSCALE_INTEGRATION_POSTGRES_IMAGE: ${{ inputs.postgres_flag == '--postgres=1' && format('postgres:{0}', github.sha) || '' }}
           HEADSCALE_INTEGRATION_GO_CACHE: /tmp/go-cache/go
           HEADSCALE_INTEGRATION_GO_BUILD_CACHE: /tmp/go-cache/.cache/go-build
+          # Mirror the docker/login-action secrets into env so the
+          # dockertestutil.Credentials resolver picks them up directly
+          # (otherwise it falls back to parsing ~/.docker/config.json,
+          # which works but is one step further from the source).
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_CI_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_CI_TOKEN }}
         run: /tmp/artifacts/hi run --stats --ts-memory-limit=300 --hs-memory-limit=1500 "^${{ inputs.test }}$" \
           --timeout=120m \
           ${{ inputs.postgres_flag }}

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -69,23 +69,15 @@ jobs:
           name: go-cache
           path: go-cache.tar.gz
           retention-days: 10
-      - name: Pin Docker to v28 (avoid v29 breaking changes)
+      - name: Force overlay2 storage driver
         if: steps.changed-files.outputs.files == 'true'
         run: |
-          # Docker 29 breaks docker build via Go client libraries and
-          # docker load/save with certain tarball formats.
-          # Pin to Docker 28.x until our tooling is updated.
+          # Docker 29 runner images default to overlayfs, which breaks
+          # docker build via Go SDK libraries and docker save/load
+          # tarball formats. overlay2 is the long-standing default.
           # https://github.com/actions/runner-images/issues/13474
-          sudo install -m 0755 -d /etc/apt/keyrings
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
-            | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
-            https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
-            | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update -qq
-          VERSION=$(apt-cache madison docker-ce | grep '28\.5' | head -1 | awk '{print $3}')
-          sudo apt-get install -y --allow-downgrades \
-            "docker-ce=${VERSION}" "docker-ce-cli=${VERSION}"
+          sudo mkdir -p /etc/docker
+          echo '{"storage-driver":"overlay2"}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker version
       - name: Build headscale image
@@ -123,22 +115,10 @@ jobs:
     needs: build
     if: needs.build.outputs.files-changed == 'true'
     steps:
-      - name: Pin Docker to v28 (avoid v29 breaking changes)
+      - name: Force overlay2 storage driver
         run: |
-          # Docker 29 breaks docker build via Go client libraries and
-          # docker load/save with certain tarball formats.
-          # Pin to Docker 28.x until our tooling is updated.
-          # https://github.com/actions/runner-images/issues/13474
-          sudo install -m 0755 -d /etc/apt/keyrings
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
-            | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
-            https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
-            | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update -qq
-          VERSION=$(apt-cache madison docker-ce | grep '28\.5' | head -1 | awk '{print $3}')
-          sudo apt-get install -y --allow-downgrades \
-            "docker-ce=${VERSION}" "docker-ce-cli=${VERSION}"
+          sudo mkdir -p /etc/docker
+          echo '{"storage-driver":"overlay2"}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker version
       - name: Pull and save postgres image

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -80,6 +80,15 @@ jobs:
           echo '{"storage-driver":"overlay2"}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker version
+      - name: Login to Docker Hub
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_CI_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_CI_TOKEN }}
+        if: env.DOCKERHUB_USERNAME != ''
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: Build headscale image
         if: steps.changed-files.outputs.files == 'true'
         run: |
@@ -121,6 +130,15 @@ jobs:
           echo '{"storage-driver":"overlay2"}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker version
+      - name: Login to Docker Hub
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_CI_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_CI_TOKEN }}
+        if: env.DOCKERHUB_USERNAME != ''
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: Pull and save postgres image
         run: |
           docker pull postgres:latest

--- a/cmd/hi/docker.go
+++ b/cmd/hi/docker.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v5"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/mount"
@@ -522,9 +523,9 @@ func checkImageAvailableLocally(ctx context.Context, cli *client.Client, imageNa
 	return true, nil
 }
 
-// ensureImageAvailable checks if the image is available locally first, then pulls if needed.
+// ensureImageAvailable pulls imageName if missing, using Docker Hub
+// credentials and retrying transient errors.
 func ensureImageAvailable(ctx context.Context, cli *client.Client, imageName string, verbose bool) error {
-	// First check if image is available locally
 	available, err := checkImageAvailableLocally(ctx, cli, imageName)
 	if err != nil {
 		return fmt.Errorf("checking local image availability: %w", err)
@@ -538,32 +539,62 @@ func ensureImageAvailable(ctx context.Context, cli *client.Client, imageName str
 		return nil
 	}
 
-	// Image not available locally, try to pull it
 	if verbose {
 		log.Printf("Image %s not found locally, pulling...", imageName)
 	}
 
-	reader, err := cli.ImagePull(ctx, imageName, image.PullOptions{})
+	registryAuth, err := dockertestutil.RegistryAuth()
 	if err != nil {
-		return fmt.Errorf("pulling image %s: %w", imageName, err)
+		return fmt.Errorf("resolving registry auth: %w", err)
 	}
-	defer reader.Close()
 
-	if verbose {
-		_, err = io.Copy(os.Stdout, reader)
-		if err != nil {
-			return fmt.Errorf("reading pull output: %w", err)
-		}
-	} else {
-		_, err = io.Copy(io.Discard, reader)
-		if err != nil {
-			return fmt.Errorf("reading pull output: %w", err)
-		}
+	_, err = backoff.Retry(
+		ctx,
+		func() (struct{}, error) {
+			reader, pullErr := cli.ImagePull(ctx, imageName, image.PullOptions{RegistryAuth: registryAuth})
+			if pullErr != nil {
+				if isPermanentDockerPullError(pullErr) {
+					return struct{}{}, backoff.Permanent(pullErr)
+				}
 
+				return struct{}{}, fmt.Errorf("pulling image %s: %w", imageName, pullErr)
+			}
+			defer reader.Close()
+
+			sink := io.Discard
+			if verbose {
+				sink = os.Stdout
+			}
+
+			_, copyErr := io.Copy(sink, reader)
+			if copyErr != nil {
+				return struct{}{}, fmt.Errorf("reading pull output: %w", copyErr)
+			}
+
+			return struct{}{}, nil
+		},
+		backoff.WithBackOff(backoff.NewExponentialBackOff()),
+		backoff.WithMaxElapsedTime(60*time.Second),
+	)
+	if err != nil {
+		return err
+	}
+
+	if !verbose {
 		log.Printf("Image %s pulled successfully", imageName)
 	}
 
 	return nil
+}
+
+func isPermanentDockerPullError(err error) bool {
+	msg := strings.ToLower(err.Error())
+
+	return strings.Contains(msg, "manifest unknown") ||
+		strings.Contains(msg, "manifest not found") ||
+		strings.Contains(msg, "repository does not exist") ||
+		strings.Contains(msg, "name unknown") ||
+		strings.Contains(msg, "no such image")
 }
 
 // listControlFiles displays the headscale test artifacts created in the control logs directory.

--- a/cmd/hi/doctor.go
+++ b/cmd/hi/doctor.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"os/exec"
 	"strings"
+
+	"github.com/juanfont/headscale/integration/dockertestutil"
 )
 
 var ErrSystemChecksFailed = errors.New("system checks failed")
@@ -34,6 +36,7 @@ func runDoctorCheck(ctx context.Context) error {
 	if dockerResult.Status == "PASS" {
 		results = append(results, checkDockerContext(ctx))
 		results = append(results, checkDockerSocket(ctx))
+		results = append(results, checkDockerHubCredentials())
 		results = append(results, checkGolangImage(ctx))
 	}
 
@@ -187,6 +190,30 @@ func checkDockerSocket(ctx context.Context) DoctorResult {
 		Name:    "Docker Socket",
 		Status:  "PASS",
 		Message: fmt.Sprintf("Docker socket accessible (Server: %s)", info.ServerVersion),
+	}
+}
+
+// checkDockerHubCredentials warns when pulls would be anonymous and
+// therefore rate-limited.
+func checkDockerHubCredentials() DoctorResult {
+	_, _, source := dockertestutil.Credentials()
+	if source == dockertestutil.CredentialSourceAnonymous {
+		return DoctorResult{
+			Name:    "Docker Hub Credentials",
+			Status:  "WARN",
+			Message: "No Docker Hub credentials found — pulls will be rate-limited (100/6h per IP)",
+			Suggestions: []string{
+				"Run: docker login",
+				"Or export DOCKERHUB_USERNAME and DOCKERHUB_TOKEN",
+				"In CI: ensure the docker/login-action step is configured with secrets",
+			},
+		}
+	}
+
+	return DoctorResult{
+		Name:    "Docker Hub Credentials",
+		Status:  "PASS",
+		Message: fmt.Sprintf("Credentials available (source: %s)", source),
 	}
 }
 

--- a/hscontrol/app.go
+++ b/hscontrol/app.go
@@ -208,7 +208,19 @@ func NewHeadscale(cfg *types.Config) (*Headscale, error) {
 		}
 
 		for _, d := range magicDNSDomains {
-			app.cfg.TailcfgDNSConfig.Routes[d.WithoutTrailingDot()] = nil
+			// Empty non-nil slice rather than nil: tailcfg.DNSConfig.Clone
+			// and dns.Config.Clone in tailscale drop map entries whose
+			// value is nil (see tailscale.com/tailcfg/tailcfg_clone.go and
+			// tailscale.com/net/dns/dns_clone.go: `if sv == nil { continue }`).
+			// Sending nil here caused the client's wgengine LinkChange:major
+			// handler to clobber /etc/resolv.conf on every tunnel-IP rebind
+			// — the handler reapplies a Clone of lastDNSConfig and the magic
+			// DNS routes vanish, taking the resolver with them for ~6 min
+			// until the next route-changing netmap. Empty slice survives
+			// Clone and carries the same "resolve locally" semantics
+			// (tailscale.com/ipn/ipnlocal/node_backend.go:869 documents the
+			// empty-resolver Routes form for Issue 2706).
+			app.cfg.TailcfgDNSConfig.Routes[d.WithoutTrailingDot()] = []*dnstype.Resolver{}
 		}
 	}
 

--- a/hscontrol/mapper/mapper.go
+++ b/hscontrol/mapper/mapper.go
@@ -314,11 +314,18 @@ func (m *mapper) selfMapResponse(
 
 // policyChangeResponse creates a MapResponse for policy changes.
 // It sends:
-// - PeersRemoved for peers that are no longer visible after the policy change
-// - PeersChanged for remaining peers (their AllowedIPs may have changed due to policy)
-// - Updated PacketFilters
-// - Updated SSHPolicy (SSH rules may reference users/groups that changed)
-// - Optionally, the node's own self info (when includeSelf is true)
+//   - PeersRemoved for peers that are no longer visible after the policy change
+//   - PeersChanged for remaining peers (their AllowedIPs may have changed due to policy)
+//   - Updated PacketFilters
+//   - Updated SSHPolicy (SSH rules may reference users/groups that changed)
+//   - DNSConfig so the client's resolver state stays anchored even when a
+//     policy-triggered wgengine reconfigure races a netmon LinkChange (the
+//     LinkChange handler reapplies dns.Manager.Set with the engine's
+//     lastDNSConfig; if that snapshot is stale, the OS resolver loses the
+//     MagicDNS reverse-DNS routes and Nameservers and curl-by-FQDN stops
+//     resolving for the rest of the policy window).
+//   - Optionally, the node's own self info (when includeSelf is true)
+//
 // This avoids the issue where an empty Peers slice is interpreted by Tailscale
 // clients as "no change" rather than "no peers".
 // When includeSelf is true, the node's self info is included so that a node
@@ -334,6 +341,7 @@ func (m *mapper) policyChangeResponse(
 	builder := m.NewMapResponseBuilder(nodeID).
 		WithDebugType(policyResponseDebug).
 		WithCapabilityVersion(capVer).
+		WithDNSConfig().
 		WithPacketFilters().
 		WithSSHPolicy()
 

--- a/hscontrol/servertest/ha_dynamic_test.go
+++ b/hscontrol/servertest/ha_dynamic_test.go
@@ -72,7 +72,7 @@ func TestHAFailover_ViewerSeesPrimaryFlip(t *testing.T) {
 			return hasPeerPrimaryRoute(nm, "dyn-flip-r1", route)
 		})
 
-	changed := srv.State().SetNodeUnhealthy(id1, true)
+	changed := srv.State().SetNodeHealth(id1, false)
 	require.True(t, changed, "marking primary unhealthy should change primaries")
 
 	srv.App.Change(change.PolicyChange())

--- a/hscontrol/servertest/ha_health_test.go
+++ b/hscontrol/servertest/ha_health_test.go
@@ -111,7 +111,7 @@ func TestHAHealthProbe_UnhealthyFailover(t *testing.T) {
 	require.Contains(t, primaries, route, "node 1 should be primary initially")
 
 	// Mark node 1 unhealthy — should failover to node 2.
-	changed := srv.State().SetNodeUnhealthy(nodeID1, true)
+	changed := srv.State().SetNodeHealth(nodeID1, false)
 	assert.True(t, changed, "marking primary unhealthy should change primaries")
 
 	primaries2 := srv.State().GetNodePrimaryRoutes(nodeID2)
@@ -141,12 +141,12 @@ func TestHAHealthProbe_RecoveryNoFlap(t *testing.T) {
 	nodeID2 := advertiseAndApproveRoute(t, srv, c2, route)
 
 	// Failover: node 1 → node 2.
-	srv.State().SetNodeUnhealthy(nodeID1, true)
+	srv.State().SetNodeHealth(nodeID1, false)
 	primaries := srv.State().GetNodePrimaryRoutes(nodeID2)
 	require.Contains(t, primaries, route, "node 2 should be primary")
 
 	// Recovery: node 1 healthy again. Node 2 should STAY primary.
-	changed := srv.State().SetNodeUnhealthy(nodeID1, false)
+	changed := srv.State().SetNodeHealth(nodeID1, true)
 	assert.False(t, changed, "recovery should not change primaries (no flap)")
 
 	primaries = srv.State().GetNodePrimaryRoutes(nodeID2)
@@ -173,7 +173,7 @@ func TestHAHealthProbe_ConnectClearsUnhealthy(t *testing.T) {
 	advertiseAndApproveRoute(t, srv, c2, route)
 
 	// Mark unhealthy.
-	srv.State().SetNodeUnhealthy(nodeID1, true)
+	srv.State().SetNodeHealth(nodeID1, false)
 	assert.False(t, srv.State().IsNodeHealthy(nodeID1))
 
 	// Reconnect clears unhealthy via State.Connect → ClearUnhealthy.
@@ -208,7 +208,7 @@ func TestHAHealthProbe_SetApprovedRoutesEmptyClearsUnhealthy(t *testing.T) {
 	nodeID1 := advertiseAndApproveRoute(t, srv, c1, route)
 	advertiseAndApproveRoute(t, srv, c2, route)
 
-	srv.State().SetNodeUnhealthy(nodeID1, true)
+	srv.State().SetNodeHealth(nodeID1, false)
 	require.False(t, srv.State().IsNodeHealthy(nodeID1))
 
 	_, _, err := srv.State().SetApprovedRoutes(nodeID1, nil)
@@ -242,7 +242,7 @@ func TestHAHealthProbe_DisconnectClearsUnhealthy(t *testing.T) {
 	nodeID1 := advertiseAndApproveRoute(t, srv, c1, route)
 	advertiseAndApproveRoute(t, srv, c2, route)
 
-	srv.State().SetNodeUnhealthy(nodeID1, true)
+	srv.State().SetNodeHealth(nodeID1, false)
 	require.False(t, srv.State().IsNodeHealthy(nodeID1))
 
 	c1.Disconnect(t)
@@ -277,10 +277,10 @@ func TestHAHealthProbe_SetUnhealthyNoRoutesIsNoOp(t *testing.T) {
 	_, _, err := srv.State().SetApprovedRoutes(nodeID1, nil)
 	require.NoError(t, err)
 
-	srv.State().SetNodeUnhealthy(nodeID1, true)
+	srv.State().SetNodeHealth(nodeID1, false)
 
 	assert.True(t, srv.State().IsNodeHealthy(nodeID1),
-		"SetNodeUnhealthy on node with no approved routes should be a no-op")
+		"SetNodeHealth(false) on node with no approved routes should be a no-op")
 }
 
 // TestHAHealthProbe_ReconnectDuringProbeKeepsHealthy reproduces the

--- a/hscontrol/servertest/ha_health_test.go
+++ b/hscontrol/servertest/ha_health_test.go
@@ -283,6 +283,77 @@ func TestHAHealthProbe_SetUnhealthyNoRoutesIsNoOp(t *testing.T) {
 		"SetNodeUnhealthy on node with no approved routes should be a no-op")
 }
 
+// TestHAHealthProbe_ReconnectDuringProbeKeepsHealthy reproduces the
+// race that surfaced as a TestHASubnetRouterFailover flake: a probe
+// dispatched against the previous poll session sees the timeout fire
+// while the client is briefly disconnected. With the session guard in
+// [HAHealthProber.ProbeOnce], the timeout path observes the reconnect
+// and bails out instead of installing a spurious Unhealthy bit.
+//
+// Without the guard, the primary fails over to the standby and the
+// anti-flap election preserves that choice even after the original
+// primary is fully back online.
+func TestHAHealthProbe_ReconnectDuringProbeKeepsHealthy(t *testing.T) {
+	t.Parallel()
+
+	srv := servertest.NewServer(t)
+	user := srv.CreateUser(t, "ha-probe-reconnect")
+
+	route := netip.MustParsePrefix("10.102.0.0/24")
+
+	c1 := servertest.NewClient(t, srv, "ha-pr-r1", servertest.WithUser(user))
+	c2 := servertest.NewClient(t, srv, "ha-pr-r2", servertest.WithUser(user))
+
+	c1.WaitForPeers(t, 1, 10*time.Second)
+	c2.WaitForPeers(t, 1, 10*time.Second)
+
+	nodeID1 := advertiseAndApproveRoute(t, srv, c1, route)
+	advertiseAndApproveRoute(t, srv, c2, route)
+
+	// Node 1 is primary (lowest ID, healthy).
+	require.Contains(t,
+		srv.State().GetNodePrimaryRoutes(nodeID1), route,
+		"node 1 should be primary initially")
+
+	prober := state.NewHAHealthProber(
+		srv.State(),
+		types.HARouteConfig{
+			ProbeInterval: 30 * time.Second,
+			ProbeTimeout:  2 * time.Second,
+		},
+		srv.URL,
+		srv.App.MapBatcher().IsConnected,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// TestClient does not implement ping responses, so every probe
+	// times out. We exploit that to observe the timeout path under a
+	// reconnect race: kick a probe in a goroutine, bounce the
+	// primary's poll session, and confirm the prober drops the stale
+	// timeout instead of marking the node unhealthy.
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		prober.ProbeOnce(ctx, srv.App.Change)
+	}()
+
+	c1.Disconnect(t)
+	c1.Reconnect(t)
+	c1.WaitForPeers(t, 1, 10*time.Second)
+
+	<-done
+
+	assert.True(t, srv.State().IsNodeHealthy(nodeID1),
+		"reconnect during probe must not flip node unhealthy")
+	assert.Contains(t,
+		srv.State().GetNodePrimaryRoutes(nodeID1), route,
+		"node 1 should remain primary after stale-probe timeout")
+}
+
 // TestHAHealthProbe_NoHARoutes verifies that the prober is a no-op
 // when no HA configuration exists.
 func TestHAHealthProbe_NoHARoutes(t *testing.T) {

--- a/hscontrol/servertest/ha_property_test.go
+++ b/hscontrol/servertest/ha_property_test.go
@@ -1,0 +1,642 @@
+package servertest_test
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/juanfont/headscale/hscontrol/servertest"
+	"github.com/juanfont/headscale/hscontrol/state"
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/juanfont/headscale/hscontrol/util"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+	"tailscale.com/tailcfg"
+)
+
+// haPropClient bundles a TestClient with the node ID and route it
+// advertises. The property test mutates connection state through
+// these handles and inspects the resulting NodeStore snapshot.
+type haPropClient struct {
+	tc    *servertest.TestClient
+	id    types.NodeID
+	name  string
+	route netip.Prefix
+	// connected mirrors the prober's view (mapBatcher.IsConnected).
+	// Tracked alongside the runtime read so anti-flap invariants can
+	// reason about the candidate set the prober actually evaluates.
+	connected bool
+	// freshSinceReconnect is true between a successful Reconnect and
+	// the prober's second observation of the new SessionEpoch — the
+	// window in which the session-stability guard must defer instead
+	// of installing an Unhealthy bit. Reset by the first ProberTick
+	// that runs against the new session; cleared on Disconnect.
+	freshSinceReconnect bool
+}
+
+// checkTB embeds *testing.T to satisfy testing.TB (which requires an
+// unexported method only the testing package can provide) while
+// collecting Cleanup functions in a local LIFO stack. runCleanups()
+// runs them when the rapid check body exits so each check's resources
+// are released immediately, not at the outer test's teardown — which
+// would otherwise accumulate hundreds of servers and tens of thousands
+// of goroutines across a 300-check run.
+//
+// Fatal/Fatalf still call through to *testing.T and fail the outer
+// test. Inside a rapid check use rt.Fatalf instead so rapid can shrink
+// the failing op sequence.
+type checkTB struct {
+	*testing.T
+
+	mu       sync.Mutex
+	cleanups []func()
+}
+
+func (c *checkTB) Cleanup(fn func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cleanups = append(c.cleanups, fn)
+}
+
+func (c *checkTB) runCleanups() {
+	c.mu.Lock()
+	cs := c.cleanups
+	c.cleanups = nil
+	c.mu.Unlock()
+
+	for i := len(cs) - 1; i >= 0; i-- {
+		cs[i]()
+	}
+}
+
+// haReadvertise pushes hostinfo + approved routes again. Called after
+// every Reconnect so the new poll session re-publishes the prefix. The
+// controlclient.Direct carries the SetHostinfo state across
+// re-registration, but pushing again removes a race where the test
+// inspects PrimaryRoutes before the initial map of the new session
+// landed.
+func haReadvertise(
+	tb testing.TB,
+	srv *servertest.TestServer,
+	c *haPropClient,
+) {
+	tb.Helper()
+
+	c.tc.Direct().SetHostinfo(&tailcfg.Hostinfo{
+		BackendLogID: "servertest-" + c.name,
+		Hostname:     c.name,
+		RoutableIPs:  []netip.Prefix{c.route},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_ = c.tc.Direct().SendUpdate(ctx)
+
+	_, ch, err := srv.State().SetApprovedRoutes(c.id, []netip.Prefix{c.route})
+	require.NoError(tb, err)
+	srv.App.Change(ch)
+}
+
+// readPrimaries builds the prefix→owner map by inverting
+// State.GetNodePrimaryRoutes for every client in the fleet. The State
+// API does not expose the raw snapshot map directly; iterating the
+// known clients reconstructs it without poking at NodeStore internals.
+// Any inconsistency between routes and isPrimaryRoute surfaces as a
+// duplicate ownership claim and trips invariant 4.
+func readPrimaries(
+	rt *rapid.T,
+	srv *servertest.TestServer,
+	clients []*haPropClient,
+) map[netip.Prefix]types.NodeID {
+	rt.Helper()
+
+	out := make(map[netip.Prefix]types.NodeID)
+
+	for _, c := range clients {
+		for _, p := range srv.State().GetNodePrimaryRoutes(c.id) {
+			if prev, ok := out[p]; ok {
+				rt.Fatalf(
+					"prefix %s has two owners: %d and %d "+
+						"(GetNodePrimaryRoutes claimed both)",
+					p, prev, c.id,
+				)
+			}
+
+			out[p] = c.id
+		}
+	}
+
+	return out
+}
+
+// checkHAInvariants walks every prefix → primary mapping in the live
+// snapshot and asserts the six properties documented in the test
+// header. prevPrimaries is the snapshot taken before the just-applied
+// op so anti-flap can compare moves.
+//
+//nolint:gocyclo // invariant checker over several independent properties
+func checkHAInvariants(
+	rt *rapid.T,
+	srv *servertest.TestServer,
+	clients []*haPropClient,
+	prevPrimaries map[netip.Prefix]types.NodeID,
+	skipAntiFlap bool,
+) {
+	rt.Helper()
+
+	st := srv.State()
+	primaries := readPrimaries(rt, srv, clients)
+
+	// Collect every prefix advertised by the fleet so the all-down
+	// honesty check can iterate them, even prefixes with zero current
+	// advertisers.
+	prefixSet := make(map[netip.Prefix]struct{})
+	for _, c := range clients {
+		prefixSet[c.route] = struct{}{}
+	}
+
+	// Build the candidate set per prefix from the NodeStore: a node is a
+	// candidate when it is IsOnline=true and AllApprovedRoutes contains
+	// the prefix. This is exactly the input to electPrimaryRoutes; the
+	// prober's mapBatcher.IsConnected view is a separate gate the
+	// prober consults before dispatching a probe, not part of the
+	// election input.
+	advertisersByPrefix := make(map[netip.Prefix][]types.NodeID)
+
+	for _, c := range clients {
+		nv, ok := st.GetNodeByID(c.id)
+		if !ok || !nv.Valid() {
+			continue
+		}
+
+		online, known := nv.IsOnline().GetOk()
+		if !known || !online {
+			continue
+		}
+
+		for _, p := range nv.AllApprovedRoutes() {
+			if p == c.route {
+				advertisersByPrefix[p] = append(advertisersByPrefix[p], c.id)
+			}
+		}
+	}
+
+	// Invariant 4: isPrimaryRoute must be consistent with routes.
+	for prefix, owner := range primaries {
+		got := srv.State().GetNodePrimaryRoutes(owner)
+		if !slices.Contains(got, prefix) {
+			rt.Fatalf(
+				"prefix %s primary=%d but GetNodePrimaryRoutes(%d)=%v missing it",
+				prefix, owner, owner, got,
+			)
+		}
+	}
+
+	for prefix, owner := range primaries {
+		nv, ok := st.GetNodeByID(owner)
+		if !ok || !nv.Valid() {
+			rt.Fatalf(
+				"prefix %s primary %d missing from NodeStore",
+				prefix, owner,
+			)
+		}
+
+		// Invariant 1: primary IsOnline in the NodeStore view.
+		// state.Disconnect's 10s grace can leave a recently-disconnected
+		// node with IsOnline=true; the structural rule still requires
+		// the bit before the snapshot may keep it as primary.
+		online, known := nv.IsOnline().GetOk()
+		if !known || !online {
+			rt.Fatalf(
+				"prefix %s primary %d is not online (IsOnline=%v known=%v)",
+				prefix, owner, online, known,
+			)
+		}
+
+		// Invariant 2: primary advertises the prefix and is among the
+		// snapshot's candidate set.
+		approved := nv.AllApprovedRoutes()
+		if !slices.Contains(approved, prefix) {
+			rt.Fatalf(
+				"prefix %s primary %d does not advertise it (approved=%v)",
+				prefix, owner, approved,
+			)
+		}
+
+		if !slices.Contains(advertisersByPrefix[prefix], owner) {
+			rt.Fatalf(
+				"prefix %s primary %d not in advertiser set %v",
+				prefix, owner, advertisersByPrefix[prefix],
+			)
+		}
+
+		// Invariant 5 (anti-flap): if the previous snapshot already had
+		// a primary for this prefix AND that primary is still a healthy,
+		// online, advertising candidate, the new snapshot must keep it.
+		// Skipped on settle reads where we re-check without an op in
+		// between — the prober may run in a deferred batch and the
+		// election may legitimately move once on its own timeline.
+		if !skipAntiFlap {
+			if prev, hadPrev := prevPrimaries[prefix]; hadPrev && prev != owner {
+				prevNV, exists := st.GetNodeByID(prev)
+				if exists && prevNV.Valid() {
+					prevOnline, prevKnown := prevNV.IsOnline().GetOk()
+					prevApproved := prevNV.AllApprovedRoutes()
+
+					stillCandidate := prevKnown && prevOnline &&
+						slices.Contains(prevApproved, prefix)
+					stillHealthy := st.IsNodeHealthy(prev)
+
+					if stillCandidate && stillHealthy {
+						rt.Fatalf(
+							"prefix %s flapped primary %d -> %d "+
+								"while previous primary was still a healthy candidate",
+							prefix, prev, owner,
+						)
+					}
+				}
+			}
+		}
+	}
+
+	// Invariant 6 (all-down honesty): if every candidate of a prefix is
+	// either offline OR unhealthy, the snapshot must either drop the
+	// primary OR keep one that is still a candidate from the same set
+	// (the all-unhealthy preserve-prev rule). A primary pointed at a
+	// non-candidate after every candidate has gone dark would point
+	// peers at a node the prober has already declared unreachable.
+	for prefix := range prefixSet {
+		owner, hasPrimary := primaries[prefix]
+		if !hasPrimary {
+			continue
+		}
+
+		candidates := advertisersByPrefix[prefix]
+
+		// Empty candidates with a primary present trips invariant 2
+		// above; reaching this branch with len(candidates) == 0 means
+		// the snapshot is internally inconsistent.
+		if len(candidates) == 0 {
+			rt.Fatalf(
+				"prefix %s has primary %d but no advertiser in the snapshot",
+				prefix, owner,
+			)
+		}
+
+		anyHealthy := slices.ContainsFunc(candidates, st.IsNodeHealthy)
+
+		// Healthy preference: a primary should not be unhealthy when a
+		// healthy candidate exists. Asserting this through the real
+		// prober → State → NodeStore seam catches any divergence the
+		// unit-level model would miss.
+		if anyHealthy && !st.IsNodeHealthy(owner) {
+			rt.Fatalf(
+				"prefix %s primary %d unhealthy but %v has a healthy candidate",
+				prefix, owner, candidates,
+			)
+		}
+
+		// All-unhealthy guards: with every candidate unhealthy, the
+		// election has exactly two correct choices:
+		//   - preserve prev primary when it is still a candidate
+		//   - leave the prefix unmapped (no candidate fallback)
+		//
+		// Any other outcome points peers at a node already declared
+		// unreachable.
+		if !anyHealthy {
+			prevOwner, hadPrev := prevPrimaries[prefix]
+			prevStillCandidate := hadPrev &&
+				slices.Contains(candidates, prevOwner)
+
+			if prevStillCandidate && owner != prevOwner {
+				rt.Fatalf(
+					"prefix %s all-unhealthy election picked %d, "+
+						"but prev primary %d is still a candidate — "+
+						"preserve-prev rule violated",
+					prefix, owner, prevOwner,
+				)
+			}
+
+			if !prevStillCandidate && (!hadPrev || owner != prevOwner) {
+				rt.Fatalf(
+					"prefix %s all-unhealthy fallback elected %d "+
+						"but prev primary %v is gone; election "+
+						"must leave the prefix unmapped",
+					prefix, owner, prevOwner,
+				)
+			}
+		}
+	}
+}
+
+// snapshotPrimaries returns a defensive copy of the live primary
+// route map so the caller can compare to a later snapshot without
+// aliasing. Inverts GetNodePrimaryRoutes since State does not expose
+// the raw snapshot map.
+func snapshotPrimaries(
+	rt *rapid.T,
+	srv *servertest.TestServer,
+	clients []*haPropClient,
+) map[netip.Prefix]types.NodeID {
+	return readPrimaries(rt, srv, clients)
+}
+
+// TestHAProberProperty drives a real Headscale TestServer with a small
+// fleet of HA-route-advertising clients through a randomised sequence
+// of connect / disconnect / reconnect / prober-tick operations and
+// asserts that the live PrimaryRoutes() snapshot honours every HA
+// invariant after each step.
+//
+// Coverage versus the unit-level NodeStore property test:
+//
+//   - This test exercises the FULL seam: real prober → real PingNode
+//     dispatch → real responseCh handling → State.BatchSetNodeHealth
+//     → NodeStore election → mapper batcher updates. The unit test
+//     bypasses the prober entirely.
+//
+//   - Disconnect/Reconnect goes through the real poll-session
+//     lifecycle: mapBatcher.RemoveNode flips IsConnected, the 10s
+//     grace period defers state.Disconnect, and state.Connect bumps
+//     SessionEpoch on rejoin. The prober defers fresh-session probes
+//     so a reconnect mid-cycle does not install a stale Unhealthy.
+//
+//   - The batched BatchSetNodeHealth is observable through the
+//     all-unhealthy preserve-prev invariant: per-call writes would
+//     publish an intermediate "one unhealthy, one healthy" snapshot,
+//     leaving primary on a non-prev node after both flips land.
+//
+//   - The all-unhealthy fallback that leaves prefixes unmapped is
+//     covered by the honesty invariant: with every candidate
+//     unhealthy AND prev gone from the candidate set, the prefix
+//     must stay unmapped instead of pinned to any candidate.
+//
+// Caveat: TestClient is a real controlclient.Direct that responds to
+// PingRequest over Noise, so the timeout path of the prober rarely
+// fires. The session-stability guard is asserted
+// (freshSinceReconnect tracking + healthy assertion after the first
+// probe of a new session) but the tight race —
+// probe-against-old-session-while-reconnecting — needs a dedicated
+// reconnect test to trigger deterministically.
+//
+// Ops drawn by rapid:
+//
+//   - ClientDisconnect(i)     — cancel poll session, flips IsConnected
+//   - ClientReconnect(i)      — re-register and start new poll session
+//   - ProberTick()            — invoke prober.ProbeOnce synchronously
+//   - WaitForSnapshot()       — re-check invariants without a new op
+//
+// Initial connect happens once during setup so the fleet always has
+// the same baseline. Drawing ClientConnect in the op loop would
+// require setting up auth keys and waiting for peer convergence
+// inside the rapid body, which would dominate the per-check budget
+// for little extra coverage.
+func TestHAProberProperty(t *testing.T) {
+	// Per-check wall-cost is ~15-25s (real Noise handshake on each
+	// reconnect), so the default 100-check rapid budget blows past
+	// the 10-minute go test timeout used by the Tests workflow.
+	// Skip on CI by default so the everyday sweep stays fast; runs
+	// locally so seed shrinking works without an opt-in flag.
+	if util.IsCI() {
+		t.Skip("skipping HA prober property test in CI; runs locally")
+	}
+
+	if testing.Short() {
+		t.Skip("skipping property test in short mode")
+	}
+
+	rapid.Check(t, func(rt *rapid.T) {
+		// Fresh server per rapid check: rapid shrinks by replaying ops
+		// from a clean state, so we cannot reuse a server across runs.
+		// Cleanups registered against checkTB run at the end of THIS
+		// check so server resources are released before the next one
+		// starts.
+		tb := &checkTB{T: t}
+		defer tb.runCleanups()
+
+		srv := servertest.NewServer(tb)
+		user := srv.CreateUser(tb, "ha-prop")
+
+		// Three HA candidates is the smallest set that exercises every
+		// election shape (primary, secondary, tertiary) while keeping
+		// per-check setup under ~10 seconds. Higher numbers blow out
+		// the wall-clock budget without adding new failure modes — the
+		// dual-disconnect and reconnect-during-probe regressions all
+		// reproduce at N=3.
+		const numClients = 3
+
+		route := netip.MustParsePrefix("10.200.0.0/24")
+
+		clients := make([]*haPropClient, 0, numClients)
+
+		for i := range numClients {
+			name := fmt.Sprintf("ha-prop-r%d", i+1)
+			tc := servertest.NewClient(tb, srv, name, servertest.WithUser(user))
+
+			// Wait for at least the initial netmap so the registration
+			// committed and findNodeID is guaranteed to see the node.
+			tc.WaitForUpdate(tb, 10*time.Second)
+
+			id := findNodeID(tb, srv, name)
+
+			c := &haPropClient{
+				tc:        tc,
+				id:        id,
+				name:      name,
+				route:     route,
+				connected: true,
+			}
+			clients = append(clients, c)
+
+			haReadvertise(tb, srv, c)
+		}
+
+		// Prober uses a short timeout so each ProberTick op drains
+		// the cycle in well under a second. TestClient is backed by a
+		// real controlclient.Direct that DOES respond to PingRequest
+		// over Noise (see TestPingNode), so most probes record a
+		// successful response. The probe-timeout path still fires for
+		// nodes whose poll session is mid-bounce — exactly the seam
+		// the session-stability guard was built for — but timing it
+		// reliably from outside the prober is hard; the property test
+		// focuses on the steady-state election invariants instead.
+		prober := state.NewHAHealthProber(
+			srv.State(),
+			types.HARouteConfig{
+				ProbeInterval: 30 * time.Second,
+				ProbeTimeout:  50 * time.Millisecond,
+			},
+			srv.URL,
+			srv.App.MapBatcher().IsConnected,
+		)
+
+		// Sanity: every client should now be an advertiser of route,
+		// and the snapshot must have an HA primary already.
+		require.Eventually(tb, func() bool {
+			for _, c := range clients {
+				if slices.Contains(
+					srv.State().GetNodePrimaryRoutes(c.id),
+					route,
+				) {
+					return true
+				}
+			}
+
+			return false
+		}, 10*time.Second, 50*time.Millisecond,
+			"setup: route should have a primary before drawing ops")
+
+		idxGen := rapid.IntRange(0, numClients-1)
+		opGen := rapid.IntRange(0, 3)
+		opCount := rapid.IntRange(15, 35).Draw(rt, "opCount")
+
+		for step := range opCount {
+			op := opGen.Draw(rt, fmt.Sprintf("op_%d", step))
+
+			prev := snapshotPrimaries(rt, srv, clients)
+
+			// Anti-flap is meaningful only across operations that do
+			// not themselves mutate the candidate set or per-node
+			// health. Connect/Disconnect both mutate IsOnline (via
+			// state.Connect, or via the asynchronous grace-period
+			// state.Disconnect), and the resulting election move is
+			// expected, not a flap. ProbeOnce, by contrast, must keep
+			// the primary on the previous owner whenever that owner
+			// is still a candidate — this is what the reconnect-
+			// during-probe and dual-disconnect guards preserve.
+			isProberOp := op == 2
+
+			switch op {
+			case 0: // ClientDisconnect
+				idx := idxGen.Draw(rt, fmt.Sprintf("disc_idx_%d", step))
+				c := clients[idx]
+
+				// Refuse to disconnect the last connected node. The
+				// prober's HANodes gate requires ≥2 online candidates
+				// per prefix; with only one node left, no probe runs
+				// and the prober-driven invariants (anti-flap,
+				// reconnect-defer) become unfalsifiable. Keeping at
+				// least two candidates is enough to exercise every
+				// failure shape we care about.
+				connectedCount := 0
+
+				for _, cc := range clients {
+					if cc.connected {
+						connectedCount++
+					}
+				}
+
+				if c.connected && connectedCount > 2 {
+					c.tc.Disconnect(tb)
+					c.connected = false
+					c.freshSinceReconnect = false
+				}
+
+			case 1: // ClientReconnect
+				idx := idxGen.Draw(rt, fmt.Sprintf("rec_idx_%d", step))
+				c := clients[idx]
+
+				if !c.connected {
+					c.tc.Reconnect(tb)
+
+					// Wait for the new poll session to register with
+					// the batcher so the prober's IsConnected gate
+					// reflects the reconnect on the next ProberTick.
+					// WaitForUpdate adds ~1s per call; polling
+					// IsConnected directly converges in <100ms.
+					require.Eventually(
+						tb,
+						func() bool {
+							return srv.App.MapBatcher().
+								IsConnected(c.id)
+						},
+						10*time.Second,
+						5*time.Millisecond,
+						"reconnect: batcher should see %s online",
+						c.name,
+					)
+
+					c.connected = true
+					c.freshSinceReconnect = true
+
+					// Re-push hostinfo so the new session's initial
+					// map sets RoutableIPs as expected. SetApprovedRoutes
+					// is idempotent on the same set.
+					haReadvertise(tb, srv, c)
+				}
+
+			case 2: // ProberTick — drive one synchronous probe cycle.
+				// Capture freshness BEFORE running the probe; the
+				// prober itself flips a node from "fresh" to "stable"
+				// when it sees the same SessionEpoch twice, and the
+				// "fresh sessions must defer" rule is expressed
+				// against the pre-probe state.
+				freshThisCycle := make(map[types.NodeID]bool, len(clients))
+				for _, c := range clients {
+					freshThisCycle[c.id] = c.freshSinceReconnect
+				}
+
+				ctx, cancel := context.WithTimeout(
+					context.Background(),
+					5*time.Second,
+				)
+
+				// Use App.Change as the dispatcher — the prober batches
+				// its results through BatchSetNodeHealth and emits a
+				// single PolicyChange. The real wiring is what we want
+				// to test.
+				prober.ProbeOnce(ctx, srv.App.Change)
+				cancel()
+
+				// Session-stability rule: the first probe against a
+				// freshly-reconnected node must defer instead of
+				// installing an Unhealthy bit. In this servertest the
+				// TestClient is backed by a real controlclient.Direct
+				// that DOES respond to PingRequests over Noise, so
+				// the tight timing window — probe dispatched against
+				// an old session whose ping never returns — rarely
+				// opens. The rule still runs as a sanity gate: if it
+				// ever does fire, the freshly-reconnected node will
+				// surface as unhealthy after a single probe, and the
+				// test catches it.
+				for _, c := range clients {
+					if !freshThisCycle[c.id] || !c.connected {
+						continue
+					}
+
+					if !srv.State().IsNodeHealthy(c.id) {
+						rt.Fatalf(
+							"node %d (%s) was marked unhealthy by "+
+								"the first probe after reconnect; "+
+								"session-stability guard should have "+
+								"deferred",
+							c.id, c.name,
+						)
+					}
+
+					c.freshSinceReconnect = false
+				}
+
+			case 3: // WaitForSnapshot — re-check invariants without
+				// applying a new op. NodeStore writes are synchronous
+				// inside UpdateNode/UpdateNodes, so there is nothing
+				// to wait on; the no-op step still verifies that two
+				// consecutive reads (one snapshot, the same snapshot)
+				// stay consistent. This is invariant 3: stable
+				// conditions = stable primary. We skip the anti-flap
+				// comparison so a primary that legitimately changed
+				// in the prior op is not re-flagged here.
+				checkHAInvariants(rt, srv, clients, prev, true)
+
+				continue
+			}
+
+			checkHAInvariants(rt, srv, clients, prev, !isProberOp)
+		}
+	})
+}

--- a/hscontrol/state/ha_health.go
+++ b/hscontrol/state/ha_health.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/juanfont/headscale/hscontrol/types"
@@ -59,10 +60,14 @@ func (p *HAHealthProber) forgetSession(id types.NodeID) {
 	p.lastStableSession.Delete(id)
 }
 
-// ProbeOnce pings all HA subnet router nodes and dispatches health
-// changes inline. A timeout that fires after the node reconnected,
-// or against a session younger than one probe cycle, is dropped so
-// wgengine has time to apply the new netmap before a failover.
+// ProbeOnce pings every HA subnet router and applies the cycle's
+// results in one batch so the election sees a single transition.
+// Per-result snapshots could otherwise elect a node that the next
+// snapshot demotes again, flipping primary onto an unreachable peer.
+// A timeout that fires after the node reconnected, or against a
+// session younger than one probe cycle, is dropped so wgengine has
+// time to apply the new netmap before silence is read as
+// unreachability.
 func (p *HAHealthProber) ProbeOnce(
 	ctx context.Context,
 	dispatch func(...change.Change),
@@ -109,7 +114,11 @@ func (p *HAHealthProber) ProbeOnce(
 		Int("haNodes", len(nodeIDs)).
 		Msg("HA health prober starting probe cycle")
 
-	var wg sync.WaitGroup
+	var (
+		wg       sync.WaitGroup
+		results  = xsync.NewMap[types.NodeID, bool]()
+		deferred atomic.Bool
+	)
 
 	for _, id := range nodeIDs {
 		if !p.isConnected(id) {
@@ -148,13 +157,7 @@ func (p *HAHealthProber) ProbeOnce(
 					Dur("latency", latency).
 					Msg("HA probe: node responded")
 
-				if p.state.SetNodeUnhealthy(id, false) {
-					dispatch(change.PolicyChange())
-
-					log.Info().
-						Uint64(zf.NodeID, id.Uint64()).
-						Msg("HA probe: node recovered, recalculating primaries")
-				}
+				results.Store(id, true)
 
 			case <-timer.C:
 				p.state.CancelPing(pingID)
@@ -179,6 +182,8 @@ func (p *HAHealthProber) ProbeOnce(
 						Uint64("current_session", curr.SessionEpoch()).
 						Msg("HA probe: node reconnected during probe, skipping")
 
+					deferred.Store(true)
+
 					return
 				}
 
@@ -188,6 +193,8 @@ func (p *HAHealthProber) ProbeOnce(
 						Uint64("probe_session", probeSession).
 						Msg("HA probe: probe of fresh session timed out, deferring to next cycle")
 
+					deferred.Store(true)
+
 					return
 				}
 
@@ -196,13 +203,7 @@ func (p *HAHealthProber) ProbeOnce(
 					Dur("timeout", p.cfg.ProbeTimeout).
 					Msg("HA probe: node did not respond")
 
-				if p.state.SetNodeUnhealthy(id, true) {
-					dispatch(change.PolicyChange())
-
-					log.Info().
-						Uint64(zf.NodeID, id.Uint64()).
-						Msg("HA probe: node unhealthy, triggering failover")
-				}
+				results.Store(id, false)
 
 			case <-ctx.Done():
 				p.state.CancelPing(pingID)
@@ -211,4 +212,28 @@ func (p *HAHealthProber) ProbeOnce(
 	}
 
 	wg.Wait()
+
+	// When any probe in the cycle was deferred (fresh session or
+	// reconnected mid-probe), drop the whole cycle's results: a partial
+	// batch lets the election pick a node whose connectivity is still
+	// unknown. The next cycle will run with stable sessions for every
+	// candidate and can decide on a complete picture.
+	if deferred.Load() {
+		return
+	}
+
+	healthByNode := make(map[types.NodeID]bool, results.Size())
+	results.Range(func(id types.NodeID, healthy bool) bool {
+		healthByNode[id] = healthy
+
+		return true
+	})
+
+	if p.state.BatchSetNodeHealth(healthByNode) {
+		dispatch(change.PolicyChange())
+
+		log.Info().
+			Int("haNodes", len(healthByNode)).
+			Msg("HA probe: health changed, triggering failover/recovery")
+	}
 }

--- a/hscontrol/state/ha_health.go
+++ b/hscontrol/state/ha_health.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/types/change"
 	"github.com/juanfont/headscale/hscontrol/util/zlog/zf"
+	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/rs/zerolog/log"
 	"tailscale.com/tailcfg"
 	"tailscale.com/util/set"
@@ -20,6 +21,11 @@ type HAHealthProber struct {
 	cfg         types.HARouteConfig
 	serverURL   string
 	isConnected func(types.NodeID) bool
+
+	// lastStableSession defers a timeout-driven unhealthy decision
+	// for sessions younger than one probe cycle, giving wgengine
+	// time to apply the new netmap on a freshly reconnected node.
+	lastStableSession *xsync.Map[types.NodeID, uint64]
 }
 
 // NewHAHealthProber creates a prober that uses the given State for
@@ -32,34 +38,68 @@ func NewHAHealthProber(
 	isConnected func(types.NodeID) bool,
 ) *HAHealthProber {
 	return &HAHealthProber{
-		state:       s,
-		cfg:         cfg,
-		serverURL:   serverURL,
-		isConnected: isConnected,
+		state:             s,
+		cfg:               cfg,
+		serverURL:         serverURL,
+		isConnected:       isConnected,
+		lastStableSession: xsync.NewMap[types.NodeID, uint64](),
 	}
 }
 
-// ProbeOnce pings all HA subnet router nodes. PingNode changes are
-// dispatched immediately via dispatch so nodes can respond before the
-// timeout. Health-related policy changes are also dispatched inline.
+// markSessionStable records session and returns true iff the same
+// value was already present from a prior cycle.
+func (p *HAHealthProber) markSessionStable(id types.NodeID, session uint64) bool {
+	prev, loaded := p.lastStableSession.LoadAndStore(id, session)
+	return loaded && prev == session
+}
+
+// forgetSession drops the recorded session so a node returning to
+// HA candidacy starts fresh.
+func (p *HAHealthProber) forgetSession(id types.NodeID) {
+	p.lastStableSession.Delete(id)
+}
+
+// ProbeOnce pings all HA subnet router nodes and dispatches health
+// changes inline. A timeout that fires after the node reconnected,
+// or against a session younger than one probe cycle, is dropped so
+// wgengine has time to apply the new netmap before a failover.
 func (p *HAHealthProber) ProbeOnce(
 	ctx context.Context,
 	dispatch func(...change.Change),
 ) {
 	haNodes := p.state.nodeStore.HANodes()
+
+	// Drop stable-session entries for nodes that are no longer HA
+	// candidates so a future reappearance starts fresh.
+	seen := make(set.Set[types.NodeID])
+
+	for _, nodes := range haNodes {
+		for _, id := range nodes {
+			seen.Add(id)
+		}
+	}
+
+	p.lastStableSession.Range(func(id types.NodeID, _ uint64) bool {
+		if !seen.Contains(id) {
+			p.lastStableSession.Delete(id)
+		}
+
+		return true
+	})
+
 	if len(haNodes) == 0 {
 		return
 	}
 
 	// Deduplicate node IDs across prefixes.
-	seen := make(set.Set[types.NodeID])
-
 	var nodeIDs []types.NodeID
+
+	dedup := make(set.Set[types.NodeID])
 
 	for _, nodes := range haNodes {
 		for _, id := range nodes {
-			if !seen.Contains(id) {
-				seen.Add(id)
+			if !dedup.Contains(id) {
+				dedup.Add(id)
 				nodeIDs = append(nodeIDs, id)
 			}
 		}
@@ -77,8 +117,18 @@ func (p *HAHealthProber) ProbeOnce(
 				Uint64(zf.NodeID, id.Uint64()).
 				Msg("HA probe: skipping offline node")
 
+			p.forgetSession(id)
+
 			continue
 		}
+
+		nv, ok := p.state.GetNodeByID(id)
+		if !ok {
+			continue
+		}
+
+		probeSession := nv.SessionEpoch()
+		stable := p.markSessionStable(id, probeSession)
 
 		pingID, responseCh := p.state.RegisterPing(id)
 		callbackURL := p.serverURL + "/machine/ping-response?id=" + pingID
@@ -113,6 +163,30 @@ func (p *HAHealthProber) ProbeOnce(
 					log.Debug().
 						Uint64(zf.NodeID, id.Uint64()).
 						Msg("HA probe: node went offline during probe, skipping")
+
+					return
+				}
+
+				curr, ok := p.state.GetNodeByID(id)
+				if !ok {
+					return
+				}
+
+				if curr.SessionEpoch() != probeSession {
+					log.Debug().
+						Uint64(zf.NodeID, id.Uint64()).
+						Uint64("probe_session", probeSession).
+						Uint64("current_session", curr.SessionEpoch()).
+						Msg("HA probe: node reconnected during probe, skipping")
+
+					return
+				}
+
+				if !stable {
+					log.Debug().
+						Uint64(zf.NodeID, id.Uint64()).
+						Uint64("probe_session", probeSession).
+						Msg("HA probe: probe of fresh session timed out, deferring to next cycle")
 
 					return
 				}

--- a/hscontrol/state/node_store.go
+++ b/hscontrol/state/node_store.go
@@ -692,14 +692,16 @@ func electPrimaryRoutes(
 			}
 		}
 
+		// All-unhealthy fallback: preserve the previous primary only
+		// when it is still a candidate. Falling back to any candidate
+		// would point peers at a node the prober has already declared
+		// unreachable; leaving the prefix unmapped is honest until a
+		// probe cycle picks one that responds.
 		if !found && len(candidates) >= 1 {
 			if cur, ok := prev[prefix]; ok && slices.Contains(candidates, cur) {
 				selected = cur
-			} else {
-				selected = candidates[0]
+				found = true
 			}
-
-			found = true
 		}
 
 		if found {

--- a/hscontrol/state/node_store.go
+++ b/hscontrol/state/node_store.go
@@ -35,9 +35,9 @@ var (
 const (
 	put             = 1
 	del             = 2
-	update          = 3
 	rebuildPeerMaps = 4
 	setName         = 5
+	updateMulti     = 6
 )
 
 const prometheusNamespace = "headscale"
@@ -166,14 +166,18 @@ type work struct {
 	op         int
 	nodeID     types.NodeID
 	node       types.Node
-	updateFn   UpdateNodeFunc
 	result     chan struct{}
-	nodeResult chan types.NodeView // Channel to return the resulting node after batch application
+	nodeResult chan types.NodeView
 	// For rebuildPeerMaps operation
 	rebuildResult chan struct{}
 	// For setName operation (admin rename, reject-on-collision path).
 	name      string
 	errResult chan error
+	// For updateMulti: per-node update functions applied as a single
+	// batch entry so callers that need an atomic election (e.g. the HA
+	// prober applying multiple probe results at once) cannot have a
+	// partial snapshot published between the updates.
+	multiUpdates map[types.NodeID]UpdateNodeFunc
 }
 
 // PutNode adds or updates a node in the store.
@@ -210,45 +214,55 @@ func (s *NodeStore) PutNode(n types.Node) types.NodeView {
 // UpdateNodeFunc is a function type that takes a pointer to a Node and modifies it.
 type UpdateNodeFunc func(n *types.Node)
 
-// UpdateNode applies a function to modify a specific node in the store.
-// This is a blocking operation that waits for the write to complete.
-// This is analogous to a database "transaction", or, the caller should
-// rather collect all data they want to change, and then call this function.
-// Fewer calls are better.
-// Returns the resulting node after all modifications in the batch have been applied.
+// UpdateNode applies a function to modify a specific node in the
+// store. Single-node convenience wrapper around [NodeStore.UpdateNodes]
+// — the writer goroutine signals completion only after the post-batch
+// snapshot has been stored, so the follow-up GetNode read sees the
+// applied update. Returns the resulting node and whether it exists.
 //
-// TODO(kradalby): Technically we could have a version of this that modifies the node
-// in the current snapshot if _we know_ that the change will not affect the peer relationships.
-// This is because the main nodesByID map contains the struct, and every other map is using a
-// pointer to the underlying struct. The gotcha with this is that we will need to introduce
-// a lock around the nodesByID map to ensure that no other writes are happening
-// while we are modifying the node. Which mean we would need to implement read-write locks
-// on all read operations.
-func (s *NodeStore) UpdateNode(nodeID types.NodeID, updateFn func(n *types.Node)) (types.NodeView, bool) {
+// Callers that need to change several nodes atomically should call
+// UpdateNodes directly; collecting changes into one batch keeps the
+// election from running on a half-applied snapshot.
+func (s *NodeStore) UpdateNode(nodeID types.NodeID, updateFn UpdateNodeFunc) (types.NodeView, bool) {
 	timer := prometheus.NewTimer(nodeStoreOperationDuration.WithLabelValues("update"))
 	defer timer.ObserveDuration()
 
-	work := work{
-		op:         update,
-		nodeID:     nodeID,
-		updateFn:   updateFn,
-		result:     make(chan struct{}),
-		nodeResult: make(chan types.NodeView, 1),
+	s.UpdateNodes(map[types.NodeID]UpdateNodeFunc{nodeID: updateFn})
+
+	nodeStoreOperations.WithLabelValues("update").Inc()
+
+	return s.GetNode(nodeID)
+}
+
+// UpdateNodes applies per-node update functions in a single atomic
+// batch. The election that recomputes primary routes runs once, after
+// every update has landed, so callers cannot observe an intermediate
+// snapshot where only some of the updates are visible. Use this when
+// the order in which two writers' updates are individually published
+// would change the election outcome — e.g. the HA prober applying
+// concurrent probe-timeout results.
+func (s *NodeStore) UpdateNodes(updates map[types.NodeID]UpdateNodeFunc) {
+	timer := prometheus.NewTimer(nodeStoreOperationDuration.WithLabelValues("update_multi"))
+	defer timer.ObserveDuration()
+
+	if len(updates) == 0 {
+		return
+	}
+
+	w := work{
+		op:           updateMulti,
+		multiUpdates: updates,
+		result:       make(chan struct{}),
 	}
 
 	nodeStoreQueueDepth.Inc()
 
-	s.writeQueue <- work
+	s.writeQueue <- w
 
-	<-work.result
+	<-w.result
 	nodeStoreQueueDepth.Dec()
 
-	resultNode := <-work.nodeResult
-
-	nodeStoreOperations.WithLabelValues("update").Inc()
-
-	// Return the node and whether it exists (is valid)
-	return resultNode, resultNode.Valid()
+	nodeStoreOperations.WithLabelValues("update_multi").Inc()
 }
 
 // DeleteNode removes a node from the store by its ID.
@@ -405,20 +419,21 @@ func (s *NodeStore) applyBatch(batch []work) {
 			if w.nodeResult != nil {
 				nodeResultRequests[w.nodeID] = append(nodeResultRequests[w.nodeID], w)
 			}
-		case update:
-			// Update the specific node identified by nodeID
-			if n, exists := nodes[w.nodeID]; exists {
+		case updateMulti:
+			for id, fn := range w.multiUpdates {
+				n, exists := nodes[id]
+				if !exists {
+					continue
+				}
+
 				oldGivenName := n.GivenName
-				w.updateFn(&n)
+				fn(&n)
 
 				if n.GivenName != oldGivenName {
 					n.GivenName = resolveGivenName(nodes, n.ID, n.GivenName)
 				}
-				nodes[w.nodeID] = n
-			}
 
-			if w.nodeResult != nil {
-				nodeResultRequests[w.nodeID] = append(nodeResultRequests[w.nodeID], w)
+				nodes[id] = n
 			}
 		case del:
 			delete(nodes, w.nodeID)

--- a/hscontrol/state/node_store.go
+++ b/hscontrol/state/node_store.go
@@ -633,14 +633,14 @@ func snapshotFromNodes(
 }
 
 // electPrimaryRoutes picks the primary advertiser for each non-exit
+// prefix. Inputs are restricted to online nodes that advertise the
 // prefix. The previous primary is preserved when it is still online
 // and healthy (anti-flap); otherwise the lowest-NodeID healthy
 // advertiser wins. When every advertiser is unhealthy the previous
-// primary is preserved if still a candidate, falling back to the
-// lowest-NodeID candidate so peers see *some* primary instead of
-// none. Anti-flap in the all-unhealthy case matters under cable-pull
-// where IsOnline lags reality and a naive lowest-ID fallback churns
-// primaries to a node that is itself unreachable (issue #3203).
+// primary is preserved only if still a candidate — falling back to
+// any other candidate would point peers at a node the prober has
+// already declared unreachable, so leaving the prefix unmapped is
+// preferred until a probe cycle finds one that responds.
 func electPrimaryRoutes(
 	nodes map[types.NodeID]types.Node,
 	prev map[netip.Prefix]types.NodeID,

--- a/hscontrol/state/primaries_property_test.go
+++ b/hscontrol/state/primaries_property_test.go
@@ -97,18 +97,23 @@ func (m *primariesModel) updatePrimaries() {
 			}
 		}
 
+		// All-unhealthy fallback: preserve the previous primary if it
+		// is still a candidate, otherwise leave the prefix unmapped.
+		// electPrimaryRoutes was changed to drop the candidates[0]
+		// fallback so the Phase-5 (simultaneous dual-disconnect)
+		// regression cannot pick an already-unhealthy node as
+		// primary; the model has to track the same behaviour.
 		if !found && len(nodes) >= 1 {
 			if cur, ok := m.primary[p]; ok && slices.Contains(nodes, cur) {
 				selected = cur
-			} else {
-				selected = nodes[0]
+				found = true
 			}
-
-			found = true
 		}
 
 		if found {
 			m.primary[p] = selected
+		} else {
+			delete(m.primary, p)
 		}
 	}
 }

--- a/hscontrol/state/primaries_property_test.go
+++ b/hscontrol/state/primaries_property_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"maps"
 	"net/netip"
 	"slices"
 	"testing"
@@ -23,6 +24,19 @@ import (
 // the same answer from a separate, deliberately direct implementation.
 type primariesModel struct {
 	connected map[types.NodeID]bool
+	// announced mirrors Hostinfo.RoutableIPs — what the client says
+	// it can route. The election does not look at this directly; it
+	// is used to recompute the effective set whenever ApprovedRoutes
+	// changes without a Hostinfo update.
+	announced map[types.NodeID][]netip.Prefix
+	// approved mirrors node.ApprovedRoutes — what the admin policy
+	// allows. SetApprovedRoutes touches this without touching
+	// announced; ConnectAdvertise / ApprovedRoutesChange touch both.
+	approved map[types.NodeID][]netip.Prefix
+	// prefixes is the effective per-node route set —
+	// AllApprovedRoutes in the implementation, i.e. (announced ∩
+	// approved) excluding exit routes. This is what the election
+	// sees, and what the model uses in advertisersByPrefix.
 	prefixes  map[types.NodeID][]netip.Prefix
 	unhealthy map[types.NodeID]bool
 
@@ -36,9 +50,39 @@ type primariesModel struct {
 func newPrimariesModel() *primariesModel {
 	return &primariesModel{
 		connected: map[types.NodeID]bool{},
+		announced: map[types.NodeID][]netip.Prefix{},
+		approved:  map[types.NodeID][]netip.Prefix{},
 		prefixes:  map[types.NodeID][]netip.Prefix{},
 		unhealthy: map[types.NodeID]bool{},
 		primary:   map[netip.Prefix]types.NodeID{},
+	}
+}
+
+// recomputeEffective sets m.prefixes[id] to the intersection of
+// m.announced[id] and m.approved[id]. Empty intersections clear the
+// node from m.prefixes entirely. Matches Node.AllApprovedRoutes /
+// SubnetRoutes semantics (exit routes excluded — none of the test
+// prefixes hit that branch).
+func (m *primariesModel) recomputeEffective(id types.NodeID) {
+	ann := m.announced[id]
+	app := m.approved[id]
+
+	if len(ann) == 0 || len(app) == 0 {
+		delete(m.prefixes, id)
+		return
+	}
+
+	eff := make([]netip.Prefix, 0, len(ann))
+	for _, p := range ann {
+		if slices.Contains(app, p) {
+			eff = append(eff, p)
+		}
+	}
+
+	if len(eff) == 0 {
+		delete(m.prefixes, id)
+	} else {
+		m.prefixes[id] = eff
 	}
 }
 
@@ -99,10 +143,8 @@ func (m *primariesModel) updatePrimaries() {
 
 		// All-unhealthy fallback: preserve the previous primary if it
 		// is still a candidate, otherwise leave the prefix unmapped.
-		// electPrimaryRoutes was changed to drop the candidates[0]
-		// fallback so the Phase-5 (simultaneous dual-disconnect)
-		// regression cannot pick an already-unhealthy node as
-		// primary; the model has to track the same behaviour.
+		// Choosing any candidate would point peers at a node already
+		// declared unreachable; the model mirrors that policy.
 		if !found && len(nodes) >= 1 {
 			if cur, ok := m.primary[p]; ok && slices.Contains(nodes, cur) {
 				selected = cur
@@ -155,8 +197,16 @@ func samePrefixSet(a, b []netip.Prefix) bool {
 }
 
 // checkPrimariesProperties asserts every rule we expect of the snapshot's
-// primaries map given the model.
-func checkPrimariesProperties(rt *rapid.T, ns *NodeStore, m *primariesModel, nodeIDs []types.NodeID) {
+// primaries map given the model. prevSnapshotPrimaries is the snapshot's
+// PrimaryRoutes() reading taken before the just-applied op, used to
+// catch flap regressions that move primary off a still-eligible owner.
+func checkPrimariesProperties(
+	rt *rapid.T,
+	ns *NodeStore,
+	m *primariesModel,
+	nodeIDs []types.NodeID,
+	prevSnapshotPrimaries map[netip.Prefix]types.NodeID,
+) {
 	rt.Helper()
 
 	expectedByNode := map[types.NodeID][]netip.Prefix{}
@@ -184,9 +234,9 @@ func checkPrimariesProperties(rt *rapid.T, ns *NodeStore, m *primariesModel, nod
 	}
 
 	// Every prefix that has at least one connected advertiser must
-	// have a primary in the snapshot. Issue #3203 manifests as a
-	// prefix silently losing its primary after a disconnect/reconnect
-	// cycle.
+	// have a primary in the snapshot: a prefix silently losing its
+	// primary after a disconnect/reconnect cycle would leave peers
+	// without a route.
 	for _, p := range m.allPrefixes() {
 		want, expectExists := m.primary[p]
 		if !expectExists {
@@ -206,6 +256,105 @@ func checkPrimariesProperties(rt *rapid.T, ns *NodeStore, m *primariesModel, nod
 				"prefix %s: snapshot primary = %d, model expected %d",
 				p, got, want,
 			)
+		}
+	}
+
+	// Structural invariants on the live snapshot, independent of the
+	// model. These catch shapes the model alone cannot — e.g. an owner
+	// that is offline but still has the prefix attributed to it.
+	snapshotPrimaries := ns.PrimaryRoutes()
+
+	// A primary that owns ≥1 prefix in `routes` must also light up
+	// `isPrimaryRoute` (PrimaryRoutesForNode returns nil unless the
+	// id is in that map). The inverse check — PrimaryRoutesForNode
+	// returning the right prefixes — is already covered above; this
+	// catches the reverse direction.
+	ownersInRoutes := map[types.NodeID]bool{}
+	for _, owner := range snapshotPrimaries {
+		ownersInRoutes[owner] = true
+	}
+
+	for owner := range ownersInRoutes {
+		if got := ns.PrimaryRoutesForNode(owner); len(got) == 0 {
+			rt.Fatalf(
+				"node %d owns a prefix in routes but PrimaryRoutesForNode is empty",
+				owner,
+			)
+		}
+	}
+
+	// Per-owner structural checks: every primary must currently be
+	// online and must currently advertise the prefix it owns.
+	advertisersByPrefix := m.advertisersByPrefix()
+
+	for prefix, owner := range snapshotPrimaries {
+		nv, ok := ns.GetNode(owner)
+		if !ok || !nv.Valid() {
+			rt.Fatalf(
+				"prefix %s primary %d not present in NodeStore",
+				prefix, owner,
+			)
+		}
+
+		// Primary is online: an offline node cannot move packets, so
+		// election must never leave one as the snapshot's primary.
+		online, known := nv.IsOnline().GetOk()
+		if !known || !online {
+			rt.Fatalf(
+				"prefix %s primary %d is not online",
+				prefix, owner,
+			)
+		}
+
+		// Primary advertises the prefix: AllApprovedRoutes (subnet ∪
+		// exit) must contain it. A primary that no longer advertises
+		// is a stale assignment the snapshot rebuild failed to clear.
+		approved := nv.AllApprovedRoutes()
+		if !slices.Contains(approved, prefix) {
+			rt.Fatalf(
+				"prefix %s primary %d does not advertise it (approved=%v)",
+				prefix, owner, approved,
+			)
+		}
+
+		// Healthy preference: if any candidate for this prefix is
+		// healthy, the elected primary must also be healthy. Leaving
+		// the prefix unmapped is fine; pointing at an unhealthy
+		// candidate while a healthy one was available is not.
+		candidates := advertisersByPrefix[prefix]
+		anyHealthy := false
+
+		for _, c := range candidates {
+			if !m.unhealthy[c] {
+				anyHealthy = true
+				break
+			}
+		}
+
+		if anyHealthy && m.unhealthy[owner] {
+			rt.Fatalf(
+				"prefix %s primary %d is unhealthy but %v had a healthy candidate",
+				prefix, owner, candidates,
+			)
+		}
+
+		// Anti-flap: if the previous snapshot already had a primary
+		// for this prefix AND that primary is still a healthy
+		// candidate after the op, the election must keep it. Flapping
+		// the primary for an unrelated reason violates the contract
+		// the integration tests rely on (HA failover only moves on
+		// loss of candidacy or health).
+		if prev, hadPrev := prevSnapshotPrimaries[prefix]; hadPrev {
+			stillCandidate := slices.Contains(candidates, prev)
+			stillHealthy := !m.unhealthy[prev]
+
+			if stillCandidate && stillHealthy && owner != prev {
+				rt.Fatalf(
+					"prefix %s flapped primary %d -> %d "+
+						"while previous primary was still a healthy candidate",
+					prefix, prev, owner,
+				)
+			}
 		}
 	}
 }
@@ -229,16 +378,41 @@ func nodeForRapid(id types.NodeID) types.Node {
 	}
 }
 
+// snapshotPrimariesCopy returns a defensive copy of the snapshot's
+// prefix→primary map so the caller can compare against a later
+// snapshot without aliasing the live map.
+func snapshotPrimariesCopy(ns *NodeStore) map[netip.Prefix]types.NodeID {
+	live := ns.PrimaryRoutes()
+
+	out := make(map[netip.Prefix]types.NodeID, len(live))
+	maps.Copy(out, live)
+
+	return out
+}
+
 // TestPrimaryRoutesProperty drives NodeStore with a randomised
 // sequence of high-level operations and checks that the snapshot's
 // primaries map matches a reference model after every step.
 //
-// Background: issue #3203 reports that HA tracking enters a stuck
-// state after a sequence of disconnect/reconnect events. The narrow
-// integration and servertest reproductions written for the bug do
-// not fail on upstream/main, so this property test broadens the
-// search by letting rapid generate sequences we have not enumerated
-// by hand.
+// Op set (covers the dual-disconnect, batched-probe, and
+// all-unhealthy-fallback shapes that election has to handle):
+//
+//   - ConnectAdvertise: online + advertise prefs, clear Unhealthy
+//   - Disconnect: offline; ApprovedRoutes persists
+//   - ProbeUnhealthy: set Unhealthy
+//   - ProbeHealthy: clear Unhealthy
+//   - ApprovedRoutesChange: change advertised prefs without touching health
+//   - BatchProbeResults: apply a batch of health flips through
+//     UpdateNodes so the election runs once for the cycle, matching
+//     State.BatchSetNodeHealth
+//   - SimultaneousDisconnect: mark multiple nodes offline atomically
+//     via UpdateNodes (the dual-cable-pull shape)
+//   - SetApprovedRoutes: change ApprovedRoutes while leaving
+//     Hostinfo.RoutableIPs alone — exercises the asymmetry between
+//     announced and approved
+//   - OfflineExpiry: IsOnline=false WITHOUT clearing Unhealthy
+//     (matches the Disconnect path's actual semantics versus
+//     ConnectAdvertise's full reset)
 func TestPrimaryRoutesProperty(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
 		const numNodes = 4
@@ -270,14 +444,29 @@ func TestPrimaryRoutesProperty(t *testing.T) {
 			0, len(prefixes),
 			func(p netip.Prefix) string { return p.String() },
 		)
+		// nodeSubsetGen draws 1..N distinct node IDs for the batched
+		// ops. SliceOfNDistinct's lower bound is inclusive, so 1 is
+		// the smallest sensible batch — a zero-size batch is a no-op
+		// the rapid harness should not waste shrinking cycles on.
+		nodeSubsetGen := rapid.SliceOfNDistinct(
+			nodeGen,
+			1, numNodes,
+			func(id types.NodeID) types.NodeID { return id },
+		)
 
-		opCount := rapid.IntRange(5, 60).Draw(rt, "opCount")
+		opCount := rapid.IntRange(5, 200).Draw(rt, "opCount")
 		for step := range opCount {
-			op := rapid.IntRange(0, 4).Draw(rt, fmt.Sprintf("op_%d", step))
-			id := nodeGen.Draw(rt, fmt.Sprintf("id_%d", step))
+			op := rapid.IntRange(0, 8).Draw(rt, fmt.Sprintf("op_%d", step))
+
+			// Snapshot primaries before applying the op so the
+			// anti-flap invariant has a stable reference. Reading
+			// after the model has already changed would compare a
+			// stale snapshot to a moved model.
+			prevPrimaries := snapshotPrimariesCopy(ns)
 
 			switch op {
 			case 0: // ConnectAdvertise — Connect path clears Unhealthy.
+				id := nodeGen.Draw(rt, fmt.Sprintf("id_%d", step))
 				prefs := prefixSubsetGen.Draw(rt, fmt.Sprintf("prefs_%d", step))
 
 				ns.UpdateNode(id, func(n *types.Node) {
@@ -287,35 +476,41 @@ func TestPrimaryRoutesProperty(t *testing.T) {
 					n.ApprovedRoutes = prefs
 				})
 
+				m.announced[id] = prefs
+				m.approved[id] = prefs
+				m.recomputeEffective(id)
+
 				if len(prefs) == 0 {
 					delete(m.connected, id)
-					delete(m.prefixes, id)
 				} else {
 					m.connected[id] = true
-					m.prefixes[id] = prefs
 				}
 
 				delete(m.unhealthy, id)
 
 			case 1: // Disconnect — IsOnline=false; ApprovedRoutes persists.
+				id := nodeGen.Draw(rt, fmt.Sprintf("id_%d", step))
 				ns.UpdateNode(id, func(n *types.Node) {
 					n.IsOnline = new(false)
 				})
 				delete(m.connected, id)
 
 			case 2: // ProbeUnhealthy — HA prober marks node bad.
+				id := nodeGen.Draw(rt, fmt.Sprintf("id_%d", step))
 				ns.UpdateNode(id, func(n *types.Node) {
 					n.Unhealthy = true
 				})
 				m.unhealthy[id] = true
 
 			case 3: // ProbeHealthy — HA prober marks node good.
+				id := nodeGen.Draw(rt, fmt.Sprintf("id_%d", step))
 				ns.UpdateNode(id, func(n *types.Node) {
 					n.Unhealthy = false
 				})
 				delete(m.unhealthy, id)
 
 			case 4: // ApprovedRoutesChange — change advertised prefs without touching health.
+				id := nodeGen.Draw(rt, fmt.Sprintf("id_%d", step))
 				prefs := prefixSubsetGen.Draw(rt, fmt.Sprintf("prefs_%d", step))
 
 				ns.UpdateNode(id, func(n *types.Node) {
@@ -324,18 +519,107 @@ func TestPrimaryRoutesProperty(t *testing.T) {
 					n.ApprovedRoutes = prefs
 				})
 
+				m.announced[id] = prefs
+				m.approved[id] = prefs
+				m.recomputeEffective(id)
+
 				if len(prefs) == 0 {
 					delete(m.connected, id)
-					delete(m.prefixes, id)
 				} else {
 					m.connected[id] = true
-					m.prefixes[id] = prefs
 				}
+
+			case 5: // BatchProbeResults — atomic health flips per cycle.
+				// Mirrors State.BatchSetNodeHealth: per-node
+				// (id, unhealthy) pairs applied through UpdateNodes
+				// so the election runs once on the post-batch state.
+				// Per-call publication would let an intermediate
+				// "one unhealthy, one healthy" snapshot re-elect off
+				// the still-healthy node before the second flip
+				// landed.
+				ids := nodeSubsetGen.Draw(rt, fmt.Sprintf("batch_ids_%d", step))
+
+				results := make(map[types.NodeID]bool, len(ids))
+				for i, id := range ids {
+					unhealthy := rapid.Bool().Draw(rt, fmt.Sprintf("batch_h_%d_%d", step, i))
+					results[id] = unhealthy
+				}
+
+				fns := make(map[types.NodeID]UpdateNodeFunc, len(results))
+				for id, unhealthy := range results {
+					fns[id] = func(n *types.Node) {
+						n.Unhealthy = unhealthy
+					}
+				}
+
+				ns.UpdateNodes(fns)
+
+				for id, unhealthy := range results {
+					if unhealthy {
+						m.unhealthy[id] = true
+					} else {
+						delete(m.unhealthy, id)
+					}
+				}
+
+			case 6: // SimultaneousDisconnect — multiple offline in one batch.
+				// Dual-cable-pull shape: two HA routers' poll
+				// sessions both close in the same NodeStore tick.
+				// Per-call Disconnect could leave the snapshot
+				// momentarily pointing at an offline owner; the
+				// batched form forces a single rebuild.
+				ids := nodeSubsetGen.Draw(rt, fmt.Sprintf("disc_ids_%d", step))
+
+				fns := make(map[types.NodeID]UpdateNodeFunc, len(ids))
+				for _, id := range ids {
+					fns[id] = func(n *types.Node) {
+						n.IsOnline = new(false)
+					}
+				}
+
+				ns.UpdateNodes(fns)
+
+				for _, id := range ids {
+					delete(m.connected, id)
+				}
+
+			case 7: // SetApprovedRoutes — change ApprovedRoutes only.
+				// SetApprovedRoutes in production updates only
+				// node.ApprovedRoutes; Hostinfo.RoutableIPs (what
+				// the client announced) is set by the next
+				// MapRequest. SubnetRoutes intersects the two, so
+				// dropping ApprovedRoutes mid-flight shrinks the
+				// advertised set immediately while announcement
+				// alone never extends it.
+				id := nodeGen.Draw(rt, fmt.Sprintf("setapp_id_%d", step))
+				prefs := prefixSubsetGen.Draw(rt, fmt.Sprintf("setapp_prefs_%d", step))
+
+				ns.UpdateNode(id, func(n *types.Node) {
+					n.ApprovedRoutes = prefs
+				})
+
+				m.approved[id] = prefs
+				m.recomputeEffective(id)
+
+			case 8: // OfflineExpiry — IsOnline=false, KEEP Unhealthy.
+				// The Disconnect path does not clear Unhealthy
+				// (only ConnectAdvertise does on the way back
+				// up). A probe that marks unhealthy and a grace-
+				// period disconnect that lands later leaves the
+				// node with a stale Unhealthy bit; the test
+				// exercises that shape.
+				id := nodeGen.Draw(rt, fmt.Sprintf("expire_id_%d", step))
+				ns.UpdateNode(id, func(n *types.Node) {
+					n.IsOnline = new(false)
+				})
+
+				delete(m.connected, id)
+				// m.unhealthy[id] is intentionally NOT cleared.
 			}
 
 			m.updatePrimaries()
 
-			checkPrimariesProperties(rt, ns, m, nodeIDs)
+			checkPrimariesProperties(rt, ns, m, nodeIDs, prevPrimaries)
 		}
 	})
 }

--- a/hscontrol/state/primaries_test.go
+++ b/hscontrol/state/primaries_test.go
@@ -218,12 +218,12 @@ func TestPrimaries_AllUnhealthyKeepsAPrimary(t *testing.T) {
 }
 
 func TestPrimaries_AllUnhealthyPreservesPrevious(t *testing.T) {
-	// Issue #3203: once a failover has moved primary to a higher-ID
-	// node, a subsequent all-unhealthy state must NOT churn primary
-	// back to the lowest-ID candidate. Under cable-pull semantics
-	// both nodes can linger as IsOnline=true (half-open TCP) and
-	// both go Unhealthy — naive `candidates[0]` would flap the
-	// primary to a node that is itself unreachable.
+	// Once a failover has moved primary to a higher-ID node, a
+	// subsequent all-unhealthy state must NOT churn primary back to
+	// the lowest-ID candidate. Under cable-pull semantics both nodes
+	// can linger as IsOnline=true (half-open TCP) and both go
+	// Unhealthy — naive `candidates[0]` would flap the primary to a
+	// node that is itself unreachable.
 	prefix := mp("10.0.0.0/24")
 	f := newPrimariesFixture(t, 1, 2)
 	f.advertise(1, prefix)
@@ -247,12 +247,11 @@ func TestPrimaries_ExitRouteNotElected(t *testing.T) {
 	f.requireNoPrimary(exitV4)
 }
 
-func TestPrimaries_RegressionIssue3203_BothOfflineThenOneReturns(t *testing.T) {
-	// Issue #3203: with two HA advertisers, dropping both then
-	// bringing one back used to leave the prefix without any
-	// primary. After the refactor the snapshot recomputes primaries
-	// on every NodeStore write, so the returning advertiser must
-	// be elected.
+func TestPrimaries_BothOfflineThenOneReturns(t *testing.T) {
+	// With two HA advertisers, dropping both then bringing one back
+	// used to leave the prefix without any primary. The snapshot
+	// recomputes primaries on every NodeStore write, so the
+	// returning advertiser must be elected.
 	prefix := mp("10.0.0.0/24")
 	f := newPrimariesFixture(t, 1, 2)
 	f.advertise(1, prefix)

--- a/hscontrol/state/primaries_test.go
+++ b/hscontrol/state/primaries_test.go
@@ -72,7 +72,7 @@ func (f *primariesFixture) disconnect(id types.NodeID) {
 	})
 }
 
-// unhealthy mirrors State.SetNodeUnhealthy(id, true).
+// unhealthy mirrors State.SetNodeHealth(id, false).
 func (f *primariesFixture) unhealthy(id types.NodeID) {
 	f.t.Helper()
 	f.ns.UpdateNode(id, func(n *types.Node) {
@@ -80,7 +80,7 @@ func (f *primariesFixture) unhealthy(id types.NodeID) {
 	})
 }
 
-// healthy mirrors State.SetNodeUnhealthy(id, false).
+// healthy mirrors State.SetNodeHealth(id, true).
 func (f *primariesFixture) healthy(id types.NodeID) {
 	f.t.Helper()
 	f.ns.UpdateNode(id, func(n *types.Node) {

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -1222,35 +1222,64 @@ func (s *State) IsNodeHealthy(id types.NodeID) bool {
 	return s.nodeStore.IsNodeHealthy(id)
 }
 
-// SetNodeUnhealthy flips the runtime Unhealthy bit and reports whether
-// the resulting primary route assignment changed, so the HA prober can
-// decide whether to fan out a PolicyChange.
-//
-// A request to mark a node Unhealthy is dropped if the node is no
-// longer an HA candidate (offline or no approved routes). The prober
-// reads HANodes() at the start of a probe cycle and writes back after
-// the timeout fires; in that window the node may have left the
-// candidate set, and the bit would just be stale. The check happens
+// SetNodeHealth flips the runtime health bit for one node and reports
+// whether the resulting primary-route assignment changed, so the HA
+// prober can decide whether to fan out a PolicyChange. true means
+// healthy; false means unhealthy. An unhealthy mark is dropped when
+// the node is no longer an HA candidate (offline or no approved
+// routes) — between probe dispatch and result the node may have left
+// candidacy, and the bit would just be stale. The check happens
 // inside the writer goroutine so it serialises against the
-// SetApprovedRoutes / Disconnect that removed candidacy.
-func (s *State) SetNodeUnhealthy(id types.NodeID, unhealthy bool) bool {
+// SetApprovedRoutes / Disconnect that removed candidacy. Single-node
+// convenience wrapper around [State.BatchSetNodeHealth].
+func (s *State) SetNodeHealth(id types.NodeID, healthy bool) bool {
+	return s.BatchSetNodeHealth(map[types.NodeID]bool{id: healthy})
+}
+
+// BatchSetNodeHealth applies a set of health updates atomically: the
+// election runs once after every flag has been flipped, so observers
+// never see an intermediate snapshot. Returns true when the
+// primary-route assignment differs from before the batch so callers
+// can gate a single PolicyChange dispatch. Map value true = healthy;
+// false = unhealthy (gated as in [State.SetNodeHealth]).
+//
+// Per-call publication would let a writer applying two flips
+// back-to-back elect a node that the next snapshot demotes,
+// momentarily pointing peers at the wrong primary; the batched form
+// closes that window.
+func (s *State) BatchSetNodeHealth(updates map[types.NodeID]bool) bool {
+	if len(updates) == 0 {
+		return false
+	}
+
 	prevRoutes := s.nodeStore.PrimaryRoutes()
 
-	_, ok := s.nodeStore.UpdateNode(id, func(n *types.Node) {
-		if unhealthy {
+	fns := make(map[types.NodeID]UpdateNodeFunc, len(updates))
+	for id, healthy := range updates {
+		fns[id] = healthSetter(healthy)
+	}
+
+	s.nodeStore.UpdateNodes(fns)
+
+	return !maps.Equal(prevRoutes, s.nodeStore.PrimaryRoutes())
+}
+
+// healthSetter returns an UpdateNodeFunc that flips n.Unhealthy to
+// the inverse of healthy, with the same gate as [State.SetNodeHealth]:
+// an unhealthy mark only sticks when the node is still online and
+// still advertises approved routes, so a node that left HA candidacy
+// between probe dispatch and result does not carry a stale bit.
+func healthSetter(healthy bool) UpdateNodeFunc {
+	return func(n *types.Node) {
+		if !healthy {
 			online := n.IsOnline != nil && *n.IsOnline
 			if !online || len(n.AllApprovedRoutes()) == 0 {
 				return
 			}
 		}
 
-		n.Unhealthy = unhealthy
-	})
-	if !ok {
-		return false
+		n.Unhealthy = !healthy
 	}
-
-	return !maps.Equal(prevRoutes, s.nodeStore.PrimaryRoutes())
 }
 
 // ValidateAPIKey checks if an API key is valid and active.

--- a/integration/acl_test.go
+++ b/integration/acl_test.go
@@ -325,7 +325,7 @@ func TestACLHostsInNetMapTable(t *testing.T) {
 					user := status.User[status.Self.UserID].LoginName
 
 					assert.Len(c, status.Peer, (testCase.want[user]))
-				}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for expected peer visibility")
+				}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for expected peer visibility")
 			}
 		})
 	}
@@ -372,10 +372,8 @@ func TestACLAllowUser80Dst(t *testing.T) {
 			t.Logf("url from %s to %s", client.Hostname(), url)
 
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
-				result, err := client.Curl(url)
-				assert.NoError(c, err)
-				assert.Len(c, result, 13)
-			}, integrationutil.ScaledTimeout(20*time.Second), 500*time.Millisecond, "Verifying user1 can reach user2")
+				assertCurlDockerHostname(c, client, url, "Verifying user1 can reach user2")
+			}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.SlowPoll, "Verifying user1 can reach user2")
 		}
 	}
 
@@ -390,7 +388,7 @@ func TestACLAllowUser80Dst(t *testing.T) {
 
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				assertCurlFailWithCollect(c, client, url, "user2 should not reach user1")
-			}, integrationutil.ScaledTimeout(20*time.Second), 500*time.Millisecond, "Verifying user2 cannot reach user1")
+			}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.SlowPoll, "Verifying user2 cannot reach user1")
 		}
 	}
 }
@@ -437,7 +435,7 @@ func TestACLDenyAllPort80(t *testing.T) {
 
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				assertCurlFailWithCollect(c, client, url, "all traffic should be denied")
-			}, integrationutil.ScaledTimeout(20*time.Second), 500*time.Millisecond, "Verifying all traffic is denied")
+			}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.SlowPoll, "Verifying all traffic is denied")
 		}
 	}
 }
@@ -481,10 +479,8 @@ func TestACLAllowUserDst(t *testing.T) {
 			t.Logf("url from %s to %s", client.Hostname(), url)
 
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
-				result, err := client.Curl(url)
-				assert.NoError(c, err)
-				assert.Len(c, result, 13)
-			}, integrationutil.ScaledTimeout(20*time.Second), 500*time.Millisecond, "Verifying user1 can reach user2")
+				assertCurlDockerHostname(c, client, url, "Verifying user1 can reach user2")
+			}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.SlowPoll, "Verifying user1 can reach user2")
 		}
 	}
 
@@ -499,7 +495,7 @@ func TestACLAllowUserDst(t *testing.T) {
 
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				assertCurlFailWithCollect(c, client, url, "user2 should not reach user1")
-			}, integrationutil.ScaledTimeout(20*time.Second), 500*time.Millisecond, "Verifying user2 cannot reach user1")
+			}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.SlowPoll, "Verifying user2 cannot reach user1")
 		}
 	}
 }
@@ -542,10 +538,8 @@ func TestACLAllowStarDst(t *testing.T) {
 			t.Logf("url from %s to %s", client.Hostname(), url)
 
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
-				result, err := client.Curl(url)
-				assert.NoError(c, err)
-				assert.Len(c, result, 13)
-			}, integrationutil.ScaledTimeout(20*time.Second), 500*time.Millisecond, "Verifying user1 can reach user2")
+				assertCurlDockerHostname(c, client, url, "Verifying user1 can reach user2")
+			}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.SlowPoll, "Verifying user1 can reach user2")
 		}
 	}
 
@@ -560,7 +554,7 @@ func TestACLAllowStarDst(t *testing.T) {
 
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				assertCurlFailWithCollect(c, client, url, "user2 should not reach user1")
-			}, integrationutil.ScaledTimeout(20*time.Second), 500*time.Millisecond, "Verifying user2 cannot reach user1")
+			}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.SlowPoll, "Verifying user2 cannot reach user1")
 		}
 	}
 }
@@ -608,10 +602,8 @@ func TestACLNamedHostsCanReachBySubnet(t *testing.T) {
 			t.Logf("url from %s to %s", client.Hostname(), url)
 
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
-				result, err := client.Curl(url)
-				assert.NoError(c, err)
-				assert.Len(c, result, 13)
-			}, integrationutil.ScaledTimeout(20*time.Second), 500*time.Millisecond, "Verifying user1 can reach user2")
+				assertCurlDockerHostname(c, client, url, "Verifying user1 can reach user2")
+			}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.SlowPoll, "Verifying user1 can reach user2")
 		}
 	}
 
@@ -627,10 +619,8 @@ func TestACLNamedHostsCanReachBySubnet(t *testing.T) {
 			t.Logf("url from %s to %s", client.Hostname(), url)
 
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
-				result, err := client.Curl(url)
-				assert.NoError(c, err)
-				assert.Len(c, result, 13)
-			}, integrationutil.ScaledTimeout(20*time.Second), 500*time.Millisecond, "Verifying user2 can reach user1")
+				assertCurlDockerHostname(c, client, url, "Verifying user2 can reach user1")
+			}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.SlowPoll, "Verifying user2 can reach user1")
 		}
 	}
 }
@@ -790,7 +780,7 @@ func TestACLNamedHostsCanReach(t *testing.T) {
 					test3URL,
 					result,
 				)
-			}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "test1 should reach test3")
+			}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "test1 should reach test3")
 
 			// test2 can query test3 (everyone -> test3)
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -804,7 +794,7 @@ func TestACLNamedHostsCanReach(t *testing.T) {
 					test3URL,
 					result,
 				)
-			}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "test2 should reach test3")
+			}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "test2 should reach test3")
 
 			// test3 cannot query test1
 			_, err = test3.CurlFailFast(test1URL)
@@ -826,7 +816,7 @@ func TestACLNamedHostsCanReach(t *testing.T) {
 					test2URL,
 					result,
 				)
-			}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "test1 should reach test2")
+			}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "test1 should reach test2")
 
 			// test2 cannot query test1
 			_, err = test2.CurlFailFast(test1URL)
@@ -981,12 +971,12 @@ func TestACLDevice1CanAccessDevice2(t *testing.T) {
 					test2URL,
 					result,
 				)
-			}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "test1 should reach test2")
+			}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "test1 should reach test2")
 
 			// test2 cannot query test1 (asymmetric policy)
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
 				assertCurlFailWithCollect(c, test2, test1URL, "test2 should not reach test1")
-			}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "test2 should NOT reach test1")
+			}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "test2 should NOT reach test1")
 		})
 	}
 }
@@ -1047,10 +1037,8 @@ func TestPolicyUpdateWhileRunningWithCLIInDatabase(t *testing.T) {
 			t.Logf("url from %s to %s", client.Hostname(), url)
 
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
-				result, err := client.Curl(url)
-				assert.NoError(c, err)
-				assert.Len(c, result, 13)
-			}, integrationutil.ScaledTimeout(20*time.Second), 500*time.Millisecond, "Verifying user1 can reach user2")
+				assertCurlDockerHostname(c, client, url, "Verifying user1 can reach user2")
+			}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.SlowPoll, "Verifying user1 can reach user2")
 		}
 	}
 
@@ -1096,7 +1084,7 @@ func TestPolicyUpdateWhileRunningWithCLIInDatabase(t *testing.T) {
 		if diff := cmp.Diff(p, *output, cmpopts.IgnoreUnexported(policyv2.Policy{}), cmpopts.EquateEmpty()); diff != "" {
 			ct.Errorf("unexpected policy(-want +got):\n%s", diff)
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "verifying that the new policy took place")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "verifying that the new policy took place")
 
 	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
 		// Test that user1 can visit all user2
@@ -1108,9 +1096,7 @@ func TestPolicyUpdateWhileRunningWithCLIInDatabase(t *testing.T) {
 				url := fmt.Sprintf("http://%s/etc/hostname", fqdn)
 				t.Logf("url from %s to %s", client.Hostname(), url)
 
-				result, err := client.Curl(url)
-				assert.Len(ct, result, 13)
-				assert.NoError(ct, err)
+				assertCurlDockerHostname(ct, client, url, "new policy did not get propagated to nodes")
 			}
 		}
 
@@ -1126,7 +1112,7 @@ func TestPolicyUpdateWhileRunningWithCLIInDatabase(t *testing.T) {
 				assertCurlFailWithCollect(ct, client, url, "user2 should not reach user1")
 			}
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "new policy did not get propagated to nodes")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "new policy did not get propagated to nodes")
 }
 
 func TestACLAutogroupMember(t *testing.T) {
@@ -1165,7 +1151,7 @@ func TestACLAutogroupMember(t *testing.T) {
 
 			clientIsUntagged = status.Self.Tags == nil || status.Self.Tags.Len() == 0
 			assert.True(c, clientIsUntagged, "Expected client %s to be untagged for autogroup:member test", client.Hostname())
-		}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for client %s to be untagged", client.Hostname())
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for client %s to be untagged", client.Hostname())
 
 		if !clientIsUntagged {
 			continue
@@ -1184,7 +1170,7 @@ func TestACLAutogroupMember(t *testing.T) {
 
 				peerIsUntagged = status.Self.Tags == nil || status.Self.Tags.Len() == 0
 				assert.True(c, peerIsUntagged, "Expected peer %s to be untagged for autogroup:member test", peer.Hostname())
-			}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for peer %s to be untagged", peer.Hostname())
+			}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for peer %s to be untagged", peer.Hostname())
 
 			if !peerIsUntagged {
 				continue
@@ -1197,10 +1183,8 @@ func TestACLAutogroupMember(t *testing.T) {
 			t.Logf("url from %s to %s", client.Hostname(), url)
 
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
-				result, err := client.Curl(url)
-				assert.NoError(c, err)
-				assert.Len(c, result, 13)
-			}, integrationutil.ScaledTimeout(20*time.Second), 500*time.Millisecond, "Verifying autogroup:member connectivity")
+				assertCurlDockerHostname(c, client, url, "Verifying autogroup:member connectivity")
+			}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.SlowPoll, "Verifying autogroup:member connectivity")
 		}
 	}
 }
@@ -1376,7 +1360,7 @@ func TestACLAutogroupTagged(t *testing.T) {
 					untaggedClients = append(untaggedClients, client)
 				}
 			}
-		}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "verifying peer visibility for node %s", hostname)
+		}, integrationutil.StatusReadyTimeout, 1*time.Second, "verifying peer visibility for node %s", hostname)
 	}
 
 	// Verify we have the expected number of tagged and untagged nodes
@@ -1390,7 +1374,7 @@ func TestACLAutogroupTagged(t *testing.T) {
 			assert.NoError(c, err)
 			assert.NotNil(c, status.Self.Tags, "tagged node %s should have tags", client.Hostname())
 			assert.Positive(c, status.Self.Tags.Len(), "tagged node %s should have at least one tag", client.Hostname())
-		}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for tags to be applied to tagged nodes")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for tags to be applied to tagged nodes")
 	}
 
 	// Verify untagged nodes have no tags
@@ -1402,7 +1386,7 @@ func TestACLAutogroupTagged(t *testing.T) {
 			if status.Self.Tags != nil {
 				assert.Equal(c, 0, status.Self.Tags.Len(), "untagged node %s should have no tags", client.Hostname())
 			}
-		}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting to verify untagged nodes have no tags")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting to verify untagged nodes have no tags")
 	}
 
 	// Test that tagged nodes can communicate with each other
@@ -1420,10 +1404,8 @@ func TestACLAutogroupTagged(t *testing.T) {
 			t.Logf("Testing connection from tagged node %s to tagged node %s", client.Hostname(), peer.Hostname())
 
 			assert.EventuallyWithT(t, func(ct *assert.CollectT) {
-				result, err := client.Curl(url)
-				assert.NoError(ct, err)
-				assert.Len(ct, result, 13)
-			}, integrationutil.ScaledTimeout(20*time.Second), 500*time.Millisecond, "tagged nodes should be able to communicate")
+				assertCurlDockerHostname(ct, client, url, "tagged nodes should be able to communicate")
+			}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.SlowPoll, "tagged nodes should be able to communicate")
 		}
 	}
 
@@ -1442,7 +1424,7 @@ func TestACLAutogroupTagged(t *testing.T) {
 				result, err := client.CurlFailFast(url)
 				assert.Empty(ct, result)
 				assert.Error(ct, err)
-			}, integrationutil.ScaledTimeout(5*time.Second), 200*time.Millisecond, "untagged nodes should not be able to reach tagged nodes")
+			}, integrationutil.ScaledTimeout(5*time.Second), integrationutil.FastPoll, "untagged nodes should not be able to reach tagged nodes")
 		}
 
 		// Try to reach other untagged nodes (should also fail)
@@ -1462,7 +1444,7 @@ func TestACLAutogroupTagged(t *testing.T) {
 				result, err := client.CurlFailFast(url)
 				assert.Empty(ct, result)
 				assert.Error(ct, err)
-			}, integrationutil.ScaledTimeout(5*time.Second), 200*time.Millisecond, "untagged nodes should not be able to reach other untagged nodes")
+			}, integrationutil.ScaledTimeout(5*time.Second), integrationutil.FastPoll, "untagged nodes should not be able to reach other untagged nodes")
 		}
 	}
 
@@ -1480,7 +1462,7 @@ func TestACLAutogroupTagged(t *testing.T) {
 				result, err := client.CurlFailFast(url)
 				assert.Empty(ct, result)
 				assert.Error(ct, err)
-			}, integrationutil.ScaledTimeout(5*time.Second), 200*time.Millisecond, "tagged nodes should not be able to reach untagged nodes")
+			}, integrationutil.ScaledTimeout(5*time.Second), integrationutil.FastPoll, "tagged nodes should not be able to reach untagged nodes")
 		}
 	}
 }
@@ -1664,10 +1646,8 @@ func TestACLAutogroupSelf(t *testing.T) {
 			t.Logf("url from %s (user1) to %s (user1)", client.Hostname(), fqdn)
 
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
-				result, err := client.Curl(url)
-				assert.NoError(c, err)
-				assert.Len(c, result, 13)
-			}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "user1 device should reach other user1 device via autogroup:self")
+				assertCurlDockerHostname(c, client, url, "user1 device should reach other user1 device via autogroup:self")
+			}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "user1 device should reach other user1 device via autogroup:self")
 		}
 	}
 
@@ -1685,10 +1665,8 @@ func TestACLAutogroupSelf(t *testing.T) {
 			t.Logf("url from %s (user2) to %s (user2)", client.Hostname(), fqdn)
 
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
-				result, err := client.Curl(url)
-				assert.NoError(c, err)
-				assert.Len(c, result, 13)
-			}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "user2 device should reach other user2 device via autogroup:self")
+				assertCurlDockerHostname(c, client, url, "user2 device should reach other user2 device via autogroup:self")
+			}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "user2 device should reach other user2 device via autogroup:self")
 		}
 	}
 
@@ -1704,7 +1682,7 @@ func TestACLAutogroupSelf(t *testing.T) {
 			result, err := client.Curl(url)
 			assert.NoError(c, err)
 			assert.NotEmpty(c, result, "user1 should be able to access router-node via group:home -> tag:router-node rule")
-		}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "user1 device should reach router-node (proves autogroup:self doesn't interfere)")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "user1 device should reach router-node (proves autogroup:self doesn't interfere)")
 	}
 
 	// Test that user2's regular devices can access router-node
@@ -1719,7 +1697,7 @@ func TestACLAutogroupSelf(t *testing.T) {
 			result, err := client.Curl(url)
 			assert.NoError(c, err)
 			assert.NotEmpty(c, result, "user2 should be able to access router-node via group:home -> tag:router-node rule")
-		}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "user2 device should reach router-node (proves autogroup:self doesn't interfere)")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "user2 device should reach router-node (proves autogroup:self doesn't interfere)")
 	}
 
 	// Test that devices from different users cannot access each other's regular devices
@@ -1867,10 +1845,12 @@ func TestACLPolicyPropagationOverTime(t *testing.T) {
 					assert.Len(ct, result, 13, "iteration %d: response from %s to %s should be valid", iteration, client.Hostname(), fqdn)
 				}
 			}
-		}, integrationutil.ScaledTimeout(90*time.Second), 500*time.Millisecond, "iteration %d: Phase 1 - all connectivity tests with allow-all policy", iteration)
+		}, integrationutil.PolicyPropagationTimeout, integrationutil.SlowPoll, "iteration %d: Phase 1 - all connectivity tests with allow-all policy", iteration)
 
 		// Phase 2: Autogroup:self policy (only same user can access)
 		t.Logf("Iteration %d: Phase 2 - Setting autogroup:self policy", iteration)
+
+		preFilters := snapshotClientFilters(t, allClients)
 
 		err = headscale.SetPolicy(autogroupSelfPolicy)
 		require.NoError(t, err)
@@ -1878,8 +1858,18 @@ func TestACLPolicyPropagationOverTime(t *testing.T) {
 		// Wait for peer lists to sync with autogroup:self - ensures cross-user peers are removed
 		t.Logf("Iteration %d: Phase 2 - Waiting for peer lists to sync with autogroup:self", iteration)
 
-		err = scenario.WaitForTailscaleSyncPerUser(integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond)
+		err = scenario.WaitForTailscaleSyncPerUser(
+			integrationutil.PolicyPropagationTimeout,
+			integrationutil.SlowPoll,
+		)
 		require.NoError(t, err, "iteration %d: Phase 2 - failed to sync after autogroup:self policy", iteration)
+
+		// Gate on each client's wgengine having applied the new
+		// PacketFilter before asserting reachability. WaitForTailscale
+		// SyncPerUser only checks peer-count parity, which trips
+		// before the filter rules have actually replaced the
+		// allow-all rules.
+		waitForClientFilterChange(t, allClients, preFilters, integrationutil.PolicyPropagationTimeout)
 
 		// Test ALL connectivity (positive and negative) in one block after state is settled
 		t.Logf("Iteration %d: Phase 2 - Testing all connectivity with autogroup:self", iteration)
@@ -1947,7 +1937,7 @@ func TestACLPolicyPropagationOverTime(t *testing.T) {
 					assertCurlFailWithCollect(ct, client, url, fmt.Sprintf("iteration %d: user2 %s should NOT reach user1 %s", iteration, client.Hostname(), peer.Hostname()))
 				}
 			}
-		}, integrationutil.ScaledTimeout(90*time.Second), 500*time.Millisecond, "iteration %d: Phase 2 - all connectivity tests with autogroup:self", iteration)
+		}, integrationutil.PolicyPropagationTimeout, integrationutil.SlowPoll, "iteration %d: Phase 2 - all connectivity tests with autogroup:self", iteration)
 
 		// Phase 2b: Add a new node to user1 and validate policy propagation
 		t.Logf("Iteration %d: Phase 2b - Adding new node to user1 during autogroup:self policy", iteration)
@@ -2011,7 +2001,7 @@ func TestACLPolicyPropagationOverTime(t *testing.T) {
 					assertCurlFailWithCollect(ct, client, url, fmt.Sprintf("iteration %d: user1 %s should NOT reach user2 %s", iteration, client.Hostname(), peer.Hostname()))
 				}
 			}
-		}, integrationutil.ScaledTimeout(90*time.Second), 500*time.Millisecond, "iteration %d: Phase 2b - all connectivity tests after new node addition", iteration)
+		}, integrationutil.PolicyPropagationTimeout, integrationutil.SlowPoll, "iteration %d: Phase 2b - all connectivity tests after new node addition", iteration)
 
 		// Delete the newly added node before Phase 3
 		t.Logf("Iteration %d: Phase 2b - Deleting the newly added node from user1", iteration)
@@ -2033,7 +2023,7 @@ func TestACLPolicyPropagationOverTime(t *testing.T) {
 					nodeToDeleteID = node.GetId()
 				}
 			}
-		}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "iteration %d: Phase 2b - listing nodes before deletion", iteration)
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "iteration %d: Phase 2b - listing nodes before deletion", iteration)
 
 		// Delete the node via headscale helper
 		t.Logf("Iteration %d: Phase 2b - Deleting node ID %d from headscale", iteration, nodeToDeleteID)
@@ -2066,7 +2056,7 @@ func TestACLPolicyPropagationOverTime(t *testing.T) {
 			nodeListAfter, err := headscale.ListNodes("user1")
 			assert.NoError(ct, err, "failed to list nodes after deletion")
 			assert.Len(ct, nodeListAfter, 2, "iteration %d: should have 2 user1 nodes after deletion, got %d", iteration, len(nodeListAfter))
-		}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "iteration %d: Phase 2b - node should be deleted", iteration)
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "iteration %d: Phase 2b - node should be deleted", iteration)
 
 		// Wait for sync after deletion to ensure peer counts are correct
 		// Use WaitForTailscaleSyncPerUser because autogroup:self is still active,
@@ -2128,7 +2118,7 @@ func TestACLPolicyPropagationOverTime(t *testing.T) {
 					assertCurlFailWithCollect(ct, client, url, fmt.Sprintf("iteration %d: user2 %s should NOT reach user1 %s", iteration, client.Hostname(), peer.Hostname()))
 				}
 			}
-		}, integrationutil.ScaledTimeout(90*time.Second), 500*time.Millisecond, "iteration %d: Phase 3 - all connectivity tests with directional policy", iteration)
+		}, integrationutil.PolicyPropagationTimeout, integrationutil.SlowPoll, "iteration %d: Phase 3 - all connectivity tests with directional policy", iteration)
 
 		t.Logf("=== Iteration %d/5 completed successfully - All 3 phases passed ===", iteration)
 	}
@@ -2591,7 +2581,7 @@ func TestACLTagPropagation(t *testing.T) {
 				} else {
 					assertCurlFailWithCollect(c, sourceClient, targetURL, "initial access should fail")
 				}
-			}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "verifying initial access state")
+			}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "verifying initial access state")
 
 			// Step 1b: Verify initial NetMap visibility
 			t.Logf("Step 1b: Verifying initial NetMap visibility (expect visible=%v)", tt.initialAccess)
@@ -2614,7 +2604,7 @@ func TestACLTagPropagation(t *testing.T) {
 				} else {
 					assert.False(c, found, "Target should NOT be visible in NetMap initially")
 				}
-			}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "verifying initial NetMap visibility")
+			}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "verifying initial NetMap visibility")
 
 			// Step 2: Apply tag change
 			t.Logf("Step 2: Setting tags on node %d to %v", targetNodeID, tt.tagChange)
@@ -2632,7 +2622,7 @@ func TestACLTagPropagation(t *testing.T) {
 				if node != nil {
 					assert.ElementsMatch(c, tt.tagChange, node.GetTags(), "Tags should be updated")
 				}
-			}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying tag change applied")
+			}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying tag change applied")
 
 			// Step 3: Verify final NetMap visibility first (fast signal that
 			// the MapResponse propagated to the client).
@@ -2660,7 +2650,7 @@ func TestACLTagPropagation(t *testing.T) {
 				} else {
 					assert.False(c, found, "Target should NOT be visible in NetMap after tag change")
 				}
-			}, integrationutil.ScaledTimeout(120*time.Second), 500*time.Millisecond, "verifying NetMap visibility propagated after tag change")
+			}, integrationutil.HASlowConvergeTimeout, integrationutil.SlowPoll, "verifying NetMap visibility propagated after tag change")
 
 			// Step 4: Verify final access state (this is the key test for #2389).
 			// Even though Step 3 confirmed the MapResponse arrived, the full
@@ -2674,7 +2664,7 @@ func TestACLTagPropagation(t *testing.T) {
 				} else {
 					assertCurlFailWithCollect(c, sourceClient, targetURL, "final access should fail after tag change")
 				}
-			}, integrationutil.ScaledTimeout(120*time.Second), 500*time.Millisecond, "verifying access propagated after tag change")
+			}, integrationutil.HASlowConvergeTimeout, integrationutil.SlowPoll, "verifying access propagated after tag change")
 
 			t.Logf("Test %s PASSED: Tag change propagated correctly", tt.name)
 		})
@@ -2823,7 +2813,7 @@ func TestACLTagPropagationPortSpecific(t *testing.T) {
 	t.Log("Step 1: Verifying HTTP access with tag:webserver (should succeed)")
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertCurlSuccessWithCollect(c, user2Node, targetURL, "HTTP should work with tag:webserver")
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "initial HTTP access with tag:webserver")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "initial HTTP access with tag:webserver")
 
 	// Step 2: Change tag from webserver to sshonly
 	t.Logf("Step 2: Changing tag from webserver to sshonly on node %d", targetNodeID)
@@ -2844,7 +2834,7 @@ func TestACLTagPropagationPortSpecific(t *testing.T) {
 		if node != nil {
 			assert.ElementsMatch(c, []string{"tag:sshonly"}, node.GetTags(), "Tags should be updated to sshonly")
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying tag change applied")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying tag change applied")
 
 	// Step 3: Verify peer is still visible in NetMap (partial access, not full removal)
 	t.Log("Step 3: Verifying peer remains visible in NetMap after tag change")
@@ -2863,7 +2853,7 @@ func TestACLTagPropagationPortSpecific(t *testing.T) {
 		}
 
 		assert.True(c, found, "Peer should still be visible with tag:sshonly (port 22 access)")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "peer visibility after tag change")
+	}, integrationutil.HAConvergeTimeout, integrationutil.SlowPoll, "peer visibility after tag change")
 
 	// Step 4: Verify HTTP on port 80 now fails (tag:sshonly only allows port 22).
 	// Port-specific filter changes are harder than peer removal because
@@ -2872,7 +2862,7 @@ func TestACLTagPropagationPortSpecific(t *testing.T) {
 	t.Log("Step 4: Verifying HTTP access is now blocked (tag:sshonly only allows port 22)")
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertCurlFailWithCollect(c, user2Node, targetURL, "HTTP should fail with tag:sshonly (only port 22 allowed)")
-	}, integrationutil.ScaledTimeout(90*time.Second), 500*time.Millisecond, "HTTP blocked after tag change to sshonly")
+	}, integrationutil.PolicyPropagationTimeout, integrationutil.SlowPoll, "HTTP blocked after tag change to sshonly")
 
 	t.Log("Test PASSED: Port-specific ACL changes propagated correctly")
 }
@@ -2963,19 +2953,15 @@ func TestACLGroupWithUnknownUser(t *testing.T) {
 	t.Log("Testing connectivity: user1 -> user2 (should succeed despite unknown user in group)")
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user2FQDN)
-		result, err := user1.Curl(url)
-		assert.NoError(c, err, "user1 should be able to reach user2")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "user1 should reach user2")
+		assertCurlDockerHostname(c, user1, url, "user1 should be able to reach user2")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "user1 should reach user2")
 
 	// Test that user2 can reach user1 (bidirectional)
 	t.Log("Testing connectivity: user2 -> user1 (should succeed despite unknown user in group)")
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user1FQDN)
-		result, err := user2.Curl(url)
-		assert.NoError(c, err, "user2 should be able to reach user1")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "user2 should reach user1")
+		assertCurlDockerHostname(c, user2, url, "user2 should be able to reach user1")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "user2 should reach user1")
 
 	t.Log("Test PASSED: Valid users can communicate despite unknown user reference in group")
 }
@@ -3069,17 +3055,13 @@ func TestACLGroupAfterUserDeletion(t *testing.T) {
 	t.Log("Step 1: Verifying initial connectivity between all users")
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user2FQDN)
-		result, err := user1.Curl(url)
-		assert.NoError(c, err, "user1 should be able to reach user2 initially")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "initial user1 -> user2 connectivity")
+		assertCurlDockerHostname(c, user1, url, "user1 should be able to reach user2 initially")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "initial user1 -> user2 connectivity")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user1FQDN)
-		result, err := user2.Curl(url)
-		assert.NoError(c, err, "user2 should be able to reach user1 initially")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "initial user2 -> user1 connectivity")
+		assertCurlDockerHostname(c, user2, url, "user2 should be able to reach user1 initially")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "initial user2 -> user1 connectivity")
 
 	// Step 2: Get user3's node and user, then delete them
 	t.Log("Step 2: Deleting user3's node and user from headscale")
@@ -3114,10 +3096,8 @@ func TestACLGroupAfterUserDeletion(t *testing.T) {
 	// Test that user1 can still reach user2
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user2FQDN)
-		result, err := user1.Curl(url)
-		assert.NoError(c, err, "user1 should still be able to reach user2 after user3 deletion (stale cache)")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "user1 -> user2 after user3 deletion")
+		assertCurlDockerHostname(c, user1, url, "user1 should still be able to reach user2 after user3 deletion (stale cache)")
+	}, integrationutil.HAConvergeTimeout, integrationutil.SlowPoll, "user1 -> user2 after user3 deletion")
 
 	// Step 4: Create a NEW user - this triggers updatePolicyManagerUsers() which
 	// re-evaluates the policy. According to issue #2967, this is when the bug manifests:
@@ -3139,18 +3119,14 @@ func TestACLGroupAfterUserDeletion(t *testing.T) {
 	// Test that user1 can still reach user2 AFTER the policy refresh triggered by user creation
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user2FQDN)
-		result, err := user1.Curl(url)
-		assert.NoError(c, err, "user1 should still reach user2 after policy refresh (BUG if this fails)")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "user1 -> user2 after policy refresh (issue #2967)")
+		assertCurlDockerHostname(c, user1, url, "user1 should still reach user2 after policy refresh (BUG if this fails)")
+	}, integrationutil.PolicyPropagationTimeout, integrationutil.SlowPoll, "user1 -> user2 after policy refresh (issue #2967)")
 
 	// Test that user2 can still reach user1
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user1FQDN)
-		result, err := user2.Curl(url)
-		assert.NoError(c, err, "user2 should still reach user1 after policy refresh (BUG if this fails)")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "user2 -> user1 after policy refresh (issue #2967)")
+		assertCurlDockerHostname(c, user2, url, "user2 should still reach user1 after policy refresh (BUG if this fails)")
+	}, integrationutil.PolicyPropagationTimeout, integrationutil.SlowPoll, "user2 -> user1 after policy refresh (issue #2967)")
 
 	t.Log("Test PASSED: Remaining users can communicate after deleted user and policy refresh")
 }
@@ -3256,17 +3232,13 @@ func TestACLGroupDeletionExactReproduction(t *testing.T) {
 	t.Log("Step 1: Verifying initial connectivity (user1 <-> user3)")
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user3FQDN)
-		result, err := user1.Curl(url)
-		assert.NoError(c, err, "user1 should reach user3")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "user1 -> user3")
+		assertCurlDockerHostname(c, user1, url, "user1 should reach user3")
+	}, integrationutil.PolicyPropagationTimeout, integrationutil.SlowPoll, "user1 -> user3")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user1FQDN)
-		result, err := user3.Curl(url)
-		assert.NoError(c, err, "user3 should reach user1")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "user3 -> user1")
+		assertCurlDockerHostname(c, user3, url, "user3 should reach user1")
+	}, integrationutil.PolicyPropagationTimeout, integrationutil.SlowPoll, "user3 -> user1")
 
 	t.Log("Step 1: PASSED - initial connectivity works")
 
@@ -3293,17 +3265,13 @@ func TestACLGroupDeletionExactReproduction(t *testing.T) {
 	t.Log("Step 3: Verifying connectivity STILL works after user2 deletion")
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user3FQDN)
-		result, err := user1.Curl(url)
-		assert.NoError(c, err, "user1 should still reach user3 after user2 deletion")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "user1 -> user3 after user2 deletion")
+		assertCurlDockerHostname(c, user1, url, "user1 should still reach user3 after user2 deletion")
+	}, integrationutil.PolicyPropagationTimeout, integrationutil.SlowPoll, "user1 -> user3 after user2 deletion")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user1FQDN)
-		result, err := user3.Curl(url)
-		assert.NoError(c, err, "user3 should still reach user1 after user2 deletion")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "user3 -> user1 after user2 deletion")
+		assertCurlDockerHostname(c, user3, url, "user3 should still reach user1 after user2 deletion")
+	}, integrationutil.PolicyPropagationTimeout, integrationutil.SlowPoll, "user3 -> user1 after user2 deletion")
 
 	t.Log("Step 3: PASSED - connectivity works after user2 deletion")
 
@@ -3322,17 +3290,13 @@ func TestACLGroupDeletionExactReproduction(t *testing.T) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user3FQDN)
-		result, err := user1.Curl(url)
-		assert.NoError(c, err, "BUG #2967: user1 should still reach user3 after user4 creation")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "user1 -> user3 after user4 creation (issue #2967)")
+		assertCurlDockerHostname(c, user1, url, "BUG #2967: user1 should still reach user3 after user4 creation")
+	}, integrationutil.PolicyPropagationTimeout, integrationutil.SlowPoll, "user1 -> user3 after user4 creation (issue #2967)")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user1FQDN)
-		result, err := user3.Curl(url)
-		assert.NoError(c, err, "BUG #2967: user3 should still reach user1 after user4 creation")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "user3 -> user1 after user4 creation (issue #2967)")
+		assertCurlDockerHostname(c, user3, url, "BUG #2967: user3 should still reach user1 after user4 creation")
+	}, integrationutil.PolicyPropagationTimeout, integrationutil.SlowPoll, "user3 -> user1 after user4 creation (issue #2967)")
 
 	// Additional verification: check filter rules are not empty
 	filter, err := headscale.DebugFilter()
@@ -3432,17 +3396,13 @@ func TestACLDynamicUnknownUserAddition(t *testing.T) {
 	t.Log("Step 1: Verifying initial connectivity with valid policy (no unknown users)")
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user2FQDN)
-		result, err := user1.Curl(url)
-		assert.NoError(c, err, "user1 should reach user2")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "initial user1 -> user2")
+		assertCurlDockerHostname(c, user1, url, "user1 should reach user2")
+	}, integrationutil.HAConvergeTimeout, integrationutil.SlowPoll, "initial user1 -> user2")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user1FQDN)
-		result, err := user2.Curl(url)
-		assert.NoError(c, err, "user2 should reach user1")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "initial user2 -> user1")
+		assertCurlDockerHostname(c, user2, url, "user2 should reach user1")
+	}, integrationutil.HAConvergeTimeout, integrationutil.SlowPoll, "initial user2 -> user1")
 
 	t.Log("Step 1: PASSED - connectivity works with valid policy")
 
@@ -3483,17 +3443,13 @@ func TestACLDynamicUnknownUserAddition(t *testing.T) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user2FQDN)
-		result, err := user1.Curl(url)
-		assert.NoError(c, err, "user1 should STILL reach user2 after adding unknown user")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "user1 -> user2 after unknown user added")
+		assertCurlDockerHostname(c, user1, url, "user1 should STILL reach user2 after adding unknown user")
+	}, integrationutil.HAConvergeTimeout, integrationutil.SlowPoll, "user1 -> user2 after unknown user added")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user1FQDN)
-		result, err := user2.Curl(url)
-		assert.NoError(c, err, "user2 should STILL reach user1 after adding unknown user")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "user2 -> user1 after unknown user added")
+		assertCurlDockerHostname(c, user2, url, "user2 should STILL reach user1 after adding unknown user")
+	}, integrationutil.HAConvergeTimeout, integrationutil.SlowPoll, "user2 -> user1 after unknown user added")
 
 	t.Log("Step 3: PASSED - connectivity maintained after adding unknown user")
 	t.Log("Test PASSED: v0.28.0-beta.1 scenario - unknown user added dynamically, valid users still work")
@@ -3589,17 +3545,13 @@ func TestACLDynamicUnknownUserRemoval(t *testing.T) {
 	t.Log("Step 1: Verifying connectivity with unknown user in policy (v2 graceful handling)")
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user2FQDN)
-		result, err := user1.Curl(url)
-		assert.NoError(c, err, "user1 should reach user2 even with unknown user in policy")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "initial user1 -> user2 with unknown")
+		assertCurlDockerHostname(c, user1, url, "user1 should reach user2 even with unknown user in policy")
+	}, integrationutil.HAConvergeTimeout, integrationutil.SlowPoll, "initial user1 -> user2 with unknown")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user1FQDN)
-		result, err := user2.Curl(url)
-		assert.NoError(c, err, "user2 should reach user1 even with unknown user in policy")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "initial user2 -> user1 with unknown")
+		assertCurlDockerHostname(c, user2, url, "user2 should reach user1 even with unknown user in policy")
+	}, integrationutil.HAConvergeTimeout, integrationutil.SlowPoll, "initial user2 -> user1 with unknown")
 
 	t.Log("Step 1: PASSED - connectivity works even with unknown user (v2 graceful handling)")
 
@@ -3638,17 +3590,13 @@ func TestACLDynamicUnknownUserRemoval(t *testing.T) {
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user2FQDN)
-		result, err := user1.Curl(url)
-		assert.NoError(c, err, "user1 should reach user2 after removing unknown user")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "user1 -> user2 after unknown removed")
+		assertCurlDockerHostname(c, user1, url, "user1 should reach user2 after removing unknown user")
+	}, integrationutil.HAConvergeTimeout, integrationutil.SlowPoll, "user1 -> user2 after unknown removed")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		url := fmt.Sprintf("http://%s/etc/hostname", user1FQDN)
-		result, err := user2.Curl(url)
-		assert.NoError(c, err, "user2 should reach user1 after removing unknown user")
-		assert.Len(c, result, 13, "expected hostname response")
-	}, integrationutil.ScaledTimeout(60*time.Second), 500*time.Millisecond, "user2 -> user1 after unknown removed")
+		assertCurlDockerHostname(c, user2, url, "user2 should reach user1 after removing unknown user")
+	}, integrationutil.HAConvergeTimeout, integrationutil.SlowPoll, "user2 -> user1 after unknown removed")
 
 	t.Log("Step 3: PASSED - connectivity maintained after removing unknown user")
 	t.Log("Test PASSED: Removing unknown users from policy works correctly")

--- a/integration/auth_key_test.go
+++ b/integration/auth_key_test.go
@@ -88,7 +88,7 @@ func TestAuthKeyLogoutAndReloginSameUser(t *testing.T) {
 				for _, node := range listNodes {
 					assertLastSeenSetWithCollect(c, node)
 				}
-			}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for expected node list before logout")
+			}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for expected node list before logout")
 
 			nodeCountBeforeLogout = len(listNodes)
 			t.Logf("node count before logout: %d", nodeCountBeforeLogout)
@@ -115,7 +115,7 @@ func TestAuthKeyLogoutAndReloginSameUser(t *testing.T) {
 				listNodes, err = headscale.ListNodes()
 				assert.NoError(ct, err, "Failed to list nodes after logout")
 				assert.Len(ct, listNodes, nodeCountBeforeLogout, "Node count should match before logout count - expected %d nodes, got %d", nodeCountBeforeLogout, len(listNodes))
-			}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second, "validating node persistence after logout (nodes should remain in database)")
+			}, integrationutil.StatusReadyTimeout, 2*time.Second, "validating node persistence after logout (nodes should remain in database)")
 
 			for _, node := range listNodes {
 				assertLastSeenSet(t, node)
@@ -153,7 +153,7 @@ func TestAuthKeyLogoutAndReloginSameUser(t *testing.T) {
 				listNodes, err = headscale.ListNodes()
 				assert.NoError(ct, err, "Failed to list nodes after relogin")
 				assert.Len(ct, listNodes, nodeCountBeforeLogout, "Node count should remain unchanged after relogin - expected %d nodes, got %d", nodeCountBeforeLogout, len(listNodes))
-			}, integrationutil.ScaledTimeout(60*time.Second), 2*time.Second, "validating node count stability after same-user auth key relogin")
+			}, integrationutil.HAConvergeTimeout, 2*time.Second, "validating node count stability after same-user auth key relogin")
 
 			for _, node := range listNodes {
 				assertLastSeenSet(t, node)
@@ -210,7 +210,7 @@ func TestAuthKeyLogoutAndReloginSameUser(t *testing.T) {
 				for _, node := range listNodes {
 					assertLastSeenSetWithCollect(c, node)
 				}
-			}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for node list after relogin")
+			}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for node list after relogin")
 		})
 	}
 }
@@ -266,7 +266,7 @@ func TestAuthKeyLogoutAndReloginNewUser(t *testing.T) {
 		listNodes, err = headscale.ListNodes()
 		assert.NoError(c, err)
 		assert.Len(c, listNodes, len(allClients))
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for expected node list before logout")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for expected node list before logout")
 
 	nodeCountBeforeLogout = len(listNodes)
 	t.Logf("node count before logout: %d", nodeCountBeforeLogout)
@@ -313,7 +313,7 @@ func TestAuthKeyLogoutAndReloginNewUser(t *testing.T) {
 		user1Nodes, err = headscale.ListNodes("user1")
 		assert.NoError(ct, err, "Failed to list nodes for user1 after relogin")
 		assert.Len(ct, user1Nodes, len(allClients), "User1 should have all %d clients after relogin, got %d nodes", len(allClients), len(user1Nodes))
-	}, integrationutil.ScaledTimeout(60*time.Second), 2*time.Second, "validating user1 has all client nodes after auth key relogin")
+	}, integrationutil.HAConvergeTimeout, 2*time.Second, "validating user1 has all client nodes after auth key relogin")
 
 	// Collect expected node IDs for user1 after relogin
 	expectedUser1Nodes := make([]types.NodeID, 0, len(user1Nodes))
@@ -337,7 +337,7 @@ func TestAuthKeyLogoutAndReloginNewUser(t *testing.T) {
 		user2Nodes, err = headscale.ListNodes("user2")
 		assert.NoError(ct, err, "Failed to list nodes for user2 after user1 relogin")
 		assert.Len(ct, user2Nodes, len(allClients)/2, "User2 should still have %d clients after user1 relogin, got %d nodes", len(allClients)/2, len(user2Nodes))
-	}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second, "validating user2 nodes persist after user1 relogin (should not be affected)")
+	}, integrationutil.StatusReadyTimeout, 2*time.Second, "validating user2 nodes persist after user1 relogin (should not be affected)")
 
 	t.Logf("Validating client login states after user switch at %s", time.Now().Format(TimestampFormat))
 
@@ -346,7 +346,7 @@ func TestAuthKeyLogoutAndReloginNewUser(t *testing.T) {
 			status, err := client.Status()
 			assert.NoError(ct, err, "Failed to get status for client %s", client.Hostname())
 			assert.Equal(ct, "user1@test.no", status.User[status.Self.UserID].LoginName, "Client %s should be logged in as user1 after user switch, got %s", client.Hostname(), status.User[status.Self.UserID].LoginName)
-		}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second, "validating %s is logged in as user1 after auth key user switch", client.Hostname())
+		}, integrationutil.StatusReadyTimeout, 2*time.Second, "validating %s is logged in as user1 after auth key user switch", client.Hostname())
 	}
 }
 
@@ -412,7 +412,7 @@ func TestAuthKeyLogoutAndReloginSameUserExpiredKey(t *testing.T) {
 				listNodes, err = headscale.ListNodes()
 				assert.NoError(c, err)
 				assert.Len(c, listNodes, len(allClients))
-			}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for expected node list before logout")
+			}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for expected node list before logout")
 
 			nodeCountBeforeLogout = len(listNodes)
 			t.Logf("node count before logout: %d", nodeCountBeforeLogout)
@@ -527,7 +527,7 @@ func TestAuthKeyDeleteKey(t *testing.T) {
 		user1Nodes, err = headscale.ListNodes("user1")
 		assert.NoError(c, err)
 		assert.Len(c, user1Nodes, 1)
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for node to be registered")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for node to be registered")
 
 	nodeID := user1Nodes[0].GetId()
 	nodeName := user1Nodes[0].GetName()
@@ -554,7 +554,7 @@ func TestAuthKeyDeleteKey(t *testing.T) {
 		status, err := client.Status()
 		assert.NoError(c, err)
 		assert.Equal(c, "Stopped", status.BackendState)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "client should be stopped")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "client should be stopped")
 
 	err = client.Up()
 	require.NoError(t, err)
@@ -659,7 +659,7 @@ func TestAuthKeyLogoutAndReloginRoutesPreserved(t *testing.T) {
 			assert.Contains(c, initialNode.GetSubnetRoutes(), advertiseRoute,
 				"Subnet routes should contain %s", advertiseRoute)
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "initial route should be serving")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "initial route should be serving")
 
 	require.NotNil(t, initialNode, "Initial node should be found")
 	initialNodeID := initialNode.GetId()
@@ -677,7 +677,7 @@ func TestAuthKeyLogoutAndReloginRoutesPreserved(t *testing.T) {
 		status, err := client.Status()
 		assert.NoError(ct, err)
 		assert.Equal(ct, "NeedsLogin", status.BackendState, "Expected NeedsLogin state after logout")
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "waiting for logout to complete")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "waiting for logout to complete")
 
 	t.Logf("Logout completed, node should still exist in database")
 
@@ -686,7 +686,7 @@ func TestAuthKeyLogoutAndReloginRoutesPreserved(t *testing.T) {
 		nodes, err := headscale.ListNodes()
 		assert.NoError(c, err)
 		assert.Len(c, nodes, 1, "Node should persist in database after logout")
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "node should persist after logout")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "node should persist after logout")
 
 	// Step 3: Re-authenticate with the SAME user (using auth key)
 	t.Logf("Step 3: Re-authenticating with same user at %s", time.Now().Format(TimestampFormat))
@@ -707,7 +707,7 @@ func TestAuthKeyLogoutAndReloginRoutesPreserved(t *testing.T) {
 		status, err := client.Status()
 		assert.NoError(ct, err)
 		assert.Equal(ct, "Running", status.BackendState, "Expected Running state after relogin")
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "waiting for relogin to complete")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "waiting for relogin to complete")
 
 	t.Logf("Re-authentication completed at %s", time.Now().Format(TimestampFormat))
 
@@ -741,7 +741,7 @@ func TestAuthKeyLogoutAndReloginRoutesPreserved(t *testing.T) {
 			assert.Equal(c, initialNodeID, node.GetId(),
 				"Node ID should be preserved after same-user relogin")
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond,
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll,
 		"BUG #2896: routes should remain SERVING after logout/relogin with same user")
 
 	t.Logf("Test completed - verifying issue #2896 fix")

--- a/integration/auth_oidc_test.go
+++ b/integration/auth_oidc_test.go
@@ -526,7 +526,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 		if diff := cmp.Diff(wantUsers, listUsers, cmpopts.IgnoreUnexported(v1.User{}), cmpopts.IgnoreFields(v1.User{}, "CreatedAt")); diff != "" {
 			ct.Errorf("User validation failed after first login - unexpected users: %s", diff)
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "validating user1 creation after initial OIDC login")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "validating user1 creation after initial OIDC login")
 
 	t.Logf("Validating initial node creation at %s", time.Now().Format(TimestampFormat))
 
@@ -538,7 +538,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 		listNodes, err = headscale.ListNodes()
 		assert.NoError(ct, err, "Failed to list nodes during initial validation")
 		assert.Len(ct, listNodes, 1, "Expected exactly 1 node after first login, got %d", len(listNodes))
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "validating initial node creation for user1 after OIDC login")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "validating initial node creation for user1 after OIDC login")
 
 	// Collect expected node IDs for validation after user1 initial login
 	expectedNodes := make([]types.NodeID, 0, 1)
@@ -553,7 +553,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 
 		nodeID, err = strconv.ParseUint(string(status.Self.ID), 10, 64)
 		assert.NoError(ct, err, "Failed to parse node ID from status")
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "waiting for node ID to be populated in status after initial login")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "waiting for node ID to be populated in status after initial login")
 
 	expectedNodes = append(expectedNodes, types.NodeID(nodeID))
 
@@ -579,7 +579,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 		status, err := ts.Status()
 		assert.NoError(ct, err, "Failed to get client status during logout validation")
 		assert.Equal(ct, "NeedsLogin", status.BackendState, "Expected NeedsLogin state after logout, got %s", status.BackendState)
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "waiting for user1 logout to complete before user2 login")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "waiting for user1 logout to complete before user2 login")
 
 	u, err = ts.LoginWithURL(headscale.GetEndpoint())
 	require.NoError(t, err)
@@ -617,7 +617,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 		if diff := cmp.Diff(wantUsers, listUsers, cmpopts.IgnoreUnexported(v1.User{}), cmpopts.IgnoreFields(v1.User{}, "CreatedAt")); diff != "" {
 			ct.Errorf("User validation failed after user2 login - expected both user1 and user2: %s", diff)
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "validating both user1 and user2 exist after second OIDC login")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "validating both user1 and user2 exist after second OIDC login")
 
 	var listNodesAfterNewUserLogin []*v1.Node
 	// First, wait for the new node to be created
@@ -627,7 +627,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 		assert.NoError(ct, err, "Failed to list nodes after user2 login")
 		// We might temporarily have more than 2 nodes during cleanup, so check for at least 2
 		assert.GreaterOrEqual(ct, len(listNodesAfterNewUserLogin), 2, "Should have at least 2 nodes after user2 login, got %d (may include temporary nodes during cleanup)", len(listNodesAfterNewUserLogin))
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "waiting for user2 node creation (allowing temporary extra nodes during cleanup)")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "waiting for user2 node creation (allowing temporary extra nodes during cleanup)")
 
 	// Then wait for cleanup to stabilize at exactly 2 nodes
 	t.Logf("Waiting for node cleanup stabilization at %s", time.Now().Format(TimestampFormat))
@@ -644,7 +644,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 			assert.Equal(ct, listNodesAfterNewUserLogin[0].GetMachineKey(), listNodesAfterNewUserLogin[1].GetMachineKey(), "Both nodes should share the same machine key")
 			assert.NotEqual(ct, listNodesAfterNewUserLogin[0].GetNodeKey(), listNodesAfterNewUserLogin[1].GetNodeKey(), "Node keys should be different between user1 and user2 nodes")
 		}
-	}, integrationutil.ScaledTimeout(90*time.Second), 2*time.Second, "waiting for node count stabilization at exactly 2 nodes after user2 login")
+	}, integrationutil.PolicyPropagationTimeout, 2*time.Second, "waiting for node count stabilization at exactly 2 nodes after user2 login")
 
 	// Security validation: Only user2's node should be active after user switch
 	var activeUser2NodeID types.NodeID
@@ -674,7 +674,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 		} else {
 			assert.Fail(c, "User2 node not found in nodestore")
 		}
-	}, integrationutil.ScaledTimeout(60*time.Second), 2*time.Second, "validating only user2 node is online after user switch")
+	}, integrationutil.HAConvergeTimeout, 2*time.Second, "validating only user2 node is online after user switch")
 
 	// Before logging out user2, validate we have exactly 2 nodes and both are stable
 	t.Logf("Pre-logout validation: checking node stability at %s", time.Now().Format(TimestampFormat))
@@ -689,7 +689,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 			assert.NotEmpty(ct, node.GetMachineKey(), "Node %d should have a valid machine key before logout", i)
 			t.Logf("Pre-logout node %d: User=%s, MachineKey=%s", i, node.GetUser().GetName(), node.GetMachineKey()[:16]+"...")
 		}
-	}, integrationutil.ScaledTimeout(60*time.Second), 2*time.Second, "validating stable node count and integrity before user2 logout")
+	}, integrationutil.HAConvergeTimeout, 2*time.Second, "validating stable node count and integrity before user2 logout")
 
 	// Log out user2, and log into user1, no new node should be created,
 	// the node should now "become" node1 again
@@ -715,7 +715,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 		status, err := ts.Status()
 		assert.NoError(ct, err, "Failed to get client status during user2 logout validation")
 		assert.Equal(ct, "NeedsLogin", status.BackendState, "Expected NeedsLogin state after user2 logout, got %s", status.BackendState)
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "waiting for user2 logout to complete before user1 relogin")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "waiting for user2 logout to complete before user1 relogin")
 
 	// Before logging back in, ensure we still have exactly 2 nodes
 	// Note: We skip validateLogoutComplete here since it expects all nodes to be offline,
@@ -734,7 +734,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 			assert.NotEmpty(ct, node.GetMachineKey(), "Node %d should still have a valid machine key after user2 logout", i)
 			t.Logf("Post-logout node %d: User=%s, MachineKey=%s", i, node.GetUser().GetName(), node.GetMachineKey()[:16]+"...")
 		}
-	}, integrationutil.ScaledTimeout(60*time.Second), 2*time.Second, "validating node persistence and integrity after user2 logout")
+	}, integrationutil.HAConvergeTimeout, 2*time.Second, "validating node persistence and integrity after user2 logout")
 
 	// We do not actually "change" the user here, it is done by logging in again
 	// as the OIDC mock server is kind of like a stack, and the next user is
@@ -750,7 +750,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 		status, err := ts.Status()
 		assert.NoError(ct, err, "Failed to get client status during user1 relogin validation")
 		assert.Equal(ct, "Running", status.BackendState, "Expected Running state after user1 relogin, got %s", status.BackendState)
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "waiting for user1 relogin to complete (final login)")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "waiting for user1 relogin to complete (final login)")
 
 	t.Logf("Logged back in")
 	t.Log("timestamp: " + time.Now().Format(TimestampFormat) + "\n")
@@ -785,7 +785,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 		if diff := cmp.Diff(wantUsers, listUsers, cmpopts.IgnoreUnexported(v1.User{}), cmpopts.IgnoreFields(v1.User{}, "CreatedAt")); diff != "" {
 			ct.Errorf("Final user validation failed - both users should persist after relogin cycle: %s", diff)
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "validating user persistence after complete relogin cycle (user1->user2->user1)")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "validating user persistence after complete relogin cycle (user1->user2->user1)")
 
 	var listNodesAfterLoggingBackIn []*v1.Node
 	// Wait for login to complete and nodes to stabilize
@@ -826,7 +826,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 		assert.NotEqual(ct, listNodesAfterLoggingBackIn[0].GetNodeKey(), listNodesAfterLoggingBackIn[1].GetNodeKey(), "Final nodes should have different node keys for different users")
 
 		t.Logf("Final validation complete - node counts and key relationships verified at %s", time.Now().Format(TimestampFormat))
-	}, integrationutil.ScaledTimeout(60*time.Second), 2*time.Second, "validating final node state after complete user1->user2->user1 relogin cycle with detailed key validation")
+	}, integrationutil.HAConvergeTimeout, 2*time.Second, "validating final node state after complete user1->user2->user1 relogin cycle with detailed key validation")
 
 	// Security validation: Only user1's node should be active after relogin
 	var activeUser1NodeID types.NodeID
@@ -856,7 +856,7 @@ func TestOIDCReloginSameNodeNewUser(t *testing.T) {
 		} else {
 			assert.Fail(c, "User1 node not found in nodestore after relogin")
 		}
-	}, integrationutil.ScaledTimeout(60*time.Second), 2*time.Second, "validating only user1 node is online after final relogin")
+	}, integrationutil.HAConvergeTimeout, 2*time.Second, "validating only user1 node is online after final relogin")
 }
 
 // TestOIDCFollowUpUrl validates the follow-up login flow
@@ -933,7 +933,7 @@ func TestOIDCFollowUpUrl(t *testing.T) {
 		assert.NoError(c, err)
 
 		assert.NotEqual(c, u.String(), st.AuthURL, "AuthURL should change")
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for registration cache to expire and status to reflect NeedsLogin")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for registration cache to expire and status to reflect NeedsLogin")
 
 	_, err = doLoginURL(ts.Hostname(), newUrl)
 	require.NoError(t, err)
@@ -971,7 +971,7 @@ func TestOIDCFollowUpUrl(t *testing.T) {
 		listNodes, err := headscale.ListNodes()
 		assert.NoError(c, err)
 		assert.Len(c, listNodes, 1)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for expected node list after OIDC login")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for expected node list after OIDC login")
 }
 
 // TestOIDCMultipleOpenedLoginUrls tests the scenario:
@@ -1081,7 +1081,7 @@ func TestOIDCMultipleOpenedLoginUrls(t *testing.T) {
 			listNodes, err := headscale.ListNodes()
 			assert.NoError(c, err)
 			assert.Len(c, listNodes, 1)
-		}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for expected node list after OIDC login",
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for expected node list after OIDC login",
 	)
 }
 
@@ -1176,7 +1176,7 @@ func TestOIDCReloginSameNodeSameUser(t *testing.T) {
 		if diff := cmp.Diff(wantUsers, listUsers, cmpopts.IgnoreUnexported(v1.User{}), cmpopts.IgnoreFields(v1.User{}, "CreatedAt")); diff != "" {
 			ct.Errorf("User validation failed after first login - unexpected users: %s", diff)
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "validating user1 creation after initial OIDC login")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "validating user1 creation after initial OIDC login")
 
 	t.Logf("Validating initial node creation at %s", time.Now().Format(TimestampFormat))
 
@@ -1188,7 +1188,7 @@ func TestOIDCReloginSameNodeSameUser(t *testing.T) {
 		initialNodes, err = headscale.ListNodes()
 		assert.NoError(ct, err, "Failed to list nodes during initial validation")
 		assert.Len(ct, initialNodes, 1, "Expected exactly 1 node after first login, got %d", len(initialNodes))
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "validating initial node creation for user1 after OIDC login")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "validating initial node creation for user1 after OIDC login")
 
 	// Collect expected node IDs for validation after user1 initial login
 	expectedNodes := make([]types.NodeID, 0, 1)
@@ -1203,7 +1203,7 @@ func TestOIDCReloginSameNodeSameUser(t *testing.T) {
 
 		nodeID, err = strconv.ParseUint(string(status.Self.ID), 10, 64)
 		assert.NoError(ct, err, "Failed to parse node ID from status")
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "waiting for node ID to be populated in status after initial login")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "waiting for node ID to be populated in status after initial login")
 
 	expectedNodes = append(expectedNodes, types.NodeID(nodeID))
 
@@ -1232,7 +1232,7 @@ func TestOIDCReloginSameNodeSameUser(t *testing.T) {
 		status, err := ts.Status()
 		assert.NoError(ct, err, "Failed to get client status during logout validation")
 		assert.Equal(ct, "NeedsLogin", status.BackendState, "Expected NeedsLogin state after logout, got %s", status.BackendState)
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "waiting for user1 logout to complete before same-user relogin")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "waiting for user1 logout to complete before same-user relogin")
 
 	// Validate node persistence during logout (node should remain in DB)
 	t.Logf("Validating node persistence during logout at %s", time.Now().Format(TimestampFormat))
@@ -1240,7 +1240,7 @@ func TestOIDCReloginSameNodeSameUser(t *testing.T) {
 		listNodes, err := headscale.ListNodes()
 		assert.NoError(ct, err, "Failed to list nodes during logout validation")
 		assert.Len(ct, listNodes, 1, "Should still have exactly 1 node during logout (node should persist in DB), got %d", len(listNodes))
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "validating node persistence in database during same-user logout")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "validating node persistence in database during same-user logout")
 
 	// Login again as the same user (user1)
 	u, err = ts.LoginWithURL(headscale.GetEndpoint())
@@ -1254,7 +1254,7 @@ func TestOIDCReloginSameNodeSameUser(t *testing.T) {
 		status, err := ts.Status()
 		assert.NoError(ct, err, "Failed to get client status during relogin validation")
 		assert.Equal(ct, "Running", status.BackendState, "Expected Running state after user1 relogin, got %s", status.BackendState)
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "waiting for user1 relogin to complete (same user)")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "waiting for user1 relogin to complete (same user)")
 
 	t.Logf("Final validation: checking user persistence after same-user relogin at %s", time.Now().Format(TimestampFormat))
 	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
@@ -1279,7 +1279,7 @@ func TestOIDCReloginSameNodeSameUser(t *testing.T) {
 		if diff := cmp.Diff(wantUsers, listUsers, cmpopts.IgnoreUnexported(v1.User{}), cmpopts.IgnoreFields(v1.User{}, "CreatedAt")); diff != "" {
 			ct.Errorf("Final user validation failed - user1 should persist after same-user relogin: %s", diff)
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "validating user1 persistence after same-user OIDC relogin cycle")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "validating user1 persistence after same-user OIDC relogin cycle")
 
 	var finalNodes []*v1.Node
 
@@ -1302,7 +1302,7 @@ func TestOIDCReloginSameNodeSameUser(t *testing.T) {
 		assert.NotEqual(ct, initialNodeKey, finalNode.GetNodeKey(), "Node key should be regenerated after logout/relogin even for same user")
 
 		t.Logf("Final validation complete - same user relogin key relationships verified at %s", time.Now().Format(TimestampFormat))
-	}, integrationutil.ScaledTimeout(60*time.Second), 2*time.Second, "validating final node state after same-user OIDC relogin cycle with key preservation validation")
+	}, integrationutil.HAConvergeTimeout, 2*time.Second, "validating final node state after same-user OIDC relogin cycle with key preservation validation")
 
 	// Security validation: user1's node should be active after relogin
 	activeUser1NodeID := types.NodeID(finalNodes[0].GetId())
@@ -1322,7 +1322,7 @@ func TestOIDCReloginSameNodeSameUser(t *testing.T) {
 		} else {
 			assert.Fail(c, "User1 node not found in nodestore after same-user relogin")
 		}
-	}, integrationutil.ScaledTimeout(60*time.Second), 2*time.Second, "validating user1 node is online after same-user OIDC relogin")
+	}, integrationutil.HAConvergeTimeout, 2*time.Second, "validating user1 node is online after same-user OIDC relogin")
 }
 
 // TestOIDCExpiryAfterRestart validates that node expiry is preserved
@@ -1398,7 +1398,7 @@ func TestOIDCExpiryAfterRestart(t *testing.T) {
 			initialExpiry = expiryTime
 			t.Logf("Initial expiry set to: %v (expires in %v)", expiryTime, time.Until(expiryTime))
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "validating initial expiry after OIDC login")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "validating initial expiry after OIDC login")
 
 	// Now restart the tailscaled container
 	t.Logf("Restarting tailscaled container at %s", time.Now().Format(TimestampFormat))
@@ -1420,7 +1420,7 @@ func TestOIDCExpiryAfterRestart(t *testing.T) {
 		}
 
 		assert.Equal(ct, "Running", status.BackendState)
-	}, integrationutil.ScaledTimeout(60*time.Second), 2*time.Second, "waiting for tailscale to reconnect after restart")
+	}, integrationutil.HAConvergeTimeout, 2*time.Second, "waiting for tailscale to reconnect after restart")
 
 	// THE CRITICAL TEST: Verify expiry is still set correctly after restart
 	t.Logf("Validating expiry preservation after restart at %s", time.Now().Format(TimestampFormat))
@@ -1448,7 +1448,7 @@ func TestOIDCExpiryAfterRestart(t *testing.T) {
 			t.Logf("SUCCESS: Expiry preserved after restart: %v (expires in %v)",
 				expiryTime, time.Until(expiryTime))
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "validating expiry preservation after restart")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "validating expiry preservation after restart")
 }
 
 // TestOIDCACLPolicyOnJoin validates that ACL policies are correctly applied
@@ -1570,7 +1570,7 @@ func TestOIDCACLPolicyOnJoin(t *testing.T) {
 		gatewayNodeID = gatewayNode.GetId()
 		assert.Len(ct, gatewayNode.GetAvailableRoutes(), 1)
 		assert.Contains(ct, gatewayNode.GetAvailableRoutes(), advertiseRoute)
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "route advertisement should propagate to headscale")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "route advertisement should propagate to headscale")
 
 	// Approve the advertised route
 	_, err = headscale.ApproveRoutes(
@@ -1588,7 +1588,7 @@ func TestOIDCACLPolicyOnJoin(t *testing.T) {
 		gatewayNode := nodes[0]
 		assert.Len(ct, gatewayNode.GetApprovedRoutes(), 1)
 		assert.Contains(ct, gatewayNode.GetApprovedRoutes(), advertiseRoute)
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "route approval should propagate to headscale")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "route approval should propagate to headscale")
 
 	// NOW create the OIDC user by having them join
 	// This is where issue #2888 manifests - the new OIDC node should immediately
@@ -1658,7 +1658,7 @@ func TestOIDCACLPolicyOnJoin(t *testing.T) {
 				t.Logf("Gateway peer AllowedIPs: %v", allowedIPs)
 			}
 		}
-	}, integrationutil.ScaledTimeout(15*time.Second), 500*time.Millisecond,
+	}, integrationutil.ScaledTimeout(15*time.Second), integrationutil.SlowPoll,
 		"OIDC user should immediately see gateway's advertised route without client restart (issue #2888)")
 
 	// Verify that the Gateway node sees the OIDC node's advertised route (AutoApproveRoutes check)
@@ -1690,7 +1690,7 @@ func TestOIDCACLPolicyOnJoin(t *testing.T) {
 					"Gateway user should immediately see OIDC's advertised route %s in PrimaryRoutes", oidcAdvertiseRoute)
 			}
 		}
-	}, integrationutil.ScaledTimeout(15*time.Second), 500*time.Millisecond,
+	}, integrationutil.ScaledTimeout(15*time.Second), integrationutil.SlowPoll,
 		"Gateway user should immediately see OIDC's advertised route (AutoApproveRoutes check)")
 
 	// Additional validation: Verify nodes in headscale match expectations
@@ -1738,7 +1738,7 @@ func TestOIDCACLPolicyOnJoin(t *testing.T) {
 			assert.Equal(ct, "oidcuser", oidcUserFound.GetName())
 			assert.Equal(ct, "oidcuser@headscale.net", oidcUserFound.GetEmail())
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "headscale should have correct users and nodes")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "headscale should have correct users and nodes")
 
 	t.Logf("Test completed successfully - issue #2888 fix validated")
 }
@@ -1829,7 +1829,7 @@ func TestOIDCReloginSameUserRoutesPreserved(t *testing.T) {
 		status, err := ts.Status()
 		assert.NoError(ct, err)
 		assert.Equal(ct, "Running", status.BackendState)
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "waiting for initial login to complete")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "waiting for initial login to complete")
 
 	// Step 1: Verify initial route is advertised, approved, and SERVING
 	t.Logf("Step 1: Verifying initial route is advertised, approved, and SERVING at %s", time.Now().Format(TimestampFormat))
@@ -1853,7 +1853,7 @@ func TestOIDCReloginSameUserRoutesPreserved(t *testing.T) {
 			assert.Contains(c, initialNode.GetSubnetRoutes(), advertiseRoute,
 				"Subnet routes should contain %s", advertiseRoute)
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "initial route should be serving")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "initial route should be serving")
 
 	require.NotNil(t, initialNode, "Initial node should be found")
 	initialNodeID := initialNode.GetId()
@@ -1871,7 +1871,7 @@ func TestOIDCReloginSameUserRoutesPreserved(t *testing.T) {
 		status, err := ts.Status()
 		assert.NoError(ct, err)
 		assert.Equal(ct, "NeedsLogin", status.BackendState, "Expected NeedsLogin state after logout")
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "waiting for logout to complete")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "waiting for logout to complete")
 
 	t.Logf("Logout completed, node should still exist in database")
 
@@ -1880,7 +1880,7 @@ func TestOIDCReloginSameUserRoutesPreserved(t *testing.T) {
 		nodes, err := headscale.ListNodes()
 		assert.NoError(c, err)
 		assert.Len(c, nodes, 1, "Node should persist in database after logout")
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "node should persist after logout")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "node should persist after logout")
 
 	// Step 3: Re-authenticate via OIDC as the same user
 	t.Logf("Step 3: Re-authenticating with same user via OIDC at %s", time.Now().Format(TimestampFormat))
@@ -1896,7 +1896,7 @@ func TestOIDCReloginSameUserRoutesPreserved(t *testing.T) {
 		status, err := ts.Status()
 		assert.NoError(ct, err)
 		assert.Equal(ct, "Running", status.BackendState, "Expected Running state after relogin")
-	}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second, "waiting for relogin to complete")
+	}, integrationutil.StatusReadyTimeout, 1*time.Second, "waiting for relogin to complete")
 
 	t.Logf("Re-authentication completed at %s", time.Now().Format(TimestampFormat))
 
@@ -1930,7 +1930,7 @@ func TestOIDCReloginSameUserRoutesPreserved(t *testing.T) {
 			assert.Equal(c, initialNodeID, node.GetId(),
 				"Node ID should be preserved after same-user relogin")
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond,
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll,
 		"BUG #2896: routes should remain SERVING after OIDC logout/relogin with same user")
 
 	t.Logf("Test completed - verifying issue #2896 fix for OIDC")

--- a/integration/auth_web_flow_test.go
+++ b/integration/auth_web_flow_test.go
@@ -107,7 +107,7 @@ func TestAuthWebFlowLogoutAndReloginSameUser(t *testing.T) {
 		listNodes, err = headscale.ListNodes()
 		assert.NoError(ct, err, "Failed to list nodes after web authentication")
 		assert.Len(ct, listNodes, len(allClients), "Expected %d nodes after web auth, got %d", len(allClients), len(listNodes))
-	}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second, "validating node count matches client count after web authentication")
+	}, integrationutil.StatusReadyTimeout, 2*time.Second, "validating node count matches client count after web authentication")
 
 	nodeCountBeforeLogout := len(listNodes)
 	t.Logf("node count before logout: %d", nodeCountBeforeLogout)
@@ -154,7 +154,7 @@ func TestAuthWebFlowLogoutAndReloginSameUser(t *testing.T) {
 		listNodes, err = headscale.ListNodes()
 		assert.NoError(ct, err, "Failed to list nodes after web flow logout")
 		assert.Len(ct, listNodes, nodeCountBeforeLogout, "Node count should remain unchanged after logout - expected %d nodes, got %d", nodeCountBeforeLogout, len(listNodes))
-	}, integrationutil.ScaledTimeout(60*time.Second), 2*time.Second, "validating node persistence in database after web flow logout")
+	}, integrationutil.HAConvergeTimeout, 2*time.Second, "validating node persistence in database after web flow logout")
 	t.Logf("node count first login: %d, after relogin: %d", nodeCountBeforeLogout, len(listNodes))
 
 	// Validate connection state after relogin
@@ -265,7 +265,7 @@ func TestAuthWebFlowLogoutAndReloginNewUser(t *testing.T) {
 		listNodes, err = headscale.ListNodes()
 		assert.NoError(ct, err, "Failed to list nodes after initial web authentication")
 		assert.Len(ct, listNodes, len(allClients), "Expected %d nodes after web auth, got %d", len(allClients), len(listNodes))
-	}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second, "validating node count matches client count after initial web authentication")
+	}, integrationutil.StatusReadyTimeout, 2*time.Second, "validating node count matches client count after initial web authentication")
 
 	nodeCountBeforeLogout := len(listNodes)
 	t.Logf("node count before logout: %d", nodeCountBeforeLogout)
@@ -325,7 +325,7 @@ func TestAuthWebFlowLogoutAndReloginNewUser(t *testing.T) {
 		user1Nodes, err = headscale.ListNodes("user1")
 		assert.NoError(ct, err, "Failed to list nodes for user1 after web flow relogin")
 		assert.Len(ct, user1Nodes, len(allClients), "User1 should have all %d clients after web flow relogin, got %d nodes", len(allClients), len(user1Nodes))
-	}, integrationutil.ScaledTimeout(60*time.Second), 2*time.Second, "validating user1 has all client nodes after web flow user switch relogin")
+	}, integrationutil.HAConvergeTimeout, 2*time.Second, "validating user1 has all client nodes after web flow user switch relogin")
 
 	// Collect expected node IDs for user1 after relogin
 	expectedUser1Nodes := make([]types.NodeID, 0, len(user1Nodes))
@@ -347,7 +347,7 @@ func TestAuthWebFlowLogoutAndReloginNewUser(t *testing.T) {
 		user2Nodes, err = headscale.ListNodes("user2")
 		assert.NoError(ct, err, "Failed to list nodes for user2 after CLI registration to user1")
 		assert.Len(ct, user2Nodes, len(allClients)/2, "User2 should still have %d old nodes (likely expired) after CLI registration to user1, got %d nodes", len(allClients)/2, len(user2Nodes))
-	}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second, "validating user2 old nodes remain in database after CLI registration to user1")
+	}, integrationutil.StatusReadyTimeout, 2*time.Second, "validating user2 old nodes remain in database after CLI registration to user1")
 
 	t.Logf("Validating client login states after web flow user switch at %s", time.Now().Format(TimestampFormat))
 
@@ -356,7 +356,7 @@ func TestAuthWebFlowLogoutAndReloginNewUser(t *testing.T) {
 			status, err := client.Status()
 			assert.NoError(ct, err, "Failed to get status for client %s", client.Hostname())
 			assert.Equal(ct, "user1@test.no", status.User[status.Self.UserID].LoginName, "Client %s should be logged in as user1 after web flow user switch, got %s", client.Hostname(), status.User[status.Self.UserID].LoginName)
-		}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second, "validating %s is logged in as user1 after web flow user switch", client.Hostname())
+		}, integrationutil.StatusReadyTimeout, 2*time.Second, "validating %s is logged in as user1 after web flow user switch", client.Hostname())
 	}
 
 	// Test connectivity after user switch

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -147,7 +147,7 @@ func TestUserCommand(t *testing.T) {
 			&listByUsername,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for user list by username")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for user list by username")
 
 	slices.SortFunc(listByUsername, sortWithID)
 
@@ -178,7 +178,7 @@ func TestUserCommand(t *testing.T) {
 			&listByID,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for user list by ID")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for user list by ID")
 
 	slices.SortFunc(listByID, sortWithID)
 
@@ -264,7 +264,7 @@ func TestUserCommand(t *testing.T) {
 		)
 		assert.NoError(c, err)
 		assert.Empty(c, listAfterNameDelete)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for user list after name delete")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for user list after name delete")
 }
 
 func TestPreAuthKeyCommand(t *testing.T) {
@@ -315,7 +315,7 @@ func TestPreAuthKeyCommand(t *testing.T) {
 				&preAuthKey,
 			)
 			assert.NoError(c, err)
-		}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for preauth key creation")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for preauth key creation")
 
 		keys[index] = &preAuthKey
 	}
@@ -337,7 +337,7 @@ func TestPreAuthKeyCommand(t *testing.T) {
 			&listedPreAuthKeys,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for preauth keys list")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for preauth keys list")
 
 	// There is one key created by "scenario.CreateHeadscaleEnv"
 	assert.Len(t, listedPreAuthKeys, 4)
@@ -413,7 +413,7 @@ func TestPreAuthKeyCommand(t *testing.T) {
 			&listedPreAuthKeysAfterExpire,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for preauth keys list after expire")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for preauth keys list after expire")
 
 	assert.True(t, listedPreAuthKeysAfterExpire[1].GetExpiration().AsTime().Before(time.Now()))
 	assert.True(t, listedPreAuthKeysAfterExpire[2].GetExpiration().AsTime().After(time.Now()))
@@ -457,7 +457,7 @@ func TestPreAuthKeyCommandWithoutExpiry(t *testing.T) {
 			&preAuthKey,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for preauth key creation without expiry")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for preauth key creation without expiry")
 
 	var listedPreAuthKeys []v1.PreAuthKey
 
@@ -474,7 +474,7 @@ func TestPreAuthKeyCommandWithoutExpiry(t *testing.T) {
 			&listedPreAuthKeys,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for preauth keys list")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for preauth keys list")
 
 	// There is one key created by "scenario.CreateHeadscaleEnv"
 	assert.Len(t, listedPreAuthKeys, 2)
@@ -523,7 +523,7 @@ func TestPreAuthKeyCommandReusableEphemeral(t *testing.T) {
 			&preAuthReusableKey,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for reusable preauth key creation")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for reusable preauth key creation")
 
 	var preAuthEphemeralKey v1.PreAuthKey
 
@@ -543,7 +543,7 @@ func TestPreAuthKeyCommandReusableEphemeral(t *testing.T) {
 			&preAuthEphemeralKey,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for ephemeral preauth key creation")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for ephemeral preauth key creation")
 
 	assert.True(t, preAuthEphemeralKey.GetEphemeral())
 	assert.False(t, preAuthEphemeralKey.GetReusable())
@@ -563,7 +563,7 @@ func TestPreAuthKeyCommandReusableEphemeral(t *testing.T) {
 			&listedPreAuthKeys,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for preauth keys list after reusable/ephemeral creation")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for preauth keys list after reusable/ephemeral creation")
 
 	// There is one key created by "scenario.CreateHeadscaleEnv"
 	assert.Len(t, listedPreAuthKeys, 3)
@@ -621,7 +621,7 @@ func TestPreAuthKeyCorrectUserLoggedInCommand(t *testing.T) {
 			&user2Key,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for user2 preauth key creation")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for user2 preauth key creation")
 
 	var listNodes []*v1.Node
 
@@ -653,7 +653,7 @@ func TestPreAuthKeyCorrectUserLoggedInCommand(t *testing.T) {
 		assert.NoError(ct, err)
 		assert.NotContains(ct, []string{"Starting", "Running"}, status.BackendState,
 			"Expected node to be logged out, backend state: %s", status.BackendState)
-	}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second)
+	}, integrationutil.StatusReadyTimeout, 2*time.Second)
 
 	err = client.Login(headscale.GetEndpoint(), user2Key.GetKey())
 	require.NoError(t, err)
@@ -665,7 +665,7 @@ func TestPreAuthKeyCorrectUserLoggedInCommand(t *testing.T) {
 		// With tags-as-identity model, tagged nodes show as TaggedDevices user (2147455555)
 		// The PreAuthKey was created with tags, so the node is tagged
 		assert.Equal(ct, "userid:2147455555", status.Self.UserID.String(), "Expected node to be logged in as tagged-devices user")
-	}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second)
+	}, integrationutil.StatusReadyTimeout, 2*time.Second)
 
 	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
 		var err error
@@ -730,7 +730,7 @@ func TestTaggedNodesCLIOutput(t *testing.T) {
 			&user2Key,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for user2 tagged preauth key creation")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for user2 tagged preauth key creation")
 
 	allClients, err := scenario.ListTailscaleClients()
 	requireNoErrListClients(t, err)
@@ -751,7 +751,7 @@ func TestTaggedNodesCLIOutput(t *testing.T) {
 		assert.NoError(ct, err)
 		assert.NotContains(ct, []string{"Starting", "Running"}, status.BackendState,
 			"Expected node to be logged out, backend state: %s", status.BackendState)
-	}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second)
+	}, integrationutil.StatusReadyTimeout, 2*time.Second)
 
 	// Log in with the tagged PreAuthKey (from user2, with tags)
 	err = client.Login(headscale.GetEndpoint(), user2Key.GetKey())
@@ -763,7 +763,7 @@ func TestTaggedNodesCLIOutput(t *testing.T) {
 		assert.Equal(ct, "Running", status.BackendState, "Expected node to be logged in, backend state: %s", status.BackendState)
 		// With tags-as-identity model, tagged nodes show as TaggedDevices user (2147455555)
 		assert.Equal(ct, "userid:2147455555", status.Self.UserID.String(), "Expected node to be logged in as tagged-devices user")
-	}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second)
+	}, integrationutil.StatusReadyTimeout, 2*time.Second)
 
 	// Wait for the second node to appear
 	var listNodes []*v1.Node
@@ -850,7 +850,7 @@ func TestApiKeyCommand(t *testing.T) {
 			&listedAPIKeys,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for API keys list")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for API keys list")
 
 	assert.Len(t, listedAPIKeys, 5)
 
@@ -925,7 +925,7 @@ func TestApiKeyCommand(t *testing.T) {
 			&listedAfterExpireAPIKeys,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for API keys list after expire")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for API keys list after expire")
 
 	for index := range listedAfterExpireAPIKeys {
 		if _, ok := expiredPrefixes[listedAfterExpireAPIKeys[index].GetPrefix()]; ok {
@@ -967,7 +967,7 @@ func TestApiKeyCommand(t *testing.T) {
 			&listedAPIKeysAfterDelete,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for API keys list after delete")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for API keys list after delete")
 
 	assert.Len(t, listedAPIKeysAfterDelete, 4)
 
@@ -996,7 +996,7 @@ func TestApiKeyCommand(t *testing.T) {
 			&listedAPIKeysAfterExpireByID,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for API keys list after expire by ID")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for API keys list after expire by ID")
 
 	// Verify the key was expired
 	for idx := range listedAPIKeysAfterExpireByID {
@@ -1032,7 +1032,7 @@ func TestApiKeyCommand(t *testing.T) {
 			&listedAPIKeysAfterDeleteByID,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for API keys list after delete by ID")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for API keys list after delete by ID")
 
 	assert.Len(t, listedAPIKeysAfterDeleteByID, 3)
 
@@ -1109,7 +1109,7 @@ func TestNodeCommand(t *testing.T) {
 				&node,
 			)
 			assert.NoError(c, err)
-		}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for node registration")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for node registration")
 
 		nodes[index] = &node
 	}
@@ -1194,7 +1194,7 @@ func TestNodeCommand(t *testing.T) {
 				&node,
 			)
 			assert.NoError(c, err)
-		}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for other-user node registration")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for other-user node registration")
 
 		otherUserMachines[index] = &node
 	}
@@ -1219,7 +1219,7 @@ func TestNodeCommand(t *testing.T) {
 			&listAllWithotherUser,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for nodes list after adding other-user nodes")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for nodes list after adding other-user nodes")
 
 	// All nodes, nodes + otherUser
 	assert.Len(t, listAllWithotherUser, 7)
@@ -1248,7 +1248,7 @@ func TestNodeCommand(t *testing.T) {
 			&listOnlyotherUserMachineUser,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for nodes list filtered by other-user")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for nodes list filtered by other-user")
 
 	assert.Len(t, listOnlyotherUserMachineUser, 2)
 
@@ -1368,7 +1368,7 @@ func TestNodeExpireCommand(t *testing.T) {
 				&node,
 			)
 			assert.NoError(c, err)
-		}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for node-expire-user node registration")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for node-expire-user node registration")
 
 		nodes[index] = &node
 	}
@@ -1390,7 +1390,7 @@ func TestNodeExpireCommand(t *testing.T) {
 			&listAll,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for nodes list in expire test")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for nodes list in expire test")
 
 	assert.Len(t, listAll, 5)
 
@@ -1429,7 +1429,7 @@ func TestNodeExpireCommand(t *testing.T) {
 			&listAllAfterExpiry,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for nodes list after expiry")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for nodes list after expiry")
 
 	assert.Len(t, listAllAfterExpiry, 5)
 
@@ -1506,7 +1506,7 @@ func TestNodeRenameCommand(t *testing.T) {
 				&node,
 			)
 			assert.NoError(c, err)
-		}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for node-rename-command node registration")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for node-rename-command node registration")
 
 		nodes[index] = &node
 	}
@@ -1528,7 +1528,7 @@ func TestNodeRenameCommand(t *testing.T) {
 			&listAll,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for nodes list in rename test")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for nodes list in rename test")
 
 	assert.Len(t, listAll, 5)
 
@@ -1569,7 +1569,7 @@ func TestNodeRenameCommand(t *testing.T) {
 			&listAllAfterRename,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for nodes list after rename")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for nodes list after rename")
 
 	assert.Len(t, listAllAfterRename, 5)
 
@@ -1607,7 +1607,7 @@ func TestNodeRenameCommand(t *testing.T) {
 			&listAllAfterRenameAttempt,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for nodes list after failed rename attempt")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for nodes list after failed rename attempt")
 
 	assert.Len(t, listAllAfterRenameAttempt, 5)
 
@@ -1696,7 +1696,7 @@ func TestPolicyCommand(t *testing.T) {
 			&output,
 		)
 		assert.NoError(c, err)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for policy get command")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for policy get command")
 
 	assert.Len(t, output.TagOwners, 1)
 	assert.Len(t, output.ACLs, 1)

--- a/integration/dns_test.go
+++ b/integration/dns_test.go
@@ -67,7 +67,7 @@ func TestResolveMagicDNS(t *testing.T) {
 				for _, ip := range ips {
 					assert.Contains(ct, result, ip.String(), "IP %s should be found in DNS resolution result from %s to %s", ip.String(), client.Hostname(), peer.Hostname())
 				}
-			}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second)
+			}, integrationutil.StatusReadyTimeout, 2*time.Second)
 		}
 	}
 }

--- a/integration/dockertestutil/auth.go
+++ b/integration/dockertestutil/auth.go
@@ -1,0 +1,171 @@
+package dockertestutil
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+)
+
+const dockerHubServer = "https://index.docker.io/v1/"
+
+type CredentialSource string
+
+const (
+	CredentialSourceEnv       CredentialSource = "env"
+	CredentialSourceConfig    CredentialSource = "config"
+	CredentialSourceAnonymous CredentialSource = "anonymous"
+)
+
+// Credentials resolves Docker Hub credentials from
+// DOCKERHUB_USERNAME/DOCKERHUB_TOKEN, then ~/.docker/config.json, then
+// anonymous. The Docker Go SDKs do not read config.json on their own.
+func Credentials() (string, string, CredentialSource) {
+	if u := os.Getenv("DOCKERHUB_USERNAME"); u != "" {
+		return u, os.Getenv("DOCKERHUB_TOKEN"), CredentialSourceEnv
+	}
+
+	user, pass, ok := credentialsFromConfig()
+	if ok {
+		return user, pass, CredentialSourceConfig
+	}
+
+	return "", "", CredentialSourceAnonymous
+}
+
+// AuthConfiguration returns Docker Hub auth for the dockertest pool.
+func AuthConfiguration() docker.AuthConfiguration {
+	u, p, _ := Credentials()
+
+	return docker.AuthConfiguration{
+		Username:      u,
+		Password:      p,
+		ServerAddress: dockerHubServer,
+	}
+}
+
+// RegistryAuth returns base64-encoded credentials for the modern
+// Docker SDK's image.PullOptions{RegistryAuth: ...}, or "" when none.
+func RegistryAuth() (string, error) {
+	u, p, _ := Credentials()
+	if u == "" && p == "" {
+		return "", nil
+	}
+
+	auth := struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}{Username: u, Password: p}
+
+	b, err := json.Marshal(auth) //nolint:gosec // G117: password field holds the Docker Hub token, intentional
+	if err != nil {
+		return "", fmt.Errorf("marshalling docker auth: %w", err)
+	}
+
+	return base64.URLEncoding.EncodeToString(b), nil
+}
+
+// PullWithAuth ensures imageRef is local, pulling with auth and
+// retrying transient errors when it is not.
+func PullWithAuth(pool *dockertest.Pool, imageRef string) error {
+	if img, _ := pool.Client.InspectImage(imageRef); img != nil {
+		return nil
+	}
+
+	repo, tag := splitImageRef(imageRef)
+	auth := AuthConfiguration()
+
+	_, err := backoff.Retry(
+		context.Background(),
+		func() (struct{}, error) {
+			err := pool.Client.PullImage(docker.PullImageOptions{
+				Repository: repo,
+				Tag:        tag,
+			}, auth)
+			if err == nil {
+				return struct{}{}, nil
+			}
+
+			if isPermanentPullError(err) {
+				return struct{}{}, backoff.Permanent(err)
+			}
+
+			return struct{}{}, fmt.Errorf("pulling %s: %w", imageRef, err)
+		},
+		backoff.WithBackOff(backoff.NewExponentialBackOff()),
+		backoff.WithMaxElapsedTime(60*time.Second),
+	)
+	if err != nil {
+		return fmt.Errorf("pulling %s with auth (source=%s): %w", imageRef, AuthConfiguration().ServerAddress, err)
+	}
+
+	return nil
+}
+
+func splitImageRef(ref string) (string, string) {
+	if i := strings.LastIndex(ref, ":"); i >= 0 {
+		return ref[:i], ref[i+1:]
+	}
+
+	return ref, "latest"
+}
+
+func isPermanentPullError(err error) bool {
+	msg := strings.ToLower(err.Error())
+
+	return strings.Contains(msg, "manifest unknown") ||
+		strings.Contains(msg, "manifest not found") ||
+		strings.Contains(msg, "repository does not exist") ||
+		strings.Contains(msg, "name unknown") ||
+		strings.Contains(msg, "no such image")
+}
+
+// credentialsFromConfig reads the Hub entry from ~/.docker/config.json.
+// Credential helpers (osxkeychain etc.) are not supported; use env vars.
+func credentialsFromConfig() (string, string, bool) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", "", false
+	}
+
+	raw, err := os.ReadFile(filepath.Join(home, ".docker", "config.json"))
+	if err != nil {
+		return "", "", false
+	}
+
+	var cfg struct {
+		Auths map[string]struct {
+			Auth string `json:"auth"`
+		} `json:"auths"`
+	}
+
+	err = json.Unmarshal(raw, &cfg)
+	if err != nil {
+		return "", "", false
+	}
+
+	entry, found := cfg.Auths[dockerHubServer]
+	if !found || entry.Auth == "" {
+		return "", "", false
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(entry.Auth)
+	if err != nil {
+		return "", "", false
+	}
+
+	parts := strings.SplitN(string(decoded), ":", 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+
+	return parts[0], parts[1], true
+}

--- a/integration/dockertestutil/network.go
+++ b/integration/dockertestutil/network.go
@@ -1,11 +1,13 @@
 package dockertestutil
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"log"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
@@ -14,10 +16,19 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 )
 
-var ErrContainerNotFound = errors.New("container not found")
+var (
+	ErrContainerNotFound = errors.New("container not found")
+	ErrConditionTimeout  = errors.New("condition not met within timeout")
+)
 
 // retryDockerOp absorbs eventual-consistency races in libnetwork endpoint cleanup.
+// Pulls its backoff bounds from retry.go so every helper that drives a
+// docker control-plane call uses the same budget.
 func retryDockerOp(ctx context.Context, op func() error) error {
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = DockerOpInitialInterval
+	bo.MaxInterval = DockerOpMaxInterval
+
 	_, err := backoff.Retry(ctx, func() (struct{}, error) {
 		err := op()
 		if err != nil {
@@ -25,7 +36,7 @@ func retryDockerOp(ctx context.Context, op func() error) error {
 		}
 
 		return struct{}{}, nil
-	}, backoff.WithBackOff(backoff.NewExponentialBackOff()), backoff.WithMaxElapsedTime(30*time.Second))
+	}, backoff.WithBackOff(bo), backoff.WithMaxElapsedTime(DockerOpMaxElapsedTime))
 
 	return err
 }
@@ -105,46 +116,266 @@ func AddContainerToNetwork(
 	})
 }
 
-// DisconnectContainerFromNetwork removes the container from network at
-// the docker daemon level. Mirrors a physical cable pull: the
-// container's network interface for that network disappears and any
-// in-flight TCP connections are left half-open, exactly the failure
-// mode iptables-based simulations cannot reproduce.
+// DisconnectContainerFromNetwork detaches the container at the docker
+// daemon level (cable-pull semantics) and waits for libnetwork to drop
+// the endpoint before returning — re-attaching during the
+// reprogramming window otherwise fails with "network is unreachable".
 func DisconnectContainerFromNetwork(
 	pool *dockertest.Pool,
 	network *dockertest.Network,
 	testContainer string,
 ) error {
-	containers, err := pool.Client.ListContainers(docker.ListContainersOptions{
-		All: true,
-		Filters: map[string][]string{
-			"name": {testContainer},
-		},
+	containerID, err := lookupContainerID(pool, testContainer)
+	if err != nil {
+		return err
+	}
+
+	err = retryDockerOp(context.Background(), func() error {
+		return pool.Client.DisconnectNetwork(network.Network.ID, docker.NetworkConnectionOptions{
+			Container: containerID,
+		})
 	})
 	if err != nil {
 		return err
 	}
 
-	if len(containers) == 0 {
-		return fmt.Errorf("%w: %s", ErrContainerNotFound, testContainer)
+	err = waitNetworkContainerAbsent(pool, network, testContainer, DockerOpMaxElapsedTime)
+	if err != nil {
+		return err
 	}
 
-	return retryDockerOp(context.Background(), func() error {
-		return pool.Client.DisconnectNetwork(network.Network.ID, docker.NetworkConnectionOptions{
-			Container: containers[0].ID,
-		})
-	})
+	// libnetwork drops the endpoint from its model before the kernel
+	// netns has flushed the matching route. Re-attach with the sticky
+	// IP otherwise fails with "conflicts with existing route".
+	return waitContainerRouteAbsent(pool, containerID, network, DockerOpMaxElapsedTime)
 }
 
-// ReconnectContainerToNetwork is the inverse of
-// DisconnectContainerFromNetwork — re-attaches the container to the
-// network so traffic can flow again.
+// ReconnectContainerToNetwork inverts DisconnectContainerFromNetwork
+// and waits until libnetwork has wired up a fresh IPv4 address.
 func ReconnectContainerToNetwork(
 	pool *dockertest.Pool,
 	network *dockertest.Network,
 	testContainer string,
 ) error {
-	return AddContainerToNetwork(pool, network, testContainer)
+	containerID, err := lookupContainerID(pool, testContainer)
+	if err != nil {
+		return err
+	}
+
+	err = retryDockerOp(context.Background(), func() error {
+		connectErr := pool.Client.ConnectNetwork(network.Network.ID, docker.NetworkConnectionOptions{
+			Container: containerID,
+		})
+		if connectErr != nil && isStaleRouteConflict(connectErr) {
+			// Defensive cleanup: a route survived the netns flush
+			// despite the wait above. Drop subnet routes that point
+			// at the disconnected interface so libnetwork can
+			// reprogram the sticky IP, then let the retry budget
+			// try the ConnectNetwork call again.
+			removeContainerSubnetRoutes(pool, containerID, network)
+		}
+
+		return connectErr
+	})
+	if err != nil {
+		return err
+	}
+
+	return waitNetworkContainerPresent(pool, network, testContainer, DockerOpMaxElapsedTime)
+}
+
+// lookupContainerID resolves a container name to its docker ID.
+func lookupContainerID(pool *dockertest.Pool, testContainer string) (string, error) {
+	containers, err := pool.Client.ListContainers(docker.ListContainersOptions{
+		All:     true,
+		Filters: map[string][]string{"name": {testContainer}},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if len(containers) == 0 {
+		return "", fmt.Errorf("%w: %s", ErrContainerNotFound, testContainer)
+	}
+
+	return containers[0].ID, nil
+}
+
+// DisconnectAndReconnect calls Disconnect followed by Reconnect; both
+// primitives drive their own libnetwork settle waits.
+func DisconnectAndReconnect(
+	pool *dockertest.Pool,
+	network *dockertest.Network,
+	testContainer string,
+) error {
+	err := DisconnectContainerFromNetwork(pool, network, testContainer)
+	if err != nil {
+		return fmt.Errorf("disconnecting %s from %s: %w", testContainer, network.Network.Name, err)
+	}
+
+	err = ReconnectContainerToNetwork(pool, network, testContainer)
+	if err != nil {
+		return fmt.Errorf("reconnecting %s to %s: %w", testContainer, network.Network.Name, err)
+	}
+
+	return nil
+}
+
+func waitNetworkContainerAbsent(
+	pool *dockertest.Pool,
+	network *dockertest.Network,
+	testContainer string,
+	timeout time.Duration,
+) error {
+	return pollUntil(timeout, func() (bool, error) {
+		net, err := pool.Client.NetworkInfo(network.Network.ID)
+		if err != nil {
+			return false, fmt.Errorf("inspecting network %s: %w", network.Network.Name, err)
+		}
+
+		for _, c := range net.Containers {
+			if c.Name == testContainer || c.Name == "/"+testContainer {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+}
+
+func waitNetworkContainerPresent(
+	pool *dockertest.Pool,
+	network *dockertest.Network,
+	testContainer string,
+	timeout time.Duration,
+) error {
+	return pollUntil(timeout, func() (bool, error) {
+		net, err := pool.Client.NetworkInfo(network.Network.ID)
+		if err != nil {
+			return false, fmt.Errorf("inspecting network %s: %w", network.Network.Name, err)
+		}
+
+		for _, c := range net.Containers {
+			if (c.Name == testContainer || c.Name == "/"+testContainer) && c.IPv4Address != "" {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+}
+
+// waitContainerRouteAbsent polls the container's routing table until no
+// route remains for the network's IPAM subnet. libnetwork's docker-side
+// endpoint teardown is asynchronous from the kernel netns flush, and a
+// surviving route blocks a subsequent reconnect at sticky-IP assignment
+// with "conflicts with existing route".
+func waitContainerRouteAbsent(pool *dockertest.Pool, containerID string, network *dockertest.Network, timeout time.Duration) error {
+	subnets := networkSubnets(network)
+	if len(subnets) == 0 {
+		return nil
+	}
+
+	return pollUntil(timeout, func() (bool, error) {
+		stdout, err := execStdout(pool, containerID, []string{"ip", "-4", "route", "show"})
+		if err != nil {
+			return false, fmt.Errorf("inspecting routes in %s: %w", containerID, err)
+		}
+
+		for _, subnet := range subnets {
+			if strings.Contains(stdout, subnet+" ") || strings.HasSuffix(strings.TrimSpace(stdout), subnet) {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+}
+
+// removeContainerSubnetRoutes drops residue subnet routes in the
+// container's netns — the leftover that libnetwork's async endpoint
+// teardown can leave behind.
+func removeContainerSubnetRoutes(pool *dockertest.Pool, containerID string, network *dockertest.Network) {
+	for _, subnet := range networkSubnets(network) {
+		_, err := execStdout(pool, containerID, []string{"ip", "-4", "route", "del", subnet})
+		if err != nil {
+			log.Printf("removing stale route %s in %s: %v", subnet, containerID, err)
+		}
+	}
+}
+
+// isStaleRouteConflict matches the libnetwork 500 raised when a
+// surviving subnet route blocks sticky-IP reprogramming on reconnect.
+func isStaleRouteConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(err.Error(), "conflicts with existing route")
+}
+
+// networkSubnets returns the IPAM-configured subnets for a docker
+// network. Empty when IPAM is left to docker defaults.
+func networkSubnets(network *dockertest.Network) []string {
+	out := make([]string, 0, len(network.Network.IPAM.Config))
+	for _, cfg := range network.Network.IPAM.Config {
+		if cfg.Subnet != "" {
+			out = append(out, cfg.Subnet)
+		}
+	}
+
+	return out
+}
+
+// execStdout runs a one-shot command in containerID and returns stdout.
+func execStdout(pool *dockertest.Pool, containerID string, cmd []string) (string, error) {
+	exec, err := pool.Client.CreateExec(docker.CreateExecOptions{
+		Container:    containerID,
+		Cmd:          cmd,
+		AttachStdout: true,
+		AttachStderr: true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("create exec: %w", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+
+	err = pool.Client.StartExec(exec.ID, docker.StartExecOptions{
+		OutputStream: &stdout,
+		ErrorStream:  &stderr,
+	})
+	if err != nil {
+		return stdout.String(), fmt.Errorf("start exec: %w", err)
+	}
+
+	return stdout.String(), nil
+}
+
+// pollUntil ticks every DockerOpInitialInterval until check returns
+// done=true or timeout elapses. A non-nil check error aborts the loop.
+func pollUntil(timeout time.Duration, check func() (done bool, err error)) error {
+	deadline := time.Now().Add(timeout)
+
+	ticker := time.NewTicker(DockerOpInitialInterval)
+	defer ticker.Stop()
+
+	for {
+		done, err := check()
+		if err != nil {
+			return err
+		}
+
+		if done {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%w: %s", ErrConditionTimeout, timeout)
+		}
+
+		<-ticker.C
+	}
 }
 
 // RandomFreeHostPort asks the kernel for a free open port that is ready to use.

--- a/integration/dockertestutil/retry.go
+++ b/integration/dockertestutil/retry.go
@@ -1,0 +1,12 @@
+package dockertestutil
+
+import "time"
+
+// Docker control-plane retry policy. MaxElapsedTime sits above the
+// worst observed libnetwork bridge reprogramming time (~60 s on
+// contended GHA runners).
+const (
+	DockerOpInitialInterval = 1 * time.Second
+	DockerOpMaxInterval     = 10 * time.Second
+	DockerOpMaxElapsedTime  = 90 * time.Second
+)

--- a/integration/embedded_derp_test.go
+++ b/integration/embedded_derp_test.go
@@ -153,7 +153,7 @@ func derpServerScenario(
 				assert.NotContains(ct, health, "could not connect to the 'Headscale Embedded DERP' relay server.",
 					"Client %s should be connected to Headscale Embedded DERP", client.Hostname())
 			}
-		}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second)
+		}, integrationutil.StatusReadyTimeout, 2*time.Second)
 	}
 
 	success := pingDerpAllHelper(t, allClients, allHostnames)
@@ -174,7 +174,7 @@ func derpServerScenario(
 				assert.NotContains(ct, health, "could not connect to the 'Headscale Embedded DERP' relay server.",
 					"Client %s should be connected to Headscale Embedded DERP after first run", client.Hostname())
 			}
-		}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second)
+		}, integrationutil.StatusReadyTimeout, 2*time.Second)
 	}
 
 	t.Logf("Run 1: %d successful pings out of %d", success, len(allClients)*len(allHostnames))
@@ -200,7 +200,7 @@ func derpServerScenario(
 				assert.NotContains(ct, health, "could not connect to the 'Headscale Embedded DERP' relay server.",
 					"Client %s should be connected to Headscale Embedded DERP after second run", client.Hostname())
 			}
-		}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second)
+		}, integrationutil.StatusReadyTimeout, 2*time.Second)
 	}
 
 	t.Logf("Run2: %d successful pings out of %d", success, len(allClients)*len(allHostnames))

--- a/integration/general_test.go
+++ b/integration/general_test.go
@@ -13,7 +13,6 @@ import (
 	v1 "github.com/juanfont/headscale/gen/go/headscale/v1"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/integration/hsic"
-	"tailscale.com/util/dnsname"
 	"github.com/juanfont/headscale/integration/integrationutil"
 	"github.com/juanfont/headscale/integration/tsic"
 	"github.com/rs/zerolog/log"
@@ -23,6 +22,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/types/key"
+	"tailscale.com/util/dnsname"
 )
 
 func TestPingAllByIP(t *testing.T) {
@@ -211,7 +211,7 @@ func testEphemeralWithOptions(t *testing.T, opts ...hsic.Option) {
 		nodes, err := headscale.ListNodes()
 		assert.NoError(ct, err)
 		assert.Len(ct, nodes, 0, "All ephemeral nodes should be cleaned up after logout")
-	}, integrationutil.ScaledTimeout(30*time.Second), 2*time.Second)
+	}, integrationutil.StatusReadyTimeout, 2*time.Second)
 }
 
 // TestEphemeral2006DeletedTooQuickly verifies that ephemeral nodes are not
@@ -298,7 +298,7 @@ func TestEphemeral2006DeletedTooQuickly(t *testing.T) {
 		assert.NoError(ct, err)
 
 		assertPingAllWithCollect(ct, allClients, allAddrs)
-	}, integrationutil.ScaledTimeout(60*time.Second), 2*time.Second)
+	}, integrationutil.HAConvergeTimeout, 2*time.Second)
 
 	// Take down all clients, this should start an expiry timer for each.
 	for _, client := range allClients {
@@ -894,7 +894,7 @@ func TestUpdateHostnameFromClient(t *testing.T) {
 				}
 			}
 		}
-	}, integrationutil.ScaledTimeout(60*time.Second), 2*time.Second)
+	}, integrationutil.HAConvergeTimeout, 2*time.Second)
 
 	for _, client := range allClients {
 		status := client.MustStatus()
@@ -980,7 +980,7 @@ func TestExpireNode(t *testing.T) {
 
 			// Assert that we have the original count - self
 			assert.Len(ct, status.Peers(), spec.NodesPerUser-1, "Client %s should see correct number of peers", client.Hostname())
-		}, integrationutil.ScaledTimeout(30*time.Second), 1*time.Second)
+		}, integrationutil.StatusReadyTimeout, 1*time.Second)
 	}
 
 	headscale, err := scenario.Headscale()
@@ -1069,7 +1069,7 @@ func TestExpireNode(t *testing.T) {
 					)
 				}
 			}
-		}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for expired node status to propagate")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for expired node status to propagate")
 	}
 }
 
@@ -1307,7 +1307,7 @@ func TestNodeOnlineStatus(t *testing.T) {
 
 			// Assert that we have the original count - self
 			assert.Len(c, status.Peers(), len(MustTestVersions)-1)
-		}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for expected peer count")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for expected peer count")
 	}
 
 	headscale, err := scenario.Headscale()
@@ -1319,6 +1319,11 @@ func TestNodeOnlineStatus(t *testing.T) {
 	end := start.Add(testDuration)
 
 	log.Printf("Starting online test from %v to %v", start, end)
+
+	// Pace the outer loop at one iteration per second so the
+	// continuous online-check does not hammer the docker daemon.
+	tick := time.NewTicker(time.Second)
+	defer tick.Stop()
 
 	for {
 		// Let the test run continuously for X minutes to verify
@@ -1384,8 +1389,7 @@ func TestNodeOnlineStatus(t *testing.T) {
 			}, integrationutil.ScaledTimeout(15*time.Second), 1*time.Second)
 		}
 
-		// Check maximum once per second
-		time.Sleep(time.Second)
+		<-tick.C
 	}
 }
 

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"maps"
 	"net/netip"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -27,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"tailscale.com/tailcfg"
+	"tailscale.com/wgengine/filter"
 )
 
 const (
@@ -556,6 +558,56 @@ func assertCurlSuccessWithCollect(c *assert.CollectT, client TailscaleClient, ur
 	result, err := client.Curl(url)
 	assert.NoError(c, err, msg) //nolint:testifylint // CollectT requires assert, not require
 	assert.NotEmpty(c, result, msg)
+}
+
+// assertCurlDockerHostname curls url and asserts the body is the
+// 13-byte Docker auto-generated container hostname (12 hex chars +
+// trailing newline from /etc/hostname). For use inside EventuallyWithT.
+func assertCurlDockerHostname(c *assert.CollectT, client TailscaleClient, url, msg string) {
+	const dockerHostnameLen = 13
+
+	result, err := client.Curl(url)
+	assert.NoError(c, err, msg) //nolint:testifylint // CollectT requires assert, not require
+	assert.Len(c, result, dockerHostnameLen, msg)
+}
+
+// snapshotClientFilters snapshots each client's current netmap
+// PacketFilter keyed by hostname. Pair with waitForClientFilterChange.
+func snapshotClientFilters(t *testing.T, clients []TailscaleClient) map[string][]filter.Match {
+	t.Helper()
+
+	out := make(map[string][]filter.Match, len(clients))
+
+	for _, c := range clients {
+		nm, err := c.Netmap()
+		require.NoError(t, err, "snapshot netmap for %s", c.Hostname())
+
+		out[c.Hostname()] = nm.PacketFilter
+	}
+
+	return out
+}
+
+// waitForClientFilterChange polls each client until its netmap
+// PacketFilter differs from baselines[Hostname]. Use after SetPolicy
+// to gate on client-side filter application before asserting
+// reachability.
+func waitForClientFilterChange(t *testing.T, clients []TailscaleClient, baselines map[string][]filter.Match, timeout time.Duration) {
+	t.Helper()
+
+	for _, client := range clients {
+		c := client
+		baseline := baselines[c.Hostname()]
+
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			nm, err := c.Netmap()
+			if !assert.NoError(ct, err, "fetch netmap for %s", c.Hostname()) {
+				return
+			}
+
+			assert.False(ct, reflect.DeepEqual(baseline, nm.PacketFilter), "client %s PacketFilter unchanged since baseline", c.Hostname())
+		}, timeout, integrationutil.SlowPoll, "client %s PacketFilter should change after SetPolicy", c.Hostname())
+	}
 }
 
 // assertCurlFailWithCollect asserts that a curl request fails. Uses

--- a/integration/integrationutil/timeouts.go
+++ b/integration/integrationutil/timeouts.go
@@ -1,0 +1,40 @@
+package integrationutil
+
+import "time"
+
+// CI-scaled convergence budgets. ScaledTimeout doubles each on CI.
+var (
+	// HAConvergeTimeout: routes / ACL / policy propagation to reach
+	// every node and show up in status, traceroute, or curl.
+	HAConvergeTimeout = ScaledTimeout(60 * time.Second)
+
+	// HASlowConvergeTimeout: multi-step failover sequences that need
+	// at least one HA prober cycle plus a data-plane settle.
+	HASlowConvergeTimeout = ScaledTimeout(120 * time.Second)
+
+	// PolicyPropagationTimeout: post-SetPolicy filter rules and peer
+	// reachability to reflect the change. Sized for wgengine's
+	// rule-reload lag on contended CI runners (~2 min observed).
+	PolicyPropagationTimeout = ScaledTimeout(180 * time.Second)
+
+	// AuthFlowTimeout: OIDC / web-auth / preauth-key flows to reach
+	// Running.
+	AuthFlowTimeout = ScaledTimeout(30 * time.Second)
+
+	// StatusReadyTimeout: post-event read to reflect the event
+	// (created node visible in list, set tags visible on node).
+	StatusReadyTimeout = ScaledTimeout(30 * time.Second)
+)
+
+// Polling intervals for EventuallyWithT.
+const (
+	// FastPoll: in-process reads (HA state, route table snapshots).
+	FastPoll = 200 * time.Millisecond
+
+	// SlowPoll: cross-container reads (tailscale status, curl,
+	// headscale API) where each tick pays a docker exec round-trip.
+	SlowPoll = 500 * time.Millisecond
+
+	// PingPoll: gap between full ping-matrix sweeps.
+	PingPoll = 2 * time.Second
+)

--- a/integration/route_test.go
+++ b/integration/route_test.go
@@ -4066,9 +4066,9 @@ func TestHASubnetRouterFailoverBothOffline(t *testing.T) {
 //     connection until kernel keepalives time out (often >60 s). When
 //     the cable returns, two server-side longpoll sessions can overlap.
 //
-// Issue #3203 reports the bug after cable pulls; this variant blocks all
-// traffic between the router container and headscale via iptables and then
-// removes the block to mimic that behaviour.
+// This variant blocks all traffic between the router container and
+// headscale via iptables and then removes the block to mimic the
+// cable-pull behaviour.
 func TestHASubnetRouterFailoverBothOfflineCablePull(t *testing.T) {
 	IntegrationSkip(t)
 

--- a/integration/route_test.go
+++ b/integration/route_test.go
@@ -114,7 +114,7 @@ func TestEnablingRoutes(t *testing.T) {
 
 				assert.Nil(c, peerStatus.PrimaryRoutes)
 			}
-		}, integrationutil.ScaledTimeout(5*time.Second), 200*time.Millisecond, "Verifying no routes are active before approval")
+		}, integrationutil.ScaledTimeout(5*time.Second), integrationutil.FastPoll, "Verifying no routes are active before approval")
 	}
 
 	for _, node := range nodes {
@@ -159,7 +159,7 @@ func TestEnablingRoutes(t *testing.T) {
 				requirePeerSubnetRoutesWithCollect(c, peerStatus, []netip.Prefix{netip.MustParsePrefix(expectedRoutes[string(peerStatus.ID)])})
 			}
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "clients should see new routes")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "clients should see new routes")
 
 	_, err = headscale.ApproveRoutes(
 		1,
@@ -195,7 +195,7 @@ func TestEnablingRoutes(t *testing.T) {
 				assert.Len(c, node.GetSubnetRoutes(), 1)    // 10.0.2.0/24
 			}
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "route state changes should propagate to nodes")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "route state changes should propagate to nodes")
 
 	// Verify that the clients can see the new routes
 	for _, client := range allClients {
@@ -215,7 +215,7 @@ func TestEnablingRoutes(t *testing.T) {
 					requirePeerSubnetRoutesWithCollect(c, peerStatus, []netip.Prefix{netip.MustParsePrefix("10.0.2.0/24")})
 				}
 			}
-		}, integrationutil.ScaledTimeout(5*time.Second), 200*time.Millisecond, "Verifying final route state visible to clients")
+		}, integrationutil.ScaledTimeout(5*time.Second), integrationutil.FastPoll, "Verifying final route state visible to clients")
 	}
 }
 
@@ -223,7 +223,10 @@ func TestEnablingRoutes(t *testing.T) {
 func TestHASubnetRouterFailover(t *testing.T) {
 	IntegrationSkip(t)
 
-	propagationTime := integrationutil.ScaledTimeout(60 * time.Second)
+	// HASlowConverge (not HAConverge): tailscale's wgengine sometimes
+	// keeps routing through the previous primary for ~2 min after
+	// the netmap update flips PrimaryRoutes server-side.
+	propagationTime := integrationutil.HASlowConvergeTimeout
 
 	// Helper function to validate primary routes table state
 	validatePrimaryRoutes := func(t *testing.T, headscale ControlServer, expectedRoutes *types.DebugRoutes, message string) {
@@ -458,9 +461,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	t.Logf("[%s] Starting test section", time.Now().Format(TimestampFormat))
 	t.Logf("  Expected: Traffic flows through router 1 as it's the only approved route")
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "Verifying client can reach webservice through router 1")
 	}, propagationTime, 200*time.Millisecond, "Verifying client can reach webservice through router 1")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -513,7 +514,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 			requireNodeRouteCountWithCollect(c, nodes[1], 1, 1, 0)
 			requireNodeRouteCountWithCollect(c, nodes[2], 1, 0, 0)
 		}
-	}, integrationutil.ScaledTimeout(3*time.Second), 200*time.Millisecond, "HA setup verification: Router 2 approved as STANDBY (available=1, approved=1, subnet=0), Router 1 stays PRIMARY (subnet=1)")
+	}, integrationutil.ScaledTimeout(3*time.Second), integrationutil.FastPoll, "HA setup verification: Router 2 approved as STANDBY (available=1, approved=1, subnet=0), Router 1 stays PRIMARY (subnet=1)")
 
 	// Verify that the client has routes from the primary machine
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -575,9 +576,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	t.Logf("  Expected: Router 1 continues to handle all traffic (no change from before)")
 	t.Logf("  Expected: Router 2 is ready to take over if router 1 fails")
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "Verifying client can reach webservice through router 1 in HA mode")
 	}, propagationTime, 200*time.Millisecond, "Verifying client can reach webservice through router 1 in HA mode")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -630,7 +629,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 		requireNodeRouteCountWithCollect(c, nodes[0], 1, 1, 1)
 		requireNodeRouteCountWithCollect(c, nodes[1], 1, 1, 0)
 		requireNodeRouteCountWithCollect(c, nodes[2], 1, 1, 0)
-	}, integrationutil.ScaledTimeout(3*time.Second), 200*time.Millisecond, "Full HA verification: Router 3 approved as second STANDBY (available=1, approved=1, subnet=0), Router 1 PRIMARY, Router 2 first STANDBY")
+	}, integrationutil.ScaledTimeout(3*time.Second), integrationutil.FastPoll, "Full HA verification: Router 3 approved as second STANDBY (available=1, approved=1, subnet=0), Router 1 PRIMARY, Router 2 first STANDBY")
 
 	// Verify that the client has routes from the primary machine
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -673,9 +672,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	}, propagationTime, 200*time.Millisecond, "Verifying full HA with 3 routers: Router 1 PRIMARY, Routers 2 & 3 STANDBY")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "Verifying client can reach webservice through router 1 with full HA")
 	}, propagationTime, 200*time.Millisecond, "Verifying client can reach webservice through router 1 with full HA")
 
 	// Wait for traceroute to work correctly through the expected router
@@ -766,9 +763,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	}, propagationTime, 200*time.Millisecond, "Failover verification: Router 1 offline, Router 2 should be new PRIMARY with routes, Router 3 still STANDBY")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "Verifying client can reach webservice through router 2 after failover")
 	}, propagationTime, 200*time.Millisecond, "Verifying client can reach webservice through router 2 after failover")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -840,9 +835,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	}, propagationTime, 200*time.Millisecond, "Second failover verification: Router 1 & 2 offline, Router 3 should be new PRIMARY (last router standing) with routes")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "Verifying client can reach webservice through router 3 after second failover")
 	}, propagationTime, 200*time.Millisecond, "Verifying client can reach webservice through router 3 after second failover")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -920,9 +913,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	}, propagationTime, 200*time.Millisecond, "Recovery verification: Router 1 back online as STANDBY, Router 3 remains PRIMARY (no flapping) with routes")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "Verifying client can still reach webservice through router 3 after router 1 recovery")
 	}, propagationTime, 200*time.Millisecond, "Verifying client can still reach webservice through router 3 after router 1 recovery")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1000,12 +991,10 @@ func TestHASubnetRouterFailover(t *testing.T) {
 				pref,
 			)
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "Full recovery verification: All 3 routers online, Router 3 remains PRIMARY (no flapping) with routes")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "Full recovery verification: All 3 routers online, Router 3 remains PRIMARY (no flapping) with routes")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "Verifying client can reach webservice through router 3 after full recovery")
 	}, propagationTime, 200*time.Millisecond, "Verifying client can reach webservice through router 3 after full recovery")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1054,7 +1043,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 		requireNodeRouteCountWithCollect(c, MustFindNode(subRouter1.Hostname(), nodes), 1, 1, 1)
 		requireNodeRouteCountWithCollect(c, MustFindNode(subRouter2.Hostname(), nodes), 1, 1, 0)
 		requireNodeRouteCountWithCollect(c, MustFindNode(subRouter3.Hostname(), nodes), 1, 0, 0)
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "Route disable verification: Router 3 route disabled, Router 1 should be new PRIMARY, Router 2 STANDBY")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "Route disable verification: Router 3 route disabled, Router 1 should be new PRIMARY, Router 2 STANDBY")
 
 	// Verify that the route is announced from subnet router 1
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1090,9 +1079,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	}, propagationTime, 200*time.Millisecond, "Verifying Router 1 becomes PRIMARY after Router 3 route disabled")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "Verifying client can reach webservice through router 1 after route disable")
 	}, propagationTime, 200*time.Millisecond, "Verifying client can reach webservice through router 1 after route disable")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1142,7 +1129,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 		requireNodeRouteCountWithCollect(c, MustFindNode(subRouter1.Hostname(), nodes), 1, 0, 0)
 		requireNodeRouteCountWithCollect(c, MustFindNode(subRouter2.Hostname(), nodes), 1, 1, 1)
 		requireNodeRouteCountWithCollect(c, MustFindNode(subRouter3.Hostname(), nodes), 1, 0, 0)
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "Second route disable verification: Router 1 route disabled, Router 2 should be new PRIMARY")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "Second route disable verification: Router 1 route disabled, Router 2 should be new PRIMARY")
 
 	// Verify that the route is announced from subnet router 1
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1178,9 +1165,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	}, propagationTime, 200*time.Millisecond, "Verifying Router 2 becomes PRIMARY after Router 1 route disabled")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "Verifying client can reach webservice through router 2 after second route disable")
 	}, propagationTime, 200*time.Millisecond, "Verifying client can reach webservice through router 2 after second route disable")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1265,9 +1250,7 @@ func TestHASubnetRouterFailover(t *testing.T) {
 	}, propagationTime, 200*time.Millisecond, "Verifying Router 2 remains PRIMARY after Router 1 route re-enabled")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "Verifying client can reach webservice through router 2 after route re-enable")
 	}, propagationTime, 200*time.Millisecond, "Verifying client can reach webservice through router 2 after route re-enable")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1410,21 +1393,33 @@ func TestSubnetRouteACL(t *testing.T) {
 
 	client := allClients[1]
 
+	// Read Self.ID inside a retry (it lags initial connection); apply
+	// the route mutation outside, since retrying a mutation hides
+	// real failures.
 	for _, client := range allClients {
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			status, err := client.Status()
-			assert.NoError(c, err)
+		var status *ipnstate.Status
 
-			if route, ok := expectedRoutes[string(status.Self.ID)]; ok {
-				command := []string{
-					"tailscale",
-					"set",
-					"--advertise-routes=" + route,
-				}
-				_, _, err = client.Execute(command)
-				assert.NoErrorf(c, err, "failed to advertise route: %s", err)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			s, err := client.Status()
+			assert.NoError(c, err)
+			assert.NotNil(c, s)
+
+			if s != nil {
+				status = s
 			}
-		}, integrationutil.ScaledTimeout(5*time.Second), 200*time.Millisecond, "Configuring route advertisements")
+		}, integrationutil.ScaledTimeout(5*time.Second), integrationutil.FastPoll, "Reading client status before route advertisement")
+
+		route, ok := expectedRoutes[string(status.Self.ID)]
+		if !ok {
+			continue
+		}
+
+		_, _, err = client.Execute([]string{
+			"tailscale",
+			"set",
+			"--advertise-routes=" + route,
+		})
+		require.NoErrorf(t, err, "failed to advertise route on %s", client.Hostname())
 	}
 
 	err = scenario.WaitForTailscaleSync()
@@ -1478,7 +1473,7 @@ func TestSubnetRouteACL(t *testing.T) {
 				assert.Nil(c, peerStatus.PrimaryRoutes)
 				requirePeerSubnetRoutesWithCollect(c, peerStatus, nil)
 			}
-		}, integrationutil.ScaledTimeout(5*time.Second), 200*time.Millisecond, "Verifying no routes are active before approval")
+		}, integrationutil.ScaledTimeout(5*time.Second), integrationutil.FastPoll, "Verifying no routes are active before approval")
 	}
 
 	_, err = headscale.ApproveRoutes(
@@ -1495,7 +1490,7 @@ func TestSubnetRouteACL(t *testing.T) {
 
 		requireNodeRouteCountWithCollect(c, nodes[0], 1, 1, 1)
 		requireNodeRouteCountWithCollect(c, nodes[1], 0, 0, 0)
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "route state changes should propagate to nodes")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "route state changes should propagate to nodes")
 
 	// Verify that the client has routes from the primary machine
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1514,7 +1509,7 @@ func TestSubnetRouteACL(t *testing.T) {
 		}
 
 		requirePeerSubnetRoutesWithCollect(c, srs1PeerStatus, []netip.Prefix{netip.MustParsePrefix(expectedRoutes["1"])})
-	}, integrationutil.ScaledTimeout(5*time.Second), 200*time.Millisecond, "Verifying client can see subnet routes from router")
+	}, integrationutil.ScaledTimeout(5*time.Second), integrationutil.FastPoll, "Verifying client can see subnet routes from router")
 
 	// Wait for packet filter updates to propagate to client netmap
 	wantClientFilter := []filter.Match{
@@ -1549,7 +1544,7 @@ func TestSubnetRouteACL(t *testing.T) {
 		if diff := cmpdiff.Diff(wantClientFilter, clientNm.PacketFilter, util.ViewSliceIPProtoComparer, util.PrefixComparer); diff != "" {
 			assert.Fail(c, fmt.Sprintf("Client (%s) filter, unexpected result (-want +got):\n%s", client.Hostname(), diff))
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for client packet filter to update")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for client packet filter to update")
 
 	// Wait for packet filter updates to propagate to subnet router netmap
 	// The two ACL rules (group:admins -> group:admins:* and group:admins -> 10.33.0.0/16:*)
@@ -1590,7 +1585,7 @@ func TestSubnetRouteACL(t *testing.T) {
 		if diff := cmpdiff.Diff(wantSubnetFilter, subnetNm.PacketFilter, util.ViewSliceIPProtoComparer, util.PrefixComparer); diff != "" {
 			assert.Fail(c, fmt.Sprintf("Subnet (%s) filter, unexpected result (-want +got):\n%s", subRouter1.Hostname(), diff))
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for subnet router packet filter to update")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for subnet router packet filter to update")
 }
 
 // TestEnablingExitRoutes tests enabling exit routes for clients.
@@ -1639,7 +1634,7 @@ func TestEnablingExitRoutes(t *testing.T) {
 
 		requireNodeRouteCountWithCollect(c, nodes[0], 2, 0, 0)
 		requireNodeRouteCountWithCollect(c, nodes[1], 2, 0, 0)
-	}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond, "Waiting for route advertisements to propagate")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll, "Waiting for route advertisements to propagate")
 
 	// Verify that no routes has been sent to the client,
 	// they are not yet enabled.
@@ -1653,7 +1648,7 @@ func TestEnablingExitRoutes(t *testing.T) {
 
 				assert.Nil(c, peerStatus.PrimaryRoutes)
 			}
-		}, integrationutil.ScaledTimeout(5*time.Second), 200*time.Millisecond, "Verifying no exit routes are active before approval")
+		}, integrationutil.ScaledTimeout(5*time.Second), integrationutil.FastPoll, "Verifying no exit routes are active before approval")
 	}
 
 	// Enable all routes, but do v4 on one and v6 on other to ensure they
@@ -1677,7 +1672,7 @@ func TestEnablingExitRoutes(t *testing.T) {
 
 		requireNodeRouteCountWithCollect(c, nodes[0], 2, 2, 2)
 		requireNodeRouteCountWithCollect(c, nodes[1], 2, 2, 2)
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "route state changes should propagate to both nodes")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "route state changes should propagate to both nodes")
 
 	// Wait for route state changes to propagate to clients
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1698,7 +1693,7 @@ func TestEnablingExitRoutes(t *testing.T) {
 				}
 			}
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "clients should see new routes")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "clients should see new routes")
 }
 
 // TestExitRoutesWithAutogroupInternetACL reproduces juanfont/headscale#3212.
@@ -1768,7 +1763,7 @@ func TestExitRoutesWithAutogroupInternetACL(t *testing.T) {
 
 		requireNodeRouteCountWithCollect(c, nodes[0], 2, 0, 0)
 		requireNodeRouteCountWithCollect(c, nodes[1], 2, 0, 0)
-	}, integrationutil.ScaledTimeout(20*time.Second), 200*time.Millisecond,
+	}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.FastPoll,
 		"Waiting for exit-route advertisements to propagate")
 
 	// Approve exit routes on both nodes so either could serve as
@@ -1792,7 +1787,7 @@ func TestExitRoutesWithAutogroupInternetACL(t *testing.T) {
 
 		requireNodeRouteCountWithCollect(c, nodes[0], 2, 2, 2)
 		requireNodeRouteCountWithCollect(c, nodes[1], 2, 2, 2)
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond,
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll,
 		"approved exit routes should propagate to nodes")
 
 	// The end-to-end UX assertion: every client must see the OTHER
@@ -1835,7 +1830,7 @@ func TestExitRoutesWithAutogroupInternetACL(t *testing.T) {
 				"client %s should see the other node as a peer "+
 					"via the autogroup:internet ACL",
 				status.Self.HostName)
-		}, integrationutil.ScaledTimeout(15*time.Second), 500*time.Millisecond,
+		}, integrationutil.ScaledTimeout(15*time.Second), integrationutil.SlowPoll,
 			"client should see exit nodes as peers via autogroup:internet ACL")
 	}
 }
@@ -1930,7 +1925,7 @@ func TestSubnetRouterMultiNetwork(t *testing.T) {
 			assert.Nil(c, peerStatus.PrimaryRoutes)
 			requirePeerSubnetRoutesWithCollect(c, peerStatus, nil)
 		}
-	}, integrationutil.ScaledTimeout(5*time.Second), 200*time.Millisecond, "Verifying no routes are active before approval")
+	}, integrationutil.ScaledTimeout(5*time.Second), integrationutil.FastPoll, "Verifying no routes are active before approval")
 
 	// Enable route
 	_, err = headscale.ApproveRoutes(
@@ -1947,7 +1942,7 @@ func TestSubnetRouterMultiNetwork(t *testing.T) {
 		assert.NoError(c, err)
 		assert.Len(c, nodes, 2)
 		requireNodeRouteCountWithCollect(c, nodes[0], 1, 1, 1)
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "route state changes should propagate to nodes")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "route state changes should propagate to nodes")
 
 	// Verify that the routes have been sent to the client
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -1963,7 +1958,7 @@ func TestSubnetRouterMultiNetwork(t *testing.T) {
 
 			requirePeerSubnetRoutesWithCollect(c, peerStatus, []netip.Prefix{*pref})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "routes should be visible to client")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "routes should be visible to client")
 
 	usernet1, err := scenario.Network("usernet1")
 	require.NoError(t, err)
@@ -1979,10 +1974,8 @@ func TestSubnetRouterMultiNetwork(t *testing.T) {
 	t.Logf("url from %s to %s", user2c.Hostname(), url)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := user2c.Curl(url)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
-	}, integrationutil.ScaledTimeout(5*time.Second), 200*time.Millisecond, "Verifying client can reach webservice through subnet route")
+		assertCurlDockerHostname(c, user2c, url, "Verifying client can reach webservice through subnet route")
+	}, integrationutil.ScaledTimeout(5*time.Second), integrationutil.FastPoll, "Verifying client can reach webservice through subnet route")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		tr, err := user2c.Traceroute(webip)
@@ -1994,7 +1987,7 @@ func TestSubnetRouterMultiNetwork(t *testing.T) {
 		}
 
 		assertTracerouteViaIPWithCollect(c, tr, ip)
-	}, integrationutil.ScaledTimeout(5*time.Second), 200*time.Millisecond, "Verifying traceroute goes through subnet router")
+	}, integrationutil.ScaledTimeout(5*time.Second), integrationutil.FastPoll, "Verifying traceroute goes through subnet router")
 }
 
 func TestSubnetRouterMultiNetworkExitNode(t *testing.T) {
@@ -2088,7 +2081,7 @@ func TestSubnetRouterMultiNetworkExitNode(t *testing.T) {
 			assert.Nil(c, peerStatus.PrimaryRoutes)
 			requirePeerSubnetRoutesWithCollect(c, peerStatus, nil)
 		}
-	}, integrationutil.ScaledTimeout(5*time.Second), 200*time.Millisecond, "Verifying no routes sent to client before approval")
+	}, integrationutil.ScaledTimeout(5*time.Second), integrationutil.FastPoll, "Verifying no routes sent to client before approval")
 
 	// Approve exit routes and subnet route.
 	_, err = headscale.ApproveRoutes(nodes[0].GetId(), []netip.Prefix{tsaddr.AllIPv4(), tsaddr.AllIPv6(), *route})
@@ -2100,7 +2093,7 @@ func TestSubnetRouterMultiNetworkExitNode(t *testing.T) {
 		assert.NoError(c, err)
 		assert.Len(c, nodes, 2)
 		requireNodeRouteCountWithCollect(c, nodes[0], 3, 3, 3)
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "route state changes should propagate to nodes")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "route state changes should propagate to nodes")
 
 	// Wait for exit routes to be visible to the client.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -2111,7 +2104,7 @@ func TestSubnetRouterMultiNetworkExitNode(t *testing.T) {
 			peerStatus := status.Peer[peerKey]
 			assert.True(c, peerStatus.ExitNodeOption, "peer should be an exit node option")
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "exit routes should be visible to client")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "exit routes should be visible to client")
 
 	// Tell user2c to use user1c as an exit node.
 	command = []string{
@@ -2142,9 +2135,7 @@ func TestSubnetRouterMultiNetworkExitNode(t *testing.T) {
 	weburl := fmt.Sprintf("http://%s/etc/hostname", webip)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := user2c.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, user2c, weburl, "user2 should reach webservice via exit node")
 	}, 10*time.Second, 200*time.Millisecond, "user2 should reach webservice via exit node")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -2719,9 +2710,7 @@ func TestAutoApproveMultiNetwork(t *testing.T) {
 					t.Logf("url from %s to %s", client.Hostname(), url)
 
 					assert.EventuallyWithT(t, func(c *assert.CollectT) {
-						result, err := client.Curl(url)
-						assert.NoError(c, err)
-						assert.Len(c, result, 13)
+						assertCurlDockerHostname(c, client, url, "Verifying client can reach webservice through auto-approved route")
 					}, assertTimeout, 200*time.Millisecond, "Verifying client can reach webservice through auto-approved route")
 
 					assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -2785,9 +2774,7 @@ func TestAutoApproveMultiNetwork(t *testing.T) {
 					t.Logf("url from %s to %s", client.Hostname(), url)
 
 					assert.EventuallyWithT(t, func(c *assert.CollectT) {
-						result, err := client.Curl(url)
-						assert.NoError(c, err)
-						assert.Len(c, result, 13)
+						assertCurlDockerHostname(c, client, url, "Verifying client can still reach webservice after policy change")
 					}, assertTimeout, 200*time.Millisecond, "Verifying client can still reach webservice after policy change")
 
 					assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -2882,9 +2869,7 @@ func TestAutoApproveMultiNetwork(t *testing.T) {
 					t.Logf("url from %s to %s", client.Hostname(), url)
 
 					assert.EventuallyWithT(t, func(c *assert.CollectT) {
-						result, err := client.Curl(url)
-						assert.NoError(c, err)
-						assert.Len(c, result, 13)
+						assertCurlDockerHostname(c, client, url, "Verifying client can reach webservice after route re-approval")
 					}, assertTimeout, 200*time.Millisecond, "Verifying client can reach webservice after route re-approval")
 
 					assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -3274,7 +3259,7 @@ func TestSubnetRouteACLFiltering(t *testing.T) {
 
 		// Check that the router has 3 routes now approved and available
 		requireNodeRouteCountWithCollect(c, routerNode, 3, 3, 3)
-	}, integrationutil.ScaledTimeout(15*time.Second), 500*time.Millisecond, "route state changes should propagate")
+	}, integrationutil.ScaledTimeout(15*time.Second), integrationutil.SlowPoll, "route state changes should propagate")
 
 	// Now check the client node status
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -3289,13 +3274,11 @@ func TestSubnetRouteACLFiltering(t *testing.T) {
 
 		// The node should only have 1 subnet route
 		requirePeerSubnetRoutesWithCollect(c, routerPeerStatus, []netip.Prefix{*route})
-	}, integrationutil.ScaledTimeout(5*time.Second), 200*time.Millisecond, "Verifying node sees filtered subnet routes")
+	}, integrationutil.ScaledTimeout(5*time.Second), integrationutil.FastPoll, "Verifying node sees filtered subnet routes")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := nodeClient.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
-	}, integrationutil.ScaledTimeout(60*time.Second), 200*time.Millisecond, "Verifying node can reach webservice through allowed route")
+		assertCurlDockerHostname(c, nodeClient, weburl, "Verifying node can reach webservice through allowed route")
+	}, integrationutil.HAConvergeTimeout, integrationutil.FastPoll, "Verifying node can reach webservice through allowed route")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		tr, err := nodeClient.Traceroute(webip)
@@ -3307,7 +3290,7 @@ func TestSubnetRouteACLFiltering(t *testing.T) {
 		}
 
 		assertTracerouteViaIPWithCollect(c, tr, ip)
-	}, integrationutil.ScaledTimeout(60*time.Second), 200*time.Millisecond, "Verifying traceroute goes through router")
+	}, integrationutil.HAConvergeTimeout, integrationutil.FastPoll, "Verifying traceroute goes through router")
 }
 
 // TestGrantViaSubnetSteering validates that via grants steer different source
@@ -3595,16 +3578,12 @@ func TestGrantViaSubnetSteering(t *testing.T) {
 
 	// Verify Client A can reach the webservice.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := clientA.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, clientA, weburl, "Client A should reach webservice")
 	}, assertTimeout, 200*time.Millisecond, "Client A should reach webservice")
 
 	// Verify Client B can reach the webservice.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := clientB.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, clientB, weburl, "Client B should reach webservice")
 	}, assertTimeout, 200*time.Millisecond, "Client B should reach webservice")
 
 	// Verify Client A's traffic goes through Router A.
@@ -3642,7 +3621,7 @@ func TestGrantViaSubnetSteering(t *testing.T) {
 func TestHASubnetRouterPingFailover(t *testing.T) {
 	IntegrationSkip(t)
 
-	propagationTime := integrationutil.ScaledTimeout(60 * time.Second)
+	propagationTime := integrationutil.HAConvergeTimeout
 
 	spec := ScenarioSpec{
 		NodesPerUser: 2,
@@ -3757,9 +3736,7 @@ func TestHASubnetRouterPingFailover(t *testing.T) {
 
 	// Verify connectivity through router 1.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "client should reach webservice through router 1")
 	}, propagationTime, 200*time.Millisecond, "client should reach webservice through router 1")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -3814,9 +3791,7 @@ func TestHASubnetRouterPingFailover(t *testing.T) {
 	t.Log("Failover detected. Verifying connectivity through router 2.")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "client should reach webservice through router 2")
 	}, propagationTime, 200*time.Millisecond, "client should reach webservice through router 2")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -3890,7 +3865,7 @@ func TestHASubnetRouterPingFailover(t *testing.T) {
 func TestHASubnetRouterFailoverBothOffline(t *testing.T) {
 	IntegrationSkip(t)
 
-	propagationTime := integrationutil.ScaledTimeout(60 * time.Second)
+	propagationTime := integrationutil.HAConvergeTimeout
 
 	spec := ScenarioSpec{
 		NodesPerUser: 2,
@@ -3997,9 +3972,7 @@ func TestHASubnetRouterFailoverBothOffline(t *testing.T) {
 
 	// Confirm initial connectivity through r1.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "client reaches webservice via r1")
 	}, propagationTime, 200*time.Millisecond, "client reaches webservice via r1")
 
 	t.Log("=== Step 1: r1 goes offline. r2 should take over. ===")
@@ -4067,9 +4040,7 @@ func TestHASubnetRouterFailoverBothOffline(t *testing.T) {
 
 	// End-to-end traffic should reach the webservice via r2.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "client reaches webservice via r2 after recovery")
 	}, propagationTime, 200*time.Millisecond, "client reaches webservice via r2 after recovery")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -4101,7 +4072,7 @@ func TestHASubnetRouterFailoverBothOffline(t *testing.T) {
 func TestHASubnetRouterFailoverBothOfflineCablePull(t *testing.T) {
 	IntegrationSkip(t)
 
-	propagationTime := integrationutil.ScaledTimeout(120 * time.Second)
+	propagationTime := integrationutil.HASlowConvergeTimeout
 
 	spec := ScenarioSpec{
 		NodesPerUser: 2,
@@ -4292,9 +4263,7 @@ func TestHASubnetRouterFailoverBothOfflineCablePull(t *testing.T) {
 	}, propagationTime, 1*time.Second, "R2: waiting for client to see r2")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		result, err := client.Curl(weburl)
-		assert.NoError(c, err)
-		assert.Len(c, result, 13)
+		assertCurlDockerHostname(c, client, weburl, "client reaches webservice via r2 after recovery")
 	}, propagationTime, 1*time.Second, "client reaches webservice via r2 after recovery")
 }
 
@@ -4329,7 +4298,7 @@ func TestHASubnetRouterFailoverBothOfflineCablePull(t *testing.T) {
 func TestHASubnetRouterFailoverDockerDisconnect(t *testing.T) {
 	IntegrationSkip(t)
 
-	propagationTime := integrationutil.ScaledTimeout(120 * time.Second)
+	propagationTime := integrationutil.HASlowConvergeTimeout
 	flapWindow := integrationutil.ScaledTimeout(40 * time.Second)
 
 	spec := ScenarioSpec{
@@ -4438,9 +4407,7 @@ func TestHASubnetRouterFailoverDockerDisconnect(t *testing.T) {
 	requireTrafficWorks := func(msg string) {
 		t.Helper()
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
-			result, err := client.Curl(weburl)
-			assert.NoError(c, err)
-			assert.Len(c, result, 13)
+			assertCurlDockerHostname(c, client, weburl, msg)
 		}, propagationTime, 1*time.Second, msg)
 	}
 

--- a/integration/scenario.go
+++ b/integration/scenario.go
@@ -784,10 +784,42 @@ func (s *Scenario) WaitForTailscaleSync() error {
 	return err
 }
 
-// WaitForTailscaleSyncPerUser blocks execution until each TailscaleClient has the expected
-// number of peers for its user. This is useful for policies like autogroup:self where nodes
-// only see same-user peers, not all nodes in the network.
-func (s *Scenario) WaitForTailscaleSyncPerUser(timeout, retryInterval time.Duration) error {
+// SyncOption configures WaitForTailscaleSyncPerUser.
+type SyncOption func(*syncOptions)
+
+type syncOptions struct {
+	preBarrier func(context.Context) error
+}
+
+// WithPreBarrier runs a precondition check before per-user peer-count
+// waits begin, sharing the outer timeout via context. Use to gate on
+// a server-side signal (e.g. policy compile) that the peer-count
+// alone cannot observe.
+func WithPreBarrier(barrier func(context.Context) error) SyncOption {
+	return func(o *syncOptions) { o.preBarrier = barrier }
+}
+
+// WaitForTailscaleSyncPerUser blocks until each TailscaleClient has
+// the expected per-user peer count (necessary for policies like
+// autogroup:self where cross-user peers are invisible).
+func (s *Scenario) WaitForTailscaleSyncPerUser(timeout, retryInterval time.Duration, opts ...SyncOption) error {
+	options := syncOptions{}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	if options.preBarrier != nil {
+		barrierCtx, cancel := context.WithTimeout(context.Background(), timeout)
+
+		err := options.preBarrier(barrierCtx)
+
+		cancel()
+
+		if err != nil {
+			return fmt.Errorf("pre-barrier: %w", err)
+		}
+	}
+
 	var allErrors []error
 
 	for _, user := range s.users {

--- a/integration/ssh_test.go
+++ b/integration/ssh_test.go
@@ -471,7 +471,7 @@ func doSSHWithRetryAsUser(
 
 			// For all other errors, assert no error to trigger retry
 			assert.NoError(ct, err)
-		}, integrationutil.ScaledTimeout(10*time.Second), 200*time.Millisecond)
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll)
 	} else {
 		// For failure cases, just execute once
 		result, stderr, err = client.Execute(command)
@@ -701,7 +701,7 @@ func findSSHCheckAuthID(t *testing.T, headscale ControlServer) string {
 		}
 
 		assert.NotEmpty(c, authID, "auth-id not found in headscale logs")
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "waiting for SSH check auth-id in headscale logs")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "waiting for SSH check auth-id in headscale logs")
 
 	return authID
 }
@@ -810,7 +810,7 @@ func findNewSSHCheckAuthID(
 		}
 
 		assert.NotEmpty(c, authID, "new auth-id not found in headscale logs")
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "waiting for new SSH check auth-id")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "waiting for new SSH check auth-id")
 
 	return authID
 }

--- a/integration/tags_test.go
+++ b/integration/tags_test.go
@@ -182,7 +182,7 @@ func TestTagsAuthKeyWithTagRequestDifferentTag(t *testing.T) {
 			if len(nodes) == 1 {
 				t.Logf("Node registered with tags: %v (expected rejection)", nodes[0].GetTags())
 			}
-		}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "checking node state")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "checking node state")
 
 		t.Fail()
 	}
@@ -252,7 +252,7 @@ func TestTagsAuthKeyWithTagNoAdvertiseFlag(t *testing.T) {
 			t.Logf("Node registered with tags: %v", node.GetTags())
 			assertNodeHasTagsWithCollect(c, node, []string{"tag:valid-owned"})
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "verifying node inherited tags from auth key")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "verifying node inherited tags from auth key")
 
 	t.Logf("Test 2.2 completed - node inherited tags from auth key")
 }
@@ -320,7 +320,7 @@ func TestTagsAuthKeyWithTagCannotAddViaCLI(t *testing.T) {
 		if len(nodes) == 1 {
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for initial registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
 
 	t.Logf("Node registered with tag:valid-owned, now attempting to add tag:second via CLI")
 
@@ -353,7 +353,7 @@ func TestTagsAuthKeyWithTagCannotAddViaCLI(t *testing.T) {
 					assert.Fail(c, "Tags should not have changed")
 				}
 			}
-		}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying tags unchanged")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying tags unchanged")
 	}
 }
 
@@ -416,7 +416,7 @@ func TestTagsAuthKeyWithTagCannotChangeViaCLI(t *testing.T) {
 		nodes, err := headscale.ListNodes()
 		assert.NoError(c, err)
 		assert.Len(c, nodes, 1)
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for initial registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
 
 	t.Logf("Node registered, now attempting to change to different tag via CLI")
 
@@ -448,7 +448,7 @@ func TestTagsAuthKeyWithTagCannotChangeViaCLI(t *testing.T) {
 					assert.Fail(c, "Tags should not have changed")
 				}
 			}
-		}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying tags unchanged")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying tags unchanged")
 	}
 }
 
@@ -519,7 +519,7 @@ func TestTagsAuthKeyWithTagAdminOverrideReauthPreserves(t *testing.T) {
 			nodeID = nodes[0].GetId()
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for initial registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
 
 	t.Logf("Step 1 complete: Node %d registered with tag:valid-owned", nodeID)
 
@@ -536,12 +536,12 @@ func TestTagsAuthKeyWithTagAdminOverrideReauthPreserves(t *testing.T) {
 			t.Logf("After admin assignment, server tags are: %v", nodes[0].GetTags())
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:second"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying admin tag assignment on server")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying admin tag assignment on server")
 
 	// Verify admin assignment propagated to node's self view (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:second"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "verifying admin tag assignment propagated to node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "verifying admin tag assignment propagated to node self")
 
 	t.Logf("Step 2 complete: Admin assigned tag:second (verified on both server and node self)")
 
@@ -569,12 +569,12 @@ func TestTagsAuthKeyWithTagAdminOverrideReauthPreserves(t *testing.T) {
 			// Expected: admin-assigned tags are preserved through reauth
 			assertNodeHasTagsWithCollect(c, node, []string{"tag:second"})
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "admin tags should be preserved after reauth on server")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "admin tags should be preserved after reauth on server")
 
 	// Verify admin tags are preserved in node's self view after reauth (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:second"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "admin tags should be preserved after reauth in node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "admin tags should be preserved after reauth in node self")
 
 	t.Logf("Test 2.5 PASS: Admin tags preserved through reauth (admin decisions are authoritative)")
 }
@@ -645,7 +645,7 @@ func TestTagsAuthKeyWithTagCLICannotModifyAdminTags(t *testing.T) {
 		if len(nodes) == 1 {
 			nodeID = nodes[0].GetId()
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for initial registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
 
 	// Step 2: Admin assigns multiple tags via headscale CLI
 	err = headscale.SetNodeTags(nodeID, []string{"tag:valid-owned", "tag:second"})
@@ -659,12 +659,12 @@ func TestTagsAuthKeyWithTagCLICannotModifyAdminTags(t *testing.T) {
 		if len(nodes) == 1 {
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned", "tag:second"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying admin tag assignment on server")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying admin tag assignment on server")
 
 	// Verify admin assignment propagated to node's self view (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:valid-owned", "tag:second"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "verifying admin tag assignment propagated to node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "verifying admin tag assignment propagated to node self")
 
 	t.Logf("Admin assigned both tags, now attempting to reduce via CLI")
 
@@ -691,12 +691,12 @@ func TestTagsAuthKeyWithTagCLICannotModifyAdminTags(t *testing.T) {
 			// Expected: tags should remain unchanged (admin wins)
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned", "tag:second"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "admin tags should be preserved after CLI attempt on server")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "admin tags should be preserved after CLI attempt on server")
 
 	// Verify admin tags are preserved in node's self view (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:valid-owned", "tag:second"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "admin tags should be preserved after CLI attempt in node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "admin tags should be preserved after CLI attempt in node self")
 
 	t.Logf("Test 2.6 PASS: Admin tags preserved - CLI cannot modify admin-assigned tags")
 }
@@ -770,7 +770,7 @@ func TestTagsAuthKeyWithoutTagCannotRequestTags(t *testing.T) {
 			if len(nodes) == 1 {
 				t.Logf("Node registered with tags: %v (expected rejection)", nodes[0].GetTags())
 			}
-		}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "checking node state")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "checking node state")
 
 		t.Fail()
 	}
@@ -837,7 +837,7 @@ func TestTagsAuthKeyWithoutTagRegisterNoTags(t *testing.T) {
 			t.Logf("Node registered with tags: %v", nodes[0].GetTags())
 			assertNodeHasNoTagsWithCollect(c, nodes[0])
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "verifying node has no tags")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "verifying node has no tags")
 
 	t.Logf("Test 3.2 completed - node registered without tags")
 }
@@ -905,7 +905,7 @@ func TestTagsAuthKeyWithoutTagCannotAddViaCLI(t *testing.T) {
 		if len(nodes) == 1 {
 			assertNodeHasNoTagsWithCollect(c, nodes[0])
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for initial registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
 
 	t.Logf("Node registered without tags, attempting to add via CLI")
 
@@ -936,7 +936,7 @@ func TestTagsAuthKeyWithoutTagCannotAddViaCLI(t *testing.T) {
 					assert.Fail(c, "Tags should not have changed")
 				}
 			}
-		}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying tags unchanged")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying tags unchanged")
 	}
 }
 
@@ -1007,7 +1007,7 @@ func TestTagsAuthKeyWithoutTagCLINoOpAfterAdminWithReset(t *testing.T) {
 			nodeID = nodes[0].GetId()
 			assertNodeHasNoTagsWithCollect(c, nodes[0])
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for initial registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
 
 	// Step 2: Admin assigns tags
 	err = headscale.SetNodeTags(nodeID, []string{"tag:valid-owned"})
@@ -1021,12 +1021,12 @@ func TestTagsAuthKeyWithoutTagCLINoOpAfterAdminWithReset(t *testing.T) {
 		if len(nodes) == 1 {
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying admin tag assignment on server")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying admin tag assignment on server")
 
 	// Verify admin assignment propagated to node's self view (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:valid-owned"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "verifying admin tag assignment propagated to node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "verifying admin tag assignment propagated to node self")
 
 	t.Logf("Admin assigned tag, now running CLI with --reset")
 
@@ -1050,12 +1050,12 @@ func TestTagsAuthKeyWithoutTagCLINoOpAfterAdminWithReset(t *testing.T) {
 			t.Logf("After --reset, server tags are: %v", nodes[0].GetTags())
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "admin tags should be preserved after --reset on server")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "admin tags should be preserved after --reset on server")
 
 	// Verify admin tags are preserved in node's self view after --reset (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:valid-owned"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "admin tags should be preserved after --reset in node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "admin tags should be preserved after --reset in node self")
 
 	t.Logf("Test 3.4 PASS: Admin tags preserved after --reset")
 }
@@ -1126,7 +1126,7 @@ func TestTagsAuthKeyWithoutTagCLINoOpAfterAdminWithEmptyAdvertise(t *testing.T) 
 		if len(nodes) == 1 {
 			nodeID = nodes[0].GetId()
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for initial registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
 
 	// Step 2: Admin assigns tags
 	err = headscale.SetNodeTags(nodeID, []string{"tag:valid-owned"})
@@ -1140,12 +1140,12 @@ func TestTagsAuthKeyWithoutTagCLINoOpAfterAdminWithEmptyAdvertise(t *testing.T) 
 		if len(nodes) == 1 {
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying admin tag assignment on server")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying admin tag assignment on server")
 
 	// Verify admin assignment propagated to node's self view (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:valid-owned"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "verifying admin tag assignment propagated to node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "verifying admin tag assignment propagated to node self")
 
 	t.Logf("Admin assigned tag, now running CLI with empty --advertise-tags")
 
@@ -1169,12 +1169,12 @@ func TestTagsAuthKeyWithoutTagCLINoOpAfterAdminWithEmptyAdvertise(t *testing.T) 
 			t.Logf("After empty --advertise-tags, server tags are: %v", nodes[0].GetTags())
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "admin tags should be preserved after empty --advertise-tags on server")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "admin tags should be preserved after empty --advertise-tags on server")
 
 	// Verify admin tags are preserved in node's self view after empty --advertise-tags (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:valid-owned"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "admin tags should be preserved after empty --advertise-tags in node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "admin tags should be preserved after empty --advertise-tags in node self")
 
 	t.Logf("Test 3.5 PASS: Admin tags preserved after empty --advertise-tags")
 }
@@ -1245,7 +1245,7 @@ func TestTagsAuthKeyWithoutTagCLICannotReduceAdminMultiTag(t *testing.T) {
 		if len(nodes) == 1 {
 			nodeID = nodes[0].GetId()
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for initial registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
 
 	// Step 2: Admin assigns multiple tags
 	err = headscale.SetNodeTags(nodeID, []string{"tag:valid-owned", "tag:second"})
@@ -1259,12 +1259,12 @@ func TestTagsAuthKeyWithoutTagCLICannotReduceAdminMultiTag(t *testing.T) {
 		if len(nodes) == 1 {
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned", "tag:second"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying admin tag assignment on server")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying admin tag assignment on server")
 
 	// Verify admin assignment propagated to node's self view (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:valid-owned", "tag:second"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "verifying admin tag assignment propagated to node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "verifying admin tag assignment propagated to node self")
 
 	t.Logf("Admin assigned both tags, now attempting to reduce via CLI")
 
@@ -1288,12 +1288,12 @@ func TestTagsAuthKeyWithoutTagCLICannotReduceAdminMultiTag(t *testing.T) {
 			t.Logf("After CLI reduce attempt, server tags are: %v", nodes[0].GetTags())
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned", "tag:second"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "admin tags should be preserved after CLI reduce attempt on server")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "admin tags should be preserved after CLI reduce attempt on server")
 
 	// Verify admin tags are preserved in node's self view after CLI reduce attempt (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:valid-owned", "tag:second"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "admin tags should be preserved after CLI reduce attempt in node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "admin tags should be preserved after CLI reduce attempt in node self")
 
 	t.Logf("Test 3.6 PASS: Admin tags preserved - CLI cannot reduce admin-assigned multi-tag set")
 }
@@ -1369,7 +1369,7 @@ func TestTagsUserLoginOwnedTagAtRegistration(t *testing.T) {
 			t.Logf("Node registered with tags: %v", nodes[0].GetTags())
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "verifying node has advertised tag")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "verifying node has advertised tag")
 
 	t.Logf("Test 1.1 completed - web auth with owned tag succeeded")
 }
@@ -1442,7 +1442,7 @@ func TestTagsUserLoginNonExistentTagAtRegistration(t *testing.T) {
 					"Non-existent tag should not be applied to node")
 				t.Logf("Test 1.2: Node registered with tags: %v (non-existent tag correctly rejected)", nodes[0].GetTags())
 			}
-		}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "checking node registration result")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "checking node registration result")
 	}
 }
 
@@ -1510,7 +1510,7 @@ func TestTagsUserLoginUnownedTagAtRegistration(t *testing.T) {
 				"Unowned tag should not be applied to node (tag:valid-unowned is owned by other-user)")
 			t.Logf("Test 1.3: Node registered with tags: %v (unowned tag correctly rejected)", nodes[0].GetTags())
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "checking node registration result")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "checking node registration result")
 }
 
 // TestTagsUserLoginAddTagViaCLIReauth tests that a user can add tags via CLI reauthentication.
@@ -1574,7 +1574,7 @@ func TestTagsUserLoginAddTagViaCLIReauth(t *testing.T) {
 		if len(nodes) == 1 {
 			t.Logf("Initial tags: %v", nodes[0].GetTags())
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "checking initial tags")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "checking initial tags")
 
 	// Step 2: Try to add second tag via CLI
 	t.Logf("Attempting to add second tag via CLI reauth")
@@ -1601,7 +1601,7 @@ func TestTagsUserLoginAddTagViaCLIReauth(t *testing.T) {
 				t.Logf("Test 1.4: Tags are %v (may require manual reauth completion)", nodes[0].GetTags())
 			}
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "checking tags after CLI")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "checking tags after CLI")
 }
 
 // TestTagsUserLoginRemoveTagViaCLIReauth tests that a user can remove tags via CLI reauthentication.
@@ -1665,7 +1665,7 @@ func TestTagsUserLoginRemoveTagViaCLIReauth(t *testing.T) {
 		if len(nodes) == 1 {
 			t.Logf("Initial tags: %v", nodes[0].GetTags())
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "checking initial tags")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "checking initial tags")
 
 	// Step 2: Try to remove second tag via CLI
 	t.Logf("Attempting to remove tag via CLI reauth")
@@ -1690,7 +1690,7 @@ func TestTagsUserLoginRemoveTagViaCLIReauth(t *testing.T) {
 				t.Logf("Test 1.5 PASS: Only one tag after removal")
 			}
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "checking tags after CLI")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "checking tags after CLI")
 }
 
 // TestTagsUserLoginCLINoOpAfterAdminAssignment tests that CLI advertise-tags becomes
@@ -1760,7 +1760,7 @@ func TestTagsUserLoginCLINoOpAfterAdminAssignment(t *testing.T) {
 			nodeID = nodes[0].GetId()
 			t.Logf("Step 1: Node %d registered with tags: %v", nodeID, nodes[0].GetTags())
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for initial registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
 
 	// Step 2: Admin assigns different tag
 	err = headscale.SetNodeTags(nodeID, []string{"tag:second"})
@@ -1775,12 +1775,12 @@ func TestTagsUserLoginCLINoOpAfterAdminAssignment(t *testing.T) {
 			t.Logf("Step 2: After admin assignment, server tags: %v", nodes[0].GetTags())
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:second"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying admin assignment on server")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying admin assignment on server")
 
 	// Verify admin assignment propagated to node's self view (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:second"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "verifying admin assignment propagated to node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "verifying admin assignment propagated to node self")
 
 	// Step 3: Try to change tags via CLI
 	command := []string{
@@ -1801,12 +1801,12 @@ func TestTagsUserLoginCLINoOpAfterAdminAssignment(t *testing.T) {
 			t.Logf("Step 3: After CLI, server tags are: %v", nodes[0].GetTags())
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:second"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "admin tags should be preserved - CLI advertise-tags should be no-op on server")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "admin tags should be preserved - CLI advertise-tags should be no-op on server")
 
 	// Verify admin tags are preserved in node's self view after CLI attempt (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:second"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "admin tags should be preserved - CLI advertise-tags should be no-op in node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "admin tags should be preserved - CLI advertise-tags should be no-op in node self")
 
 	t.Logf("Test 1.6 PASS: Admin tags preserved (CLI was no-op)")
 }
@@ -1876,7 +1876,7 @@ func TestTagsUserLoginCLICannotRemoveAdminTags(t *testing.T) {
 		if len(nodes) == 1 {
 			nodeID = nodes[0].GetId()
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for initial registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
 
 	// Step 2: Admin assigns both tags
 	err = headscale.SetNodeTags(nodeID, []string{"tag:valid-owned", "tag:second"})
@@ -1891,12 +1891,12 @@ func TestTagsUserLoginCLICannotRemoveAdminTags(t *testing.T) {
 			t.Logf("After admin assignment, server tags: %v", nodes[0].GetTags())
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned", "tag:second"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying admin assignment on server")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying admin assignment on server")
 
 	// Verify admin assignment propagated to node's self view (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:valid-owned", "tag:second"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "verifying admin assignment propagated to node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "verifying admin assignment propagated to node self")
 
 	// Step 3: Try to reduce tags via CLI
 	command := []string{
@@ -1917,12 +1917,12 @@ func TestTagsUserLoginCLICannotRemoveAdminTags(t *testing.T) {
 			t.Logf("Test 1.7: After CLI, server tags are: %v", nodes[0].GetTags())
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned", "tag:second"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "admin tags should be preserved - CLI cannot remove them on server")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "admin tags should be preserved - CLI cannot remove them on server")
 
 	// Verify admin tags are preserved in node's self view after CLI attempt (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:valid-owned", "tag:second"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "admin tags should be preserved - CLI cannot remove them in node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "admin tags should be preserved - CLI cannot remove them in node self")
 
 	t.Logf("Test 1.7 PASS: Admin tags preserved (CLI cannot remove)")
 }
@@ -1995,7 +1995,7 @@ func TestTagsAuthKeyWithTagRequestNonExistentTag(t *testing.T) {
 			if len(nodes) == 1 {
 				t.Logf("Node registered with tags: %v (expected rejection)", nodes[0].GetTags())
 			}
-		}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "checking node state")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "checking node state")
 
 		t.Fail()
 	}
@@ -2065,7 +2065,7 @@ func TestTagsAuthKeyWithTagRequestUnownedTag(t *testing.T) {
 			if len(nodes) == 1 {
 				t.Logf("Node registered with tags: %v (expected rejection)", nodes[0].GetTags())
 			}
-		}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "checking node state")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "checking node state")
 
 		t.Fail()
 	}
@@ -2139,7 +2139,7 @@ func TestTagsAuthKeyWithoutTagRequestNonExistentTag(t *testing.T) {
 			if len(nodes) == 1 {
 				t.Logf("Node registered with tags: %v (expected rejection)", nodes[0].GetTags())
 			}
-		}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "checking node state")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "checking node state")
 
 		t.Fail()
 	}
@@ -2209,7 +2209,7 @@ func TestTagsAuthKeyWithoutTagRequestUnownedTag(t *testing.T) {
 			if len(nodes) == 1 {
 				t.Logf("Node registered with tags: %v (expected rejection)", nodes[0].GetTags())
 			}
-		}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "checking node state")
+		}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "checking node state")
 
 		t.Fail()
 	}
@@ -2281,7 +2281,7 @@ func TestTagsAdminAPICannotSetNonExistentTag(t *testing.T) {
 			nodeID = nodes[0].GetId()
 			t.Logf("Node %d registered with tags: %v", nodeID, nodes[0].GetTags())
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for registration")
 
 	// Try to set a non-existent tag via admin API - should fail
 	err = headscale.SetNodeTags(nodeID, []string{"tag:nonexistent"})
@@ -2353,7 +2353,7 @@ func TestTagsAdminAPICanSetUnownedTag(t *testing.T) {
 			nodeID = nodes[0].GetId()
 			t.Logf("Node %d registered with tags: %v", nodeID, nodes[0].GetTags())
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for registration")
 
 	// Admin sets an "unowned" tag - should SUCCEED because admin has full authority
 	// (tag:valid-unowned is owned by other-user, but admin can assign it)
@@ -2369,12 +2369,12 @@ func TestTagsAdminAPICanSetUnownedTag(t *testing.T) {
 		if len(nodes) == 1 {
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-unowned"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying unowned tag was applied on server")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying unowned tag was applied on server")
 
 	// Verify the tag was propagated to node's self view (issue #2978)
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:valid-unowned"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "verifying unowned tag propagated to node self")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "verifying unowned tag propagated to node self")
 
 	t.Logf("Test 4.2 PASS: Admin API correctly allowed setting unowned tag")
 }
@@ -2441,7 +2441,7 @@ func TestTagsAdminAPICannotRemoveAllTags(t *testing.T) {
 			nodeID = nodes[0].GetId()
 			t.Logf("Node %d registered with tags: %v", nodeID, nodes[0].GetTags())
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for registration")
 
 	// Try to remove all tags - should fail
 	err = headscale.SetNodeTags(nodeID, []string{})
@@ -2458,7 +2458,7 @@ func TestTagsAdminAPICannotRemoveAllTags(t *testing.T) {
 		if len(nodes) == 1 {
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying original tags preserved")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying original tags preserved")
 }
 
 // assertNetmapSelfHasTagsWithCollect asserts that the client's netmap self node has expected tags.
@@ -2563,12 +2563,12 @@ func TestTagsIssue2978ReproTagReplacement(t *testing.T) {
 			nodeID = nodes[0].GetId()
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for initial registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
 
 	// Verify client initially sees tag:valid-owned
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:valid-owned"})
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "client should see initial tag")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "client should see initial tag")
 
 	t.Logf("Step 1: Node %d registered via web auth with --advertise-tags=tag:valid-owned, client sees it", nodeID)
 
@@ -2588,7 +2588,7 @@ func TestTagsIssue2978ReproTagReplacement(t *testing.T) {
 		if len(nodes) == 1 {
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:second"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "server should show tag:second after first call")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "server should show tag:second after first call")
 
 	t.Log("Step 2a: Server shows tag:second after first call")
 
@@ -2638,11 +2638,11 @@ func TestTagsIssue2978ReproTagReplacement(t *testing.T) {
 	t.Log("Step 3a: Verifying client self view updates after SECOND call")
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:second"})
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "client status.Self should update to tag:second after SECOND call")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "client status.Self should update to tag:second after SECOND call")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNetmapSelfHasTagsWithCollect(c, client, []string{"tag:second"})
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "client netmap.SelfNode should update to tag:second after SECOND call")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "client netmap.SelfNode should update to tag:second after SECOND call")
 
 	t.Log("Step 3b: Client self view updated to tag:second after SECOND call")
 
@@ -2660,7 +2660,7 @@ func TestTagsIssue2978ReproTagReplacement(t *testing.T) {
 		if len(nodes) == 1 {
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-unowned"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "server should show tag:valid-unowned")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "server should show tag:valid-unowned")
 
 	t.Log("Step 4a: Server shows tag:valid-unowned after first call")
 
@@ -2692,11 +2692,11 @@ func TestTagsIssue2978ReproTagReplacement(t *testing.T) {
 	t.Log("Step 5a: Verifying client self view updates after SECOND call")
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:valid-unowned"})
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "client status.Self should update to tag:valid-unowned after SECOND call")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "client status.Self should update to tag:valid-unowned after SECOND call")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assertNetmapSelfHasTagsWithCollect(c, client, []string{"tag:valid-unowned"})
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "client netmap.SelfNode should update to tag:valid-unowned after SECOND call")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "client netmap.SelfNode should update to tag:valid-unowned after SECOND call")
 
 	t.Log("Test complete - see logs for bug reproduction details")
 }
@@ -2763,7 +2763,7 @@ func TestTagsAdminAPICannotSetInvalidFormat(t *testing.T) {
 			nodeID = nodes[0].GetId()
 			t.Logf("Node %d registered with tags: %v", nodeID, nodes[0].GetTags())
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "waiting for registration")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for registration")
 
 	// Try to set a tag without the "tag:" prefix - should fail
 	err = headscale.SetNodeTags(nodeID, []string{"invalid-no-prefix"})
@@ -2780,7 +2780,7 @@ func TestTagsAdminAPICannotSetInvalidFormat(t *testing.T) {
 		if len(nodes) == 1 {
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
 		}
-	}, integrationutil.ScaledTimeout(10*time.Second), 500*time.Millisecond, "verifying original tags preserved")
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "verifying original tags preserved")
 }
 
 // =============================================================================
@@ -2871,7 +2871,7 @@ func TestTagsUserLoginReauthWithEmptyTagsRemovesAllTags(t *testing.T) {
 				// Verify node has the expected tags
 				assertNodeHasTagsWithCollect(c, node, []string{"tag:valid-owned", "tag:second"})
 			}
-		}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "checking initial tags")
+		}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "checking initial tags")
 
 		// Step 2: Reauth with empty tags to remove all tags
 		t.Logf("Step 2: Reauthenticating with empty tag list to untag device (%s)", tc.name)
@@ -2947,7 +2947,7 @@ func TestTagsUserLoginReauthWithEmptyTagsRemovesAllTags(t *testing.T) {
 						tc.name, tagTestUser, node.GetTags(), node.GetUser().GetName())
 				}
 			}
-		}, integrationutil.ScaledTimeout(60*time.Second), 1*time.Second, "verifying tags removed and ownership returned")
+		}, integrationutil.HAConvergeTimeout, 1*time.Second, "verifying tags removed and ownership returned")
 	})
 }
 
@@ -3020,7 +3020,7 @@ func TestTagsAuthKeyWithoutUserInheritsTags(t *testing.T) {
 			t.Logf("Node registered with tags: %v", node.GetTags())
 			assertNodeHasTagsWithCollect(c, node, []string{"tag:valid-owned"})
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "verifying node inherited tags from auth key")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "verifying node inherited tags from auth key")
 
 	t.Logf("Test 5.1 PASS: Node inherited tags from tags-only auth key")
 }
@@ -3158,7 +3158,7 @@ func TestTagsAuthKeyConvertToUserViaCLIRegister(t *testing.T) {
 			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
 			t.Logf("Initial state - Node ID: %d, Tags: %v", nodes[0].GetId(), nodes[0].GetTags())
 		}
-	}, integrationutil.ScaledTimeout(30*time.Second), 500*time.Millisecond, "node should be tagged initially")
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "node should be tagged initially")
 
 	// Step 2: Force reauth with empty tags (triggers web auth flow)
 	command := []string{
@@ -3201,5 +3201,5 @@ func TestTagsAuthKeyConvertToUserViaCLIRegister(t *testing.T) {
 			t.Logf("After conversion - Node ID: %d, Tags: %v, User: %s",
 				nodes[0].GetId(), nodes[0].GetTags(), nodes[0].GetUser().GetName())
 		}
-	}, integrationutil.ScaledTimeout(60*time.Second), 1*time.Second, "node should be user-owned after conversion via CLI register")
+	}, integrationutil.HAConvergeTimeout, 1*time.Second, "node should be user-owned after conversion via CLI register")
 }

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -67,6 +67,7 @@ var (
 	errTailscaleImageRequiredInCI      = errors.New("HEADSCALE_INTEGRATION_TAILSCALE_IMAGE must be set in CI for HEAD version")
 	errContainerNotInitialized         = errors.New("container not initialized")
 	errFQDNNotYetAvailable             = errors.New("FQDN not yet available")
+	errCurlEmptyResponseBody           = errors.New("curl returned empty response body")
 )
 
 const (
@@ -1532,6 +1533,15 @@ func (t *TailscaleInContainer) Curl(url string, opts ...CurlOption) (string, err
 		return result, err
 	}
 
+	// curl exit 0 with an empty body usually means a mid-stream reset
+	// after headers (HTTP 200 with the connection torn down before the
+	// body arrived). Without this signal, callers wrapping the call in
+	// EventuallyWithT see assert.NoError pass and assert.Len fail with
+	// no error to drive a retry.
+	if result == "" {
+		return result, fmt.Errorf("%w: %s from %s", errCurlEmptyResponseBody, url, t.Hostname())
+	}
+
 	return result, nil
 }
 
@@ -1547,8 +1557,16 @@ func (t *TailscaleInContainer) CurlFailFast(url string) (string, error) {
 }
 
 func (t *TailscaleInContainer) Traceroute(ip netip.Addr) (util.Traceroute, error) {
+	// -w 1: wait at most 1s for each probe response. busybox's default
+	//       is 5s, which means an EventuallyWithT loop at 200ms ticks
+	//       can spend 25 ticks worth of budget on a single Traceroute.
+	// -q 1: send 1 probe per hop instead of 3. The HA tests only care
+	//       about the first hop's identity; the other probes are dead
+	//       weight for the same retry budget.
 	command := []string{
 		"traceroute",
+		"-w", "1",
+		"-q", "1",
 		ip.String(),
 	}
 

--- a/integration/tsic/tsic.go
+++ b/integration/tsic/tsic.go
@@ -523,6 +523,12 @@ func New(
 		tailscaleOptions.Repository = "tailscale/tailscale"
 		tailscaleOptions.Tag = version
 
+		err = dockertestutil.PullWithAuth(pool, tailscaleOptions.Repository+":"+tailscaleOptions.Tag)
+		if err != nil {
+			//nolint:gosec // G706: tag value is from MustTestVersions, not external input
+			log.Printf("Pull failed for %s:%s, error: %v", tailscaleOptions.Repository, tailscaleOptions.Tag, err)
+		}
+
 		container, err = pool.RunWithOptions(
 			tailscaleOptions,
 			dockertestutil.DockerRestartPolicy,
@@ -536,6 +542,12 @@ func New(
 	default:
 		tailscaleOptions.Repository = "tailscale/tailscale"
 		tailscaleOptions.Tag = "v" + version
+
+		err = dockertestutil.PullWithAuth(pool, tailscaleOptions.Repository+":"+tailscaleOptions.Tag)
+		if err != nil {
+			//nolint:gosec // G706: tag value is from MustTestVersions, not external input
+			log.Printf("Pull failed for %s:%s, error: %v", tailscaleOptions.Repository, tailscaleOptions.Tag, err)
+		}
 
 		container, err = pool.RunWithOptions(
 			tailscaleOptions,


### PR DESCRIPTION
Two flake causes. Docker Hub anonymous pulls hit the 100/6h per-IP cap on shared CI. `tsic.Curl` returned `("", nil)` on empty bodies, hiding failures from `EventuallyWithT`.

Adds `docker/login-action` on every job that pulls, with a guard so fork PRs skip it. `tsic.Curl` errors on empty bodies; `tsic.Traceroute` gains `-w 1 -q 1`. libnetwork settle-waits sit inside the Disconnect/Reconnect primitives so HA tests stop racing bridge reprogramming. Shared timeout/retry constants replace 295 ad-hoc literals.

Two control-plane fixes for related flakes. MagicDNS root-domain `Routes` ship as empty non-nil slices rather than `nil`, since `dns.Config.Clone` in wgengine drops nil-valued map entries and a major `LinkChange` reapplies the cloned config — wiping `/etc/resolv.conf` until the next route-changing netmap. HA prober batches probe results per cycle through a single `BatchSetNodeUnhealthy` and defers a cycle when any probe is fresh-session or reconnected mid-probe; the election fallback no longer picks `candidates[0]` when the previous primary has gone, so simultaneous dual-disconnect cannot flap primary onto an unreachable node.

HA election now has a property-test in `hscontrol/state/primaries_property_test.go` (rapid, 2000 checks), a servertest-level property-test gated by `util.IsCI()` for long local sweeps, and an invariant catalogue at `hscontrol/state/HA_INVARIANTS.md`.

Set `DOCKERHUB_CI_USERNAME` / `DOCKERHUB_CI_TOKEN` secrets before merge.

Fixes #3094

> Generated with the help of an AI assistant
