### PR TITLE
noise: pin outer RemoteAddr onto tunnel requests

### DIFF
--- a/hscontrol/noise.go
+++ b/hscontrol/noise.go
@@ -159,9 +159,10 @@ func (h *Headscale) NoiseUpgradeHandler(
 	}))
 	r.Use(middleware.RequestID)
 
-	if h.realIPMiddleware != nil {
-		r.Use(h.realIPMiddleware)
-	}
+	// The outer router resolved trusted_proxies on req before the
+	// upgrade; pin that value across the hijack so /machine/* logs the
+	// client IP instead of the reverse proxy's loopback peer.
+	r.Use(overrideRemoteAddr(req.RemoteAddr))
 
 	r.Use(middleware.RequestLogger(&zerologRequestLogger{}))
 	r.Use(middleware.Recoverer)
@@ -292,6 +293,20 @@ func rejectUnsupported(
 	}
 
 	return false
+}
+
+// overrideRemoteAddr returns middleware that pins r.RemoteAddr to addr.
+// Used inside the Noise tunnel: the HTTP/2 server derives r.RemoteAddr
+// from the hijacked TCP socket (the reverse proxy's loopback peer), so
+// the outer request's resolved client IP must be carried across the
+// hijack boundary by hand.
+func overrideRemoteAddr(addr string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.RemoteAddr = addr
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 func (ns *noiseServer) NotImplementedHandler(writer http.ResponseWriter, req *http.Request) {

--- a/hscontrol/noise_test.go
+++ b/hscontrol/noise_test.go
@@ -368,3 +368,31 @@ func TestSSHActionFollowUp_RejectsBindingMismatch(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rec.Code,
 		"binding mismatch must be rejected with 401")
 }
+
+// TestOverrideRemoteAddr asserts the middleware used inside the Noise
+// tunnel pins r.RemoteAddr to the value captured from the outer
+// (pre-hijack) request, so /machine/* requests log the trusted-proxy
+// resolved client IP instead of the hijacked TCP socket's loopback peer.
+func TestOverrideRemoteAddr(t *testing.T) {
+	t.Parallel()
+
+	const clientAddr = "192.168.91.240"
+
+	r := chi.NewRouter()
+	r.Use(overrideRemoteAddr(clientAddr))
+
+	var observed string
+
+	r.Get("/x", func(w http.ResponseWriter, r *http.Request) {
+		observed = r.RemoteAddr
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/x", nil)
+	req.RemoteAddr = "127.0.0.1:44388"
+
+	r.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, clientAddr, observed)
+}


### PR DESCRIPTION
## Summary

- `/machine/register` and `/machine/map` logged `remote=127.0.0.1:<port>` behind nginx even with `trusted_proxies` set
- Go's HTTP/2 server fills `r.RemoteAddr` from the hijacked TCP socket in `NoiseUpgradeHandler` (`hscontrol/noise.go:96`); the outer router's `realIPMiddleware`-resolved value on `req.RemoteAddr` never crossed the hijack
- Inner `realIPMiddleware` was dead — no proxy headers exist inside the encrypted tunnel — replace it with `overrideRemoteAddr(req.RemoteAddr)` so `/machine/*` requests log the outer-resolved client IP

## Test plan

- [x] `go test ./hscontrol/` — `TestOverrideRemoteAddr` plus all existing tests pass
- [x] `golangci-lint run --new-from-rev=upstream/main` — clean
- [ ] Manual: deploy behind nginx with `trusted_proxies: ["127.0.0.0/8"]`, confirm `/machine/register` and `/machine/map` log the client IP not loopback