### PR TITLE
policy/v2: match via-grant destinations by prefix overlap

### DIFF
--- a/hscontrol/policy/v2/compiled.go
+++ b/hscontrol/policy/v2/compiled.go
@@ -66,12 +66,52 @@ type selfGrantData struct {
 }
 
 // viaGrantData holds data needed for per-node via-grant compilation.
-// Sources are already resolved into srcIPStrings.
+// Sources are already resolved into srcIPStrings; destinations are
+// pre-resolved into prefixes plus a flag for autogroup:internet, which
+// the consumers handle separately because its gate is per-node
+// (IsExitNode()) rather than per-prefix overlap.
 type viaGrantData struct {
-	viaTags           []Tag
-	destinations      Aliases
-	internetProtocols []ProtocolPort
-	srcIPStrings      []string
+	viaTags              []Tag
+	resolvedDsts         []netip.Prefix
+	hasAutoGroupInternet bool
+	internetProtocols    []ProtocolPort
+	srcIPStrings         []string
+}
+
+// resolveViaDestinations splits a via grant's destinations into the
+// flat list of IP prefixes they resolve to plus a flag for
+// autogroup:internet. Every alias kind goes through Alias.Resolve so
+// adding a new alias type to the policy parser does not silently
+// disappear from the via path. Non-IP alias kinds (tag, user, group,
+// wildcard) resolve to /32 host IPs that never overlap with subnet
+// route advertisements and therefore contribute nothing here.
+func resolveViaDestinations(
+	pol *Policy,
+	users types.Users,
+	nodes views.Slice[types.NodeView],
+	dsts Aliases,
+) ([]netip.Prefix, bool) {
+	var (
+		prefixes             []netip.Prefix
+		hasAutoGroupInternet bool
+	)
+
+	for _, d := range dsts {
+		if ag, ok := d.(*AutoGroup); ok && ag.Is(AutoGroupInternet) {
+			hasAutoGroupInternet = true
+
+			continue
+		}
+
+		ips, err := d.Resolve(pol, users, nodes)
+		if err != nil || ips == nil {
+			continue
+		}
+
+		prefixes = append(prefixes, ips.Prefixes()...)
+	}
+
+	return prefixes, hasAutoGroupInternet
 }
 
 // userNodeIndex maps user IDs to their untagged nodes. Built once per
