### PR TITLE
types, state, db: persist Node JSON slices via named IsZero types

### DIFF
--- a/hscontrol/db/db_test.go
+++ b/hscontrol/db/db_test.go
@@ -122,7 +122,7 @@ func TestSQLiteMigrationAndDataValidation(t *testing.T) {
 				// Expected: tags = ["tag:server"] (no duplicates)
 				node4 := findNode("node4")
 				require.NotNil(t, node4, "node4 should exist")
-				assert.Equal(t, []string{"tag:server"}, node4.Tags, "node4 should have tag:server without duplicates")
+				assert.Equal(t, []string{"tag:server"}, node4.Tags.List(), "node4 should have tag:server without duplicates") //nolint:goconst // descriptive test assertions read better with the literal inline
 
 				// Node 5: user2 has no RequestTags
 				// Expected: tags = [] (unchanged)

--- a/hscontrol/db/node.go
+++ b/hscontrol/db/node.go
@@ -1,11 +1,9 @@
 package db
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/netip"
-	"slices"
 	"sort"
 	"strconv"
 	"sync"
@@ -17,7 +15,6 @@ import (
 	"github.com/juanfont/headscale/hscontrol/util/zlog/zf"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
-	"tailscale.com/net/tsaddr"
 	"tailscale.com/types/key"
 	"tailscale.com/util/dnsname"
 )
@@ -186,87 +183,6 @@ func GetNodeByNodeKey(
 	}
 
 	return &mach, nil
-}
-
-func (hsdb *HSDatabase) SetTags(
-	nodeID types.NodeID,
-	tags []string,
-) error {
-	return hsdb.Write(func(tx *gorm.DB) error {
-		return SetTags(tx, nodeID, tags)
-	})
-}
-
-// SetTags takes a NodeID and update the forced tags.
-// It will overwrite any tags with the new list.
-func SetTags(
-	tx *gorm.DB,
-	nodeID types.NodeID,
-	tags []string,
-) error {
-	if len(tags) == 0 {
-		// if no tags are provided, we remove all tags
-		err := tx.Model(&types.Node{}).Where("id = ?", nodeID).Update("tags", "[]").Error
-		if err != nil {
-			return fmt.Errorf("removing tags: %w", err)
-		}
-
-		return nil
-	}
-
-	slices.Sort(tags)
-	tags = slices.Compact(tags)
-
-	b, err := json.Marshal(tags)
-	if err != nil {
-		return err
-	}
-
-	err = tx.Model(&types.Node{}).Where("id = ?", nodeID).Update("tags", string(b)).Error
-	if err != nil {
-		return fmt.Errorf("updating tags: %w", err)
-	}
-
-	return nil
-}
-
-// SetApprovedRoutes takes a Node struct pointer and updates the approved routes.
-func SetApprovedRoutes(
-	tx *gorm.DB,
-	nodeID types.NodeID,
-	routes []netip.Prefix,
-) error {
-	if len(routes) == 0 {
-		// if no routes are provided, we remove all
-		err := tx.Model(&types.Node{}).Where("id = ?", nodeID).Update("approved_routes", "[]").Error
-		if err != nil {
-			return fmt.Errorf("removing approved routes: %w", err)
-		}
-
-		return nil
-	}
-
-	// When approving exit routes, ensure both IPv4 and IPv6 are included
-	// If either 0.0.0.0/0 or ::/0 is being approved, both should be approved
-	hasIPv4Exit := slices.Contains(routes, tsaddr.AllIPv4())
-	hasIPv6Exit := slices.Contains(routes, tsaddr.AllIPv6())
-
-	if hasIPv4Exit && !hasIPv6Exit {
-		routes = append(routes, tsaddr.AllIPv6())
-	} else if hasIPv6Exit && !hasIPv4Exit {
-		routes = append(routes, tsaddr.AllIPv4())
-	}
-
-	b, err := json.Marshal(routes)
-	if err != nil {
-		return err
-	}
-
-	if err := tx.Model(&types.Node{}).Where("id = ?", nodeID).Update("approved_routes", string(b)).Error; err != nil { //nolint:noinlineerr
-		return fmt.Errorf("updating approved routes: %w", err)
-	}
-
-	return nil
 }
 
 // SetLastSeen sets a node's last seen field indicating that we

