### PR TITLE
Fix registration cache debug output

### DIFF
--- a/hscontrol/state/debug.go
+++ b/hscontrol/state/debug.go
@@ -60,6 +60,49 @@ type DebugStringInfo struct {
 	Content string `json:"content"`
 }
 
+// DebugRegistrationCacheInfo represents the registration cache in a JSON-safe
+// format for the debug endpoint.
+type DebugRegistrationCacheInfo struct {
+	Type       string                        `json:"type"`
+	Expiration string                        `json:"expiration"`
+	MaxEntries int                           `json:"max_entries"`
+	CurrentLen int                           `json:"current_len"`
+	Status     string                        `json:"status"`
+	Entries    []DebugRegistrationCacheEntry `json:"entries"`
+}
+
+// DebugRegistrationCacheEntry represents a pending auth cache entry without
+// exposing internal channels or one-time secrets.
+type DebugRegistrationCacheEntry struct {
+	ID                  string                                     `json:"id"`
+	Kind                string                                     `json:"kind"`
+	Registration        *DebugRegistrationCacheRegistration        `json:"registration,omitempty"`
+	SSHCheck            *DebugRegistrationCacheSSHCheck            `json:"ssh_check,omitempty"`
+	PendingConfirmation *DebugRegistrationCachePendingConfirmation `json:"pending_confirmation,omitempty"`
+}
+
+// DebugRegistrationCacheRegistration represents a pending node registration.
+type DebugRegistrationCacheRegistration struct {
+	Hostname    string     `json:"hostname,omitempty"`
+	HasHostinfo bool       `json:"has_hostinfo"`
+	Endpoints   []string   `json:"endpoints,omitempty"`
+	Expiry      *time.Time `json:"expiry,omitempty"`
+}
+
+// DebugRegistrationCacheSSHCheck represents a pending SSH check auth request.
+type DebugRegistrationCacheSSHCheck struct {
+	SrcNodeID types.NodeID `json:"src_node_id"`
+	DstNodeID types.NodeID `json:"dst_node_id"`
+}
+
+// DebugRegistrationCachePendingConfirmation represents pending OIDC
+// confirmation state without exposing the one-time CSRF token.
+type DebugRegistrationCachePendingConfirmation struct {
+	UserID     uint       `json:"user_id"`
+	NodeExpiry *time.Time `json:"node_expiry,omitempty"`
+	HasCSRF    bool       `json:"has_csrf"`
+}
+
 // DebugOverview returns a comprehensive overview of the current state for debugging.
 func (s *State) DebugOverview() string {
 	allNodes := s.nodeStore.ListNodes()
@@ -213,14 +256,76 @@ func (s *State) DebugSSHPolicies() map[string]*tailcfg.SSHPolicy {
 }
 
 // DebugRegistrationCache returns debug information about the registration cache.
-func (s *State) DebugRegistrationCache() map[string]any {
-	return map[string]any{
-		"type":        "expirable-lru",
-		"expiration":  registerCacheExpiration.String(),
-		"max_entries": defaultRegisterCacheMaxEntries,
-		"current_len": s.authCache.Len(),
-		"status":      "active",
+func (s *State) DebugRegistrationCache() DebugRegistrationCacheInfo {
+	keys := s.authCache.Keys()
+	entries := make([]DebugRegistrationCacheEntry, 0, len(keys))
+
+	for _, id := range keys {
+		entry, ok := s.authCache.Peek(id)
+		if !ok {
+			continue
+		}
+
+		entries = append(entries, debugRegistrationCacheEntry(id, entry))
 	}
+
+	return DebugRegistrationCacheInfo{
+		Type:       "expirable-lru",
+		Expiration: registerCacheExpiration.String(),
+		MaxEntries: defaultRegisterCacheMaxEntries,
+		CurrentLen: s.authCache.Len(),
+		Status:     "active",
+		Entries:    entries,
+	}
+}
+
+func debugRegistrationCacheEntry(
+	id types.AuthID,
+	request *types.AuthRequest,
+) DebugRegistrationCacheEntry {
+	entry := DebugRegistrationCacheEntry{
+		ID:   id.String(),
+		Kind: "unknown",
+	}
+
+	if request == nil {
+		return entry
+	}
+
+	if request.IsRegistration() {
+		registrationData := request.RegistrationData()
+		endpoints := make([]string, 0, len(registrationData.Endpoints))
+		for _, endpoint := range registrationData.Endpoints {
+			endpoints = append(endpoints, endpoint.String())
+		}
+
+		entry.Kind = "registration"
+		entry.Registration = &DebugRegistrationCacheRegistration{
+			Hostname:    registrationData.Hostname,
+			HasHostinfo: registrationData.Hostinfo != nil,
+			Endpoints:   endpoints,
+			Expiry:      registrationData.Expiry,
+		}
+	}
+
+	if request.IsSSHCheck() {
+		binding := request.SSHCheckBinding()
+		entry.Kind = "ssh_check"
+		entry.SSHCheck = &DebugRegistrationCacheSSHCheck{
+			SrcNodeID: binding.SrcNodeID,
+			DstNodeID: binding.DstNodeID,
+		}
+	}
+
+	if pendingConfirmation := request.PendingConfirmation(); pendingConfirmation != nil {
+		entry.PendingConfirmation = &DebugRegistrationCachePendingConfirmation{
+			UserID:     pendingConfirmation.UserID,
+			NodeExpiry: pendingConfirmation.NodeExpiry,
+			HasCSRF:    pendingConfirmation.CSRF != "",
+		}
+	}
+
+	return entry
 }
 
 // DebugConfig returns debug information about the current configuration.

--- a/hscontrol/state/debug_test.go
+++ b/hscontrol/state/debug_test.go
@@ -1,9 +1,16 @@
 package state
 
 import (
+	"encoding/json"
+	"net/netip"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"tailscale.com/tailcfg"
 )
 
 func TestNodeStoreDebugString(t *testing.T) {
@@ -65,14 +72,63 @@ func TestNodeStoreDebugString(t *testing.T) {
 }
 
 func TestDebugRegistrationCache(t *testing.T) {
-	// Create a minimal NodeStore for testing debug methods
-	store := NewNodeStore(nil, allowAllPeersFunc, TestBatchSize, TestBatchTimeout)
+	cache := expirable.NewLRU[types.AuthID, *types.AuthRequest](
+		defaultRegisterCacheMaxEntries,
+		nil,
+		time.Hour,
+	)
+	state := &State{
+		authCache: cache,
+	}
 
-	debugStr := store.DebugString()
+	expiry := time.Now().UTC().Add(time.Hour)
+	registrationID := types.MustAuthID()
+	registrationRequest := types.NewRegisterAuthRequest(&types.RegistrationData{
+		Hostname: "test-node",
+		Hostinfo: &tailcfg.Hostinfo{
+			Hostname: "test-node",
+		},
+		Endpoints: []netip.AddrPort{
+			netip.MustParseAddrPort("192.0.2.1:41641"),
+		},
+		Expiry: &expiry,
+	})
+	registrationRequest.SetPendingConfirmation(&types.PendingRegistrationConfirmation{
+		UserID:     1,
+		NodeExpiry: &expiry,
+		CSRF:       "secret-token",
+	})
+	cache.Add(registrationID, registrationRequest)
 
-	// Should contain basic debug information
-	assert.Contains(t, debugStr, "=== NodeStore Debug Information ===")
-	assert.Contains(t, debugStr, "Total Nodes: 0")
-	assert.Contains(t, debugStr, "Users with Nodes: 0")
-	assert.Contains(t, debugStr, "NodeKey Index: 0 entries")
+	sshCheckID := types.MustAuthID()
+	cache.Add(sshCheckID, types.NewSSHCheckAuthRequest(types.NodeID(1), types.NodeID(2)))
+
+	debugInfo := state.DebugRegistrationCache()
+	_, err := json.Marshal(debugInfo)
+	require.NoError(t, err)
+
+	assert.Equal(t, "expirable-lru", debugInfo.Type)
+	assert.Equal(t, 2, debugInfo.CurrentLen)
+	require.Len(t, debugInfo.Entries, 2)
+
+	entries := map[string]DebugRegistrationCacheEntry{}
+	for _, entry := range debugInfo.Entries {
+		entries[entry.ID] = entry
+	}
+
+	registrationEntry := entries[registrationID.String()]
+	assert.Equal(t, "registration", registrationEntry.Kind)
+	require.NotNil(t, registrationEntry.Registration)
+	assert.Equal(t, "test-node", registrationEntry.Registration.Hostname)
+	assert.True(t, registrationEntry.Registration.HasHostinfo)
+	assert.Equal(t, []string{"192.0.2.1:41641"}, registrationEntry.Registration.Endpoints)
+	require.NotNil(t, registrationEntry.PendingConfirmation)
+	assert.Equal(t, uint(1), registrationEntry.PendingConfirmation.UserID)
+	assert.True(t, registrationEntry.PendingConfirmation.HasCSRF)
+
+	sshCheckEntry := entries[sshCheckID.String()]
+	assert.Equal(t, "ssh_check", sshCheckEntry.Kind)
+	require.NotNil(t, sshCheckEntry.SSHCheck)
+	assert.Equal(t, types.NodeID(1), sshCheckEntry.SSHCheck.SrcNodeID)
+	assert.Equal(t, types.NodeID(2), sshCheckEntry.SSHCheck.DstNodeID)
 }


### PR DESCRIPTION
Fixes #2714

This changes the registration cache debug output to return a JSON-safe representation of pending auth requests instead of exposing internal auth request state. The endpoint now includes cache metadata and serializable entries for pending registration and SSH-check auth requests, while avoiding internal channels and one-time CSRF values.

Checks run:
- `go test ./hscontrol/state -count=1`
- `go test ./hscontrol -run '^$' -count=1`
- `git diff --check`