@@ -343,12 +383,17 @@ func (pol *Policy) compileOneViaGrant(
 	hasWildcard := sourcesHaveWildcard(grant.Sources)
 	hasDangerAll := sourcesHaveDangerAll(grant.Sources)
 
+	resolvedDsts, hasAutoGroupInternet := resolveViaDestinations(
+		pol, users, nodes, grant.Destinations,
+	)
+
 	return &compiledGrant{
 		category: grantCategoryVia,
 		via: &viaGrantData{
-			viaTags:           grant.Via,
-			destinations:      grant.Destinations,
-			internetProtocols: grant.InternetProtocols,
+			viaTags:              grant.Via,
+			resolvedDsts:         resolvedDsts,
+			hasAutoGroupInternet: hasAutoGroupInternet,
+			internetProtocols:    grant.InternetProtocols,
 			srcIPStrings: srcIPsWithRoutes(
 				srcResolved, hasWildcard, hasDangerAll, nodes,
 			),
@@ -759,37 +804,38 @@ func compileViaForNode(
 		return nil
 	}
 
-	// Find matching destination prefixes. SubnetRoutes() excludes exit
-	// routes, so the *Prefix check below sees only subnet advertisements;
-	// the *AutoGroup AutoGroupInternet branch checks IsExitNode() instead.
+	// SubnetRoutes excludes exit routes, so the overlap gate below sees
+	// only subnet advertisements. autogroup:internet on a via-tagged
+	// exit advertiser is handled separately because its eligibility is
+	// per-node (IsExitNode) rather than per-prefix overlap.
 	nodeSubnetRoutes := node.SubnetRoutes()
 
 	var viaDstPrefixes []netip.Prefix
 
-	for _, dst := range cg.via.destinations {
-		switch d := dst.(type) {
-		case *Prefix:
-			dstPrefix := netip.Prefix(*d)
-			if slices.Contains(nodeSubnetRoutes, dstPrefix) {
-				viaDstPrefixes = append(
-					viaDstPrefixes, dstPrefix,
-				)
-			}
-		case *AutoGroup:
-			// autogroup:internet on a via-tagged exit advertiser
-			// becomes a rule whose DstPorts enumerate
-			// util.TheInternet(). The matchers derived from this
-			// rule let Node.CanAccess surface the exit node to the
-			// grant source via DestsIsTheInternet. ReduceFilterRules
-			// strips the rule from the wire format on non-exit
-			// advertisers, preserving SaaS PacketFilter encoding.
-			if d.Is(AutoGroupInternet) && node.IsExitNode() {
-				viaDstPrefixes = append(
-					viaDstPrefixes,
-					util.TheInternet().Prefixes()...,
-				)
-			}
+	for _, dstPrefix := range cg.via.resolvedDsts {
+		// Equality would reject any broader or narrower dst relative
+		// to the advertised route. Containment in either direction
+		// matches the operator's authorisation: a broader dst restricts
+		// traffic to the subset the router serves; a narrower dst rides
+		// on a router covering more than the operator asked for. The
+		// rule emits the literal dst either way because that is what
+		// the policy authorised.
+		if slices.ContainsFunc(nodeSubnetRoutes, dstPrefix.Overlaps) {
+			viaDstPrefixes = append(viaDstPrefixes, dstPrefix)
 		}
+	}
+
+	// autogroup:internet on a via-tagged exit advertiser becomes a rule
+	// whose DstPorts enumerate util.TheInternet(). The matchers derived
+	// from this rule let Node.CanAccess surface the exit node to the
+	// grant source via DestsIsTheInternet. ReduceFilterRules strips the
+	// rule from the wire format on non-exit advertisers, preserving
+	// SaaS PacketFilter encoding.
+	if cg.via.hasAutoGroupInternet && node.IsExitNode() {
+		viaDstPrefixes = append(
+			viaDstPrefixes,
+			util.TheInternet().Prefixes()...,
+		)
 	}
 
 	if len(viaDstPrefixes) == 0 {

--- a/hscontrol/policy/v2/issue_3267_test.go
+++ b/hscontrol/policy/v2/issue_3267_test.go
@@ -1,0 +1,120 @@
+package v2
+
+import (
+	"net/netip"
+	"slices"
+	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"tailscale.com/tailcfg"
+)
+
+const issue3267AliceEmail = "alice@headscale.net"
+
+// TestIssue3267ViaGrantBroaderDestination locks the SaaS contract for
+// a via grant whose destination is a host alias broader than (or
+// narrower than) the router's advertised subnet route. Alice's only
+// path into the subnet is via tag:subnet-router. The grant destination
+// resolves to a /64 (IPv6) or /16 (IPv4), and the router advertises a
+// contained /120 / /24. Pre-fix the policy compiler emitted no rule
+// and ViaRoutesForPeer left Include empty because the prefix relation
+// was checked by slices.Contains (exact equality). SaaS behaviour is
+// the authority — see testdata/grant_results/via-grant-v47..v51 for
+// the equivalent compatibility regression.
+func TestIssue3267ViaGrantBroaderDestination(t *testing.T) {
+	t.Parallel()
+
+	users := types.Users{
+		{Model: gorm.Model{ID: 1}, Name: "alice", Email: issue3267AliceEmail}, //nolint:goconst
+	}
+
+	cases := []struct {
+		name       string
+		hostAlias  string
+		dst        string // value the hosts alias resolves to
+		advertised string // narrower prefix the router actually serves
+	}{
+		{
+			name:       "ipv6_4via6_64_dst_with_120_advertised",
+			hostAlias:  "example-4via6",
+			dst:        "fd7a:115c:a1e0:b1a::/64",
+			advertised: "fd7a:115c:a1e0:b1a:0:13:ad2:7300/120",
+		},
+		{
+			name:       "ipv4_16_dst_with_24_advertised",
+			hostAlias:  "subnet",
+			dst:        "10.33.0.0/16",
+			advertised: "10.33.5.0/24",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			aliceLaptop := node("alice-laptop", "100.64.0.10", "fd7a:115c:a1e0::a", users[0])
+			aliceLaptop.ID = 1
+
+			router := node("subnet-router", "100.64.0.11", "fd7a:115c:a1e0::b", users[0])
+			router.ID = 2
+			router.Tags = []string{"tag:subnet-router"}
+			route := netip.MustParsePrefix(tc.advertised)
+			router.Hostinfo = &tailcfg.Hostinfo{RoutableIPs: []netip.Prefix{route}}
+			router.ApprovedRoutes = []netip.Prefix{route}
+
+			nodes := types.Nodes{aliceLaptop, router}
+
+			policy := `{
+				"tagOwners": {
+					"tag:subnet-router": ["` + issue3267AliceEmail + `"]
+				},
+				"hosts": {
+					"` + tc.hostAlias + `": "` + tc.dst + `"
+				},
+				"grants": [
+					{
+						"src": ["` + issue3267AliceEmail + `"],
+						"dst": ["` + tc.hostAlias + `"],
+						"via": ["tag:subnet-router"],
+						"ip": ["icmp:*"]
+					}
+				]
+			}`
+
+			pm, err := NewPolicyManager([]byte(policy), users, nodes.ViewSlice())
+			require.NoError(t, err)
+
+			pol, err := unmarshalPolicy([]byte(policy))
+			require.NoError(t, err)
+			require.NoError(t, pol.validate())
+
+			t.Run("compileFilterRulesForNode_emits_rule_with_grant_dst", func(t *testing.T) {
+				t.Parallel()
+
+				rules, err := pol.compileFilterRulesForNode(users, router.View(), nodes.ViewSlice())
+				require.NoError(t, err)
+
+				found := slices.ContainsFunc(rules, func(r tailcfg.FilterRule) bool {
+					return slices.ContainsFunc(r.DstPorts, func(d tailcfg.NetPortRange) bool {
+						return d.IP == tc.dst
+					})
+				})
+				require.Truef(t, found,
+					"router %s must receive a via filter rule whose DstPorts.IP equals the grant dst %q; got rules=%+v",
+					router.Hostname, tc.dst, rules)
+			})
+
+			t.Run("ViaRoutesForPeer_includes_advertised_prefix", func(t *testing.T) {
+				t.Parallel()
+
+				result := pm.ViaRoutesForPeer(aliceLaptop.View(), router.View())
+				require.Contains(t, result.Include, route,
+					"alice viewing tag:subnet-router must Include advertised prefix %s — drives AllowedIPs in state.RoutesForPeer", route)
+				require.Empty(t, result.Exclude,
+					"alice viewing tag:subnet-router must not Exclude any prefix — there is no competing via tag")
+			})
+		})
+	}
+}

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -1009,11 +1009,13 @@ func (pm *PolicyManager) ViaRoutesForPeer(viewer, peer types.NodeView) types.Via
 		grants = append(grants, aclToGrants(acl)...)
 	}
 
-	// Resolve each grant's sources against the viewer once. The three
-	// passes below reuse this result instead of calling src.Resolve
-	// per grant per pass.
+	// Resolve each grant's sources against the viewer once, and each
+	// grant's destinations into a flat prefix list. The three passes
+	// below reuse both results instead of re-resolving per pass.
 	viewerIPs := viewer.IPs()
 	viewerMatchesGrant := make([]bool, len(grants))
+	resolvedDstPrefixes := make([][]netip.Prefix, len(grants))
+	grantHasAutoGroupInternet := make([]bool, len(grants))
 
 	for i, grant := range grants {
 		for _, src := range grant.Sources {
@@ -1028,6 +1030,10 @@ func (pm *PolicyManager) ViaRoutesForPeer(viewer, peer types.NodeView) types.Via
 				break
 			}
 		}
+
+		resolvedDstPrefixes[i], grantHasAutoGroupInternet[i] = resolveViaDestinations(
+			pm.pol, pm.users, pm.nodes, grant.Destinations,
+		)
 	}
 
 	for i, grant := range grants {
@@ -1039,30 +1045,30 @@ func (pm *PolicyManager) ViaRoutesForPeer(viewer, peer types.NodeView) types.Via
 			continue
 		}
 
-		// Collect destination prefixes that the peer actually advertises.
+		// Filter rules and AllowedIPs are different layers. The filter
+		// rule carries the dst (the authorisation surface). AllowedIPs
+		// carries the advertised route (the routing fact the viewer
+		// needs to pick this peer). This loop builds the AllowedIPs
+		// side, so it emits routes — not dst prefixes.
 		peerSubnetRoutes := peer.SubnetRoutes()
 
 		var matchedPrefixes []netip.Prefix
 
-		for _, dst := range grant.Destinations {
-			switch d := dst.(type) {
-			case *Prefix:
-				dstPrefix := netip.Prefix(*d)
-				if slices.Contains(peerSubnetRoutes, dstPrefix) {
-					matchedPrefixes = append(matchedPrefixes, dstPrefix)
-				}
-			case *AutoGroup:
-				// Per-viewer steering for autogroup:internet: a peer
-				// advertising approved exit routes is the via-tagged
-				// node's analogue of "advertises the destination".
-				// The downstream Include/Exclude split below restricts
-				// alice to exit nodes carrying the via tag.
-				if d.Is(AutoGroupInternet) && peer.IsExitNode() {
-					matchedPrefixes = append(
-						matchedPrefixes, peer.ExitRoutes()...,
-					)
+		for _, dstPrefix := range resolvedDstPrefixes[i] {
+			for _, route := range peerSubnetRoutes {
+				if dstPrefix.Overlaps(route) {
+					matchedPrefixes = append(matchedPrefixes, route)
 				}
 			}
+		}
+
+		// Per-viewer steering for autogroup:internet: a peer advertising
+		// approved exit routes is the via-tagged node's analogue of
+		// "advertises the destination". The downstream Include/Exclude
+		// split below restricts the viewer to exit nodes carrying the
+		// via tag.
+		if grantHasAutoGroupInternet[i] && peer.IsExitNode() {
+			matchedPrefixes = append(matchedPrefixes, peer.ExitRoutes()...)
 		}
 
 		if len(matchedPrefixes) == 0 {
@@ -1121,40 +1127,35 @@ func (pm *PolicyManager) ViaRoutesForPeer(viewer, peer types.NodeView) types.Via
 				continue
 			}
 
-			for _, dst := range grant.Destinations {
-				d, ok := dst.(*Prefix)
-				if !ok {
-					continue
-				}
+			// Elect per matched route, not per dst — a peer can only
+			// be primary for a prefix it actually advertises, and one
+			// dst may cover multiple distinct routes.
+			for _, dstPrefix := range resolvedDstPrefixes[i] {
+				for _, included := range slices.Clone(result.Include) {
+					if !dstPrefix.Overlaps(included) {
+						continue
+					}
 
-				dstPrefix := netip.Prefix(*d)
-				if !slices.Contains(result.Include, dstPrefix) {
-					continue
-				}
+					var viaPrimaryID types.NodeID
 
-				// Find the lowest-ID peer with this via tag that
-				// advertises this prefix — the via-group primary.
-				var viaPrimaryID types.NodeID
-
-				for _, viaTag := range grant.Via {
-					for _, node := range pm.nodes.All() {
-						if node.HasTag(string(viaTag)) &&
-							slices.Contains(node.SubnetRoutes(), dstPrefix) {
-							if viaPrimaryID == 0 || node.ID() < viaPrimaryID {
-								viaPrimaryID = node.ID()
+					for _, viaTag := range grant.Via {
+						for _, node := range pm.nodes.All() {
+							if node.HasTag(string(viaTag)) &&
+								slices.Contains(node.SubnetRoutes(), included) {
+								if viaPrimaryID == 0 || node.ID() < viaPrimaryID {
+									viaPrimaryID = node.ID()
+								}
 							}
 						}
 					}
-				}
 
-				// If the current peer is not the via-group primary,
-				// demote the prefix from Include to Exclude.
-				if viaPrimaryID != 0 && peer.ID() != viaPrimaryID {
-					result.Include = slices.DeleteFunc(result.Include, func(p netip.Prefix) bool {
-						return p == dstPrefix
-					})
-					if !slices.Contains(result.Exclude, dstPrefix) {
-						result.Exclude = append(result.Exclude, dstPrefix)
+					if viaPrimaryID != 0 && peer.ID() != viaPrimaryID {
+						result.Include = slices.DeleteFunc(result.Include, func(p netip.Prefix) bool {
+							return p == included
+						})
+						if !slices.Contains(result.Exclude, included) {
+							result.Exclude = append(result.Exclude, included)
+						}
 					}
 				}
 			}
@@ -1175,21 +1176,19 @@ func (pm *PolicyManager) ViaRoutesForPeer(viewer, peer types.NodeView) types.Via
 				continue
 			}
 
-			for _, dst := range grant.Destinations {
-				if d, ok := dst.(*Prefix); ok {
-					dstPrefix := netip.Prefix(*d)
-					if slices.Contains(result.Include, dstPrefix) &&
-						!slices.Contains(result.UsePrimary, dstPrefix) {
-						result.UsePrimary = append(result.UsePrimary, dstPrefix)
+			// A non-via grant covering routes that a via grant included
+			// defers to global HA primary election. Match by overlap so
+			// a broader or narrower regular dst still catches the
+			// routes the via grant added to Include.
+			for _, dstPrefix := range resolvedDstPrefixes[i] {
+				for _, p := range result.Include {
+					if dstPrefix.Overlaps(p) &&
+						!slices.Contains(result.UsePrimary, p) {
+						result.UsePrimary = append(result.UsePrimary, p)
 					}
-
-					// A regular grant overrides a via exclusion: the
-					// peer doesn't need the via tag if the viewer has
-					// direct (non-via) access to the prefix.
-					result.Exclude = slices.DeleteFunc(result.Exclude, func(p netip.Prefix) bool {
-						return p == dstPrefix
-					})
 				}
+
+				result.Exclude = slices.DeleteFunc(result.Exclude, dstPrefix.Overlaps)
 			}
 		}
 	}

--- a/hscontrol/policy/v2/policy_test.go
+++ b/hscontrol/policy/v2/policy_test.go
@@ -1813,6 +1813,147 @@ func TestViaRoutesForPeer(t *testing.T) {
 			"client should NOT be able to access 10.0.0.0/24 via matchers alone; "+
 				"state.RoutesForPeer adds via routes after ReduceRoutes to fix this")
 	})
+
+	t.Run("broader_dst_includes_narrower_advertised_route", func(t *testing.T) {
+		t.Parallel()
+
+		nodes := types.Nodes{
+			{
+				ID:       1,
+				Hostname: "viewer",
+				IPv4:     ap("100.64.0.1"),
+				User:     new(users[0]),
+				UserID:   new(users[0].ID),
+				Hostinfo: &tailcfg.Hostinfo{},
+			},
+			{
+				ID:       2,
+				Hostname: "router",
+				IPv4:     ap("100.64.0.2"),
+				User:     new(users[0]),
+				UserID:   new(users[0].ID),
+				Tags:     []string{"tag:router"},
+				Hostinfo: &tailcfg.Hostinfo{
+					RoutableIPs: []netip.Prefix{mp("10.33.5.0/24")},
+				},
+				ApprovedRoutes: []netip.Prefix{mp("10.33.5.0/24")},
+			},
+		}
+
+		pol := `{
+			"tagOwners": {
+				"tag:router": ["user1@"]
+			},
+			"grants": [{
+				"src": ["user1@"],
+				"dst": ["10.0.0.0/8"],
+				"ip": ["*"],
+				"via": ["tag:router"]
+			}]
+		}`
+
+		pm, err := NewPolicyManager([]byte(pol), users, nodes.ViewSlice())
+		require.NoError(t, err)
+
+		result := pm.ViaRoutesForPeer(nodes[0].View(), nodes[1].View())
+		require.Equal(t, []netip.Prefix{mp("10.33.5.0/24")}, result.Include,
+			"Include must hold the advertised route /24, not the broader grant dst /8")
+		require.Empty(t, result.Exclude)
+	})
+
+	t.Run("narrower_dst_includes_advertised_route", func(t *testing.T) {
+		t.Parallel()
+
+		nodes := types.Nodes{
+			{
+				ID:       1,
+				Hostname: "viewer",
+				IPv4:     ap("100.64.0.1"),
+				User:     new(users[0]),
+				UserID:   new(users[0].ID),
+				Hostinfo: &tailcfg.Hostinfo{},
+			},
+			{
+				ID:       2,
+				Hostname: "router",
+				IPv4:     ap("100.64.0.2"),
+				User:     new(users[0]),
+				UserID:   new(users[0].ID),
+				Tags:     []string{"tag:router"},
+				Hostinfo: &tailcfg.Hostinfo{
+					RoutableIPs: []netip.Prefix{mp("10.33.0.0/16")},
+				},
+				ApprovedRoutes: []netip.Prefix{mp("10.33.0.0/16")},
+			},
+		}
+
+		pol := `{
+			"tagOwners": {
+				"tag:router": ["user1@"]
+			},
+			"grants": [{
+				"src": ["user1@"],
+				"dst": ["10.33.5.0/24"],
+				"ip": ["*"],
+				"via": ["tag:router"]
+			}]
+		}`
+
+		pm, err := NewPolicyManager([]byte(pol), users, nodes.ViewSlice())
+		require.NoError(t, err)
+
+		result := pm.ViaRoutesForPeer(nodes[0].View(), nodes[1].View())
+		require.Equal(t, []netip.Prefix{mp("10.33.0.0/16")}, result.Include,
+			"Include must hold the advertised route /16 that covers the narrower grant dst /24")
+		require.Empty(t, result.Exclude)
+	})
+
+	t.Run("disjoint_dst_emits_nothing", func(t *testing.T) {
+		t.Parallel()
+
+		nodes := types.Nodes{
+			{
+				ID:       1,
+				Hostname: "viewer",
+				IPv4:     ap("100.64.0.1"),
+				User:     new(users[0]),
+				UserID:   new(users[0].ID),
+				Hostinfo: &tailcfg.Hostinfo{},
+			},
+			{
+				ID:       2,
+				Hostname: "router",
+				IPv4:     ap("100.64.0.2"),
+				User:     new(users[0]),
+				UserID:   new(users[0].ID),
+				Tags:     []string{"tag:router"},
+				Hostinfo: &tailcfg.Hostinfo{
+					RoutableIPs: []netip.Prefix{mp("10.33.0.0/16")},
+				},
+				ApprovedRoutes: []netip.Prefix{mp("10.33.0.0/16")},
+			},
+		}
+
+		pol := `{
+			"tagOwners": {
+				"tag:router": ["user1@"]
+			},
+			"grants": [{
+				"src": ["user1@"],
+				"dst": ["192.168.0.0/16"],
+				"ip": ["*"],
+				"via": ["tag:router"]
+			}]
+		}`
+
+		pm, err := NewPolicyManager([]byte(pol), users, nodes.ViewSlice())
+		require.NoError(t, err)
+
+		result := pm.ViaRoutesForPeer(nodes[0].View(), nodes[1].View())
+		require.Empty(t, result.Include,
+			"disjoint dst must produce nothing — the via gate requires advertised-route overlap")
+		require.Empty(t, result.Exclude)
+	})
 }
 
 // TestBuildPeerMap_AutogroupInternetMakesExitNodeVisible reproduces

--- a/hscontrol/policy/v2/testdata/grant_results/via-grant-v47.hujson
+++ b/hscontrol/policy/v2/testdata/grant_results/via-grant-v47.hujson
@@ -1,0 +1,14164 @@
+// via-grant-v47
+//
+// via grant v47 dst literal cidr broader than advertised subnet
+//
+// Nodes with filter rules: 2 of 15
+// Captured at:    2026-05-18T09:07:30Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "via-grant-v47",
+	"description":    "via grant v47 dst literal cidr broader than advertised subnet",
+	"category":       "grant",
+	"captured_at":    "2026-05-18T09:07:30.233896341Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                                                      \n  \n                                                                         \n                                                                     \n                                                                   \n                                                                         \n  \n                                                              \n                                                                 \n{\n\t\"category\":    \"grant\",\n\t\"description\": \"via grant v47 dst literal cidr broader than advertised subnet\",\n\t\"id\":          \"via-grant-v47\",\n\t\"options\":     {\"capture_whois\": true},\n\t\"policy\": {\"autoApprovers\": {\"routes\": {\n\t\t\"10.33.0.0/16\": [\"tag:router\"],\n\t\t\"10.44.0.0/16\": [\"tag:spearow\"],\n\t\t\"10.55.0.0/16\": [\"tag:fearow\"]\n\t}}, \"grants\": [{\n\t\t\"dst\": [\"10.0.0.0/8\"],\n\t\t\"ip\":  [\"*\"],\n\t\t\"src\": [\"tag:group-a\"],\n\t\t\"via\": [\"tag:router\"]\n\t}], \"groups\": {\n\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\"group:empty\":      [],\n\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t}, \"hosts\": {\n\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\"webserver\": \"100.108.74.26\"\n\t}, \"tagOwners\": {\n\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\"tag:server\":   [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/grant/via-grant-v47.hujson",
+		"full_policy": {"autoApprovers": {"routes": {
+			"10.33.0.0/16": ["tag:router"],
+			"10.44.0.0/16": ["tag:spearow"],
+			"10.55.0.0/16": ["tag:fearow"]
+		}}, "grants": [{
+			"dst": ["10.0.0.0/8"],
+			"ip":  ["*"],
+			"src": ["tag:group-a"],
+			"via": ["tag:router"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"webserver": "100.108.74.26"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": ["10.33.0.0/16"]
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": ["10.55.0.0/16"]
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": ["10.44.0.0/16"]
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": ["10.33.0.0/16"]
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5981618237305639,
+			"StableID":   "nk5QY9y5io11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       5981618237305639,
+			"Key":        "nodekey:8d00dadb71723afae9a5a66f91f0969d976e421e425f9a59bf724af8ad0be044",
+			"DiscoKey":   "discokey:58a7b5d39f051fe68397efb26faf8750e5e02e9f63bd44898ab0d2072a95b606",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints": [
+				"77.164.248.136:40707",
+				"10.65.0.27:40707",
+				"172.17.0.1:40707",
+				"172.18.0.1:40707",
+				"172.19.0.1:40707",
+				"172.20.0.1:40707",
+				"172.21.0.1:40707",
+				"172.22.0.1:40707",
+				"172.23.0.1:40707",
+				"172.24.0.1:40707",
+				"172.25.0.1:40707",
+				"172.27.0.1:40707",
+				"172.28.0.1:40707",
+				"172.29.0.1:40707",
+				"172.30.0.1:40707"
+			],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:07:42.555612283Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:8d00dadb71723afae9a5a66f91f0969d976e421e425f9a59bf724af8ad0be044",
+		"MachineKey":        "mkey:c0f8e65db1b7d40ade64d7f79b1b6e8357d0b039822dfb0c2064aefe4d8d556f",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5981618237305639": {
+			"ID":          5981618237305639,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}}
+	}}, "blastoise": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.5", "fd7a:115c:a1e0::5"],
+		"DstPorts": [{"IP": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}]
+	}], "packet_filter_matches": [{
+		"IPProto": [6, 17, 1, 58],
+		"Srcs":    ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}],
+		"Caps":    []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2473353104810224,
+			"StableID":   "n9wnGwnBKL11CNTRL",
+			"Name":       "blastoise.tail78f774.ts.net.",
+			"User":       2473353104810224,
+			"Key":        "nodekey:53576a2afaa4b69cb90015c53612c7dfd379f0228b834c69c259c4e6fca4b126",
+			"DiscoKey":   "discokey:ff7cbde611949dd26d88c1b8fb4f44eb7c0d088d56f6a27b55d877b998c19154",
+			"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+			"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:34777",
+				"10.65.0.27:34777",
+				"172.17.0.1:34777",
+				"172.18.0.1:34777",
+				"172.19.0.1:34777",
+				"172.20.0.1:34777",
+				"172.21.0.1:34777",
+				"172.22.0.1:34777",
+				"172.23.0.1:34777",
+				"172.24.0.1:34777",
+				"172.25.0.1:34777",
+				"172.27.0.1:34777",
+				"172.28.0.1:34777",
+				"172.29.0.1:34777",
+				"172.30.0.1:34777"
+			],
+			"Hostinfo": {
+				"Hostname":    "blastoise",
+				"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit", "tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:07:39.354833108Z",
+			"Tags":              ["tag:exit", "tag:router"],
+			"PrimaryRoutes":     ["10.33.0.0/16"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "blastoise",
+			"ComputedNameWithHost": "blastoise"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:53576a2afaa4b69cb90015c53612c7dfd379f0228b834c69c259c4e6fca4b126",
+		"MachineKey": "mkey:fb2a0b9fb8f781ee7920910a5139ef6a349da317cd3599045dc362211893c32b",
+		"Peers": [{
+			"ID":         2235849634173111,
+			"StableID":   "nLB9skycTJ11CNTRL",
+			"Name":       "rattata.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:6db2017d3818f302a7d230746785041dbb0314a538f5d655931ebca7add23541",
+			"DiscoKey":   "discokey:483f647524f0e221cc993febe44f860f82f23540a3efa803468d7bae22cb003d",
+			"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"Endpoints": [
+				"77.164.248.136:43793",
+				"10.65.0.27:43793",
+				"172.17.0.1:43793",
+				"172.18.0.1:43793",
+				"172.19.0.1:43793",
+				"172.20.0.1:43793",
+				"172.21.0.1:43793",
+				"172.22.0.1:43793",
+				"172.23.0.1:43793",
+				"172.24.0.1:43793",
+				"172.25.0.1:43793",
+				"172.27.0.1:43793",
+				"172.28.0.1:43793",
+				"172.29.0.1:43793",
+				"172.30.0.1:43793"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+				{"Proto": "peerapi4", "Port": 41053},
+				{"Proto": "peerapi6", "Port": 41053}
+			]},
+			"Created":              "2026-05-18T09:07:38.293173157Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:group-a"],
+			"Online":               true,
+			"ComputedName":         "rattata",
+			"ComputedNameWithHost": "rattata"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}],
+			"Caps":    []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.5", "fd7a:115c:a1e0::5"],
+			"DstPorts": [{"IP": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}]
+		}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "2473353104810224": {
+			"ID":          2473353104810224,
+			"LoginName":   "blastoise.tail78f774.ts.net",
+			"DisplayName": "blastoise"
+		}}
+	}, "whois": {"100.64.0.5": {"Node": {
+		"ID":         2235849634173111,
+		"StableID":   "nLB9skycTJ11CNTRL",
+		"Name":       "rattata.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:6db2017d3818f302a7d230746785041dbb0314a538f5d655931ebca7add23541",
+		"DiscoKey":   "discokey:483f647524f0e221cc993febe44f860f82f23540a3efa803468d7bae22cb003d",
+		"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"Endpoints": [
+			"77.164.248.136:43793",
+			"10.65.0.27:43793",
+			"172.17.0.1:43793",
+			"172.18.0.1:43793",
+			"172.19.0.1:43793",
+			"172.20.0.1:43793",
+			"172.21.0.1:43793",
+			"172.22.0.1:43793",
+			"172.23.0.1:43793",
+			"172.24.0.1:43793",
+			"172.25.0.1:43793",
+			"172.27.0.1:43793",
+			"172.28.0.1:43793",
+			"172.29.0.1:43793",
+			"172.30.0.1:43793"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+			{"Proto": "peerapi4", "Port": 41053},
+			{"Proto": "peerapi6", "Port": 41053}
+		]},
+		"Created":              "2026-05-18T09:07:38.293173157Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:group-a"],
+		"Online":               true,
+		"ComputedName":         "rattata",
+		"ComputedNameWithHost": "rattata"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "fd7a:115c:a1e0::5": {"Node": {
+		"ID":         2235849634173111,
+		"StableID":   "nLB9skycTJ11CNTRL",
+		"Name":       "rattata.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:6db2017d3818f302a7d230746785041dbb0314a538f5d655931ebca7add23541",
+		"DiscoKey":   "discokey:483f647524f0e221cc993febe44f860f82f23540a3efa803468d7bae22cb003d",
+		"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"Endpoints": [
+			"77.164.248.136:43793",
+			"10.65.0.27:43793",
+			"172.17.0.1:43793",
+			"172.18.0.1:43793",
+			"172.19.0.1:43793",
+			"172.20.0.1:43793",
+			"172.21.0.1:43793",
+			"172.22.0.1:43793",
+			"172.23.0.1:43793",
+			"172.24.0.1:43793",
+			"172.25.0.1:43793",
+			"172.27.0.1:43793",
+			"172.28.0.1:43793",
+			"172.29.0.1:43793",
+			"172.30.0.1:43793"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+			{"Proto": "peerapi4", "Port": 41053},
+			{"Proto": "peerapi6", "Port": 41053}
+		]},
+		"Created":              "2026-05-18T09:07:38.293173157Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:group-a"],
+		"Online":               true,
+		"ComputedName":         "rattata",
+		"ComputedNameWithHost": "rattata"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3735169030154237,
+			"StableID":   "n239iHZfAW11CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:a774215fe8e225a2f8e3512976b66d28c99f4ec53ce5e8a9a0151bc5e6823f19",
+			"KeyExpiry":  "2026-11-14T09:07:44Z",
+			"DiscoKey":   "discokey:5ed049b7a2ab5d6db0cb238f24853358f630e8732941ab2080352cde120a8424",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints": [
+				"77.164.248.136:52052",
+				"10.65.0.27:52052",
+				"172.17.0.1:52052",
+				"172.18.0.1:52052",
+				"172.19.0.1:52052",
+				"172.20.0.1:52052",
+				"172.21.0.1:52052",
+				"172.22.0.1:52052",
+				"172.23.0.1:52052",
+				"172.24.0.1:52052",
+				"172.25.0.1:52052",
+				"172.27.0.1:52052",
+				"172.28.0.1:52052",
+				"172.29.0.1:52052",
+				"172.30.0.1:52052"
+			],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:07:44.156697605Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:a774215fe8e225a2f8e3512976b66d28c99f4ec53ce5e8a9a0151bc5e6823f19",
+		"MachineKey":        "mkey:1a4b414c9ccd8577fb02ab172093ad7e402a207afd92586edea123a590100930",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2713035784821404,
+			"StableID":   "nu57xGrjBN11CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       2713035784821404,
+			"Key":        "nodekey:5cb9f7acbae73edf559e1377876b21dc4623f284b4910afa113fee4d5b3caa22",
+			"DiscoKey":   "discokey:547d15f2e245fa1cfd074dde54335c3bcea322326dd09b2396b94a2cee1e6616",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints": [
+				"77.164.248.136:39812",
+				"10.65.0.27:39812",
+				"172.17.0.1:39812",
+				"172.18.0.1:39812",
+				"172.19.0.1:39812",
+				"172.20.0.1:39812",
+				"172.21.0.1:39812",
+				"172.22.0.1:39812",
+				"172.23.0.1:39812",
+				"172.24.0.1:39812",
+				"172.25.0.1:39812",
+				"172.27.0.1:39812",
+				"172.28.0.1:39812",
+				"172.29.0.1:39812",
+				"172.30.0.1:39812"
+			],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:07:37.761033386Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:5cb9f7acbae73edf559e1377876b21dc4623f284b4910afa113fee4d5b3caa22",
+		"MachineKey":        "mkey:57893d73ba8b22cc2ea924982dfcf12560269df0307d293cbbd432dddcda771f",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"2713035784821404": {
+			"ID":          2713035784821404,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "fearow": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1036298269181620,
+			"StableID":   "n9BqQJoL6911CNTRL",
+			"Name":       "fearow.tail78f774.ts.net.",
+			"User":       1036298269181620,
+			"Key":        "nodekey:8c80f779c4b3f88a3cea46596bc465f7c32b0e495ce49f8163f3dab22eb32027",
+			"DiscoKey":   "discokey:087e934fddc3d13002704b01725a7befd7c406315e4b4061938dc791626e8c31",
+			"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+			"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128", "10.55.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:58140",
+				"10.65.0.27:58140",
+				"172.17.0.1:58140",
+				"172.18.0.1:58140",
+				"172.19.0.1:58140",
+				"172.20.0.1:58140",
+				"172.21.0.1:58140",
+				"172.22.0.1:58140",
+				"172.23.0.1:58140",
+				"172.24.0.1:58140",
+				"172.25.0.1:58140",
+				"172.27.0.1:58140",
+				"172.28.0.1:58140",
+				"172.29.0.1:58140",
+				"172.30.0.1:58140"
+			],
+			"Hostinfo": {
+				"Hostname":    "fearow",
+				"RoutableIPs": ["10.55.0.0/16"],
+				"RequestTags": ["tag:fearow"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:07:40.418352282Z",
+			"Tags":              ["tag:fearow"],
+			"PrimaryRoutes":     ["10.55.0.0/16"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "fearow",
+			"ComputedNameWithHost": "fearow"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:8c80f779c4b3f88a3cea46596bc465f7c32b0e495ce49f8163f3dab22eb32027",
+		"MachineKey":        "mkey:b61388ca8350efc3e792f6ccf81a353d0e56cb12b010490006bea4ff8850ea53",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1036298269181620": {
+			"ID":          1036298269181620,
+			"LoginName":   "fearow.tail78f774.ts.net",
+			"DisplayName": "fearow"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         6052475718574476,
+			"StableID":   "nRjDXtGBGp11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:bf95ec3ca0ef9fcf414d6c2dbcde1ad167462596f0302534a4fb0599de2d7608",
+			"KeyExpiry":  "2026-11-14T09:07:43Z",
+			"DiscoKey":   "discokey:d2847f8e1119447612990448a50b04d407f3ef9c60b84d2087dc528f4c7d102c",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints": [
+				"77.164.248.136:47977",
+				"10.65.0.27:47977",
+				"172.17.0.1:47977",
+				"172.18.0.1:47977",
+				"172.19.0.1:47977",
+				"172.20.0.1:47977",
+				"172.21.0.1:47977",
+				"172.22.0.1:47977",
+				"172.23.0.1:47977",
+				"172.24.0.1:47977",
+				"172.25.0.1:47977",
+				"172.27.0.1:47977",
+				"172.28.0.1:47977",
+				"172.29.0.1:47977",
+				"172.30.0.1:47977"
+			],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:07:43.094398266Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:bf95ec3ca0ef9fcf414d6c2dbcde1ad167462596f0302534a4fb0599de2d7608",
+		"MachineKey":        "mkey:11c887185e0c4768aec007945b24a597760b1179c62ff13f0abd215d5e031a10",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         794053188242122,
+			"StableID":   "n5ky8zRdC711CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       794053188242122,
+			"Key":        "nodekey:0e51741477cf6d0151375bef8bf17b20be798ecfc80211cd2b5242a9357e320e",
+			"DiscoKey":   "discokey:2bca03dbb97dbdb2cc5edafc535dbe06f25ec21f76c7827ff827c1d30b593c19",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints": [
+				"77.164.248.136:59649",
+				"10.65.0.27:59649",
+				"172.17.0.1:59649",
+				"172.18.0.1:59649",
+				"172.19.0.1:59649",
+				"172.20.0.1:59649",
+				"172.21.0.1:59649",
+				"172.22.0.1:59649",
+				"172.23.0.1:59649",
+				"172.24.0.1:59649",
+				"172.25.0.1:59649",
+				"172.27.0.1:59649",
+				"172.28.0.1:59649",
+				"172.29.0.1:59649",
+				"172.30.0.1:59649"
+			],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:07:42.022585026Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:0e51741477cf6d0151375bef8bf17b20be798ecfc80211cd2b5242a9357e320e",
+		"MachineKey":        "mkey:5e46df86af2cd5bfacbc9f7d0526d488a8be09677e7b852e4fe037211bc8af17",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"794053188242122": {
+			"ID":          794053188242122,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "pidgeotto": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4812977064092943,
+			"StableID":   "nG1XtGkoae11CNTRL",
+			"Name":       "pidgeotto.tail78f774.ts.net.",
+			"User":       4812977064092943,
+			"Key":        "nodekey:9d1fd36fc77794676d764f15ba49b55085ba4d30da84cfcde57ab42304ec6a6b",
+			"DiscoKey":   "discokey:811005c8eb7cd134ad3a54ec8646d14a18c9c6f437943fd5518f232685e31b07",
+			"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+			"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+			"Endpoints": [
+				"77.164.248.136:57034",
+				"10.65.0.27:57034",
+				"172.17.0.1:57034",
+				"172.18.0.1:57034",
+				"172.19.0.1:57034",
+				"172.20.0.1:57034",
+				"172.21.0.1:57034",
+				"172.22.0.1:57034",
+				"172.23.0.1:57034",
+				"172.24.0.1:57034",
+				"172.25.0.1:57034",
+				"172.27.0.1:57034",
+				"172.28.0.1:57034",
+				"172.29.0.1:57034",
+				"172.30.0.1:57034"
+			],
+			"Hostinfo": {
+				"Hostname":    "pidgeotto",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:pidgeotto"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:07:37.243602289Z",
+			"Tags":              ["tag:pidgeotto"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "pidgeotto",
+			"ComputedNameWithHost": "pidgeotto"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:9d1fd36fc77794676d764f15ba49b55085ba4d30da84cfcde57ab42304ec6a6b",
+		"MachineKey":        "mkey:cc92e5235f0a5f4f21f80e5501305887c00be15fc602099fe62772fac452d518",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4812977064092943": {
+			"ID":          4812977064092943,
+			"LoginName":   "pidgeotto.tail78f774.ts.net",
+			"DisplayName": "pidgeotto"
+		}}
+	}}, "pidgey": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8216591946215860,
+			"StableID":   "n5PctNwJA721CNTRL",
+			"Name":       "pidgey.tail78f774.ts.net.",
+			"User":       8216591946215860,
+			"Key":        "nodekey:f54e53dd1c4183ffc21e79366245cd9ca3388580ab0693eddd6f22e666f6ce04",
+			"DiscoKey":   "discokey:5d7953f92951857532d9b605a02b7c630349de3174d0c2b6cdfebb970d766260",
+			"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+			"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+			"Endpoints": [
+				"77.164.248.136:42913",
+				"10.65.0.27:42913",
+				"172.17.0.1:42913",
+				"172.18.0.1:42913",
+				"172.19.0.1:42913",
+				"172.20.0.1:42913",
+				"172.21.0.1:42913",
+				"172.22.0.1:42913",
+				"172.23.0.1:42913",
+				"172.24.0.1:42913",
+				"172.25.0.1:42913",
+				"172.27.0.1:42913",
+				"172.28.0.1:42913",
+				"172.29.0.1:42913",
+				"172.30.0.1:42913"
+			],
+			"Hostinfo": {
+				"Hostname":    "pidgey",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:pidgey"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:07:36.71265978Z",
+			"Tags":              ["tag:pidgey"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "pidgey",
+			"ComputedNameWithHost": "pidgey"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:f54e53dd1c4183ffc21e79366245cd9ca3388580ab0693eddd6f22e666f6ce04",
+		"MachineKey":        "mkey:4c30a202339842a91c2e7ea26434618557cb1d565ca9fab62b2b4cf4b9c0f456",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8216591946215860": {
+			"ID":          8216591946215860,
+			"LoginName":   "pidgey.tail78f774.ts.net",
+			"DisplayName": "pidgey"
+		}}
+	}}, "raticate": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8892810857496319,
+			"StableID":   "ntyeUa4aSC21CNTRL",
+			"Name":       "raticate.tail78f774.ts.net.",
+			"User":       8892810857496319,
+			"Key":        "nodekey:1a7845aef659eda1c859138a1cc5bf0c67a2558c91b339fe6ac5800dcda6ae5a",
+			"DiscoKey":   "discokey:59fae4ca38649d03d183574d5bf8f4c73875161d00416df26079d973a3387561",
+			"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+			"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+			"Endpoints": [
+				"77.164.248.136:34561",
+				"10.65.0.27:34561",
+				"172.17.0.1:34561",
+				"172.18.0.1:34561",
+				"172.19.0.1:34561",
+				"172.20.0.1:34561",
+				"172.21.0.1:34561",
+				"172.22.0.1:34561",
+				"172.23.0.1:34561",
+				"172.24.0.1:34561",
+				"172.25.0.1:34561",
+				"172.27.0.1:34561",
+				"172.28.0.1:34561",
+				"172.29.0.1:34561",
+				"172.30.0.1:34561"
+			],
+			"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+				{"Proto": "peerapi4", "Port": 61927},
+				{"Proto": "peerapi6", "Port": 61927},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:07:38.818449728Z",
+			"Tags":              ["tag:group-b"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "raticate",
+			"ComputedNameWithHost": "raticate"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:1a7845aef659eda1c859138a1cc5bf0c67a2558c91b339fe6ac5800dcda6ae5a",
+		"MachineKey":        "mkey:9a874ea341056cfa481dc395dd2bc7cd1a286ab6b6ab02b644a82fb348539a63",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8892810857496319": {
+			"ID":          8892810857496319,
+			"LoginName":   "raticate.tail78f774.ts.net",
+			"DisplayName": "raticate"
+		}}
+	}}, "rattata": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2235849634173111,
+			"StableID":   "nLB9skycTJ11CNTRL",
+			"Name":       "rattata.tail78f774.ts.net.",
+			"User":       2235849634173111,
+			"Key":        "nodekey:6db2017d3818f302a7d230746785041dbb0314a538f5d655931ebca7add23541",
+			"DiscoKey":   "discokey:483f647524f0e221cc993febe44f860f82f23540a3efa803468d7bae22cb003d",
+			"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"Endpoints": [
+				"77.164.248.136:43793",
+				"10.65.0.27:43793",
+				"172.17.0.1:43793",
+				"172.18.0.1:43793",
+				"172.19.0.1:43793",
+				"172.20.0.1:43793",
+				"172.21.0.1:43793",
+				"172.22.0.1:43793",
+				"172.23.0.1:43793",
+				"172.24.0.1:43793",
+				"172.25.0.1:43793",
+				"172.27.0.1:43793",
+				"172.28.0.1:43793",
+				"172.29.0.1:43793",
+				"172.30.0.1:43793"
+			],
+			"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+				{"Proto": "peerapi4", "Port": 41053},
+				{"Proto": "peerapi6", "Port": 41053},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:07:38.293173157Z",
+			"Tags":              ["tag:group-a"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "rattata",
+			"ComputedNameWithHost": "rattata"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:6db2017d3818f302a7d230746785041dbb0314a538f5d655931ebca7add23541",
+		"MachineKey": "mkey:11b1a37b8ec4366a8bb0973dcbe374c151cdb60c99d70b7ea095c75f126e1838",
+		"Peers": [{
+			"ID":         2473353104810224,
+			"StableID":   "n9wnGwnBKL11CNTRL",
+			"Name":       "blastoise.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:53576a2afaa4b69cb90015c53612c7dfd379f0228b834c69c259c4e6fca4b126",
+			"DiscoKey":   "discokey:ff7cbde611949dd26d88c1b8fb4f44eb7c0d088d56f6a27b55d877b998c19154",
+			"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+			"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:34777",
+				"10.65.0.27:34777",
+				"172.17.0.1:34777",
+				"172.18.0.1:34777",
+				"172.19.0.1:34777",
+				"172.20.0.1:34777",
+				"172.21.0.1:34777",
+				"172.22.0.1:34777",
+				"172.23.0.1:34777",
+				"172.24.0.1:34777",
+				"172.25.0.1:34777",
+				"172.27.0.1:34777",
+				"172.28.0.1:34777",
+				"172.29.0.1:34777",
+				"172.30.0.1:34777"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+				{"Proto": "peerapi4", "Port": 60534},
+				{"Proto": "peerapi6", "Port": 60534}
+			]},
+			"Created":              "2026-05-18T09:07:39.354833108Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"PrimaryRoutes":        ["10.33.0.0/16"],
+			"Online":               true,
+			"ComputedName":         "blastoise",
+			"ComputedNameWithHost": "blastoise"
+		}, {
+			"ID":         3041776490751602,
+			"StableID":   "nyvyQ1KdkQ11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:50b6a0a0d1e146d32491c4755b27bdbf70c363b6e9e1d93f4352e6950a7c4654",
+			"DiscoKey":   "discokey:3635aa1d34b3d62fd7d260145cb8e9a1ff0358707f6767f22bc6f4da95517169",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints": [
+				"77.164.248.136:34905",
+				"10.65.0.27:34905",
+				"172.17.0.1:34905",
+				"172.18.0.1:34905",
+				"172.19.0.1:34905",
+				"172.20.0.1:34905",
+				"172.21.0.1:34905",
+				"172.22.0.1:34905",
+				"172.23.0.1:34905",
+				"172.24.0.1:34905",
+				"172.25.0.1:34905",
+				"172.27.0.1:34905",
+				"172.28.0.1:34905",
+				"172.29.0.1:34905",
+				"172.30.0.1:34905"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+				{"Proto": "peerapi4", "Port": 43119},
+				{"Proto": "peerapi6", "Port": 43119}
+			]},
+			"Created":              "2026-05-18T09:07:40.954380299Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:router"],
+			"Online":               true,
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "2235849634173111": {
+			"ID":          2235849634173111,
+			"LoginName":   "rattata.tail78f774.ts.net",
+			"DisplayName": "rattata"
+		}}
+	}, "whois": {"100.64.0.13": {"Node": {
+		"ID":         3041776490751602,
+		"StableID":   "nyvyQ1KdkQ11CNTRL",
+		"Name":       "squirtle.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:50b6a0a0d1e146d32491c4755b27bdbf70c363b6e9e1d93f4352e6950a7c4654",
+		"DiscoKey":   "discokey:3635aa1d34b3d62fd7d260145cb8e9a1ff0358707f6767f22bc6f4da95517169",
+		"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+		"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+		"Endpoints": [
+			"77.164.248.136:34905",
+			"10.65.0.27:34905",
+			"172.17.0.1:34905",
+			"172.18.0.1:34905",
+			"172.19.0.1:34905",
+			"172.20.0.1:34905",
+			"172.21.0.1:34905",
+			"172.22.0.1:34905",
+			"172.23.0.1:34905",
+			"172.24.0.1:34905",
+			"172.25.0.1:34905",
+			"172.27.0.1:34905",
+			"172.28.0.1:34905",
+			"172.29.0.1:34905",
+			"172.30.0.1:34905"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+			{"Proto": "peerapi4", "Port": 43119},
+			{"Proto": "peerapi6", "Port": 43119}
+		]},
+		"Created":              "2026-05-18T09:07:40.954380299Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:router"],
+		"Online":               true,
+		"ComputedName":         "squirtle",
+		"ComputedNameWithHost": "squirtle"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "100.64.0.9": {"Node": {
+		"ID":         2473353104810224,
+		"StableID":   "n9wnGwnBKL11CNTRL",
+		"Name":       "blastoise.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:53576a2afaa4b69cb90015c53612c7dfd379f0228b834c69c259c4e6fca4b126",
+		"DiscoKey":   "discokey:ff7cbde611949dd26d88c1b8fb4f44eb7c0d088d56f6a27b55d877b998c19154",
+		"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+		"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128", "10.33.0.0/16"],
+		"Endpoints": [
+			"77.164.248.136:34777",
+			"10.65.0.27:34777",
+			"172.17.0.1:34777",
+			"172.18.0.1:34777",
+			"172.19.0.1:34777",
+			"172.20.0.1:34777",
+			"172.21.0.1:34777",
+			"172.22.0.1:34777",
+			"172.23.0.1:34777",
+			"172.24.0.1:34777",
+			"172.25.0.1:34777",
+			"172.27.0.1:34777",
+			"172.28.0.1:34777",
+			"172.29.0.1:34777",
+			"172.30.0.1:34777"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+			{"Proto": "peerapi4", "Port": 60534},
+			{"Proto": "peerapi6", "Port": 60534}
+		]},
+		"Created":              "2026-05-18T09:07:39.354833108Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:exit", "tag:router"],
+		"PrimaryRoutes":        ["10.33.0.0/16"],
+		"Online":               true,
+		"ComputedName":         "blastoise",
+		"ComputedNameWithHost": "blastoise"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "fd7a:115c:a1e0::9": {"Node": {
+		"ID":         2473353104810224,
+		"StableID":   "n9wnGwnBKL11CNTRL",
+		"Name":       "blastoise.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:53576a2afaa4b69cb90015c53612c7dfd379f0228b834c69c259c4e6fca4b126",
+		"DiscoKey":   "discokey:ff7cbde611949dd26d88c1b8fb4f44eb7c0d088d56f6a27b55d877b998c19154",
+		"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+		"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128", "10.33.0.0/16"],
+		"Endpoints": [
+			"77.164.248.136:34777",
+			"10.65.0.27:34777",
+			"172.17.0.1:34777",
+			"172.18.0.1:34777",
+			"172.19.0.1:34777",
+			"172.20.0.1:34777",
+			"172.21.0.1:34777",
+			"172.22.0.1:34777",
+			"172.23.0.1:34777",
+			"172.24.0.1:34777",
+			"172.25.0.1:34777",
+			"172.27.0.1:34777",
+			"172.28.0.1:34777",
+			"172.29.0.1:34777",
+			"172.30.0.1:34777"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+			{"Proto": "peerapi4", "Port": 60534},
+			{"Proto": "peerapi6", "Port": 60534}
+		]},
+		"Created":              "2026-05-18T09:07:39.354833108Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:exit", "tag:router"],
+		"PrimaryRoutes":        ["10.33.0.0/16"],
+		"Online":               true,
+		"ComputedName":         "blastoise",
+		"ComputedNameWithHost": "blastoise"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "fd7a:115c:a1e0::d": {"Node": {
+		"ID":         3041776490751602,
+		"StableID":   "nyvyQ1KdkQ11CNTRL",
+		"Name":       "squirtle.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:50b6a0a0d1e146d32491c4755b27bdbf70c363b6e9e1d93f4352e6950a7c4654",
+		"DiscoKey":   "discokey:3635aa1d34b3d62fd7d260145cb8e9a1ff0358707f6767f22bc6f4da95517169",
+		"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+		"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+		"Endpoints": [
+			"77.164.248.136:34905",
+			"10.65.0.27:34905",
+			"172.17.0.1:34905",
+			"172.18.0.1:34905",
+			"172.19.0.1:34905",
+			"172.20.0.1:34905",
+			"172.21.0.1:34905",
+			"172.22.0.1:34905",
+			"172.23.0.1:34905",
+			"172.24.0.1:34905",
+			"172.25.0.1:34905",
+			"172.27.0.1:34905",
+			"172.28.0.1:34905",
+			"172.29.0.1:34905",
+			"172.30.0.1:34905"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+			{"Proto": "peerapi4", "Port": 43119},
+			{"Proto": "peerapi6", "Port": 43119}
+		]},
+		"Created":              "2026-05-18T09:07:40.954380299Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:router"],
+		"Online":               true,
+		"ComputedName":         "squirtle",
+		"ComputedNameWithHost": "squirtle"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}}}, "spearow": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2799795516713445,
+			"StableID":   "nQv2N5t2sN11CNTRL",
+			"Name":       "spearow.tail78f774.ts.net.",
+			"User":       2799795516713445,
+			"Key":        "nodekey:1add08b06d606dadeada63b16c9f03e40caba4b5f8578bc14c687e6a25b1ac7a",
+			"DiscoKey":   "discokey:6610b340849c87be81ab4747629a14f6e473a71cc0ea8da4acfbbb2d485dff55",
+			"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+			"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128", "10.44.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:39652",
+				"10.65.0.27:39652",
+				"172.17.0.1:39652",
+				"172.18.0.1:39652",
+				"172.19.0.1:39652",
+				"172.20.0.1:39652",
+				"172.21.0.1:39652",
+				"172.22.0.1:39652",
+				"172.23.0.1:39652",
+				"172.24.0.1:39652",
+				"172.25.0.1:39652",
+				"172.27.0.1:39652",
+				"172.28.0.1:39652",
+				"172.29.0.1:39652",
+				"172.30.0.1:39652"
+			],
+			"Hostinfo": {
+				"Hostname":    "spearow",
+				"RoutableIPs": ["10.44.0.0/16"],
+				"RequestTags": ["tag:spearow"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:07:39.890624348Z",
+			"Tags":              ["tag:spearow"],
+			"PrimaryRoutes":     ["10.44.0.0/16"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "spearow",
+			"ComputedNameWithHost": "spearow"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:1add08b06d606dadeada63b16c9f03e40caba4b5f8578bc14c687e6a25b1ac7a",
+		"MachineKey":        "mkey:b93eabce8cd9b6798a4dc31251d1e04b02102f4f5269e53c0ff2a33e3382aa18",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"2799795516713445": {
+			"ID":          2799795516713445,
+			"LoginName":   "spearow.tail78f774.ts.net",
+			"DisplayName": "spearow"
+		}}
+	}}, "squirtle": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.5", "fd7a:115c:a1e0::5"],
+		"DstPorts": [{"IP": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}]
+	}], "packet_filter_matches": [{
+		"IPProto": [6, 17, 1, 58],
+		"Srcs":    ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}],
+		"Caps":    []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3041776490751602,
+			"StableID":   "nyvyQ1KdkQ11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       3041776490751602,
+			"Key":        "nodekey:50b6a0a0d1e146d32491c4755b27bdbf70c363b6e9e1d93f4352e6950a7c4654",
+			"DiscoKey":   "discokey:3635aa1d34b3d62fd7d260145cb8e9a1ff0358707f6767f22bc6f4da95517169",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:34905",
+				"10.65.0.27:34905",
+				"172.17.0.1:34905",
+				"172.18.0.1:34905",
+				"172.19.0.1:34905",
+				"172.20.0.1:34905",
+				"172.21.0.1:34905",
+				"172.22.0.1:34905",
+				"172.23.0.1:34905",
+				"172.24.0.1:34905",
+				"172.25.0.1:34905",
+				"172.27.0.1:34905",
+				"172.28.0.1:34905",
+				"172.29.0.1:34905",
+				"172.30.0.1:34905"
+			],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:07:40.954380299Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:50b6a0a0d1e146d32491c4755b27bdbf70c363b6e9e1d93f4352e6950a7c4654",
+		"MachineKey": "mkey:f39e2e6f5ed734cb72eb5f65a803a4e85b2aadfa1c73df8fbe89653b4efca311",
+		"Peers": [{
+			"ID":         2235849634173111,
+			"StableID":   "nLB9skycTJ11CNTRL",
+			"Name":       "rattata.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:6db2017d3818f302a7d230746785041dbb0314a538f5d655931ebca7add23541",
+			"DiscoKey":   "discokey:483f647524f0e221cc993febe44f860f82f23540a3efa803468d7bae22cb003d",
+			"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"Endpoints": [
+				"77.164.248.136:43793",
+				"10.65.0.27:43793",
+				"172.17.0.1:43793",
+				"172.18.0.1:43793",
+				"172.19.0.1:43793",
+				"172.20.0.1:43793",
+				"172.21.0.1:43793",
+				"172.22.0.1:43793",
+				"172.23.0.1:43793",
+				"172.24.0.1:43793",
+				"172.25.0.1:43793",
+				"172.27.0.1:43793",
+				"172.28.0.1:43793",
+				"172.29.0.1:43793",
+				"172.30.0.1:43793"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+				{"Proto": "peerapi4", "Port": 41053},
+				{"Proto": "peerapi6", "Port": 41053}
+			]},
+			"Created":              "2026-05-18T09:07:38.293173157Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:group-a"],
+			"Online":               true,
+			"ComputedName":         "rattata",
+			"ComputedNameWithHost": "rattata"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}],
+			"Caps":    []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.5", "fd7a:115c:a1e0::5"],
+			"DstPorts": [{"IP": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}]
+		}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "3041776490751602": {
+			"ID":          3041776490751602,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}, "whois": {"100.64.0.5": {"Node": {
+		"ID":         2235849634173111,
+		"StableID":   "nLB9skycTJ11CNTRL",
+		"Name":       "rattata.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:6db2017d3818f302a7d230746785041dbb0314a538f5d655931ebca7add23541",
+		"DiscoKey":   "discokey:483f647524f0e221cc993febe44f860f82f23540a3efa803468d7bae22cb003d",
+		"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"Endpoints": [
+			"77.164.248.136:43793",
+			"10.65.0.27:43793",
+			"172.17.0.1:43793",
+			"172.18.0.1:43793",
+			"172.19.0.1:43793",
+			"172.20.0.1:43793",
+			"172.21.0.1:43793",
+			"172.22.0.1:43793",
+			"172.23.0.1:43793",
+			"172.24.0.1:43793",
+			"172.25.0.1:43793",
+			"172.27.0.1:43793",
+			"172.28.0.1:43793",
+			"172.29.0.1:43793",
+			"172.30.0.1:43793"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+			{"Proto": "peerapi4", "Port": 41053},
+			{"Proto": "peerapi6", "Port": 41053}
+		]},
+		"Created":              "2026-05-18T09:07:38.293173157Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:group-a"],
+		"Online":               true,
+		"ComputedName":         "rattata",
+		"ComputedNameWithHost": "rattata"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "fd7a:115c:a1e0::5": {"Node": {
+		"ID":         2235849634173111,
+		"StableID":   "nLB9skycTJ11CNTRL",
+		"Name":       "rattata.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:6db2017d3818f302a7d230746785041dbb0314a538f5d655931ebca7add23541",
+		"DiscoKey":   "discokey:483f647524f0e221cc993febe44f860f82f23540a3efa803468d7bae22cb003d",
+		"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"Endpoints": [
+			"77.164.248.136:43793",
+			"10.65.0.27:43793",
+			"172.17.0.1:43793",
+			"172.18.0.1:43793",
+			"172.19.0.1:43793",
+			"172.20.0.1:43793",
+			"172.21.0.1:43793",
+			"172.22.0.1:43793",
+			"172.23.0.1:43793",
+			"172.24.0.1:43793",
+			"172.25.0.1:43793",
+			"172.27.0.1:43793",
+			"172.28.0.1:43793",
+			"172.29.0.1:43793",
+			"172.30.0.1:43793"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+			{"Proto": "peerapi4", "Port": 41053},
+			{"Proto": "peerapi6", "Port": 41053}
+		]},
+		"Created":              "2026-05-18T09:07:38.293173157Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:group-a"],
+		"Online":               true,
+		"ComputedName":         "rattata",
+		"ComputedNameWithHost": "rattata"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2373815828419161,
+			"StableID":   "nCWQ1m77YK11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:06e4dabcb61a95f21c7addb5a986754fbe29b7b78793757eb8ad16823c17936f",
+			"KeyExpiry":  "2026-11-14T09:07:43Z",
+			"DiscoKey":   "discokey:01f918807dbcd783cbec6fc8a68db8349ba155d45b222bc28528d647831a7b64",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints": [
+				"77.164.248.136:56337",
+				"10.65.0.27:56337",
+				"172.17.0.1:56337",
+				"172.18.0.1:56337",
+				"172.19.0.1:56337",
+				"172.20.0.1:56337",
+				"172.21.0.1:56337",
+				"172.22.0.1:56337",
+				"172.23.0.1:56337",
+				"172.24.0.1:56337",
+				"172.25.0.1:56337",
+				"172.27.0.1:56337",
+				"172.28.0.1:56337",
+				"172.29.0.1:56337",
+				"172.30.0.1:56337"
+			],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:07:43.621164687Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:06e4dabcb61a95f21c7addb5a986754fbe29b7b78793757eb8ad16823c17936f",
+		"MachineKey":        "mkey:907eebd2a1d7c7f88e175e6db66c386073b22db0f4fb47d9089bb48c7fb14d7a",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5012072571545429,
+			"StableID":   "nAKT7Zey8g11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       5012072571545429,
+			"Key":        "nodekey:240035543acf1f0c2d2f9d4c0f6eeed6500f8805c7d43e74e06b6ae1ebb19578",
+			"DiscoKey":   "discokey:da4a9c01d0028620fbc9b91a315542a2e2b2931aabe6bdf692de73234e255945",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints": [
+				"77.164.248.136:35714",
+				"10.65.0.27:35714",
+				"172.17.0.1:35714",
+				"172.18.0.1:35714",
+				"172.19.0.1:35714",
+				"172.20.0.1:35714",
+				"172.21.0.1:35714",
+				"172.22.0.1:35714",
+				"172.23.0.1:35714",
+				"172.24.0.1:35714",
+				"172.25.0.1:35714",
+				"172.27.0.1:35714",
+				"172.28.0.1:35714",
+				"172.29.0.1:35714",
+				"172.30.0.1:35714"
+			],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:07:41.490756459Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:240035543acf1f0c2d2f9d4c0f6eeed6500f8805c7d43e74e06b6ae1ebb19578",
+		"MachineKey":        "mkey:28507eb157e4d6f03845a0ab0be1d48b083f3bfef571ccc9cd3d294e0cc2c656",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5012072571545429": {
+			"ID":          5012072571545429,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/grant_results/via-grant-v48.hujson
+++ b/hscontrol/policy/v2/testdata/grant_results/via-grant-v48.hujson
@@ -1,0 +1,14164 @@
+// via-grant-v48
+//
+// via grant v48 dst cidr narrower than advertised subnet
+//
+// Nodes with filter rules: 2 of 15
+// Captured at:    2026-05-18T09:08:45Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "via-grant-v48",
+	"description":    "via grant v48 dst cidr narrower than advertised subnet",
+	"category":       "grant",
+	"captured_at":    "2026-05-18T09:08:45.834537146Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                                               \n  \n                                                                         \n                                                                   \n                                                                       \n                                     \n  \n                                                                \n                                                                 \n{\n\t\"category\":    \"grant\",\n\t\"description\": \"via grant v48 dst cidr narrower than advertised subnet\",\n\t\"id\":          \"via-grant-v48\",\n\t\"options\":     {\"capture_whois\": true},\n\t\"policy\": {\"autoApprovers\": {\"routes\": {\n\t\t\"10.33.0.0/16\": [\"tag:router\"],\n\t\t\"10.44.0.0/16\": [\"tag:spearow\"],\n\t\t\"10.55.0.0/16\": [\"tag:fearow\"]\n\t}}, \"grants\": [{\n\t\t\"dst\": [\"10.33.5.0/24\"],\n\t\t\"ip\":  [\"*\"],\n\t\t\"src\": [\"tag:group-a\"],\n\t\t\"via\": [\"tag:router\"]\n\t}], \"groups\": {\n\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\"group:empty\":      [],\n\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t}, \"hosts\": {\n\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\"webserver\": \"100.108.74.26\"\n\t}, \"tagOwners\": {\n\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\"tag:server\":   [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/grant/via-grant-v48.hujson",
+		"full_policy": {"autoApprovers": {"routes": {
+			"10.33.0.0/16": ["tag:router"],
+			"10.44.0.0/16": ["tag:spearow"],
+			"10.55.0.0/16": ["tag:fearow"]
+		}}, "grants": [{
+			"dst": ["10.33.5.0/24"],
+			"ip":  ["*"],
+			"src": ["tag:group-a"],
+			"via": ["tag:router"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"webserver": "100.108.74.26"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": ["10.33.0.0/16"]
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": ["10.55.0.0/16"]
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": ["10.44.0.0/16"]
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": ["10.33.0.0/16"]
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4939789463153043,
+			"StableID":   "nGwyLntEaf11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       4939789463153043,
+			"Key":        "nodekey:96b07b5c72419047faaabdb30aa4ca151710d6fe857e1f8237754a1916ff4a57",
+			"DiscoKey":   "discokey:e6e3feefec412217a27ea78b94a14cab01b5d9c2a29598c75f05eea069d95831",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints": [
+				"77.164.248.136:54990",
+				"10.65.0.27:54990",
+				"172.17.0.1:54990",
+				"172.18.0.1:54990",
+				"172.19.0.1:54990",
+				"172.20.0.1:54990",
+				"172.21.0.1:54990",
+				"172.22.0.1:54990",
+				"172.23.0.1:54990",
+				"172.24.0.1:54990",
+				"172.25.0.1:54990",
+				"172.27.0.1:54990",
+				"172.28.0.1:54990",
+				"172.29.0.1:54990",
+				"172.30.0.1:54990"
+			],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:08:58.527680896Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:96b07b5c72419047faaabdb30aa4ca151710d6fe857e1f8237754a1916ff4a57",
+		"MachineKey":        "mkey:1310795e2e9a2d1e0af99f732ec631ca81bb9b6cba72c536f3b880f0416a4b1a",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4939789463153043": {
+			"ID":          4939789463153043,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}}
+	}}, "blastoise": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.5", "fd7a:115c:a1e0::5"],
+		"DstPorts": [{"IP": "10.33.5.0/24", "Ports": {"First": 0, "Last": 65535}}]
+	}], "packet_filter_matches": [{
+		"IPProto": [6, 17, 1, 58],
+		"Srcs":    ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "10.33.5.0/24", "Ports": {"First": 0, "Last": 65535}}],
+		"Caps":    []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8665747210852025,
+			"StableID":   "nWHpZ7VjfA21CNTRL",
+			"Name":       "blastoise.tail78f774.ts.net.",
+			"User":       8665747210852025,
+			"Key":        "nodekey:e1997bcdec8da2b3320583a153b55ef42e4e433fc0defdab0f2db8cb208d680e",
+			"DiscoKey":   "discokey:9dd4f0e3b72e928e8322334201d4688a2ba265b7bb17cb6715e83cd5d1665220",
+			"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+			"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:59708",
+				"10.65.0.27:59708",
+				"172.17.0.1:59708",
+				"172.18.0.1:59708",
+				"172.19.0.1:59708",
+				"172.20.0.1:59708",
+				"172.21.0.1:59708",
+				"172.22.0.1:59708",
+				"172.23.0.1:59708",
+				"172.24.0.1:59708",
+				"172.25.0.1:59708",
+				"172.27.0.1:59708",
+				"172.28.0.1:59708",
+				"172.29.0.1:59708",
+				"172.30.0.1:59708"
+			],
+			"Hostinfo": {
+				"Hostname":    "blastoise",
+				"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit", "tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:08:55.326839794Z",
+			"Tags":              ["tag:exit", "tag:router"],
+			"PrimaryRoutes":     ["10.33.0.0/16"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "blastoise",
+			"ComputedNameWithHost": "blastoise"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:e1997bcdec8da2b3320583a153b55ef42e4e433fc0defdab0f2db8cb208d680e",
+		"MachineKey": "mkey:af25fdb9638960447bf18984caabd69885168812fc7a95c719e5df40b2c5a079",
+		"Peers": [{
+			"ID":         7067747585838294,
+			"StableID":   "nyaAoAkzBx11CNTRL",
+			"Name":       "rattata.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f0f21941bc3aee295900c96b04335b18d1527061e6eaf773c8e56b0cec38d47f",
+			"DiscoKey":   "discokey:9e1d242539c3dd067ad5eb339aacb8a13da29ae57c218f9e91f773b7a2e7ca6e",
+			"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"Endpoints": [
+				"77.164.248.136:45427",
+				"10.65.0.27:45427",
+				"172.17.0.1:45427",
+				"172.18.0.1:45427",
+				"172.19.0.1:45427",
+				"172.20.0.1:45427",
+				"172.21.0.1:45427",
+				"172.22.0.1:45427",
+				"172.23.0.1:45427",
+				"172.24.0.1:45427",
+				"172.25.0.1:45427",
+				"172.27.0.1:45427",
+				"172.28.0.1:45427",
+				"172.29.0.1:45427",
+				"172.30.0.1:45427"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+				{"Proto": "peerapi4", "Port": 41053},
+				{"Proto": "peerapi6", "Port": 41053}
+			]},
+			"Created":              "2026-05-18T09:08:54.27787786Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:group-a"],
+			"Online":               true,
+			"ComputedName":         "rattata",
+			"ComputedNameWithHost": "rattata"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "10.33.5.0/24", "Ports": {"First": 0, "Last": 65535}}],
+			"Caps":    []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.5", "fd7a:115c:a1e0::5"],
+			"DstPorts": [{"IP": "10.33.5.0/24", "Ports": {"First": 0, "Last": 65535}}]
+		}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "8665747210852025": {
+			"ID":          8665747210852025,
+			"LoginName":   "blastoise.tail78f774.ts.net",
+			"DisplayName": "blastoise"
+		}}
+	}, "whois": {"100.64.0.5": {"Node": {
+		"ID":         7067747585838294,
+		"StableID":   "nyaAoAkzBx11CNTRL",
+		"Name":       "rattata.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:f0f21941bc3aee295900c96b04335b18d1527061e6eaf773c8e56b0cec38d47f",
+		"DiscoKey":   "discokey:9e1d242539c3dd067ad5eb339aacb8a13da29ae57c218f9e91f773b7a2e7ca6e",
+		"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"Endpoints": [
+			"77.164.248.136:45427",
+			"10.65.0.27:45427",
+			"172.17.0.1:45427",
+			"172.18.0.1:45427",
+			"172.19.0.1:45427",
+			"172.20.0.1:45427",
+			"172.21.0.1:45427",
+			"172.22.0.1:45427",
+			"172.23.0.1:45427",
+			"172.24.0.1:45427",
+			"172.25.0.1:45427",
+			"172.27.0.1:45427",
+			"172.28.0.1:45427",
+			"172.29.0.1:45427",
+			"172.30.0.1:45427"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+			{"Proto": "peerapi4", "Port": 41053},
+			{"Proto": "peerapi6", "Port": 41053}
+		]},
+		"Created":              "2026-05-18T09:08:54.27787786Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:group-a"],
+		"Online":               true,
+		"ComputedName":         "rattata",
+		"ComputedNameWithHost": "rattata"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "fd7a:115c:a1e0::5": {"Node": {
+		"ID":         7067747585838294,
+		"StableID":   "nyaAoAkzBx11CNTRL",
+		"Name":       "rattata.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:f0f21941bc3aee295900c96b04335b18d1527061e6eaf773c8e56b0cec38d47f",
+		"DiscoKey":   "discokey:9e1d242539c3dd067ad5eb339aacb8a13da29ae57c218f9e91f773b7a2e7ca6e",
+		"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"Endpoints": [
+			"77.164.248.136:45427",
+			"10.65.0.27:45427",
+			"172.17.0.1:45427",
+			"172.18.0.1:45427",
+			"172.19.0.1:45427",
+			"172.20.0.1:45427",
+			"172.21.0.1:45427",
+			"172.22.0.1:45427",
+			"172.23.0.1:45427",
+			"172.24.0.1:45427",
+			"172.25.0.1:45427",
+			"172.27.0.1:45427",
+			"172.28.0.1:45427",
+			"172.29.0.1:45427",
+			"172.30.0.1:45427"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+			{"Proto": "peerapi4", "Port": 41053},
+			{"Proto": "peerapi6", "Port": 41053}
+		]},
+		"Created":              "2026-05-18T09:08:54.27787786Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:group-a"],
+		"Online":               true,
+		"ComputedName":         "rattata",
+		"ComputedNameWithHost": "rattata"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         6568888912785811,
+			"StableID":   "npFw7Ea4Jt11CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:4ddd367622cc084368575c6d7d1b656e261dae5e9335999a22418e340202ba3c",
+			"KeyExpiry":  "2026-11-14T09:09:00Z",
+			"DiscoKey":   "discokey:fc90c3aec724921a883d1399ff15eb32384a2cc89a065105f46ce9202f481b3c",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints": [
+				"77.164.248.136:56853",
+				"10.65.0.27:56853",
+				"172.17.0.1:56853",
+				"172.18.0.1:56853",
+				"172.19.0.1:56853",
+				"172.20.0.1:56853",
+				"172.21.0.1:56853",
+				"172.22.0.1:56853",
+				"172.23.0.1:56853",
+				"172.24.0.1:56853",
+				"172.25.0.1:56853",
+				"172.27.0.1:56853",
+				"172.28.0.1:56853",
+				"172.29.0.1:56853",
+				"172.30.0.1:56853"
+			],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:09:00.131809648Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:4ddd367622cc084368575c6d7d1b656e261dae5e9335999a22418e340202ba3c",
+		"MachineKey":        "mkey:c2edfc5da989bdd4facde1ef564c6f6510086448b38f270f926a2983a7373120",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1111001440653222,
+			"StableID":   "nmGAsB8Bg911CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1111001440653222,
+			"Key":        "nodekey:d6faab2e7e0ec2fc7bbef863fac510a7dbf2b8bf288df19543f9abc7e598ec30",
+			"DiscoKey":   "discokey:e79dd72ab763fbaae737b31671dffa5dc10a527acd1eeb19d9455454b682225e",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints": [
+				"77.164.248.136:37255",
+				"10.65.0.27:37255",
+				"172.17.0.1:37255",
+				"172.18.0.1:37255",
+				"172.19.0.1:37255",
+				"172.20.0.1:37255",
+				"172.21.0.1:37255",
+				"172.22.0.1:37255",
+				"172.23.0.1:37255",
+				"172.24.0.1:37255",
+				"172.25.0.1:37255",
+				"172.27.0.1:37255",
+				"172.28.0.1:37255",
+				"172.29.0.1:37255",
+				"172.30.0.1:37255"
+			],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:08:53.740935778Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:d6faab2e7e0ec2fc7bbef863fac510a7dbf2b8bf288df19543f9abc7e598ec30",
+		"MachineKey":        "mkey:ae18966c2204844bc0dfebc122960d5ec5f330595da3ff641c8b9551a7001034",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1111001440653222": {
+			"ID":          1111001440653222,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "fearow": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2232659580769961,
+			"StableID":   "nNDcmWBBSJ11CNTRL",
+			"Name":       "fearow.tail78f774.ts.net.",
+			"User":       2232659580769961,
+			"Key":        "nodekey:0f3d03af8733585e71c3386acdabc068af290a11ad173c9dbd1d5ca2992abb23",
+			"DiscoKey":   "discokey:dee37c53da0023d677d36f42b676d8701ad5fd8730f7faab66f4f851bf185007",
+			"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+			"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128", "10.55.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:56599",
+				"10.65.0.27:56599",
+				"172.17.0.1:56599",
+				"172.18.0.1:56599",
+				"172.19.0.1:56599",
+				"172.20.0.1:56599",
+				"172.21.0.1:56599",
+				"172.22.0.1:56599",
+				"172.23.0.1:56599",
+				"172.24.0.1:56599",
+				"172.25.0.1:56599",
+				"172.27.0.1:56599",
+				"172.28.0.1:56599",
+				"172.29.0.1:56599",
+				"172.30.0.1:56599"
+			],
+			"Hostinfo": {
+				"Hostname":    "fearow",
+				"RoutableIPs": ["10.55.0.0/16"],
+				"RequestTags": ["tag:fearow"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:08:56.380377038Z",
+			"Tags":              ["tag:fearow"],
+			"PrimaryRoutes":     ["10.55.0.0/16"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "fearow",
+			"ComputedNameWithHost": "fearow"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:0f3d03af8733585e71c3386acdabc068af290a11ad173c9dbd1d5ca2992abb23",
+		"MachineKey":        "mkey:d088442e2a25a73b9a141bd39a4d887dfe23a6ff09b63cfb7f20c4dfc8f43b36",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"2232659580769961": {
+			"ID":          2232659580769961,
+			"LoginName":   "fearow.tail78f774.ts.net",
+			"DisplayName": "fearow"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4890103721196372,
+			"StableID":   "nPUBUVjjBf11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:3f948190034ff04e6a3dc51a31a607b2d1f345fe40a874a3661633927393c409",
+			"KeyExpiry":  "2026-11-14T09:08:59Z",
+			"DiscoKey":   "discokey:35972f831195fa374a6230409971d306f1fc1c88ccdc1130081ad357a686482d",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints": [
+				"77.164.248.136:55086",
+				"10.65.0.27:55086",
+				"172.17.0.1:55086",
+				"172.18.0.1:55086",
+				"172.19.0.1:55086",
+				"172.20.0.1:55086",
+				"172.21.0.1:55086",
+				"172.22.0.1:55086",
+				"172.23.0.1:55086",
+				"172.24.0.1:55086",
+				"172.25.0.1:55086",
+				"172.27.0.1:55086",
+				"172.28.0.1:55086",
+				"172.29.0.1:55086",
+				"172.30.0.1:55086"
+			],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:08:59.058953458Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:3f948190034ff04e6a3dc51a31a607b2d1f345fe40a874a3661633927393c409",
+		"MachineKey":        "mkey:00fd6a4d52a5f42222dae897d0e656d17ea8102a4bf3225f34fff4635cd8e846",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5343603949263262,
+			"StableID":   "nX5hg3R8ji11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       5343603949263262,
+			"Key":        "nodekey:50c79d4d9fa331c021289dc35df5491d972222b1cd602147bf9f697813886e5a",
+			"DiscoKey":   "discokey:870e60d598d69eedd0bba889fcaec28b2409e57c86c32d9df63b359673eb297f",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints": [
+				"77.164.248.136:48644",
+				"10.65.0.27:48644",
+				"172.17.0.1:48644",
+				"172.18.0.1:48644",
+				"172.19.0.1:48644",
+				"172.20.0.1:48644",
+				"172.21.0.1:48644",
+				"172.22.0.1:48644",
+				"172.23.0.1:48644",
+				"172.24.0.1:48644",
+				"172.25.0.1:48644",
+				"172.27.0.1:48644",
+				"172.28.0.1:48644",
+				"172.29.0.1:48644",
+				"172.30.0.1:48644"
+			],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:08:57.995162833Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:50c79d4d9fa331c021289dc35df5491d972222b1cd602147bf9f697813886e5a",
+		"MachineKey":        "mkey:7bdd1094f7b4491602c38e55d281a9adc220a1512618ec0d6e7e0becf7011e57",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5343603949263262": {
+			"ID":          5343603949263262,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "pidgeotto": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3489568170389294,
+			"StableID":   "nqNekE3SFU11CNTRL",
+			"Name":       "pidgeotto.tail78f774.ts.net.",
+			"User":       3489568170389294,
+			"Key":        "nodekey:8759e6b652900cd5327cf8daeebeff892b380c1eeee93689612df3b1a61bf71b",
+			"DiscoKey":   "discokey:5a6562a098487689ebbde39e8529472e4667927613e593a8b589a21a38564d68",
+			"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+			"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+			"Endpoints": [
+				"77.164.248.136:36194",
+				"10.65.0.27:36194",
+				"172.17.0.1:36194",
+				"172.18.0.1:36194",
+				"172.19.0.1:36194",
+				"172.20.0.1:36194",
+				"172.21.0.1:36194",
+				"172.22.0.1:36194",
+				"172.23.0.1:36194",
+				"172.24.0.1:36194",
+				"172.25.0.1:36194",
+				"172.27.0.1:36194",
+				"172.28.0.1:36194",
+				"172.29.0.1:36194",
+				"172.30.0.1:36194"
+			],
+			"Hostinfo": {
+				"Hostname":    "pidgeotto",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:pidgeotto"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:08:53.175984692Z",
+			"Tags":              ["tag:pidgeotto"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "pidgeotto",
+			"ComputedNameWithHost": "pidgeotto"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:8759e6b652900cd5327cf8daeebeff892b380c1eeee93689612df3b1a61bf71b",
+		"MachineKey":        "mkey:751f63eaa9b8fd2e1afa8601ac85a69fe2bd5b4c71b64d9e2619a950628d4f15",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3489568170389294": {
+			"ID":          3489568170389294,
+			"LoginName":   "pidgeotto.tail78f774.ts.net",
+			"DisplayName": "pidgeotto"
+		}}
+	}}, "pidgey": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         6997798859301923,
+			"StableID":   "npMtMyJKew11CNTRL",
+			"Name":       "pidgey.tail78f774.ts.net.",
+			"User":       6997798859301923,
+			"Key":        "nodekey:4351c29c87ef524718f06f845b1ff8beb79cd983c1c5cd4b35ea139eb55f141f",
+			"DiscoKey":   "discokey:868bf00822d56717aabc58a15530449fcc3a0f0ec81b253ee1ce29844be8e228",
+			"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+			"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+			"Endpoints": [
+				"77.164.248.136:36872",
+				"10.65.0.27:36872",
+				"172.17.0.1:36872",
+				"172.18.0.1:36872",
+				"172.19.0.1:36872",
+				"172.20.0.1:36872",
+				"172.21.0.1:36872",
+				"172.22.0.1:36872",
+				"172.23.0.1:36872",
+				"172.24.0.1:36872",
+				"172.25.0.1:36872",
+				"172.27.0.1:36872",
+				"172.28.0.1:36872",
+				"172.29.0.1:36872",
+				"172.30.0.1:36872"
+			],
+			"Hostinfo": {
+				"Hostname":    "pidgey",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:pidgey"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:08:52.645416183Z",
+			"Tags":              ["tag:pidgey"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "pidgey",
+			"ComputedNameWithHost": "pidgey"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:4351c29c87ef524718f06f845b1ff8beb79cd983c1c5cd4b35ea139eb55f141f",
+		"MachineKey":        "mkey:d5f643820b60fdf9d939c947a76e3a019ec03c9384c90ab1bbbdc0a82c346c46",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"6997798859301923": {
+			"ID":          6997798859301923,
+			"LoginName":   "pidgey.tail78f774.ts.net",
+			"DisplayName": "pidgey"
+		}}
+	}}, "raticate": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         6442298576950201,
+			"StableID":   "n8QYd3GjJs11CNTRL",
+			"Name":       "raticate.tail78f774.ts.net.",
+			"User":       6442298576950201,
+			"Key":        "nodekey:8b2455337fefa4aca2cd5c3b76969b6cb9bef01ae527f9ca3d73ecd8ed84ea20",
+			"DiscoKey":   "discokey:70868d428d4ad928d05f6f54aab8a996997968d793cf0e14514fd4916f94a34d",
+			"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+			"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+			"Endpoints": [
+				"77.164.248.136:48518",
+				"10.65.0.27:48518",
+				"172.17.0.1:48518",
+				"172.18.0.1:48518",
+				"172.19.0.1:48518",
+				"172.20.0.1:48518",
+				"172.21.0.1:48518",
+				"172.22.0.1:48518",
+				"172.23.0.1:48518",
+				"172.24.0.1:48518",
+				"172.25.0.1:48518",
+				"172.27.0.1:48518",
+				"172.28.0.1:48518",
+				"172.29.0.1:48518",
+				"172.30.0.1:48518"
+			],
+			"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+				{"Proto": "peerapi4", "Port": 61927},
+				{"Proto": "peerapi6", "Port": 61927},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:08:54.799700059Z",
+			"Tags":              ["tag:group-b"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "raticate",
+			"ComputedNameWithHost": "raticate"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:8b2455337fefa4aca2cd5c3b76969b6cb9bef01ae527f9ca3d73ecd8ed84ea20",
+		"MachineKey":        "mkey:b3a9bb89ed6795f9962795521ada67f7dcef0fbb146b2d5f4264f9daa0238b11",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"6442298576950201": {
+			"ID":          6442298576950201,
+			"LoginName":   "raticate.tail78f774.ts.net",
+			"DisplayName": "raticate"
+		}}
+	}}, "rattata": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7067747585838294,
+			"StableID":   "nyaAoAkzBx11CNTRL",
+			"Name":       "rattata.tail78f774.ts.net.",
+			"User":       7067747585838294,
+			"Key":        "nodekey:f0f21941bc3aee295900c96b04335b18d1527061e6eaf773c8e56b0cec38d47f",
+			"DiscoKey":   "discokey:9e1d242539c3dd067ad5eb339aacb8a13da29ae57c218f9e91f773b7a2e7ca6e",
+			"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"Endpoints": [
+				"77.164.248.136:45427",
+				"10.65.0.27:45427",
+				"172.17.0.1:45427",
+				"172.18.0.1:45427",
+				"172.19.0.1:45427",
+				"172.20.0.1:45427",
+				"172.21.0.1:45427",
+				"172.22.0.1:45427",
+				"172.23.0.1:45427",
+				"172.24.0.1:45427",
+				"172.25.0.1:45427",
+				"172.27.0.1:45427",
+				"172.28.0.1:45427",
+				"172.29.0.1:45427",
+				"172.30.0.1:45427"
+			],
+			"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+				{"Proto": "peerapi4", "Port": 41053},
+				{"Proto": "peerapi6", "Port": 41053},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:08:54.27787786Z",
+			"Tags":              ["tag:group-a"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "rattata",
+			"ComputedNameWithHost": "rattata"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:f0f21941bc3aee295900c96b04335b18d1527061e6eaf773c8e56b0cec38d47f",
+		"MachineKey": "mkey:a5683705876508cfaaae3f3875a440e784190fa1b5b4a53c77537282b8219b2d",
+		"Peers": [{
+			"ID":         8665747210852025,
+			"StableID":   "nWHpZ7VjfA21CNTRL",
+			"Name":       "blastoise.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:e1997bcdec8da2b3320583a153b55ef42e4e433fc0defdab0f2db8cb208d680e",
+			"DiscoKey":   "discokey:9dd4f0e3b72e928e8322334201d4688a2ba265b7bb17cb6715e83cd5d1665220",
+			"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+			"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:59708",
+				"10.65.0.27:59708",
+				"172.17.0.1:59708",
+				"172.18.0.1:59708",
+				"172.19.0.1:59708",
+				"172.20.0.1:59708",
+				"172.21.0.1:59708",
+				"172.22.0.1:59708",
+				"172.23.0.1:59708",
+				"172.24.0.1:59708",
+				"172.25.0.1:59708",
+				"172.27.0.1:59708",
+				"172.28.0.1:59708",
+				"172.29.0.1:59708",
+				"172.30.0.1:59708"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+				{"Proto": "peerapi4", "Port": 60534},
+				{"Proto": "peerapi6", "Port": 60534}
+			]},
+			"Created":              "2026-05-18T09:08:55.326839794Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"PrimaryRoutes":        ["10.33.0.0/16"],
+			"Online":               true,
+			"ComputedName":         "blastoise",
+			"ComputedNameWithHost": "blastoise"
+		}, {
+			"ID":         707081358747369,
+			"StableID":   "nQzPP3qEX611CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:a5bbb7881c8bca32b6efd73a03c65217dd8c438fa27792829382e992007f4b52",
+			"DiscoKey":   "discokey:6887d524dd27c2f8ad4b3676851eceea715fb13e0c0db431a0be67cd594bee4e",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints": [
+				"77.164.248.136:44108",
+				"10.65.0.27:44108",
+				"172.17.0.1:44108",
+				"172.18.0.1:44108",
+				"172.19.0.1:44108",
+				"172.20.0.1:44108",
+				"172.21.0.1:44108",
+				"172.22.0.1:44108",
+				"172.23.0.1:44108",
+				"172.24.0.1:44108",
+				"172.25.0.1:44108",
+				"172.27.0.1:44108",
+				"172.28.0.1:44108",
+				"172.29.0.1:44108",
+				"172.30.0.1:44108"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+				{"Proto": "peerapi4", "Port": 43119},
+				{"Proto": "peerapi6", "Port": 43119}
+			]},
+			"Created":              "2026-05-18T09:08:56.923114061Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:router"],
+			"Online":               true,
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "7067747585838294": {
+			"ID":          7067747585838294,
+			"LoginName":   "rattata.tail78f774.ts.net",
+			"DisplayName": "rattata"
+		}}
+	}, "whois": {"100.64.0.13": {"Node": {
+		"ID":         707081358747369,
+		"StableID":   "nQzPP3qEX611CNTRL",
+		"Name":       "squirtle.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:a5bbb7881c8bca32b6efd73a03c65217dd8c438fa27792829382e992007f4b52",
+		"DiscoKey":   "discokey:6887d524dd27c2f8ad4b3676851eceea715fb13e0c0db431a0be67cd594bee4e",
+		"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+		"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+		"Endpoints": [
+			"77.164.248.136:44108",
+			"10.65.0.27:44108",
+			"172.17.0.1:44108",
+			"172.18.0.1:44108",
+			"172.19.0.1:44108",
+			"172.20.0.1:44108",
+			"172.21.0.1:44108",
+			"172.22.0.1:44108",
+			"172.23.0.1:44108",
+			"172.24.0.1:44108",
+			"172.25.0.1:44108",
+			"172.27.0.1:44108",
+			"172.28.0.1:44108",
+			"172.29.0.1:44108",
+			"172.30.0.1:44108"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+			{"Proto": "peerapi4", "Port": 43119},
+			{"Proto": "peerapi6", "Port": 43119}
+		]},
+		"Created":              "2026-05-18T09:08:56.923114061Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:router"],
+		"Online":               true,
+		"ComputedName":         "squirtle",
+		"ComputedNameWithHost": "squirtle"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "100.64.0.9": {"Node": {
+		"ID":         8665747210852025,
+		"StableID":   "nWHpZ7VjfA21CNTRL",
+		"Name":       "blastoise.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:e1997bcdec8da2b3320583a153b55ef42e4e433fc0defdab0f2db8cb208d680e",
+		"DiscoKey":   "discokey:9dd4f0e3b72e928e8322334201d4688a2ba265b7bb17cb6715e83cd5d1665220",
+		"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+		"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128", "10.33.0.0/16"],
+		"Endpoints": [
+			"77.164.248.136:59708",
+			"10.65.0.27:59708",
+			"172.17.0.1:59708",
+			"172.18.0.1:59708",
+			"172.19.0.1:59708",
+			"172.20.0.1:59708",
+			"172.21.0.1:59708",
+			"172.22.0.1:59708",
+			"172.23.0.1:59708",
+			"172.24.0.1:59708",
+			"172.25.0.1:59708",
+			"172.27.0.1:59708",
+			"172.28.0.1:59708",
+			"172.29.0.1:59708",
+			"172.30.0.1:59708"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+			{"Proto": "peerapi4", "Port": 60534},
+			{"Proto": "peerapi6", "Port": 60534}
+		]},
+		"Created":              "2026-05-18T09:08:55.326839794Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:exit", "tag:router"],
+		"PrimaryRoutes":        ["10.33.0.0/16"],
+		"Online":               true,
+		"ComputedName":         "blastoise",
+		"ComputedNameWithHost": "blastoise"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "fd7a:115c:a1e0::9": {"Node": {
+		"ID":         8665747210852025,
+		"StableID":   "nWHpZ7VjfA21CNTRL",
+		"Name":       "blastoise.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:e1997bcdec8da2b3320583a153b55ef42e4e433fc0defdab0f2db8cb208d680e",
+		"DiscoKey":   "discokey:9dd4f0e3b72e928e8322334201d4688a2ba265b7bb17cb6715e83cd5d1665220",
+		"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+		"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128", "10.33.0.0/16"],
+		"Endpoints": [
+			"77.164.248.136:59708",
+			"10.65.0.27:59708",
+			"172.17.0.1:59708",
+			"172.18.0.1:59708",
+			"172.19.0.1:59708",
+			"172.20.0.1:59708",
+			"172.21.0.1:59708",
+			"172.22.0.1:59708",
+			"172.23.0.1:59708",
+			"172.24.0.1:59708",
+			"172.25.0.1:59708",
+			"172.27.0.1:59708",
+			"172.28.0.1:59708",
+			"172.29.0.1:59708",
+			"172.30.0.1:59708"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+			{"Proto": "peerapi4", "Port": 60534},
+			{"Proto": "peerapi6", "Port": 60534}
+		]},
+		"Created":              "2026-05-18T09:08:55.326839794Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:exit", "tag:router"],
+		"PrimaryRoutes":        ["10.33.0.0/16"],
+		"Online":               true,
+		"ComputedName":         "blastoise",
+		"ComputedNameWithHost": "blastoise"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "fd7a:115c:a1e0::d": {"Node": {
+		"ID":         707081358747369,
+		"StableID":   "nQzPP3qEX611CNTRL",
+		"Name":       "squirtle.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:a5bbb7881c8bca32b6efd73a03c65217dd8c438fa27792829382e992007f4b52",
+		"DiscoKey":   "discokey:6887d524dd27c2f8ad4b3676851eceea715fb13e0c0db431a0be67cd594bee4e",
+		"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+		"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+		"Endpoints": [
+			"77.164.248.136:44108",
+			"10.65.0.27:44108",
+			"172.17.0.1:44108",
+			"172.18.0.1:44108",
+			"172.19.0.1:44108",
+			"172.20.0.1:44108",
+			"172.21.0.1:44108",
+			"172.22.0.1:44108",
+			"172.23.0.1:44108",
+			"172.24.0.1:44108",
+			"172.25.0.1:44108",
+			"172.27.0.1:44108",
+			"172.28.0.1:44108",
+			"172.29.0.1:44108",
+			"172.30.0.1:44108"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+			{"Proto": "peerapi4", "Port": 43119},
+			{"Proto": "peerapi6", "Port": 43119}
+		]},
+		"Created":              "2026-05-18T09:08:56.923114061Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:router"],
+		"Online":               true,
+		"ComputedName":         "squirtle",
+		"ComputedNameWithHost": "squirtle"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}}}, "spearow": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         668394826740252,
+			"StableID":   "nuoe2jbiD611CNTRL",
+			"Name":       "spearow.tail78f774.ts.net.",
+			"User":       668394826740252,
+			"Key":        "nodekey:6c1416b431ea96423daddbeb1a8e0c83678d2324ddc53e2dcc2c0515fcd07570",
+			"DiscoKey":   "discokey:28e6b1477dca8bedaed0f887e145954f56aa0cc7972ef743f475c54a9557722d",
+			"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+			"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128", "10.44.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:38545",
+				"10.65.0.27:38545",
+				"172.17.0.1:38545",
+				"172.18.0.1:38545",
+				"172.19.0.1:38545",
+				"172.20.0.1:38545",
+				"172.21.0.1:38545",
+				"172.22.0.1:38545",
+				"172.23.0.1:38545",
+				"172.24.0.1:38545",
+				"172.25.0.1:38545",
+				"172.27.0.1:38545",
+				"172.28.0.1:38545",
+				"172.29.0.1:38545",
+				"172.30.0.1:38545"
+			],
+			"Hostinfo": {
+				"Hostname":    "spearow",
+				"RoutableIPs": ["10.44.0.0/16"],
+				"RequestTags": ["tag:spearow"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:08:55.85676883Z",
+			"Tags":              ["tag:spearow"],
+			"PrimaryRoutes":     ["10.44.0.0/16"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "spearow",
+			"ComputedNameWithHost": "spearow"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:6c1416b431ea96423daddbeb1a8e0c83678d2324ddc53e2dcc2c0515fcd07570",
+		"MachineKey":        "mkey:fac25f80e5a9463dfd40bbd74fda72ea0e9f0ba111a3ebeeb9a18b5cc70ca108",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"668394826740252": {
+			"ID":          668394826740252,
+			"LoginName":   "spearow.tail78f774.ts.net",
+			"DisplayName": "spearow"
+		}}
+	}}, "squirtle": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.5", "fd7a:115c:a1e0::5"],
+		"DstPorts": [{"IP": "10.33.5.0/24", "Ports": {"First": 0, "Last": 65535}}]
+	}], "packet_filter_matches": [{
+		"IPProto": [6, 17, 1, 58],
+		"Srcs":    ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "10.33.5.0/24", "Ports": {"First": 0, "Last": 65535}}],
+		"Caps":    []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         707081358747369,
+			"StableID":   "nQzPP3qEX611CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       707081358747369,
+			"Key":        "nodekey:a5bbb7881c8bca32b6efd73a03c65217dd8c438fa27792829382e992007f4b52",
+			"DiscoKey":   "discokey:6887d524dd27c2f8ad4b3676851eceea715fb13e0c0db431a0be67cd594bee4e",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:44108",
+				"10.65.0.27:44108",
+				"172.17.0.1:44108",
+				"172.18.0.1:44108",
+				"172.19.0.1:44108",
+				"172.20.0.1:44108",
+				"172.21.0.1:44108",
+				"172.22.0.1:44108",
+				"172.23.0.1:44108",
+				"172.24.0.1:44108",
+				"172.25.0.1:44108",
+				"172.27.0.1:44108",
+				"172.28.0.1:44108",
+				"172.29.0.1:44108",
+				"172.30.0.1:44108"
+			],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:08:56.923114061Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:a5bbb7881c8bca32b6efd73a03c65217dd8c438fa27792829382e992007f4b52",
+		"MachineKey": "mkey:f96acb2bd50905ee969a5c746012d94f96ce8a4476227930097e0e2f42515d42",
+		"Peers": [{
+			"ID":         7067747585838294,
+			"StableID":   "nyaAoAkzBx11CNTRL",
+			"Name":       "rattata.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:f0f21941bc3aee295900c96b04335b18d1527061e6eaf773c8e56b0cec38d47f",
+			"DiscoKey":   "discokey:9e1d242539c3dd067ad5eb339aacb8a13da29ae57c218f9e91f773b7a2e7ca6e",
+			"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"Endpoints": [
+				"77.164.248.136:45427",
+				"10.65.0.27:45427",
+				"172.17.0.1:45427",
+				"172.18.0.1:45427",
+				"172.19.0.1:45427",
+				"172.20.0.1:45427",
+				"172.21.0.1:45427",
+				"172.22.0.1:45427",
+				"172.23.0.1:45427",
+				"172.24.0.1:45427",
+				"172.25.0.1:45427",
+				"172.27.0.1:45427",
+				"172.28.0.1:45427",
+				"172.29.0.1:45427",
+				"172.30.0.1:45427"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+				{"Proto": "peerapi4", "Port": 41053},
+				{"Proto": "peerapi6", "Port": 41053}
+			]},
+			"Created":              "2026-05-18T09:08:54.27787786Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:group-a"],
+			"Online":               true,
+			"ComputedName":         "rattata",
+			"ComputedNameWithHost": "rattata"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "10.33.5.0/24", "Ports": {"First": 0, "Last": 65535}}],
+			"Caps":    []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.5", "fd7a:115c:a1e0::5"],
+			"DstPorts": [{"IP": "10.33.5.0/24", "Ports": {"First": 0, "Last": 65535}}]
+		}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "707081358747369": {
+			"ID":          707081358747369,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}, "whois": {"100.64.0.5": {"Node": {
+		"ID":         7067747585838294,
+		"StableID":   "nyaAoAkzBx11CNTRL",
+		"Name":       "rattata.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:f0f21941bc3aee295900c96b04335b18d1527061e6eaf773c8e56b0cec38d47f",
+		"DiscoKey":   "discokey:9e1d242539c3dd067ad5eb339aacb8a13da29ae57c218f9e91f773b7a2e7ca6e",
+		"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"Endpoints": [
+			"77.164.248.136:45427",
+			"10.65.0.27:45427",
+			"172.17.0.1:45427",
+			"172.18.0.1:45427",
+			"172.19.0.1:45427",
+			"172.20.0.1:45427",
+			"172.21.0.1:45427",
+			"172.22.0.1:45427",
+			"172.23.0.1:45427",
+			"172.24.0.1:45427",
+			"172.25.0.1:45427",
+			"172.27.0.1:45427",
+			"172.28.0.1:45427",
+			"172.29.0.1:45427",
+			"172.30.0.1:45427"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+			{"Proto": "peerapi4", "Port": 41053},
+			{"Proto": "peerapi6", "Port": 41053}
+		]},
+		"Created":              "2026-05-18T09:08:54.27787786Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:group-a"],
+		"Online":               true,
+		"ComputedName":         "rattata",
+		"ComputedNameWithHost": "rattata"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "fd7a:115c:a1e0::5": {"Node": {
+		"ID":         7067747585838294,
+		"StableID":   "nyaAoAkzBx11CNTRL",
+		"Name":       "rattata.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:f0f21941bc3aee295900c96b04335b18d1527061e6eaf773c8e56b0cec38d47f",
+		"DiscoKey":   "discokey:9e1d242539c3dd067ad5eb339aacb8a13da29ae57c218f9e91f773b7a2e7ca6e",
+		"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"Endpoints": [
+			"77.164.248.136:45427",
+			"10.65.0.27:45427",
+			"172.17.0.1:45427",
+			"172.18.0.1:45427",
+			"172.19.0.1:45427",
+			"172.20.0.1:45427",
+			"172.21.0.1:45427",
+			"172.22.0.1:45427",
+			"172.23.0.1:45427",
+			"172.24.0.1:45427",
+			"172.25.0.1:45427",
+			"172.27.0.1:45427",
+			"172.28.0.1:45427",
+			"172.29.0.1:45427",
+			"172.30.0.1:45427"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+			{"Proto": "peerapi4", "Port": 41053},
+			{"Proto": "peerapi6", "Port": 41053}
+		]},
+		"Created":              "2026-05-18T09:08:54.27787786Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:group-a"],
+		"Online":               true,
+		"ComputedName":         "rattata",
+		"ComputedNameWithHost": "rattata"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7881217227059504,
+			"StableID":   "nywtPKDRY421CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:c713605ecf9f8727a3a302dcecad491e7cb60b4fe1a2084b05e3c6cf82c5a83b",
+			"KeyExpiry":  "2026-11-14T09:08:59Z",
+			"DiscoKey":   "discokey:c1664318ec9349ed48ce1530ec3244ccbe891aaee31bba74450bc06e61048713",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints": [
+				"77.164.248.136:49496",
+				"10.65.0.27:49496",
+				"172.17.0.1:49496",
+				"172.18.0.1:49496",
+				"172.19.0.1:49496",
+				"172.20.0.1:49496",
+				"172.21.0.1:49496",
+				"172.22.0.1:49496",
+				"172.23.0.1:49496",
+				"172.24.0.1:49496",
+				"172.25.0.1:49496",
+				"172.27.0.1:49496",
+				"172.28.0.1:49496",
+				"172.29.0.1:49496",
+				"172.30.0.1:49496"
+			],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:08:59.597175811Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:c713605ecf9f8727a3a302dcecad491e7cb60b4fe1a2084b05e3c6cf82c5a83b",
+		"MachineKey":        "mkey:23363497a57674b8424ed254203df2e560a97c9982c0dea8674b5c20b002f24a",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8774068181880326,
+			"StableID":   "nK3BrntnWB21CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       8774068181880326,
+			"Key":        "nodekey:982431d8795a4558c52df10d87f17ad5831dee9b8c0fa715658d34389d4ffe67",
+			"DiscoKey":   "discokey:1c9023924d510ca77d8566ee1ab23733512c58d4ed073c44a256e37cd984eb37",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints": [
+				"77.164.248.136:54831",
+				"10.65.0.27:54831",
+				"172.17.0.1:54831",
+				"172.18.0.1:54831",
+				"172.19.0.1:54831",
+				"172.20.0.1:54831",
+				"172.21.0.1:54831",
+				"172.22.0.1:54831",
+				"172.23.0.1:54831",
+				"172.24.0.1:54831",
+				"172.25.0.1:54831",
+				"172.27.0.1:54831",
+				"172.28.0.1:54831",
+				"172.29.0.1:54831",
+				"172.30.0.1:54831"
+			],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:08:57.461846474Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:982431d8795a4558c52df10d87f17ad5831dee9b8c0fa715658d34389d4ffe67",
+		"MachineKey":        "mkey:c7a43d8ce9185f44c8b3263e950203728450ef77a3cca16450dead4115626479",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8774068181880326": {
+			"ID":          8774068181880326,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/grant_results/via-grant-v49.hujson
+++ b/hscontrol/policy/v2/testdata/grant_results/via-grant-v49.hujson
@@ -1,0 +1,14164 @@
+// via-grant-v49
+//
+// via grant v49 dst host alias broader than advertised subnet
+//
+// Nodes with filter rules: 2 of 15
+// Captured at:    2026-05-18T09:09:45Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "via-grant-v49",
+	"description":    "via grant v49 dst host alias broader than advertised subnet",
+	"category":       "grant",
+	"captured_at":    "2026-05-18T09:09:45.383298229Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                                      \n  \n                                                                          \n                                                                           \n                                                                        \n                                                                         \n  \n                                                                         \n                                                                 \n{\n\t\"category\":    \"grant\",\n\t\"description\": \"via grant v49 dst host alias broader than advertised subnet\",\n\t\"id\":          \"via-grant-v49\",\n\t\"options\":     {\"capture_whois\": true},\n\t\"policy\": {\"autoApprovers\": {\"routes\": {\n\t\t\"10.33.0.0/16\": [\"tag:router\"],\n\t\t\"10.44.0.0/16\": [\"tag:spearow\"],\n\t\t\"10.55.0.0/16\": [\"tag:fearow\"]\n\t}}, \"grants\": [{\n\t\t\"dst\": [\"internal\"],\n\t\t\"ip\":  [\"*\"],\n\t\t\"src\": [\"tag:group-a\"],\n\t\t\"via\": [\"tag:router\"]\n\t}], \"groups\": {\n\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\"group:empty\":      [],\n\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t}, \"hosts\": {\n\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\"webserver\": \"100.108.74.26\"\n\t}, \"tagOwners\": {\n\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\"tag:server\":   [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/grant/via-grant-v49.hujson",
+		"full_policy": {"autoApprovers": {"routes": {
+			"10.33.0.0/16": ["tag:router"],
+			"10.44.0.0/16": ["tag:spearow"],
+			"10.55.0.0/16": ["tag:fearow"]
+		}}, "grants": [{
+			"dst": ["internal"],
+			"ip":  ["*"],
+			"src": ["tag:group-a"],
+			"via": ["tag:router"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"webserver": "100.108.74.26"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": ["10.33.0.0/16"]
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": ["10.55.0.0/16"]
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": ["10.44.0.0/16"]
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": ["10.33.0.0/16"]
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1654201741972838,
+			"StableID":   "nsHePL5CvD11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1654201741972838,
+			"Key":        "nodekey:2f6ed2755d5bec53ed1d463206d6e4f324bd49285205161348efd4578829723d",
+			"DiscoKey":   "discokey:cd8c9fc6fc3c67d1d5a85cca3e9d9c305276819513e0ed87f351f24507f3cc2f",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints": [
+				"77.164.248.136:46172",
+				"10.65.0.27:46172",
+				"172.17.0.1:46172",
+				"172.18.0.1:46172",
+				"172.19.0.1:46172",
+				"172.20.0.1:46172",
+				"172.21.0.1:46172",
+				"172.22.0.1:46172",
+				"172.23.0.1:46172",
+				"172.24.0.1:46172",
+				"172.25.0.1:46172",
+				"172.27.0.1:46172",
+				"172.28.0.1:46172",
+				"172.29.0.1:46172",
+				"172.30.0.1:46172"
+			],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:09:57.643616429Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:2f6ed2755d5bec53ed1d463206d6e4f324bd49285205161348efd4578829723d",
+		"MachineKey":        "mkey:0e5fded7ceb7f42dc07075f281606ae8adaf5261bbd54e6894c43c51d3821114",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1654201741972838": {
+			"ID":          1654201741972838,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}}
+	}}, "blastoise": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.5", "fd7a:115c:a1e0::5"],
+		"DstPorts": [{"IP": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}]
+	}], "packet_filter_matches": [{
+		"IPProto": [6, 17, 1, 58],
+		"Srcs":    ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}],
+		"Caps":    []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4353680609859707,
+			"StableID":   "ncdq1ponza11CNTRL",
+			"Name":       "blastoise.tail78f774.ts.net.",
+			"User":       4353680609859707,
+			"Key":        "nodekey:b5db4038b4b10452989f805261c321d951a289c50fc7ee9e119cc43f3b60133a",
+			"DiscoKey":   "discokey:e5ac5dd18c7f96c6189e8c8a377a3bbfc606c1520a4627b8ce97c71c7ce9cc7f",
+			"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+			"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:59178",
+				"10.65.0.27:59178",
+				"172.17.0.1:59178",
+				"172.18.0.1:59178",
+				"172.19.0.1:59178",
+				"172.20.0.1:59178",
+				"172.21.0.1:59178",
+				"172.22.0.1:59178",
+				"172.23.0.1:59178",
+				"172.24.0.1:59178",
+				"172.25.0.1:59178",
+				"172.27.0.1:59178",
+				"172.28.0.1:59178",
+				"172.29.0.1:59178",
+				"172.30.0.1:59178"
+			],
+			"Hostinfo": {
+				"Hostname":    "blastoise",
+				"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit", "tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:09:54.427828038Z",
+			"Tags":              ["tag:exit", "tag:router"],
+			"PrimaryRoutes":     ["10.33.0.0/16"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "blastoise",
+			"ComputedNameWithHost": "blastoise"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:b5db4038b4b10452989f805261c321d951a289c50fc7ee9e119cc43f3b60133a",
+		"MachineKey": "mkey:e648ae1613f7d9dc9484ac10ddcb78bb2e34a44b6895b1a830e9f17277d0415b",
+		"Peers": [{
+			"ID":         1191708573799268,
+			"StableID":   "nFJSrUAjJA11CNTRL",
+			"Name":       "rattata.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:38a866479caef0d5c0e853c85a8a3df39f1fd96c005b32071b40f4ef80d6ec13",
+			"DiscoKey":   "discokey:d23472be07dfe7f1384c1d713569b6abc53d6c3a8ea28b723a8265a421e7cf59",
+			"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"Endpoints": [
+				"77.164.248.136:60165",
+				"10.65.0.27:60165",
+				"172.17.0.1:60165",
+				"172.18.0.1:60165",
+				"172.19.0.1:60165",
+				"172.20.0.1:60165",
+				"172.21.0.1:60165",
+				"172.22.0.1:60165",
+				"172.23.0.1:60165",
+				"172.24.0.1:60165",
+				"172.25.0.1:60165",
+				"172.27.0.1:60165",
+				"172.28.0.1:60165",
+				"172.29.0.1:60165",
+				"172.30.0.1:60165"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+				{"Proto": "peerapi4", "Port": 41053},
+				{"Proto": "peerapi6", "Port": 41053}
+			]},
+			"Created":              "2026-05-18T09:09:53.365800595Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:group-a"],
+			"Online":               true,
+			"ComputedName":         "rattata",
+			"ComputedNameWithHost": "rattata"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}],
+			"Caps":    []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.5", "fd7a:115c:a1e0::5"],
+			"DstPorts": [{"IP": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}]
+		}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4353680609859707": {
+			"ID":          4353680609859707,
+			"LoginName":   "blastoise.tail78f774.ts.net",
+			"DisplayName": "blastoise"
+		}}
+	}, "whois": {"100.64.0.5": {"Node": {
+		"ID":         1191708573799268,
+		"StableID":   "nFJSrUAjJA11CNTRL",
+		"Name":       "rattata.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:38a866479caef0d5c0e853c85a8a3df39f1fd96c005b32071b40f4ef80d6ec13",
+		"DiscoKey":   "discokey:d23472be07dfe7f1384c1d713569b6abc53d6c3a8ea28b723a8265a421e7cf59",
+		"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"Endpoints": [
+			"77.164.248.136:60165",
+			"10.65.0.27:60165",
+			"172.17.0.1:60165",
+			"172.18.0.1:60165",
+			"172.19.0.1:60165",
+			"172.20.0.1:60165",
+			"172.21.0.1:60165",
+			"172.22.0.1:60165",
+			"172.23.0.1:60165",
+			"172.24.0.1:60165",
+			"172.25.0.1:60165",
+			"172.27.0.1:60165",
+			"172.28.0.1:60165",
+			"172.29.0.1:60165",
+			"172.30.0.1:60165"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+			{"Proto": "peerapi4", "Port": 41053},
+			{"Proto": "peerapi6", "Port": 41053}
+		]},
+		"Created":              "2026-05-18T09:09:53.365800595Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:group-a"],
+		"Online":               true,
+		"ComputedName":         "rattata",
+		"ComputedNameWithHost": "rattata"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "fd7a:115c:a1e0::5": {"Node": {
+		"ID":         1191708573799268,
+		"StableID":   "nFJSrUAjJA11CNTRL",
+		"Name":       "rattata.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:38a866479caef0d5c0e853c85a8a3df39f1fd96c005b32071b40f4ef80d6ec13",
+		"DiscoKey":   "discokey:d23472be07dfe7f1384c1d713569b6abc53d6c3a8ea28b723a8265a421e7cf59",
+		"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"Endpoints": [
+			"77.164.248.136:60165",
+			"10.65.0.27:60165",
+			"172.17.0.1:60165",
+			"172.18.0.1:60165",
+			"172.19.0.1:60165",
+			"172.20.0.1:60165",
+			"172.21.0.1:60165",
+			"172.22.0.1:60165",
+			"172.23.0.1:60165",
+			"172.24.0.1:60165",
+			"172.25.0.1:60165",
+			"172.27.0.1:60165",
+			"172.28.0.1:60165",
+			"172.29.0.1:60165",
+			"172.30.0.1:60165"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+			{"Proto": "peerapi4", "Port": 41053},
+			{"Proto": "peerapi6", "Port": 41053}
+		]},
+		"Created":              "2026-05-18T09:09:53.365800595Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:group-a"],
+		"Online":               true,
+		"ComputedName":         "rattata",
+		"ComputedNameWithHost": "rattata"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         926567223465290,
+			"StableID":   "n7w7fHMeE811CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:ef6bd76a781c32ae5017c044987675e837068daa77b0699df609f533b6df5a57",
+			"KeyExpiry":  "2026-11-14T09:09:59Z",
+			"DiscoKey":   "discokey:9cf87cc83bb0273a8801ace89d2bd27542395a98924482edd63540db1f6ece35",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints": [
+				"77.164.248.136:51843",
+				"10.65.0.27:51843",
+				"172.17.0.1:51843",
+				"172.18.0.1:51843",
+				"172.19.0.1:51843",
+				"172.20.0.1:51843",
+				"172.21.0.1:51843",
+				"172.22.0.1:51843",
+				"172.23.0.1:51843",
+				"172.24.0.1:51843",
+				"172.25.0.1:51843",
+				"172.27.0.1:51843",
+				"172.28.0.1:51843",
+				"172.29.0.1:51843",
+				"172.30.0.1:51843"
+			],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:09:59.241340908Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:ef6bd76a781c32ae5017c044987675e837068daa77b0699df609f533b6df5a57",
+		"MachineKey":        "mkey:9f406d8cdb4b07d8938287577dc41ef14cdd5663861ac77d0c012a2093b04958",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1154714393061985,
+			"StableID":   "nJ1KnZPy1A11CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1154714393061985,
+			"Key":        "nodekey:8729c0c3cb115278d3a6503c1671517189d8db5c14b1593d49127307f31d8d1d",
+			"DiscoKey":   "discokey:39093f5aa31169f5dc3208fe0cb7a1bcca0c67fd5a6d3ad3ff93656b33d4b412",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints": [
+				"77.164.248.136:50136",
+				"10.65.0.27:50136",
+				"172.17.0.1:50136",
+				"172.18.0.1:50136",
+				"172.19.0.1:50136",
+				"172.20.0.1:50136",
+				"172.21.0.1:50136",
+				"172.22.0.1:50136",
+				"172.23.0.1:50136",
+				"172.24.0.1:50136",
+				"172.25.0.1:50136",
+				"172.27.0.1:50136",
+				"172.28.0.1:50136",
+				"172.29.0.1:50136",
+				"172.30.0.1:50136"
+			],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:09:52.838243604Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:8729c0c3cb115278d3a6503c1671517189d8db5c14b1593d49127307f31d8d1d",
+		"MachineKey":        "mkey:62bfd0315ccbbcfedb7b22991a2dcee12f458304a340f7f931992d9d37641265",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1154714393061985": {
+			"ID":          1154714393061985,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "fearow": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         6512658328578833,
+			"StableID":   "n2frwTVbrs11CNTRL",
+			"Name":       "fearow.tail78f774.ts.net.",
+			"User":       6512658328578833,
+			"Key":        "nodekey:eacb11c6f0c205ec9f4f7b3694554ab846c9fab4582b9b8a6510310626d41c7c",
+			"DiscoKey":   "discokey:fbc334bc4e07db567cd5605bf03951d67209334c38ff7690bd0d1e118cfc0028",
+			"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+			"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128", "10.55.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:60774",
+				"10.65.0.27:60774",
+				"172.17.0.1:60774",
+				"172.18.0.1:60774",
+				"172.19.0.1:60774",
+				"172.20.0.1:60774",
+				"172.21.0.1:60774",
+				"172.22.0.1:60774",
+				"172.23.0.1:60774",
+				"172.24.0.1:60774",
+				"172.25.0.1:60774",
+				"172.27.0.1:60774",
+				"172.28.0.1:60774",
+				"172.29.0.1:60774",
+				"172.30.0.1:60774"
+			],
+			"Hostinfo": {
+				"Hostname":    "fearow",
+				"RoutableIPs": ["10.55.0.0/16"],
+				"RequestTags": ["tag:fearow"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:09:55.50305827Z",
+			"Tags":              ["tag:fearow"],
+			"PrimaryRoutes":     ["10.55.0.0/16"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "fearow",
+			"ComputedNameWithHost": "fearow"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:eacb11c6f0c205ec9f4f7b3694554ab846c9fab4582b9b8a6510310626d41c7c",
+		"MachineKey":        "mkey:e550a5efb38cf93e01a19c06a53485d519152ffa932c982fba6003655b0fee10",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"6512658328578833": {
+			"ID":          6512658328578833,
+			"LoginName":   "fearow.tail78f774.ts.net",
+			"DisplayName": "fearow"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8517488899238478,
+			"StableID":   "n3boFSzaW921CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:6351d6da190536fb1dcdbaef6045950abdbee90284bb5e0d358b81fbc76a8f7e",
+			"KeyExpiry":  "2026-11-14T09:09:58Z",
+			"DiscoKey":   "discokey:a726a69088fc615c8da8473e572bbda47d26c2e452c2062252c8c582f7dbc70c",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints": [
+				"77.164.248.136:35182",
+				"10.65.0.27:35182",
+				"172.17.0.1:35182",
+				"172.18.0.1:35182",
+				"172.19.0.1:35182",
+				"172.20.0.1:35182",
+				"172.21.0.1:35182",
+				"172.22.0.1:35182",
+				"172.23.0.1:35182",
+				"172.24.0.1:35182",
+				"172.25.0.1:35182",
+				"172.27.0.1:35182",
+				"172.28.0.1:35182",
+				"172.29.0.1:35182",
+				"172.30.0.1:35182"
+			],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:09:58.170587249Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:6351d6da190536fb1dcdbaef6045950abdbee90284bb5e0d358b81fbc76a8f7e",
+		"MachineKey":        "mkey:47a38b805622722b150cf68bbdcae6bc9326b146290f477356a3c5bdcea55a0c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4398905709499259,
+			"StableID":   "nGfoC3oGMb11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       4398905709499259,
+			"Key":        "nodekey:b155c51fc9f7601ea6dec78b67cf298b3713fc02417b530bea8335274bc1ad76",
+			"DiscoKey":   "discokey:f19ef368e77535b2d3a4a8d147decc80d4ea61b0abea57b03b0fd74c6ce79111",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints": [
+				"77.164.248.136:56640",
+				"10.65.0.27:56640",
+				"172.17.0.1:56640",
+				"172.18.0.1:56640",
+				"172.19.0.1:56640",
+				"172.20.0.1:56640",
+				"172.21.0.1:56640",
+				"172.22.0.1:56640",
+				"172.23.0.1:56640",
+				"172.24.0.1:56640",
+				"172.25.0.1:56640",
+				"172.27.0.1:56640",
+				"172.28.0.1:56640",
+				"172.29.0.1:56640",
+				"172.30.0.1:56640"
+			],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:09:57.112792896Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:b155c51fc9f7601ea6dec78b67cf298b3713fc02417b530bea8335274bc1ad76",
+		"MachineKey":        "mkey:46016eeabfdc23062f5b9b92c6e103d8f682b22ab22bf04de243af1433d95e0d",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4398905709499259": {
+			"ID":          4398905709499259,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "pidgeotto": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1462701867398957,
+			"StableID":   "n8vcEUhTRC11CNTRL",
+			"Name":       "pidgeotto.tail78f774.ts.net.",
+			"User":       1462701867398957,
+			"Key":        "nodekey:d2e24d6575449f6f7f05da050cd456eea796a70fecf8f5bca2b90b981b708e64",
+			"DiscoKey":   "discokey:b9247209ed5489c8a97a9e4aaceb3a45db0bfbfe641940cd96aca8dce12a3619",
+			"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+			"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+			"Endpoints": [
+				"77.164.248.136:49323",
+				"10.65.0.27:49323",
+				"172.17.0.1:49323",
+				"172.18.0.1:49323",
+				"172.19.0.1:49323",
+				"172.20.0.1:49323",
+				"172.21.0.1:49323",
+				"172.22.0.1:49323",
+				"172.23.0.1:49323",
+				"172.24.0.1:49323",
+				"172.25.0.1:49323",
+				"172.27.0.1:49323",
+				"172.28.0.1:49323",
+				"172.29.0.1:49323",
+				"172.30.0.1:49323"
+			],
+			"Hostinfo": {
+				"Hostname":    "pidgeotto",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:pidgeotto"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:09:52.330166848Z",
+			"Tags":              ["tag:pidgeotto"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "pidgeotto",
+			"ComputedNameWithHost": "pidgeotto"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:d2e24d6575449f6f7f05da050cd456eea796a70fecf8f5bca2b90b981b708e64",
+		"MachineKey":        "mkey:48562c45554f387ac4eb430f5eec7013fad827d43c783adc210d1afc32f2142a",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1462701867398957": {
+			"ID":          1462701867398957,
+			"LoginName":   "pidgeotto.tail78f774.ts.net",
+			"DisplayName": "pidgeotto"
+		}}
+	}}, "pidgey": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1421890685488846,
+			"StableID":   "nRGmq7fy6C11CNTRL",
+			"Name":       "pidgey.tail78f774.ts.net.",
+			"User":       1421890685488846,
+			"Key":        "nodekey:c8fcfbdfc7940b880da1345f4b9d4308d4206d8e8b67d730f6302a0c6e6f1d3f",
+			"DiscoKey":   "discokey:6e5ea488a1e1ad360f3e23b92cd1250847f52d8fe9d9c528a4cd30fa046ca922",
+			"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+			"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+			"Endpoints": [
+				"77.164.248.136:59725",
+				"10.65.0.27:59725",
+				"172.17.0.1:59725",
+				"172.18.0.1:59725",
+				"172.19.0.1:59725",
+				"172.20.0.1:59725",
+				"172.21.0.1:59725",
+				"172.22.0.1:59725",
+				"172.23.0.1:59725",
+				"172.24.0.1:59725",
+				"172.25.0.1:59725",
+				"172.27.0.1:59725",
+				"172.28.0.1:59725",
+				"172.29.0.1:59725",
+				"172.30.0.1:59725"
+			],
+			"Hostinfo": {
+				"Hostname":    "pidgey",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:pidgey"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:09:51.783297044Z",
+			"Tags":              ["tag:pidgey"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "pidgey",
+			"ComputedNameWithHost": "pidgey"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:c8fcfbdfc7940b880da1345f4b9d4308d4206d8e8b67d730f6302a0c6e6f1d3f",
+		"MachineKey":        "mkey:7f1d861dba06f6b5d10c8e20bef0038714f88c3fb9d6e4dab0c89815eb1ca01f",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1421890685488846": {
+			"ID":          1421890685488846,
+			"LoginName":   "pidgey.tail78f774.ts.net",
+			"DisplayName": "pidgey"
+		}}
+	}}, "raticate": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         6830479516309268,
+			"StableID":   "nm1jyd7YLv11CNTRL",
+			"Name":       "raticate.tail78f774.ts.net.",
+			"User":       6830479516309268,
+			"Key":        "nodekey:c4d281f165fd2867c4d67011cd71701fa9be987348ddb36641109f9a8caea561",
+			"DiscoKey":   "discokey:a2a38ca3a8d76366a4649f5219b7e36c23d9d449188acd52da16b31490ef2161",
+			"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+			"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+			"Endpoints": [
+				"77.164.248.136:34630",
+				"10.65.0.27:34630",
+				"172.17.0.1:34630",
+				"172.18.0.1:34630",
+				"172.19.0.1:34630",
+				"172.20.0.1:34630",
+				"172.21.0.1:34630",
+				"172.22.0.1:34630",
+				"172.23.0.1:34630",
+				"172.24.0.1:34630",
+				"172.25.0.1:34630",
+				"172.27.0.1:34630",
+				"172.28.0.1:34630",
+				"172.29.0.1:34630",
+				"172.30.0.1:34630"
+			],
+			"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+				{"Proto": "peerapi4", "Port": 61927},
+				{"Proto": "peerapi6", "Port": 61927},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:09:53.9152509Z",
+			"Tags":              ["tag:group-b"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "raticate",
+			"ComputedNameWithHost": "raticate"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:c4d281f165fd2867c4d67011cd71701fa9be987348ddb36641109f9a8caea561",
+		"MachineKey":        "mkey:9b49218879ebcd1bf07a0b140e7bed1b19850e5bec7adb590ee8dfd54ac4ca6e",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"6830479516309268": {
+			"ID":          6830479516309268,
+			"LoginName":   "raticate.tail78f774.ts.net",
+			"DisplayName": "raticate"
+		}}
+	}}, "rattata": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1191708573799268,
+			"StableID":   "nFJSrUAjJA11CNTRL",
+			"Name":       "rattata.tail78f774.ts.net.",
+			"User":       1191708573799268,
+			"Key":        "nodekey:38a866479caef0d5c0e853c85a8a3df39f1fd96c005b32071b40f4ef80d6ec13",
+			"DiscoKey":   "discokey:d23472be07dfe7f1384c1d713569b6abc53d6c3a8ea28b723a8265a421e7cf59",
+			"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"Endpoints": [
+				"77.164.248.136:60165",
+				"10.65.0.27:60165",
+				"172.17.0.1:60165",
+				"172.18.0.1:60165",
+				"172.19.0.1:60165",
+				"172.20.0.1:60165",
+				"172.21.0.1:60165",
+				"172.22.0.1:60165",
+				"172.23.0.1:60165",
+				"172.24.0.1:60165",
+				"172.25.0.1:60165",
+				"172.27.0.1:60165",
+				"172.28.0.1:60165",
+				"172.29.0.1:60165",
+				"172.30.0.1:60165"
+			],
+			"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+				{"Proto": "peerapi4", "Port": 41053},
+				{"Proto": "peerapi6", "Port": 41053},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:09:53.365800595Z",
+			"Tags":              ["tag:group-a"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "rattata",
+			"ComputedNameWithHost": "rattata"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:38a866479caef0d5c0e853c85a8a3df39f1fd96c005b32071b40f4ef80d6ec13",
+		"MachineKey": "mkey:91230ff01950c8ec552b951556bdac624112f0816e7ca2e675bf2cd99d885c5d",
+		"Peers": [{
+			"ID":         4353680609859707,
+			"StableID":   "ncdq1ponza11CNTRL",
+			"Name":       "blastoise.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:b5db4038b4b10452989f805261c321d951a289c50fc7ee9e119cc43f3b60133a",
+			"DiscoKey":   "discokey:e5ac5dd18c7f96c6189e8c8a377a3bbfc606c1520a4627b8ce97c71c7ce9cc7f",
+			"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+			"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:59178",
+				"10.65.0.27:59178",
+				"172.17.0.1:59178",
+				"172.18.0.1:59178",
+				"172.19.0.1:59178",
+				"172.20.0.1:59178",
+				"172.21.0.1:59178",
+				"172.22.0.1:59178",
+				"172.23.0.1:59178",
+				"172.24.0.1:59178",
+				"172.25.0.1:59178",
+				"172.27.0.1:59178",
+				"172.28.0.1:59178",
+				"172.29.0.1:59178",
+				"172.30.0.1:59178"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+				{"Proto": "peerapi4", "Port": 60534},
+				{"Proto": "peerapi6", "Port": 60534}
+			]},
+			"Created":              "2026-05-18T09:09:54.427828038Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:exit", "tag:router"],
+			"PrimaryRoutes":        ["10.33.0.0/16"],
+			"Online":               true,
+			"ComputedName":         "blastoise",
+			"ComputedNameWithHost": "blastoise"
+		}, {
+			"ID":         5736597902827947,
+			"StableID":   "nJ8kcZh7om11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:a82e54f5c6150a0caa9610e9287570a51cad64af696ff4432b5545f7590e804c",
+			"DiscoKey":   "discokey:105764c326fdac03402af2449523a6be028f244a3bbf9bbad5c6b5114fb1d11c",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints": [
+				"77.164.248.136:59206",
+				"10.65.0.27:59206",
+				"172.17.0.1:59206",
+				"172.18.0.1:59206",
+				"172.19.0.1:59206",
+				"172.20.0.1:59206",
+				"172.21.0.1:59206",
+				"172.22.0.1:59206",
+				"172.23.0.1:59206",
+				"172.24.0.1:59206",
+				"172.25.0.1:59206",
+				"172.27.0.1:59206",
+				"172.28.0.1:59206",
+				"172.29.0.1:59206",
+				"172.30.0.1:59206"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+				{"Proto": "peerapi4", "Port": 43119},
+				{"Proto": "peerapi6", "Port": 43119}
+			]},
+			"Created":              "2026-05-18T09:09:56.03671269Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:router"],
+			"Online":               true,
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1191708573799268": {
+			"ID":          1191708573799268,
+			"LoginName":   "rattata.tail78f774.ts.net",
+			"DisplayName": "rattata"
+		}, "1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}}
+	}, "whois": {"100.64.0.13": {"Node": {
+		"ID":         5736597902827947,
+		"StableID":   "nJ8kcZh7om11CNTRL",
+		"Name":       "squirtle.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:a82e54f5c6150a0caa9610e9287570a51cad64af696ff4432b5545f7590e804c",
+		"DiscoKey":   "discokey:105764c326fdac03402af2449523a6be028f244a3bbf9bbad5c6b5114fb1d11c",
+		"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+		"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+		"Endpoints": [
+			"77.164.248.136:59206",
+			"10.65.0.27:59206",
+			"172.17.0.1:59206",
+			"172.18.0.1:59206",
+			"172.19.0.1:59206",
+			"172.20.0.1:59206",
+			"172.21.0.1:59206",
+			"172.22.0.1:59206",
+			"172.23.0.1:59206",
+			"172.24.0.1:59206",
+			"172.25.0.1:59206",
+			"172.27.0.1:59206",
+			"172.28.0.1:59206",
+			"172.29.0.1:59206",
+			"172.30.0.1:59206"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+			{"Proto": "peerapi4", "Port": 43119},
+			{"Proto": "peerapi6", "Port": 43119}
+		]},
+		"Created":              "2026-05-18T09:09:56.03671269Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:router"],
+		"Online":               true,
+		"ComputedName":         "squirtle",
+		"ComputedNameWithHost": "squirtle"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "100.64.0.9": {"Node": {
+		"ID":         4353680609859707,
+		"StableID":   "ncdq1ponza11CNTRL",
+		"Name":       "blastoise.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:b5db4038b4b10452989f805261c321d951a289c50fc7ee9e119cc43f3b60133a",
+		"DiscoKey":   "discokey:e5ac5dd18c7f96c6189e8c8a377a3bbfc606c1520a4627b8ce97c71c7ce9cc7f",
+		"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+		"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128", "10.33.0.0/16"],
+		"Endpoints": [
+			"77.164.248.136:59178",
+			"10.65.0.27:59178",
+			"172.17.0.1:59178",
+			"172.18.0.1:59178",
+			"172.19.0.1:59178",
+			"172.20.0.1:59178",
+			"172.21.0.1:59178",
+			"172.22.0.1:59178",
+			"172.23.0.1:59178",
+			"172.24.0.1:59178",
+			"172.25.0.1:59178",
+			"172.27.0.1:59178",
+			"172.28.0.1:59178",
+			"172.29.0.1:59178",
+			"172.30.0.1:59178"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+			{"Proto": "peerapi4", "Port": 60534},
+			{"Proto": "peerapi6", "Port": 60534}
+		]},
+		"Created":              "2026-05-18T09:09:54.427828038Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:exit", "tag:router"],
+		"PrimaryRoutes":        ["10.33.0.0/16"],
+		"Online":               true,
+		"ComputedName":         "blastoise",
+		"ComputedNameWithHost": "blastoise"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "fd7a:115c:a1e0::9": {"Node": {
+		"ID":         4353680609859707,
+		"StableID":   "ncdq1ponza11CNTRL",
+		"Name":       "blastoise.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:b5db4038b4b10452989f805261c321d951a289c50fc7ee9e119cc43f3b60133a",
+		"DiscoKey":   "discokey:e5ac5dd18c7f96c6189e8c8a377a3bbfc606c1520a4627b8ce97c71c7ce9cc7f",
+		"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+		"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128", "10.33.0.0/16"],
+		"Endpoints": [
+			"77.164.248.136:59178",
+			"10.65.0.27:59178",
+			"172.17.0.1:59178",
+			"172.18.0.1:59178",
+			"172.19.0.1:59178",
+			"172.20.0.1:59178",
+			"172.21.0.1:59178",
+			"172.22.0.1:59178",
+			"172.23.0.1:59178",
+			"172.24.0.1:59178",
+			"172.25.0.1:59178",
+			"172.27.0.1:59178",
+			"172.28.0.1:59178",
+			"172.29.0.1:59178",
+			"172.30.0.1:59178"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+			{"Proto": "peerapi4", "Port": 60534},
+			{"Proto": "peerapi6", "Port": 60534}
+		]},
+		"Created":              "2026-05-18T09:09:54.427828038Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:exit", "tag:router"],
+		"PrimaryRoutes":        ["10.33.0.0/16"],
+		"Online":               true,
+		"ComputedName":         "blastoise",
+		"ComputedNameWithHost": "blastoise"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "fd7a:115c:a1e0::d": {"Node": {
+		"ID":         5736597902827947,
+		"StableID":   "nJ8kcZh7om11CNTRL",
+		"Name":       "squirtle.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:a82e54f5c6150a0caa9610e9287570a51cad64af696ff4432b5545f7590e804c",
+		"DiscoKey":   "discokey:105764c326fdac03402af2449523a6be028f244a3bbf9bbad5c6b5114fb1d11c",
+		"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+		"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+		"Endpoints": [
+			"77.164.248.136:59206",
+			"10.65.0.27:59206",
+			"172.17.0.1:59206",
+			"172.18.0.1:59206",
+			"172.19.0.1:59206",
+			"172.20.0.1:59206",
+			"172.21.0.1:59206",
+			"172.22.0.1:59206",
+			"172.23.0.1:59206",
+			"172.24.0.1:59206",
+			"172.25.0.1:59206",
+			"172.27.0.1:59206",
+			"172.28.0.1:59206",
+			"172.29.0.1:59206",
+			"172.30.0.1:59206"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+			{"Proto": "peerapi4", "Port": 43119},
+			{"Proto": "peerapi6", "Port": 43119}
+		]},
+		"Created":              "2026-05-18T09:09:56.03671269Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:router"],
+		"Online":               true,
+		"ComputedName":         "squirtle",
+		"ComputedNameWithHost": "squirtle"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}}}, "spearow": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5554457969945969,
+			"StableID":   "nNHUT9CdNk11CNTRL",
+			"Name":       "spearow.tail78f774.ts.net.",
+			"User":       5554457969945969,
+			"Key":        "nodekey:e85ccf9890a697a7faf59cddf1944fa7cf88f28eb8f8cede6d456812a815856d",
+			"DiscoKey":   "discokey:c50b6000f3e9a04b6cc80199dbb9293fed0b048fcccdcf2d50dd3ae242407243",
+			"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+			"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128", "10.44.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:32906",
+				"10.65.0.27:32906",
+				"172.17.0.1:32906",
+				"172.18.0.1:32906",
+				"172.19.0.1:32906",
+				"172.20.0.1:32906",
+				"172.21.0.1:32906",
+				"172.22.0.1:32906",
+				"172.23.0.1:32906",
+				"172.24.0.1:32906",
+				"172.25.0.1:32906",
+				"172.27.0.1:32906",
+				"172.28.0.1:32906",
+				"172.29.0.1:32906",
+				"172.30.0.1:32906"
+			],
+			"Hostinfo": {
+				"Hostname":    "spearow",
+				"RoutableIPs": ["10.44.0.0/16"],
+				"RequestTags": ["tag:spearow"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:09:54.973023641Z",
+			"Tags":              ["tag:spearow"],
+			"PrimaryRoutes":     ["10.44.0.0/16"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "spearow",
+			"ComputedNameWithHost": "spearow"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:e85ccf9890a697a7faf59cddf1944fa7cf88f28eb8f8cede6d456812a815856d",
+		"MachineKey":        "mkey:e5f41d0ea32bd6e75e786f68a93db26c678770bd32e93590053318e48e211a16",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5554457969945969": {
+			"ID":          5554457969945969,
+			"LoginName":   "spearow.tail78f774.ts.net",
+			"DisplayName": "spearow"
+		}}
+	}}, "squirtle": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.5", "fd7a:115c:a1e0::5"],
+		"DstPorts": [{"IP": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}]
+	}], "packet_filter_matches": [{
+		"IPProto": [6, 17, 1, 58],
+		"Srcs":    ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}],
+		"Caps":    []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5736597902827947,
+			"StableID":   "nJ8kcZh7om11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       5736597902827947,
+			"Key":        "nodekey:a82e54f5c6150a0caa9610e9287570a51cad64af696ff4432b5545f7590e804c",
+			"DiscoKey":   "discokey:105764c326fdac03402af2449523a6be028f244a3bbf9bbad5c6b5114fb1d11c",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:59206",
+				"10.65.0.27:59206",
+				"172.17.0.1:59206",
+				"172.18.0.1:59206",
+				"172.19.0.1:59206",
+				"172.20.0.1:59206",
+				"172.21.0.1:59206",
+				"172.22.0.1:59206",
+				"172.23.0.1:59206",
+				"172.24.0.1:59206",
+				"172.25.0.1:59206",
+				"172.27.0.1:59206",
+				"172.28.0.1:59206",
+				"172.29.0.1:59206",
+				"172.30.0.1:59206"
+			],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:09:56.03671269Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:a82e54f5c6150a0caa9610e9287570a51cad64af696ff4432b5545f7590e804c",
+		"MachineKey": "mkey:eb56e1bc39a518091833374735bbab511a36e3db348ce585e57e5716399a931c",
+		"Peers": [{
+			"ID":         1191708573799268,
+			"StableID":   "nFJSrUAjJA11CNTRL",
+			"Name":       "rattata.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:38a866479caef0d5c0e853c85a8a3df39f1fd96c005b32071b40f4ef80d6ec13",
+			"DiscoKey":   "discokey:d23472be07dfe7f1384c1d713569b6abc53d6c3a8ea28b723a8265a421e7cf59",
+			"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"Endpoints": [
+				"77.164.248.136:60165",
+				"10.65.0.27:60165",
+				"172.17.0.1:60165",
+				"172.18.0.1:60165",
+				"172.19.0.1:60165",
+				"172.20.0.1:60165",
+				"172.21.0.1:60165",
+				"172.22.0.1:60165",
+				"172.23.0.1:60165",
+				"172.24.0.1:60165",
+				"172.25.0.1:60165",
+				"172.27.0.1:60165",
+				"172.28.0.1:60165",
+				"172.29.0.1:60165",
+				"172.30.0.1:60165"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+				{"Proto": "peerapi4", "Port": 41053},
+				{"Proto": "peerapi6", "Port": 41053}
+			]},
+			"Created":              "2026-05-18T09:09:53.365800595Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:group-a"],
+			"Online":               true,
+			"ComputedName":         "rattata",
+			"ComputedNameWithHost": "rattata"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}],
+			"Caps":    []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.5", "fd7a:115c:a1e0::5"],
+			"DstPorts": [{"IP": "10.0.0.0/8", "Ports": {"First": 0, "Last": 65535}}]
+		}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "5736597902827947": {
+			"ID":          5736597902827947,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}, "whois": {"100.64.0.5": {"Node": {
+		"ID":         1191708573799268,
+		"StableID":   "nFJSrUAjJA11CNTRL",
+		"Name":       "rattata.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:38a866479caef0d5c0e853c85a8a3df39f1fd96c005b32071b40f4ef80d6ec13",
+		"DiscoKey":   "discokey:d23472be07dfe7f1384c1d713569b6abc53d6c3a8ea28b723a8265a421e7cf59",
+		"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"Endpoints": [
+			"77.164.248.136:60165",
+			"10.65.0.27:60165",
+			"172.17.0.1:60165",
+			"172.18.0.1:60165",
+			"172.19.0.1:60165",
+			"172.20.0.1:60165",
+			"172.21.0.1:60165",
+			"172.22.0.1:60165",
+			"172.23.0.1:60165",
+			"172.24.0.1:60165",
+			"172.25.0.1:60165",
+			"172.27.0.1:60165",
+			"172.28.0.1:60165",
+			"172.29.0.1:60165",
+			"172.30.0.1:60165"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+			{"Proto": "peerapi4", "Port": 41053},
+			{"Proto": "peerapi6", "Port": 41053}
+		]},
+		"Created":              "2026-05-18T09:09:53.365800595Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:group-a"],
+		"Online":               true,
+		"ComputedName":         "rattata",
+		"ComputedNameWithHost": "rattata"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "fd7a:115c:a1e0::5": {"Node": {
+		"ID":         1191708573799268,
+		"StableID":   "nFJSrUAjJA11CNTRL",
+		"Name":       "rattata.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:38a866479caef0d5c0e853c85a8a3df39f1fd96c005b32071b40f4ef80d6ec13",
+		"DiscoKey":   "discokey:d23472be07dfe7f1384c1d713569b6abc53d6c3a8ea28b723a8265a421e7cf59",
+		"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+		"Endpoints": [
+			"77.164.248.136:60165",
+			"10.65.0.27:60165",
+			"172.17.0.1:60165",
+			"172.18.0.1:60165",
+			"172.19.0.1:60165",
+			"172.20.0.1:60165",
+			"172.21.0.1:60165",
+			"172.22.0.1:60165",
+			"172.23.0.1:60165",
+			"172.24.0.1:60165",
+			"172.25.0.1:60165",
+			"172.27.0.1:60165",
+			"172.28.0.1:60165",
+			"172.29.0.1:60165",
+			"172.30.0.1:60165"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+			{"Proto": "peerapi4", "Port": 41053},
+			{"Proto": "peerapi6", "Port": 41053}
+		]},
+		"Created":              "2026-05-18T09:09:53.365800595Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:group-a"],
+		"Online":               true,
+		"ComputedName":         "rattata",
+		"ComputedNameWithHost": "rattata"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8565173068968397,
+			"StableID":   "nSmk3DaBt921CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:8d5be578b9466b6c25398b6a8cec4dfa921bb81653c26c09c6602d3335b7292f",
+			"KeyExpiry":  "2026-11-14T09:09:58Z",
+			"DiscoKey":   "discokey:b24c6d83ddffffa2ef75fc0ec43f7d992823795f4a07739c5e761f62f2125e73",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints": [
+				"77.164.248.136:54738",
+				"10.65.0.27:54738",
+				"172.17.0.1:54738",
+				"172.18.0.1:54738",
+				"172.19.0.1:54738",
+				"172.20.0.1:54738",
+				"172.21.0.1:54738",
+				"172.22.0.1:54738",
+				"172.23.0.1:54738",
+				"172.24.0.1:54738",
+				"172.25.0.1:54738",
+				"172.27.0.1:54738",
+				"172.28.0.1:54738",
+				"172.29.0.1:54738",
+				"172.30.0.1:54738"
+			],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:09:58.707802059Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:8d5be578b9466b6c25398b6a8cec4dfa921bb81653c26c09c6602d3335b7292f",
+		"MachineKey":        "mkey:aee00888869f777b2ca1c5eb63fb3333c9ee79fede7503c79ba3c0a182a74f1a",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5904929113215889,
+			"StableID":   "nGAoFYUM7o11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       5904929113215889,
+			"Key":        "nodekey:f3edbda487f65b4b5f396a8e5fb4ac2c5b81438b86499ee2660f3264080dff52",
+			"DiscoKey":   "discokey:1f5cbc97dcd670225e8a75a5b4a39bdedfd929f95d1ef6ace18a26e5ef7c7741",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints": [
+				"77.164.248.136:43137",
+				"10.65.0.27:43137",
+				"172.17.0.1:43137",
+				"172.18.0.1:43137",
+				"172.19.0.1:43137",
+				"172.20.0.1:43137",
+				"172.21.0.1:43137",
+				"172.22.0.1:43137",
+				"172.23.0.1:43137",
+				"172.24.0.1:43137",
+				"172.25.0.1:43137",
+				"172.27.0.1:43137",
+				"172.28.0.1:43137",
+				"172.29.0.1:43137",
+				"172.30.0.1:43137"
+			],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:09:56.578084606Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:f3edbda487f65b4b5f396a8e5fb4ac2c5b81438b86499ee2660f3264080dff52",
+		"MachineKey":        "mkey:dfc7fdac891e1d2343138400540e6f94c32bd2fe6d74abf31f52b9e4b11d6976",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5904929113215889": {
+			"ID":          5904929113215889,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/grant_results/via-grant-v50.hujson
+++ b/hscontrol/policy/v2/testdata/grant_results/via-grant-v50.hujson
@@ -1,0 +1,13635 @@
+// via-grant-v50
+//
+// via grant v50 dst cidr disjoint from advertised subnet
+// Captured at:    2026-05-18T09:10:44Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "via-grant-v50",
+	"description":    "via grant v50 dst cidr disjoint from advertised subnet",
+	"category":       "grant",
+	"captured_at":    "2026-05-18T09:10:44.446555363Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                                              \n  \n                                                                        \n                                                                        \n                                 \n  \n                                                                  \n                                                                 \n{\n\t\"category\":    \"grant\",\n\t\"description\": \"via grant v50 dst cidr disjoint from advertised subnet\",\n\t\"id\":          \"via-grant-v50\",\n\t\"options\":     {\"capture_whois\": true},\n\t\"policy\": {\"autoApprovers\": {\"routes\": {\n\t\t\"10.33.0.0/16\": [\"tag:router\"],\n\t\t\"10.44.0.0/16\": [\"tag:spearow\"],\n\t\t\"10.55.0.0/16\": [\"tag:fearow\"]\n\t}}, \"grants\": [{\n\t\t\"dst\": [\"192.168.0.0/16\"],\n\t\t\"ip\":  [\"*\"],\n\t\t\"src\": [\"tag:group-a\"],\n\t\t\"via\": [\"tag:router\"]\n\t}], \"groups\": {\n\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\"group:empty\":      [],\n\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t}, \"hosts\": {\n\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\"webserver\": \"100.108.74.26\"\n\t}, \"tagOwners\": {\n\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\"tag:server\":   [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/grant/via-grant-v50.hujson",
+		"full_policy": {"autoApprovers": {"routes": {
+			"10.33.0.0/16": ["tag:router"],
+			"10.44.0.0/16": ["tag:spearow"],
+			"10.55.0.0/16": ["tag:fearow"]
+		}}, "grants": [{
+			"dst": ["192.168.0.0/16"],
+			"ip":  ["*"],
+			"src": ["tag:group-a"],
+			"via": ["tag:router"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"webserver": "100.108.74.26"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": ["10.33.0.0/16"]
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": ["10.55.0.0/16"]
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": ["10.44.0.0/16"]
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": ["10.33.0.0/16"]
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         742807651721642,
+			"StableID":   "nMtKZFJRo611CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       742807651721642,
+			"Key":        "nodekey:45d7df813905a0e39a63843408c508d051e40d88ff64a02f2c5d8246661eb716",
+			"DiscoKey":   "discokey:3242b6abcbfdbe7f55ad497daa1ecc13a27a1503bbd14172abe6a15593071a41",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints": [
+				"77.164.248.136:49637",
+				"10.65.0.27:49637",
+				"172.17.0.1:49637",
+				"172.18.0.1:49637",
+				"172.19.0.1:49637",
+				"172.20.0.1:49637",
+				"172.21.0.1:49637",
+				"172.22.0.1:49637",
+				"172.23.0.1:49637",
+				"172.24.0.1:49637",
+				"172.25.0.1:49637",
+				"172.27.0.1:49637",
+				"172.28.0.1:49637",
+				"172.29.0.1:49637",
+				"172.30.0.1:49637"
+			],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:10:56.956275273Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:45d7df813905a0e39a63843408c508d051e40d88ff64a02f2c5d8246661eb716",
+		"MachineKey":        "mkey:0de60b0f194ebaa9cb84a2a734a76526bee25283326a10c2e984c7908a7e267f",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"742807651721642": {
+			"ID":          742807651721642,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}}
+	}}, "blastoise": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4115946452487668,
+			"StableID":   "n5bNcAw79Z11CNTRL",
+			"Name":       "blastoise.tail78f774.ts.net.",
+			"User":       4115946452487668,
+			"Key":        "nodekey:7c578e256bcd180c9157581f28c9aae903b4b535cc4880f7276c956567e7644c",
+			"DiscoKey":   "discokey:0dd3cc956f91bfbf57a0342898041ee443f28e01f57e0d825cc9a5b4f6f4c348",
+			"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+			"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:47019",
+				"10.65.0.27:47019",
+				"172.17.0.1:47019",
+				"172.18.0.1:47019",
+				"172.19.0.1:47019",
+				"172.20.0.1:47019",
+				"172.21.0.1:47019",
+				"172.22.0.1:47019",
+				"172.23.0.1:47019",
+				"172.24.0.1:47019",
+				"172.25.0.1:47019",
+				"172.27.0.1:47019",
+				"172.28.0.1:47019",
+				"172.29.0.1:47019",
+				"172.30.0.1:47019"
+			],
+			"Hostinfo": {
+				"Hostname":    "blastoise",
+				"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit", "tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:10:53.752738091Z",
+			"Tags":              ["tag:exit", "tag:router"],
+			"PrimaryRoutes":     ["10.33.0.0/16"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "blastoise",
+			"ComputedNameWithHost": "blastoise"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:7c578e256bcd180c9157581f28c9aae903b4b535cc4880f7276c956567e7644c",
+		"MachineKey":        "mkey:969d1cd089f03379b70814a95f0ef16ce2df65de187e76e5c474f6a822d5a369",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4115946452487668": {
+			"ID":          4115946452487668,
+			"LoginName":   "blastoise.tail78f774.ts.net",
+			"DisplayName": "blastoise"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         117941651091692,
+			"StableID":   "nD9RqN8Rv111CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:179b877ca5f2801740968a2d5920c58c08b35447b912e7c8ab4ea986e85ff513",
+			"KeyExpiry":  "2026-11-14T09:10:58Z",
+			"DiscoKey":   "discokey:57fcdacb9de1e6cbfcc57b69cb0413e61f99817b4ac91517935c39d4d994495c",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints": [
+				"77.164.248.136:47480",
+				"10.65.0.27:47480",
+				"172.17.0.1:47480",
+				"172.18.0.1:47480",
+				"172.19.0.1:47480",
+				"172.20.0.1:47480",
+				"172.21.0.1:47480",
+				"172.22.0.1:47480",
+				"172.23.0.1:47480",
+				"172.24.0.1:47480",
+				"172.25.0.1:47480",
+				"172.27.0.1:47480",
+				"172.28.0.1:47480",
+				"172.29.0.1:47480",
+				"172.30.0.1:47480"
+			],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:10:58.549729838Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:179b877ca5f2801740968a2d5920c58c08b35447b912e7c8ab4ea986e85ff513",
+		"MachineKey":        "mkey:87c7679a59c128c8d5e3ae69c84713fa14e7e2989cc9d8d43365a66fb14fa85e",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8611553749726689,
+			"StableID":   "nAZ1z2vBFA21CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       8611553749726689,
+			"Key":        "nodekey:5eb431f788096d6d4c2ad5b7639f2f76630b531981a275f6c7fb478462cadf6a",
+			"DiscoKey":   "discokey:d941d6a21f41536a54f30f1b4360f1149dd8dad27c3826f6d16bd0c71a19e209",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints": [
+				"77.164.248.136:54587",
+				"10.65.0.27:54587",
+				"172.17.0.1:54587",
+				"172.18.0.1:54587",
+				"172.19.0.1:54587",
+				"172.20.0.1:54587",
+				"172.21.0.1:54587",
+				"172.22.0.1:54587",
+				"172.23.0.1:54587",
+				"172.24.0.1:54587",
+				"172.25.0.1:54587",
+				"172.27.0.1:54587",
+				"172.28.0.1:54587",
+				"172.29.0.1:54587",
+				"172.30.0.1:54587"
+			],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:10:52.167516116Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:5eb431f788096d6d4c2ad5b7639f2f76630b531981a275f6c7fb478462cadf6a",
+		"MachineKey":        "mkey:3c4cee07a759e9892b8be7839e99dd3f8eda7c74f9e28b50672111fa6082aa45",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8611553749726689": {
+			"ID":          8611553749726689,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "fearow": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2962818332067504,
+			"StableID":   "n36zJPDs8Q11CNTRL",
+			"Name":       "fearow.tail78f774.ts.net.",
+			"User":       2962818332067504,
+			"Key":        "nodekey:ae65fa0cbc483038e5b31f1aa96ee6f9de15ce74a70fd63782c01efc14b7ed2a",
+			"DiscoKey":   "discokey:f5f3dbeb346aa6043ae7f18e7fce55ba7675996f32cbc6b35ecfed9221ca686d",
+			"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+			"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128", "10.55.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:48210",
+				"10.65.0.27:48210",
+				"172.17.0.1:48210",
+				"172.18.0.1:48210",
+				"172.19.0.1:48210",
+				"172.20.0.1:48210",
+				"172.21.0.1:48210",
+				"172.22.0.1:48210",
+				"172.23.0.1:48210",
+				"172.24.0.1:48210",
+				"172.25.0.1:48210",
+				"172.27.0.1:48210",
+				"172.28.0.1:48210",
+				"172.29.0.1:48210",
+				"172.30.0.1:48210"
+			],
+			"Hostinfo": {
+				"Hostname":    "fearow",
+				"RoutableIPs": ["10.55.0.0/16"],
+				"RequestTags": ["tag:fearow"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:10:54.809749328Z",
+			"Tags":              ["tag:fearow"],
+			"PrimaryRoutes":     ["10.55.0.0/16"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "fearow",
+			"ComputedNameWithHost": "fearow"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:ae65fa0cbc483038e5b31f1aa96ee6f9de15ce74a70fd63782c01efc14b7ed2a",
+		"MachineKey":        "mkey:627d45ac3bc7cb556e179a75a00279e5c2c42190d49f940005ed9446c6e0d400",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"2962818332067504": {
+			"ID":          2962818332067504,
+			"LoginName":   "fearow.tail78f774.ts.net",
+			"DisplayName": "fearow"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2348533302157090,
+			"StableID":   "n5nkjGzeLK11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:4fdef654e4461936edc780b227c460829b3f690acdf333c856b5bbcb03346862",
+			"KeyExpiry":  "2026-11-14T09:10:57Z",
+			"DiscoKey":   "discokey:9790b60c664988dd878024181e01253bbaf80ca667a48f7d2227e3a3933f7e24",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints": [
+				"77.164.248.136:54379",
+				"10.65.0.27:54379",
+				"172.17.0.1:54379",
+				"172.18.0.1:54379",
+				"172.19.0.1:54379",
+				"172.20.0.1:54379",
+				"172.21.0.1:54379",
+				"172.22.0.1:54379",
+				"172.23.0.1:54379",
+				"172.24.0.1:54379",
+				"172.25.0.1:54379",
+				"172.27.0.1:54379",
+				"172.28.0.1:54379",
+				"172.29.0.1:54379",
+				"172.30.0.1:54379"
+			],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:10:57.484455263Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:4fdef654e4461936edc780b227c460829b3f690acdf333c856b5bbcb03346862",
+		"MachineKey":        "mkey:bbf6b2f42e88d79b842a31699f972aaddd3822f7b782c3c5a5cb30303f42cb6c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8316404855452220,
+			"StableID":   "nBpNtVrWw721CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       8316404855452220,
+			"Key":        "nodekey:fc6c4f97df6155da8f12135b8e5b107fb3c11447a0c78aed4f97019a76355a09",
+			"DiscoKey":   "discokey:7c5b44e12f1c86dd4320eec977184995f03f1f70bcd01add7270be947871fd11",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints": [
+				"77.164.248.136:52381",
+				"10.65.0.27:52381",
+				"172.17.0.1:52381",
+				"172.18.0.1:52381",
+				"172.19.0.1:52381",
+				"172.20.0.1:52381",
+				"172.21.0.1:52381",
+				"172.22.0.1:52381",
+				"172.23.0.1:52381",
+				"172.24.0.1:52381",
+				"172.25.0.1:52381",
+				"172.27.0.1:52381",
+				"172.28.0.1:52381",
+				"172.29.0.1:52381",
+				"172.30.0.1:52381"
+			],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:10:56.419139003Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:fc6c4f97df6155da8f12135b8e5b107fb3c11447a0c78aed4f97019a76355a09",
+		"MachineKey":        "mkey:1f10dce91e6f48aa397e1f55ec84d7bbf700b6eae603a5cb6773d60786f6de62",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8316404855452220": {
+			"ID":          8316404855452220,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "pidgeotto": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         781141996409684,
+			"StableID":   "nP81LzGn6711CNTRL",
+			"Name":       "pidgeotto.tail78f774.ts.net.",
+			"User":       781141996409684,
+			"Key":        "nodekey:8454a17c478cbd84c2bbbe569015aca27171259ecc0fec3c261715289f9bdf78",
+			"DiscoKey":   "discokey:bd3827365b07af564765413e8aa789775efb48d5ea4bc8407a8ae32babc4a455",
+			"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+			"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+			"Endpoints": [
+				"77.164.248.136:39405",
+				"10.65.0.27:39405",
+				"172.17.0.1:39405",
+				"172.18.0.1:39405",
+				"172.19.0.1:39405",
+				"172.20.0.1:39405",
+				"172.21.0.1:39405",
+				"172.22.0.1:39405",
+				"172.23.0.1:39405",
+				"172.24.0.1:39405",
+				"172.25.0.1:39405",
+				"172.27.0.1:39405",
+				"172.28.0.1:39405",
+				"172.29.0.1:39405",
+				"172.30.0.1:39405"
+			],
+			"Hostinfo": {
+				"Hostname":    "pidgeotto",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:pidgeotto"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:10:51.639009594Z",
+			"Tags":              ["tag:pidgeotto"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "pidgeotto",
+			"ComputedNameWithHost": "pidgeotto"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:8454a17c478cbd84c2bbbe569015aca27171259ecc0fec3c261715289f9bdf78",
+		"MachineKey":        "mkey:e33eca0d1703f9f889f42c5eb3b55295e214f0d43849ee08a2062989966fdd7a",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"781141996409684": {
+			"ID":          781141996409684,
+			"LoginName":   "pidgeotto.tail78f774.ts.net",
+			"DisplayName": "pidgeotto"
+		}}
+	}}, "pidgey": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7957670396407127,
+			"StableID":   "nNamASW39521CNTRL",
+			"Name":       "pidgey.tail78f774.ts.net.",
+			"User":       7957670396407127,
+			"Key":        "nodekey:0fdeaf58178609371f1a726273f49154455ce398311e26fc294e975bedccba05",
+			"DiscoKey":   "discokey:bc4adfb590e9db28fcb7b36af00db93ce2472d66b94893c7656591521feb395d",
+			"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+			"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+			"Endpoints": [
+				"77.164.248.136:41325",
+				"10.65.0.27:41325",
+				"172.17.0.1:41325",
+				"172.18.0.1:41325",
+				"172.19.0.1:41325",
+				"172.20.0.1:41325",
+				"172.21.0.1:41325",
+				"172.22.0.1:41325",
+				"172.23.0.1:41325",
+				"172.24.0.1:41325",
+				"172.25.0.1:41325",
+				"172.27.0.1:41325",
+				"172.28.0.1:41325",
+				"172.29.0.1:41325",
+				"172.30.0.1:41325"
+			],
+			"Hostinfo": {
+				"Hostname":    "pidgey",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:pidgey"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:10:51.102683657Z",
+			"Tags":              ["tag:pidgey"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "pidgey",
+			"ComputedNameWithHost": "pidgey"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:0fdeaf58178609371f1a726273f49154455ce398311e26fc294e975bedccba05",
+		"MachineKey":        "mkey:2c3d102d9cc29041131813cadb074cf83965fd8b052a09e1d2ff9c7886c18505",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"7957670396407127": {
+			"ID":          7957670396407127,
+			"LoginName":   "pidgey.tail78f774.ts.net",
+			"DisplayName": "pidgey"
+		}}
+	}}, "raticate": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8774142286825719,
+			"StableID":   "ncXPFhqpWB21CNTRL",
+			"Name":       "raticate.tail78f774.ts.net.",
+			"User":       8774142286825719,
+			"Key":        "nodekey:4b5b22a10939393effca670f78d3c2ce7694db849fc0315b5b14155d5b4da051",
+			"DiscoKey":   "discokey:c4b76557ff2311f5b95d2357d140b771ca79f18c8f522270e3203e7204f5fd4a",
+			"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+			"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+			"Endpoints": [
+				"77.164.248.136:39952",
+				"10.65.0.27:39952",
+				"172.17.0.1:39952",
+				"172.18.0.1:39952",
+				"172.19.0.1:39952",
+				"172.20.0.1:39952",
+				"172.21.0.1:39952",
+				"172.22.0.1:39952",
+				"172.23.0.1:39952",
+				"172.24.0.1:39952",
+				"172.25.0.1:39952",
+				"172.27.0.1:39952",
+				"172.28.0.1:39952",
+				"172.29.0.1:39952",
+				"172.30.0.1:39952"
+			],
+			"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+				{"Proto": "peerapi4", "Port": 61927},
+				{"Proto": "peerapi6", "Port": 61927},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:10:53.21995137Z",
+			"Tags":              ["tag:group-b"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "raticate",
+			"ComputedNameWithHost": "raticate"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:4b5b22a10939393effca670f78d3c2ce7694db849fc0315b5b14155d5b4da051",
+		"MachineKey":        "mkey:dd498639926b5c582d320e8b36c1b76add012d763e00a74d441ceabc06d1b72c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8774142286825719": {
+			"ID":          8774142286825719,
+			"LoginName":   "raticate.tail78f774.ts.net",
+			"DisplayName": "raticate"
+		}}
+	}}, "rattata": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5603212911954104,
+			"StableID":   "nVdEjJuhkk11CNTRL",
+			"Name":       "rattata.tail78f774.ts.net.",
+			"User":       5603212911954104,
+			"Key":        "nodekey:308c261c7eb0104abf3e66f1646be742cdcf06036d059f919e76dfe88a2b6572",
+			"DiscoKey":   "discokey:2cc68f99012b0d824d6fd24ace704e106e80712e77fcfba34054014f7a730e69",
+			"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"Endpoints": [
+				"77.164.248.136:33694",
+				"10.65.0.27:33694",
+				"172.17.0.1:33694",
+				"172.18.0.1:33694",
+				"172.19.0.1:33694",
+				"172.20.0.1:33694",
+				"172.21.0.1:33694",
+				"172.22.0.1:33694",
+				"172.23.0.1:33694",
+				"172.24.0.1:33694",
+				"172.25.0.1:33694",
+				"172.27.0.1:33694",
+				"172.28.0.1:33694",
+				"172.29.0.1:33694",
+				"172.30.0.1:33694"
+			],
+			"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+				{"Proto": "peerapi4", "Port": 41053},
+				{"Proto": "peerapi6", "Port": 41053},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:10:52.700936185Z",
+			"Tags":              ["tag:group-a"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "rattata",
+			"ComputedNameWithHost": "rattata"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:308c261c7eb0104abf3e66f1646be742cdcf06036d059f919e76dfe88a2b6572",
+		"MachineKey":        "mkey:5f5f1ff0ccb1742d1d8cb0316a09af2fdd3fe95c92fb9fe3226ce6321ee14371",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5603212911954104": {
+			"ID":          5603212911954104,
+			"LoginName":   "rattata.tail78f774.ts.net",
+			"DisplayName": "rattata"
+		}}
+	}}, "spearow": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4263580853033713,
+			"StableID":   "npe53H3zHa11CNTRL",
+			"Name":       "spearow.tail78f774.ts.net.",
+			"User":       4263580853033713,
+			"Key":        "nodekey:ac5983ee49695f3ddbafe48311a097ecb9cb0e4806907c06323b6ac58c9af64f",
+			"DiscoKey":   "discokey:29fa1a3518796d0f50fc5b5c0b36f41eb6ac3b92a6a3e0d959fc5d8df0082a2e",
+			"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+			"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128", "10.44.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:55465",
+				"10.65.0.27:55465",
+				"172.17.0.1:55465",
+				"172.18.0.1:55465",
+				"172.19.0.1:55465",
+				"172.20.0.1:55465",
+				"172.21.0.1:55465",
+				"172.22.0.1:55465",
+				"172.23.0.1:55465",
+				"172.24.0.1:55465",
+				"172.25.0.1:55465",
+				"172.27.0.1:55465",
+				"172.28.0.1:55465",
+				"172.29.0.1:55465",
+				"172.30.0.1:55465"
+			],
+			"Hostinfo": {
+				"Hostname":    "spearow",
+				"RoutableIPs": ["10.44.0.0/16"],
+				"RequestTags": ["tag:spearow"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:10:54.283207375Z",
+			"Tags":              ["tag:spearow"],
+			"PrimaryRoutes":     ["10.44.0.0/16"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "spearow",
+			"ComputedNameWithHost": "spearow"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:ac5983ee49695f3ddbafe48311a097ecb9cb0e4806907c06323b6ac58c9af64f",
+		"MachineKey":        "mkey:0ad13c072d304401be41eb0d7000eaf9adfc111ec3ce62bf4e6ab9f7b36f7745",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4263580853033713": {
+			"ID":          4263580853033713,
+			"LoginName":   "spearow.tail78f774.ts.net",
+			"DisplayName": "spearow"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2715924301317889,
+			"StableID":   "nz5BG7j3DN11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       2715924301317889,
+			"Key":        "nodekey:0ce04552f96890506449aad321dc9453835716697eb0d0bdcc0782613036994c",
+			"DiscoKey":   "discokey:812ba325824c522e05582e005744f3f710b87d77710505678c210dc610b90e4e",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128", "10.33.0.0/16"],
+			"Endpoints": [
+				"77.164.248.136:49272",
+				"10.65.0.27:49272",
+				"172.17.0.1:49272",
+				"172.18.0.1:49272",
+				"172.19.0.1:49272",
+				"172.20.0.1:49272",
+				"172.21.0.1:49272",
+				"172.22.0.1:49272",
+				"172.23.0.1:49272",
+				"172.24.0.1:49272",
+				"172.25.0.1:49272",
+				"172.27.0.1:49272",
+				"172.28.0.1:49272",
+				"172.29.0.1:49272",
+				"172.30.0.1:49272"
+			],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:10:55.348461932Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:0ce04552f96890506449aad321dc9453835716697eb0d0bdcc0782613036994c",
+		"MachineKey":        "mkey:7746b6bcfc673aedac1e7d4cdbec81cf08347bcecdb45258daac5d32109ac037",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"2715924301317889": {
+			"ID":          2715924301317889,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7292111442929489,
+			"StableID":   "nGQrYLQcwy11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:d2a96f1163c963756c7fa4b41a4269ec0abe4e61cb3971e0a4845af4f360b141",
+			"KeyExpiry":  "2026-11-14T09:10:58Z",
+			"DiscoKey":   "discokey:57f04a4cd9d35bc8c9131a544af90524da77c3a07573ac011e70856704bad928",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints": [
+				"77.164.248.136:48636",
+				"10.65.0.27:48636",
+				"172.17.0.1:48636",
+				"172.18.0.1:48636",
+				"172.19.0.1:48636",
+				"172.20.0.1:48636",
+				"172.21.0.1:48636",
+				"172.22.0.1:48636",
+				"172.23.0.1:48636",
+				"172.24.0.1:48636",
+				"172.25.0.1:48636",
+				"172.27.0.1:48636",
+				"172.28.0.1:48636",
+				"172.29.0.1:48636",
+				"172.30.0.1:48636"
+			],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:10:58.013696855Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:d2a96f1163c963756c7fa4b41a4269ec0abe4e61cb3971e0a4845af4f360b141",
+		"MachineKey":        "mkey:00ab69d50c24300b46e0936b08cd28504b8ee7060f042fb4753e24bd0cb00b65",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7716405826229389,
+			"StableID":   "ng8sGztmF321CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       7716405826229389,
+			"Key":        "nodekey:d8b35c1dface4d18b9fafa93c6b303f4b773febf51f4c234c862f18a5de8250b",
+			"DiscoKey":   "discokey:4bba182fd9a1812cf3bfef9edfdd7933bbdafb956a2b1863555b289f1d2e6977",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints": [
+				"77.164.248.136:54114",
+				"10.65.0.27:54114",
+				"172.17.0.1:54114",
+				"172.18.0.1:54114",
+				"172.19.0.1:54114",
+				"172.20.0.1:54114",
+				"172.21.0.1:54114",
+				"172.22.0.1:54114",
+				"172.23.0.1:54114",
+				"172.24.0.1:54114",
+				"172.25.0.1:54114",
+				"172.27.0.1:54114",
+				"172.28.0.1:54114",
+				"172.29.0.1:54114",
+				"172.30.0.1:54114"
+			],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:10:55.882122812Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:d8b35c1dface4d18b9fafa93c6b303f4b773febf51f4c234c862f18a5de8250b",
+		"MachineKey":        "mkey:62d8c49eed6420a2f1ae67fe4886e9b678974846b37d689d07fce88e42563848",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"7716405826229389": {
+			"ID":          7716405826229389,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/grant_results/via-grant-v51.hujson
+++ b/hscontrol/policy/v2/testdata/grant_results/via-grant-v51.hujson
@@ -1,0 +1,2157 @@
+// via-grant-v51
+//
+// via grant v51 ipv6 4via6 dst host alias /64 broader than advertised /120
+//
+// Nodes with filter rules: 1 of 2
+// Captured at:    2026-05-18T09:11:44Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "via-grant-v51",
+	"description":    "via grant v51 ipv6 4via6 dst host alias /64 broader than advertised /120",
+	"category":       "grant",
+	"captured_at":    "2026-05-18T09:11:44.189311885Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                                                       \n  \n                                                                       \n                                                  \n                                                                     \n                                                                     \n                                           \n  \n                                                                   \n                                                                          \n                                                                 \n                   \n{\n\t\"category\":    \"grant\",\n\t\"description\": \"via grant v51 ipv6 4via6 dst host alias /64 broader than advertised /120\",\n\t\"id\":          \"via-grant-v51\",\n\t\"options\":     {\"capture_whois\": true},\n\t\"policy\": {\"autoApprovers\": {\"routes\": {\n\t\t\"fd7a:115c:a1e0:b1a:0:13:ad2:7300/120\": [\"tag:router\"]\n\t}}, \"grants\": [{\n\t\t\"dst\": [\"example-4via6\"],\n\t\t\"ip\":  [\"icmp:*\", \"tcp:3389\"],\n\t\t\"src\": [\"tag:group-a\"],\n\t\t\"via\": [\"tag:router\"]\n\t}], \"hosts\": {\n\t\t\"example-4via6\": \"fd7a:115c:a1e0:b1a::/64\"\n\t}, \"tagOwners\": {\n\t\t\"tag:group-a\": [\"odin@example.com\"],\n\t\t\"tag:router\":  [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": {\n\t\t\"users\": [{\"id\": 1, \"name\": \"odin\", \"email\": \"odin@example.com\"}],\n\t\t\"nodes\": {\n\t\t\t\"client-a\": {\n\t\t\t\t\"hostname\":        \"client-a\",\n\t\t\t\t\"tags\":            [\"tag:group-a\"],\n\t\t\t\t\"routable_ips\":    [],\n\t\t\t\t\"approved_routes\": []\n\t\t\t},\n\t\t\t\"router-6via\": {\n\t\t\t\t\"hostname\":        \"router-6via\",\n\t\t\t\t\"tags\":            [\"tag:router\"],\n\t\t\t\t\"routable_ips\":    [\"fd7a:115c:a1e0:b1a:0:13:ad2:7300/120\"],\n\t\t\t\t\"approved_routes\": []\n\t\t\t}\n\t\t}\n\t}\n}\n",
+		"scenario_path":   "scenarios/grant/via-grant-v51.hujson",
+		"full_policy": {
+			"autoApprovers": {"routes": {"fd7a:115c:a1e0:b1a:0:13:ad2:7300/120": ["tag:router"]}},
+			"grants": [{
+				"dst": ["example-4via6"],
+				"ip":  ["icmp:*", "tcp:3389"],
+				"src": ["tag:group-a"],
+				"via": ["tag:router"]
+			}],
+			"hosts":     {"example-4via6": "fd7a:115c:a1e0:b1a::/64"},
+			"tagOwners": {"tag:group-a": ["odin@example.com"], "tag:router": ["odin@example.com"]}
+		}
+	},
+	"topology": {
+		"users": [{"id": 1, "name": "odin", "email": "odin@example.com"}],
+		"nodes": {"client-a": {
+			"hostname":        "client-a",
+			"tags":            ["tag:group-a"],
+			"ipv4":            "100.95.136.121",
+			"ipv6":            "fd7a:115c:a1e0::bd37:8879",
+			"routable_ips":    [],
+			"approved_routes": []
+		}, "router-6via": {
+			"hostname":        "router-6via",
+			"tags":            ["tag:router"],
+			"ipv4":            "100.120.10.2",
+			"ipv6":            "fd7a:115c:a1e0::7537:a02",
+			"routable_ips":    ["fd7a:115c:a1e0:b1a:0:13:ad2:7300/120"],
+			"approved_routes": ["fd7a:115c:a1e0:b1a:0:13:ad2:7300/120"]
+		}}
+	},
+	"captures": {"client-a": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1523520198144354,
+			"StableID":   "nXhtrwH1uC11CNTRL",
+			"Name":       "client-a.tail78f774.ts.net.",
+			"User":       1523520198144354,
+			"Key":        "nodekey:e7e273fc7d70ffb8cef6797a3e1725f5d1f25c64a2ca47be203862f1bd5f8878",
+			"DiscoKey":   "discokey:42f94cc27341c00d3e3e056d1840f1db99a5fc47d5b2728e8739a8d6c6970365",
+			"Addresses":  ["100.95.136.121/32", "fd7a:115c:a1e0::bd37:8879/128"],
+			"AllowedIPs": ["100.95.136.121/32", "fd7a:115c:a1e0::bd37:8879/128"],
+			"Endpoints": [
+				"77.164.248.136:44313",
+				"10.65.0.27:44313",
+				"172.17.0.1:44313",
+				"172.18.0.1:44313",
+				"172.19.0.1:44313",
+				"172.20.0.1:44313",
+				"172.21.0.1:44313",
+				"172.22.0.1:44313",
+				"172.23.0.1:44313",
+				"172.24.0.1:44313",
+				"172.25.0.1:44313",
+				"172.27.0.1:44313",
+				"172.28.0.1:44313",
+				"172.29.0.1:44313",
+				"172.30.0.1:44313"
+			],
+			"Hostinfo": {"Hostname": "client-a", "RequestTags": ["tag:group-a"], "Services": [
+				{"Proto": "peerapi4", "Port": 60228},
+				{"Proto": "peerapi6", "Port": 60228},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-18T09:11:46.4498255Z",
+			"Tags":              ["tag:group-a"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "client-a",
+			"ComputedNameWithHost": "client-a"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:e7e273fc7d70ffb8cef6797a3e1725f5d1f25c64a2ca47be203862f1bd5f8878",
+		"MachineKey": "mkey:a9045bad4803f49067aec4ecf0156cb2f030a26466c9dd03b6a9da3b003e7648",
+		"Peers": [{
+			"ID":        3557161560388091,
+			"StableID":  "nAgWAwb3nU11CNTRL",
+			"Name":      "router-6via.tail78f774.ts.net.",
+			"User":      1260082990019555,
+			"Key":       "nodekey:acaabecf14a43b9a74d89c9fe3f9e6ba3421de3c28570d015dc1a11e75b80a01",
+			"DiscoKey":  "discokey:ab37a1bb878d7322f28d8ac80759bc4347819f45d58279515a04fec9fe581672",
+			"Addresses": ["100.120.10.2/32", "fd7a:115c:a1e0::7537:a02/128"],
+			"AllowedIPs": [
+				"100.120.10.2/32",
+				"fd7a:115c:a1e0::7537:a02/128",
+				"fd7a:115c:a1e0:b1a:0:13:ad2:7300/120"
+			],
+			"Endpoints": [
+				"77.164.248.136:41317",
+				"10.65.0.27:41317",
+				"172.17.0.1:41317",
+				"172.18.0.1:41317",
+				"172.19.0.1:41317",
+				"172.20.0.1:41317",
+				"172.21.0.1:41317",
+				"172.22.0.1:41317",
+				"172.23.0.1:41317",
+				"172.24.0.1:41317",
+				"172.25.0.1:41317",
+				"172.27.0.1:41317",
+				"172.28.0.1:41317",
+				"172.29.0.1:41317",
+				"172.30.0.1:41317"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "router-6via", "Services": [
+				{"Proto": "peerapi4", "Port": 59740},
+				{"Proto": "peerapi6", "Port": 59740}
+			]},
+			"Created":              "2026-05-18T09:11:46.979865427Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:router"],
+			"PrimaryRoutes":        ["fd7a:115c:a1e0:b1a:0:13:ad2:7300/120"],
+			"Online":               true,
+			"ComputedName":         "router-6via",
+			"ComputedNameWithHost": "router-6via"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "1523520198144354": {
+			"ID":          1523520198144354,
+			"LoginName":   "client-a.tail78f774.ts.net",
+			"DisplayName": "client-a"
+		}}
+	}, "whois": {"100.120.10.2": {"Node": {
+		"ID":        3557161560388091,
+		"StableID":  "nAgWAwb3nU11CNTRL",
+		"Name":      "router-6via.tail78f774.ts.net.",
+		"User":      1260082990019555,
+		"Key":       "nodekey:acaabecf14a43b9a74d89c9fe3f9e6ba3421de3c28570d015dc1a11e75b80a01",
+		"DiscoKey":  "discokey:ab37a1bb878d7322f28d8ac80759bc4347819f45d58279515a04fec9fe581672",
+		"Addresses": ["100.120.10.2/32", "fd7a:115c:a1e0::7537:a02/128"],
+		"AllowedIPs": [
+			"100.120.10.2/32",
+			"fd7a:115c:a1e0::7537:a02/128",
+			"fd7a:115c:a1e0:b1a:0:13:ad2:7300/120"
+		],
+		"Endpoints": [
+			"77.164.248.136:41317",
+			"10.65.0.27:41317",
+			"172.17.0.1:41317",
+			"172.18.0.1:41317",
+			"172.19.0.1:41317",
+			"172.20.0.1:41317",
+			"172.21.0.1:41317",
+			"172.22.0.1:41317",
+			"172.23.0.1:41317",
+			"172.24.0.1:41317",
+			"172.25.0.1:41317",
+			"172.27.0.1:41317",
+			"172.28.0.1:41317",
+			"172.29.0.1:41317",
+			"172.30.0.1:41317"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "router-6via", "Services": [
+			{"Proto": "peerapi4", "Port": 59740},
+			{"Proto": "peerapi6", "Port": 59740}
+		]},
+		"Created":              "2026-05-18T09:11:46.979865427Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:router"],
+		"PrimaryRoutes":        ["fd7a:115c:a1e0:b1a:0:13:ad2:7300/120"],
+		"Online":               true,
+		"ComputedName":         "router-6via",
+		"ComputedNameWithHost": "router-6via"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "fd7a:115c:a1e0::7537:a02": {"Node": {
+		"ID":        3557161560388091,
+		"StableID":  "nAgWAwb3nU11CNTRL",
+		"Name":      "router-6via.tail78f774.ts.net.",
+		"User":      1260082990019555,
+		"Key":       "nodekey:acaabecf14a43b9a74d89c9fe3f9e6ba3421de3c28570d015dc1a11e75b80a01",
+		"DiscoKey":  "discokey:ab37a1bb878d7322f28d8ac80759bc4347819f45d58279515a04fec9fe581672",
+		"Addresses": ["100.120.10.2/32", "fd7a:115c:a1e0::7537:a02/128"],
+		"AllowedIPs": [
+			"100.120.10.2/32",
+			"fd7a:115c:a1e0::7537:a02/128",
+			"fd7a:115c:a1e0:b1a:0:13:ad2:7300/120"
+		],
+		"Endpoints": [
+			"77.164.248.136:41317",
+			"10.65.0.27:41317",
+			"172.17.0.1:41317",
+			"172.18.0.1:41317",
+			"172.19.0.1:41317",
+			"172.20.0.1:41317",
+			"172.21.0.1:41317",
+			"172.22.0.1:41317",
+			"172.23.0.1:41317",
+			"172.24.0.1:41317",
+			"172.25.0.1:41317",
+			"172.27.0.1:41317",
+			"172.28.0.1:41317",
+			"172.29.0.1:41317",
+			"172.30.0.1:41317"
+		],
+		"HomeDERP": 14,
+		"Hostinfo": {"OS": "linux", "Hostname": "router-6via", "Services": [
+			{"Proto": "peerapi4", "Port": 59740},
+			{"Proto": "peerapi6", "Port": 59740}
+		]},
+		"Created":              "2026-05-18T09:11:46.979865427Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:router"],
+		"PrimaryRoutes":        ["fd7a:115c:a1e0:b1a:0:13:ad2:7300/120"],
+		"Online":               true,
+		"ComputedName":         "router-6via",
+		"ComputedNameWithHost": "router-6via"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}}}, "router-6via": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.95.136.121", "fd7a:115c:a1e0::bd37:8879"],
+		"DstPorts": [{"IP": "fd7a:115c:a1e0:b1a::/64", "Ports": {"First": 0, "Last": 65535}}],
+		"IPProto":  [1]
+	}, {"SrcIPs": ["100.95.136.121", "fd7a:115c:a1e0::bd37:8879"], "DstPorts": [
+		{"IP": "fd7a:115c:a1e0:b1a::/64", "Ports": {"First": 3389, "Last": 3389}}
+	], "IPProto": [6]}], "packet_filter_matches": [{
+		"IPProto": [1],
+		"Srcs":    ["100.95.136.121/32", "fd7a:115c:a1e0::bd37:8879/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "fd7a:115c:a1e0:b1a::/64", "Ports": {"First": 0, "Last": 65535}}],
+		"Caps":    []
+	}, {
+		"IPProto": [6],
+		"Srcs":    ["100.95.136.121/32", "fd7a:115c:a1e0::bd37:8879/128"],
+		"SrcCaps": null,
+		"Dsts": [
+			{"Net": "fd7a:115c:a1e0:b1a::/64", "Ports": {"First": 3389, "Last": 3389}}
+		],
+		"Caps": []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":        3557161560388091,
+			"StableID":  "nAgWAwb3nU11CNTRL",
+			"Name":      "router-6via.tail78f774.ts.net.",
+			"User":      3557161560388091,
+			"Key":       "nodekey:acaabecf14a43b9a74d89c9fe3f9e6ba3421de3c28570d015dc1a11e75b80a01",
+			"DiscoKey":  "discokey:ab37a1bb878d7322f28d8ac80759bc4347819f45d58279515a04fec9fe581672",
+			"Addresses": ["100.120.10.2/32", "fd7a:115c:a1e0::7537:a02/128"],
+			"AllowedIPs": [
+				"100.120.10.2/32",
+				"fd7a:115c:a1e0::7537:a02/128",
+				"fd7a:115c:a1e0:b1a:0:13:ad2:7300/120"
+			],
+			"Endpoints": [
+				"77.164.248.136:41317",
+				"10.65.0.27:41317",
+				"172.17.0.1:41317",
+				"172.18.0.1:41317",
+				"172.19.0.1:41317",
+				"172.20.0.1:41317",
+				"172.21.0.1:41317",
+				"172.22.0.1:41317",
+				"172.23.0.1:41317",
+				"172.24.0.1:41317",
+				"172.25.0.1:41317",
+				"172.27.0.1:41317",
+				"172.28.0.1:41317",
+				"172.29.0.1:41317",
+				"172.30.0.1:41317"
+			],
+			"Hostinfo": {
+				"Hostname":    "router-6via",
+				"RoutableIPs": ["fd7a:115c:a1e0:b1a:0:13:ad2:7300/120"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 59740},
+					{"Proto": "peerapi6", "Port": 59740},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-18T09:11:46.979865427Z",
+			"Tags":              ["tag:router"],
+			"PrimaryRoutes":     ["fd7a:115c:a1e0:b1a:0:13:ad2:7300/120"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "router-6via",
+			"ComputedNameWithHost": "router-6via"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:acaabecf14a43b9a74d89c9fe3f9e6ba3421de3c28570d015dc1a11e75b80a01",
+		"MachineKey": "mkey:504ebafa5399ca52470362f74b2b24da583b53bf1e20e5cdf0bc3bf0f9c84c6a",
+		"Peers": [{
+			"ID":         1523520198144354,
+			"StableID":   "nXhtrwH1uC11CNTRL",
+			"Name":       "client-a.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:e7e273fc7d70ffb8cef6797a3e1725f5d1f25c64a2ca47be203862f1bd5f8878",
+			"DiscoKey":   "discokey:42f94cc27341c00d3e3e056d1840f1db99a5fc47d5b2728e8739a8d6c6970365",
+			"Addresses":  ["100.95.136.121/32", "fd7a:115c:a1e0::bd37:8879/128"],
+			"AllowedIPs": ["100.95.136.121/32", "fd7a:115c:a1e0::bd37:8879/128"],
+			"Endpoints": [
+				"77.164.248.136:44313",
+				"10.65.0.27:44313",
+				"172.17.0.1:44313",
+				"172.18.0.1:44313",
+				"172.19.0.1:44313",
+				"172.20.0.1:44313",
+				"172.21.0.1:44313",
+				"172.22.0.1:44313",
+				"172.23.0.1:44313",
+				"172.24.0.1:44313",
+				"172.25.0.1:44313",
+				"172.27.0.1:44313",
+				"172.28.0.1:44313",
+				"172.29.0.1:44313",
+				"172.30.0.1:44313"
+			],
+			"HomeDERP": 8,
+			"Hostinfo": {"OS": "linux", "Hostname": "client-a", "Services": [
+				{"Proto": "peerapi4", "Port": 60228},
+				{"Proto": "peerapi6", "Port": 60228}
+			]},
+			"Created":              "2026-05-18T09:11:46.4498255Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:group-a"],
+			"Online":               true,
+			"ComputedName":         "client-a",
+			"ComputedNameWithHost": "client-a"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [1],
+			"Srcs":    ["100.95.136.121/32", "fd7a:115c:a1e0::bd37:8879/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "fd7a:115c:a1e0:b1a::/64", "Ports": {"First": 0, "Last": 65535}}],
+			"Caps":    []
+		}, {
+			"IPProto": [6],
+			"Srcs":    ["100.95.136.121/32", "fd7a:115c:a1e0::bd37:8879/128"],
+			"SrcCaps": null,
+			"Dsts": [
+				{"Net": "fd7a:115c:a1e0:b1a::/64", "Ports": {"First": 3389, "Last": 3389}}
+			],
+			"Caps": []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.95.136.121", "fd7a:115c:a1e0::bd37:8879"],
+			"DstPorts": [{"IP": "fd7a:115c:a1e0:b1a::/64", "Ports": {"First": 0, "Last": 65535}}],
+			"IPProto":  [1]
+		}, {"SrcIPs": ["100.95.136.121", "fd7a:115c:a1e0::bd37:8879"], "DstPorts": [
+			{"IP": "fd7a:115c:a1e0:b1a::/64", "Ports": {"First": 3389, "Last": 3389}}
+		], "IPProto": [6]}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "3557161560388091": {
+			"ID":          3557161560388091,
+			"LoginName":   "router-6via.tail78f774.ts.net",
+			"DisplayName": "router-6via"
+		}}
+	}, "whois": {"100.95.136.121": {"Node": {
+		"ID":         1523520198144354,
+		"StableID":   "nXhtrwH1uC11CNTRL",
+		"Name":       "client-a.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:e7e273fc7d70ffb8cef6797a3e1725f5d1f25c64a2ca47be203862f1bd5f8878",
+		"DiscoKey":   "discokey:42f94cc27341c00d3e3e056d1840f1db99a5fc47d5b2728e8739a8d6c6970365",
+		"Addresses":  ["100.95.136.121/32", "fd7a:115c:a1e0::bd37:8879/128"],
+		"AllowedIPs": ["100.95.136.121/32", "fd7a:115c:a1e0::bd37:8879/128"],
+		"Endpoints": [
+			"77.164.248.136:44313",
+			"10.65.0.27:44313",
+			"172.17.0.1:44313",
+			"172.18.0.1:44313",
+			"172.19.0.1:44313",
+			"172.20.0.1:44313",
+			"172.21.0.1:44313",
+			"172.22.0.1:44313",
+			"172.23.0.1:44313",
+			"172.24.0.1:44313",
+			"172.25.0.1:44313",
+			"172.27.0.1:44313",
+			"172.28.0.1:44313",
+			"172.29.0.1:44313",
+			"172.30.0.1:44313"
+		],
+		"HomeDERP": 8,
+		"Hostinfo": {"OS": "linux", "Hostname": "client-a", "Services": [
+			{"Proto": "peerapi4", "Port": 60228},
+			{"Proto": "peerapi6", "Port": 60228}
+		]},
+		"Created":              "2026-05-18T09:11:46.4498255Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:group-a"],
+		"Online":               true,
+		"ComputedName":         "client-a",
+		"ComputedNameWithHost": "client-a"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}, "fd7a:115c:a1e0::bd37:8879": {"Node": {
+		"ID":         1523520198144354,
+		"StableID":   "nXhtrwH1uC11CNTRL",
+		"Name":       "client-a.tail78f774.ts.net.",
+		"User":       1260082990019555,
+		"Key":        "nodekey:e7e273fc7d70ffb8cef6797a3e1725f5d1f25c64a2ca47be203862f1bd5f8878",
+		"DiscoKey":   "discokey:42f94cc27341c00d3e3e056d1840f1db99a5fc47d5b2728e8739a8d6c6970365",
+		"Addresses":  ["100.95.136.121/32", "fd7a:115c:a1e0::bd37:8879/128"],
+		"AllowedIPs": ["100.95.136.121/32", "fd7a:115c:a1e0::bd37:8879/128"],
+		"Endpoints": [
+			"77.164.248.136:44313",
+			"10.65.0.27:44313",
+			"172.17.0.1:44313",
+			"172.18.0.1:44313",
+			"172.19.0.1:44313",
+			"172.20.0.1:44313",
+			"172.21.0.1:44313",
+			"172.22.0.1:44313",
+			"172.23.0.1:44313",
+			"172.24.0.1:44313",
+			"172.25.0.1:44313",
+			"172.27.0.1:44313",
+			"172.28.0.1:44313",
+			"172.29.0.1:44313",
+			"172.30.0.1:44313"
+		],
+		"HomeDERP": 8,
+		"Hostinfo": {"OS": "linux", "Hostname": "client-a", "Services": [
+			{"Proto": "peerapi4", "Port": 60228},
+			{"Proto": "peerapi6", "Port": 60228}
+		]},
+		"Created":              "2026-05-18T09:11:46.4498255Z",
+		"Cap":                  131,
+		"Tags":                 ["tag:group-a"],
+		"Online":               true,
+		"ComputedName":         "client-a",
+		"ComputedNameWithHost": "client-a"
+	}, "UserProfile": {
+		"ID":          1260082990019555,
+		"LoginName":   "tagged-devices",
+		"DisplayName": "Tagged Devices"
+	}, "CapMap": null}}}}
+}

--- a/hscontrol/servertest/grants_test.go
+++ b/hscontrol/servertest/grants_test.go
@@ -772,6 +772,123 @@ func TestGrantViaSubnetFilterRules(t *testing.T) {
 			"without per-node filter compilation for via grants, these rules are missing")
 }
 
+// TestGrantViaSubnetBroaderDstFilterRules verifies that a via grant
+// whose destination is broader than the router's advertised subnet
+// still produces a filter rule on the router and surfaces the route in
+// the client's AllowedIPs. Reproduces juanfont/headscale#3267 at the
+// server level. Pre-fix the policy compiler required exact prefix
+// equality, so the router's PacketFilter had no rule for the steered
+// destination and traffic was silently dropped.
+func TestGrantViaSubnetBroaderDstFilterRules(t *testing.T) {
+	t.Parallel()
+
+	srv := servertest.NewServer(t)
+	routerUser := srv.CreateUser(t, "rt-user")
+	clientUser := srv.CreateUser(t, "cl-user")
+
+	advertised := netip.MustParsePrefix("10.33.0.0/16")
+	broaderDst := netip.MustParsePrefix("10.0.0.0/8")
+
+	changed, err := srv.State().SetPolicy([]byte(`{
+		"tagOwners": {
+			"tag:router-a": ["rt-user@"],
+			"tag:group-a":  ["cl-user@"]
+		},
+		"grants": [
+			{
+				"src": ["tag:router-a", "tag:group-a"],
+				"dst": ["tag:router-a", "tag:group-a"],
+				"ip": ["*"]
+			},
+			{
+				"src": ["tag:group-a"],
+				"dst": ["10.0.0.0/8"],
+				"ip": ["*"],
+				"via": ["tag:router-a"]
+			}
+		],
+		"autoApprovers": {
+			"routes": {
+				"10.33.0.0/16": ["tag:router-a"]
+			}
+		}
+	}`))
+	require.NoError(t, err)
+
+	if changed {
+		changes, err := srv.State().ReloadPolicy()
+		require.NoError(t, err)
+		srv.App.Change(changes...)
+	}
+
+	routerA := servertest.NewClient(t, srv, "router-a",
+		servertest.WithUser(routerUser),
+		servertest.WithTags("tag:router-a"))
+	clientA := servertest.NewClient(t, srv, "client-a",
+		servertest.WithUser(clientUser),
+		servertest.WithTags("tag:group-a"))
+
+	routerA.WaitForPeers(t, 1, 15*time.Second)
+	clientA.WaitForPeers(t, 1, 15*time.Second)
+
+	routerA.Direct().SetHostinfo(&tailcfg.Hostinfo{
+		BackendLogID: "servertest-router-a",
+		Hostname:     "router-a",
+		RoutableIPs:  []netip.Prefix{advertised},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_ = routerA.Direct().SendUpdate(ctx)
+
+	routerAID := findNodeID(t, srv, "router-a")
+	_, routeChange, err := srv.State().SetApprovedRoutes(
+		routerAID, []netip.Prefix{advertised})
+	require.NoError(t, err)
+	srv.App.Change(routeChange)
+
+	// Client should see the advertised route in router's AllowedIPs.
+	clientA.WaitForCondition(t, "clientA sees advertised route via router-a",
+		15*time.Second,
+		func(nm *netmap.NetworkMap) bool {
+			for _, p := range nm.Peers {
+				hi := p.Hostinfo()
+				if hi.Valid() && hi.Hostname() == "router-a" {
+					for i := range p.AllowedIPs().Len() {
+						if p.AllowedIPs().At(i) == advertised {
+							return true
+						}
+					}
+				}
+			}
+
+			return false
+		})
+
+	// Router's PacketFilter must contain the broader grant dst as a
+	// destination — that is what Tailscale SaaS emits for via grants.
+	routerNM := routerA.Netmap()
+	require.NotNil(t, routerNM)
+	require.NotNil(t, routerNM.PacketFilter,
+		"router PacketFilter should not be nil")
+
+	var foundBroaderDst bool
+
+	for _, m := range routerNM.PacketFilter {
+		for _, dst := range m.Dsts {
+			dstPrefix := netip.PrefixFrom(dst.Net.Addr(), dst.Net.Bits())
+			if dstPrefix == broaderDst {
+				foundBroaderDst = true
+			}
+		}
+	}
+
+	assert.True(t, foundBroaderDst,
+		"router PacketFilter should contain destination rules for the broader grant dst 10.0.0.0/8; "+
+			"the via gate requires advertised-route overlap, and the emitted prefix is the dst")
+}
+
 // TestGrantViaExitNodeNoFilterRules verifies wire-format SaaS compat:
 // the exit node's PacketFilter must not contain literal 0.0.0.0/0 or
 // ::/0 destinations. Internally, autogroup:internet via grants emit a


### PR DESCRIPTION
`compileViaForNode` (`hscontrol/policy/v2/compiled.go:686`) and `ViaRoutesForPeer` (`hscontrol/policy/v2/policy.go:998, 1089`) used `slices.Contains(subnetRoutes, dstPrefix)` to decide whether a node advertised a grant destination. Equality rejects any non-identical prefix pair, so a via grant with broader or narrower `dst` than the advertised subnet emitted no filter rule and added no route to the viewer's `AllowedIPs`. Tailscale SaaS uses containment in either direction.

Switch the filter-rule path to `slices.ContainsFunc(routes, dst.Overlaps)` and keep the literal `dst` in `DstPorts`. Append overlapping advertised routes to `ViaRoutesForPeer.Include` / `Exclude` rather than the dst. Rewrite the multi-router HA election and regular-grant overlap to key off the matched routes. Resolve `*Host` aliases to `*Prefix` once in `compileOneViaGrant` and at the top of `ViaRoutesForPeer` so the type switch reaches them.

Five new `testdata/grant_results/via-grant-v47..v51.hujson` lock the SaaS shape: broader literal dst, narrower literal dst, host-alias dst, disjoint dst (negative), and the reporter's exact 4via6 case. `TestGrantsCompat` replays them; existing v14-v46 captures stay green.

Fixes #3267

> Generated with the help of an AI assistant