--- a/hscontrol/db/node_test.go
+++ b/hscontrol/db/node_test.go
@@ -178,55 +178,6 @@ func TestDisableNodeExpiry(t *testing.T) {
 	assert.Nil(t, nodeFromDB.Expiry, "expiry should be nil after disabling")
 }
 
-func TestSetTags(t *testing.T) {
-	db, err := newSQLiteTestDB()
-	require.NoError(t, err)
-
-	user, err := db.CreateUser(types.User{Name: "test"})
-	require.NoError(t, err)
-
-	pak, err := db.CreatePreAuthKey(user.TypedID(), false, false, nil, nil)
-	require.NoError(t, err)
-
-	pakID := pak.ID
-
-	_, err = db.getNode(types.UserID(user.ID), "testnode")
-	require.Error(t, err)
-
-	nodeKey := key.NewNode()
-	machineKey := key.NewMachine()
-
-	node := &types.Node{
-		ID:             0,
-		MachineKey:     machineKey.Public(),
-		NodeKey:        nodeKey.Public(),
-		Hostname:       "testnode",
-		UserID:         &user.ID,
-		RegisterMethod: util.RegisterMethodAuthKey,
-		AuthKeyID:      &pakID,
-	}
-
-	trx := db.DB.Save(node)
-	require.NoError(t, trx.Error)
-
-	// assign simple tags
-	sTags := []string{"tag:test", "tag:foo"}
-	err = db.SetTags(node.ID, sTags)
-	require.NoError(t, err)
-	node, err = db.getNode(types.UserID(user.ID), "testnode")
-	require.NoError(t, err)
-	assert.Equal(t, sTags, node.Tags)
-
-	// assign duplicate tags, expect no errors but no doubles in DB
-	eTags := []string{"tag:bar", "tag:test", "tag:unknown", "tag:test"}
-	err = db.SetTags(node.ID, eTags)
-	require.NoError(t, err)
-	node, err = db.getNode(types.UserID(user.ID), "testnode")
-	require.NoError(t, err)
-	assert.Equal(t, []string{"tag:bar", "tag:test", "tag:unknown"}, node.Tags)
-}
-
-
 func TestAutoApproveRoutes(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -409,13 +360,15 @@ func TestAutoApproveRoutes(t *testing.T) {
 				assert.Equal(t, tt.expectChange, changed1)
 
 				if changed1 {
-					err = SetApprovedRoutes(adb.DB, node.ID, newRoutes1)
+					node.ApprovedRoutes = types.Prefixes(newRoutes1)
+					err = adb.DB.Save(&node).Error
 					require.NoError(t, err)
 				}
 
 				newRoutes2, changed2 := policy.ApproveRoutesWithPolicy(pm, nodeTagged.View(), nodeTagged.ApprovedRoutes, tt.routes)
 				if changed2 {
-					err = SetApprovedRoutes(adb.DB, nodeTagged.ID, newRoutes2)
+					nodeTagged.ApprovedRoutes = types.Prefixes(newRoutes2)
+					err = adb.DB.Save(&nodeTagged).Error
 					require.NoError(t, err)
 				}
 
@@ -624,7 +577,6 @@ func TestListEphemeralNodes(t *testing.T) {
 	assert.Equal(t, nodeEph.UserID, ephemeralNodes[0].UserID)
 	assert.Equal(t, nodeEph.Hostname, ephemeralNodes[0].Hostname)
 }
-
 
 func TestListPeers(t *testing.T) {
 	// Setup test database

--- a/hscontrol/db/users_test.go
+++ b/hscontrol/db/users_test.go
@@ -123,7 +123,7 @@ func TestDestroyUserErrors(t *testing.T) {
 				result := db.DB.First(&survivingNode, "id = ?", node.ID)
 				require.NoError(t, result.Error)
 				assert.Nil(t, survivingNode.UserID)
-				assert.Equal(t, []string{"tag:server"}, survivingNode.Tags)
+				assert.Equal(t, []string{"tag:server"}, survivingNode.Tags.List())
 			},
 		},
 		{

--- a/hscontrol/servertest/issues_test.go
+++ b/hscontrol/servertest/issues_test.go
@@ -563,7 +563,7 @@ func TestIssuesNodeStoreConsistency(t *testing.T) {
 		require.NoError(t, err, "node should be in database")
 
 		nsRoutes := nsView.ApprovedRoutes().AsSlice()
-		dbRoutes := dbNode.ApprovedRoutes
+		dbRoutes := dbNode.ApprovedRoutes.List()
 
 		assert.Equal(t, nsRoutes, dbRoutes,
 			"NodeStore and DB should agree on approved routes")

--- a/hscontrol/state/node_store_test.go
+++ b/hscontrol/state/node_store_test.go
@@ -684,7 +684,7 @@ func TestNodeStoreOperations(t *testing.T) {
 						finalNode := snapshot.nodesByID[1]
 						assert.Equal(t, "multi-update-hostname", finalNode.Hostname)
 						assert.Equal(t, "multi-update-givenname", finalNode.GivenName)
-						assert.Equal(t, []string{"tag1", "tag2"}, finalNode.Tags)
+						assert.Equal(t, []string{"tag1", "tag2"}, finalNode.Tags.List())
 					},
 				},
 			},
@@ -722,14 +722,14 @@ func TestNodeStoreOperations(t *testing.T) {
 						assert.NotNil(t, nodePtr)
 						assert.Equal(t, "db-save-hostname", nodePtr.Hostname)
 						assert.Equal(t, "db-save-given", nodePtr.GivenName)
-						assert.Equal(t, []string{"db-tag1", "db-tag2"}, nodePtr.Tags)
+						assert.Equal(t, []string{"db-tag1", "db-tag2"}, nodePtr.Tags.List())
 
 						// Verify the snapshot also reflects the same state
 						snapshot := store.data.Load()
 						storedNode := snapshot.nodesByID[1]
 						assert.Equal(t, "db-save-hostname", storedNode.Hostname)
 						assert.Equal(t, "db-save-given", storedNode.GivenName)
-						assert.Equal(t, []string{"db-tag1", "db-tag2"}, storedNode.Tags)
+						assert.Equal(t, []string{"db-tag1", "db-tag2"}, storedNode.Tags.List())
 					},
 				},
 				{
@@ -792,15 +792,15 @@ func TestNodeStoreOperations(t *testing.T) {
 						// All should have the complete final state
 						assert.Equal(t, "concurrent-db-hostname", nodePtr1.Hostname)
 						assert.Equal(t, "concurrent-db-given", nodePtr1.GivenName)
-						assert.Equal(t, []string{"concurrent-tag"}, nodePtr1.Tags)
+						assert.Equal(t, []string{"concurrent-tag"}, nodePtr1.Tags.List())
 
 						assert.Equal(t, "concurrent-db-hostname", nodePtr2.Hostname)
 						assert.Equal(t, "concurrent-db-given", nodePtr2.GivenName)
-						assert.Equal(t, []string{"concurrent-tag"}, nodePtr2.Tags)
+						assert.Equal(t, []string{"concurrent-tag"}, nodePtr2.Tags.List())
 
 						assert.Equal(t, "concurrent-db-hostname", nodePtr3.Hostname)
 						assert.Equal(t, "concurrent-db-given", nodePtr3.GivenName)
-						assert.Equal(t, []string{"concurrent-tag"}, nodePtr3.Tags)
+						assert.Equal(t, []string{"concurrent-tag"}, nodePtr3.Tags.List())
 
 						// Verify consistency with stored state
 						snapshot := store.data.Load()

--- a/hscontrol/state/persist_test.go
+++ b/hscontrol/state/persist_test.go
@@ -1,0 +1,211 @@
+package state
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/db"
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// persistTestSetup pre-creates a sqlite database on disk with a single
+// registered node, then constructs a State that loads it. The on-disk
+// path is returned so the test can close the State and re-open one
+// against the same file to simulate a server restart. The caller owns
+// the returned State and must Close it; persistTestReopen handles the
+// second State's lifecycle for the restart simulation.
+func persistTestSetup(t *testing.T) (string, *State, types.NodeID) {
+	t.Helper()
+
+	dbPath := t.TempDir() + "/headscale.db"
+	cfg := persistTestConfig(dbPath)
+
+	database, err := db.NewHeadscaleDatabase(cfg)
+	require.NoError(t, err)
+
+	user := database.CreateUserForTest("persist-user")
+	node := database.CreateRegisteredNodeForTest(user, "persist-node")
+
+	require.NoError(t, database.Close())
+
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+
+	return dbPath, s, node.ID
+}
+
+// persistTestReopen constructs a fresh State pointed at the same
+// sqlite file and registers a cleanup to close it at the end of the
+// test. Use it to simulate a server restart after the first State has
+// been explicitly closed by the caller.
+func persistTestReopen(t *testing.T, dbPath string) *State {
+	t.Helper()
+
+	s, err := NewState(persistTestConfig(dbPath))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	return s
+}
+
+func persistTestConfig(dbPath string) *types.Config {
+	prefixV4 := netip.MustParsePrefix("100.64.0.0/10")
+	prefixV6 := netip.MustParsePrefix("fd7a:115c:a1e0::/48")
+
+	return &types.Config{
+		Database: types.DatabaseConfig{
+			Type: types.DatabaseSqlite,
+			Sqlite: types.SqliteConfig{
+				Path: dbPath,
+			},
+		},
+		PrefixV4:     &prefixV4,
+		PrefixV6:     &prefixV6,
+		IPAllocation: types.IPAllocationStrategySequential,
+		BaseDomain:   "headscale.test",
+		Policy: types.PolicyConfig{
+			Mode: types.PolicyModeDB,
+		},
+		Tuning: types.Tuning{
+			NodeStoreBatchSize:    TestBatchSize,
+			NodeStoreBatchTimeout: TestBatchTimeout,
+		},
+	}
+}
+
+// TestPersistEmptyApprovedRoutes covers the State.SetApprovedRoutes
+// path. The gRPC handler builds the slice via append from a nil
+// declaration, so when the operator passes `-r ""` the persist layer
+// receives a nil []netip.Prefix. GORM's struct Updates skips nil
+// slices, so the column would stay populated with the previously
+// approved routes and a restart would re-apply them.
+func TestPersistEmptyApprovedRoutes(t *testing.T) {
+	dbPath, s, nodeID := persistTestSetup(t)
+
+	route := netip.MustParsePrefix("10.0.0.0/8")
+
+	_, _, err := s.SetApprovedRoutes(nodeID, []netip.Prefix{route})
+	require.NoError(t, err)
+
+	gotAfterApprove, err := s.DB().GetNodeByID(nodeID)
+	require.NoError(t, err)
+	require.Equal(t, []netip.Prefix{route}, gotAfterApprove.ApprovedRoutes.List(),
+		"approved_routes should hold the seeded route")
+
+	var noRoutes []netip.Prefix
+
+	_, _, err = s.SetApprovedRoutes(nodeID, noRoutes)
+	require.NoError(t, err)
+
+	gotAfterClear, err := s.DB().GetNodeByID(nodeID)
+	require.NoError(t, err)
+	assert.Empty(t, gotAfterClear.ApprovedRoutes,
+		"approved_routes should be empty after rejecting all routes, got %v",
+		gotAfterClear.ApprovedRoutes)
+
+	require.NoError(t, s.Close())
+
+	s2 := persistTestReopen(t, dbPath)
+
+	nv, ok := s2.GetNodeByID(nodeID)
+	require.True(t, ok, "node should be loaded from DB after restart")
+	assert.Empty(t, nv.AsStruct().ApprovedRoutes,
+		"after restart, NodeStore should reflect the cleared routes")
+}
+
+// TestPersistEmptyTags exercises the same persist path for the tags
+// column. State.SetNodeTags rejects an empty slice at the API level
+// (tags are one-way), so the test drives the bug surface directly via
+// NodeStore + persistNodeToDB, which is the same code path the public
+// SetApprovedRoutes call exercises.
+func TestPersistEmptyTags(t *testing.T) {
+	dbPath, s, nodeID := persistTestSetup(t)
+
+	_, ok := s.nodeStore.UpdateNode(nodeID, func(n *types.Node) {
+		n.Tags = []string{"tag:test"}
+	})
+	require.True(t, ok)
+
+	seeded, ok := s.nodeStore.GetNode(nodeID)
+	require.True(t, ok)
+
+	_, _, err := s.persistNodeToDB(seeded)
+	require.NoError(t, err)
+
+	gotAfterSeed, err := s.DB().GetNodeByID(nodeID)
+	require.NoError(t, err)
+	require.Equal(t, []string{"tag:test"}, gotAfterSeed.Tags.List(),
+		"tags should hold the seeded value")
+
+	cleared, ok := s.nodeStore.UpdateNode(nodeID, func(n *types.Node) {
+		n.Tags = nil
+	})
+	require.True(t, ok)
+
+	_, _, err = s.persistNodeToDB(cleared)
+	require.NoError(t, err)
+
+	gotAfterClear, err := s.DB().GetNodeByID(nodeID)
+	require.NoError(t, err)
+	assert.Empty(t, gotAfterClear.Tags,
+		"tags should be empty after clear, got %v", gotAfterClear.Tags)
+
+	require.NoError(t, s.Close())
+
+	s2 := persistTestReopen(t, dbPath)
+
+	nv, ok := s2.GetNodeByID(nodeID)
+	require.True(t, ok)
+	assert.Empty(t, nv.AsStruct().Tags,
+		"after restart, NodeStore should reflect the cleared tags")
+}
+
+// TestPersistEmptyEndpoints covers the endpoints column. Endpoints
+// arrive via MapRequest in production; the test reaches the persist
+// layer directly because the bug is in serialization, not in
+// upstream parsing.
+func TestPersistEmptyEndpoints(t *testing.T) {
+	dbPath, s, nodeID := persistTestSetup(t)
+
+	endpoint := netip.MustParseAddrPort("198.51.100.1:41641")
+
+	_, ok := s.nodeStore.UpdateNode(nodeID, func(n *types.Node) {
+		n.Endpoints = []netip.AddrPort{endpoint}
+	})
+	require.True(t, ok)
+
+	seeded, ok := s.nodeStore.GetNode(nodeID)
+	require.True(t, ok)
+
+	_, _, err := s.persistNodeToDB(seeded)
+	require.NoError(t, err)
+
+	gotAfterSeed, err := s.DB().GetNodeByID(nodeID)
+	require.NoError(t, err)
+	require.Equal(t, []netip.AddrPort{endpoint}, gotAfterSeed.Endpoints.List(),
+		"endpoints should hold the seeded value")
+
+	cleared, ok := s.nodeStore.UpdateNode(nodeID, func(n *types.Node) {
+		n.Endpoints = nil
+	})
+	require.True(t, ok)
+
+	_, _, err = s.persistNodeToDB(cleared)
+	require.NoError(t, err)
+
+	gotAfterClear, err := s.DB().GetNodeByID(nodeID)
+	require.NoError(t, err)
+	assert.Empty(t, gotAfterClear.Endpoints,
+		"endpoints should be empty after clear, got %v", gotAfterClear.Endpoints)
+
+	require.NoError(t, s.Close())
+
+	s2 := persistTestReopen(t, dbPath)
+
+	nv, ok := s2.GetNodeByID(nodeID)
+	require.True(t, ok)
+	assert.Empty(t, nv.AsStruct().Endpoints,
+		"after restart, NodeStore should reflect the cleared endpoints")
+}

--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -120,7 +120,7 @@ type Node struct {
 	NodeKey    key.NodePublic    `gorm:"serializer:text"`
 	DiscoKey   key.DiscoPublic   `gorm:"serializer:text"`
 
-	Endpoints []netip.AddrPort `gorm:"serializer:json"`
+	Endpoints AddrPorts `gorm:"serializer:json"`
 
 	Hostinfo *tailcfg.Hostinfo `gorm:"column:host_info;serializer:json"`
 
@@ -150,7 +150,7 @@ type Node struct {
 	// When non-empty, the node is "tagged" and tags define its identity.
 	// Empty for user-owned nodes.
 	// Tags cannot be removed once set (one-way transition).
-	Tags []string `gorm:"column:tags;serializer:json"`
+	Tags Strings `gorm:"column:tags;serializer:json"`
 
 	// When a node has been created with a PreAuthKey, we need to
 	// prevent the preauthkey from being deleted before the node.
@@ -169,7 +169,7 @@ type Node struct {
 	// as a subnet router. They are not necessarily the routes that the node
 	// announces at the moment.
 	// See [Node.Hostinfo]
-	ApprovedRoutes []netip.Prefix `gorm:"column:approved_routes;serializer:json"`
+	ApprovedRoutes Prefixes `gorm:"column:approved_routes;serializer:json"`
 
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/hscontrol/types/slices.go
+++ b/hscontrol/types/slices.go
@@ -1,0 +1,46 @@
+package types
+
+import "net/netip"
+
+// The named slice types below are used for GORM-persisted Node columns
+// that serialise as JSON. GORM v2's struct-based Updates skips fields
+// it considers zero — for unnamed slice types that is nil — and the
+// default reflect.Value.IsZero treats a nil slice as zero. By giving
+// each slice an IsZero() that always returns false, the column is
+// always included in UPDATE statements regardless of whether the
+// caller is clearing the field. JSON marshalling is unchanged: a nil
+// value serialises to null and an empty value serialises to [].
+//
+// The .List() helpers return the underlying unnamed slice for the
+// places (mainly testify assertions over reflect.DeepEqual) where the
+// distinction between the named and unnamed type matters.
+
+// Strings is a []string with a GORM-friendly IsZero.
+type Strings []string
+
+// IsZero implements GORM's zeroer interface to keep the column in the
+// UPDATE set even when the slice is nil or empty.
+func (Strings) IsZero() bool { return false }
+
+// List returns the underlying []string.
+func (s Strings) List() []string { return []string(s) }
+
+// Prefixes is a []netip.Prefix with a GORM-friendly IsZero.
+type Prefixes []netip.Prefix
+
+// IsZero implements GORM's zeroer interface to keep the column in the
+// UPDATE set even when the slice is nil or empty.
+func (Prefixes) IsZero() bool { return false }
+
+// List returns the underlying []netip.Prefix.
+func (s Prefixes) List() []netip.Prefix { return []netip.Prefix(s) }
+
+// AddrPorts is a []netip.AddrPort with a GORM-friendly IsZero.
+type AddrPorts []netip.AddrPort
+
+// IsZero implements GORM's zeroer interface to keep the column in the
+// UPDATE set even when the slice is nil or empty.
+func (AddrPorts) IsZero() bool { return false }
+
+// List returns the underlying []netip.AddrPort.
+func (s AddrPorts) List() []netip.AddrPort { return []netip.AddrPort(s) }

--- a/hscontrol/types/types_clone.go
+++ b/hscontrol/types/types_clone.go
@@ -86,7 +86,7 @@ var _NodeCloneNeedsRegeneration = Node(struct {
 	MachineKey     key.MachinePublic
 	NodeKey        key.NodePublic
 	DiscoKey       key.DiscoPublic
-	Endpoints      []netip.AddrPort
+	Endpoints      AddrPorts
 	Hostinfo       *tailcfg.Hostinfo
 	IPv4           *netip.Addr
 	IPv6           *netip.Addr
@@ -95,12 +95,12 @@ var _NodeCloneNeedsRegeneration = Node(struct {
 	UserID         *uint
 	User           *User
 	RegisterMethod string
-	Tags           []string
+	Tags           Strings
 	AuthKeyID      *uint64
 	AuthKey        *PreAuthKey
 	Expiry         *time.Time
 	LastSeen       *time.Time
-	ApprovedRoutes []netip.Prefix
+	ApprovedRoutes Prefixes
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 	DeletedAt      *time.Time

--- a/hscontrol/types/types_view.go
+++ b/hscontrol/types/types_view.go
@@ -275,7 +275,7 @@ var _NodeViewNeedsRegeneration = Node(struct {
 	MachineKey     key.MachinePublic
 	NodeKey        key.NodePublic
 	DiscoKey       key.DiscoPublic
-	Endpoints      []netip.AddrPort
+	Endpoints      AddrPorts
 	Hostinfo       *tailcfg.Hostinfo
 	IPv4           *netip.Addr
 	IPv6           *netip.Addr
@@ -284,12 +284,12 @@ var _NodeViewNeedsRegeneration = Node(struct {
 	UserID         *uint
 	User           *User
 	RegisterMethod string
-	Tags           []string
+	Tags           Strings
 	AuthKeyID      *uint64
 	AuthKey        *PreAuthKey
 	Expiry         *time.Time
 	LastSeen       *time.Time
-	ApprovedRoutes []netip.Prefix
+	ApprovedRoutes Prefixes
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 	DeletedAt      *time.Time


### PR DESCRIPTION
## Summary

- Named slice types `Strings`/`Prefixes`/`AddrPorts` on `Node` with `IsZero() = false`. GORM keeps `serializer:json` columns in struct `Updates` for `nil`/empty values instead of dropping them.
- Deletes dead `db.SetApprovedRoutes` and `db.SetTags`.
- Adds `hscontrol/state/persist_test.go` for the cleared-slice round-trip.

## Test plan

- [x] `go test ./hscontrol/...` — 13469 passed
- [x] `golangci-lint run --new-from-rev=upstream/main` — 0 issues
- [x] `go generate ./hscontrol/types/...` clean

Fixes [#3110](https://github.com/juanfont/headscale/issues/3110)
Closes [#3132](https://github.com/juanfont/headscale/pull/3132)