### PR TITLE
state: skip peer netmap recompute on ordinary reconnects

### DIFF
--- a/hscontrol/policy/pm.go
+++ b/hscontrol/policy/pm.go
@@ -36,6 +36,14 @@ type PolicyManager interface {
 	// NodeCanApproveRoute reports whether the given node can approve the given route.
 	NodeCanApproveRoute(node types.NodeView, route netip.Prefix) bool
 
+	// NodeNeedsPeerRecompute reports whether peers must recompute their
+	// netmap when the node's online state changes. True for subnet
+	// routers, relay targets (tailscale.com/cap/relay), and via targets;
+	// false for ordinary nodes, which only need a lightweight online or
+	// offline peer patch. [State.Connect] and [State.Disconnect] use it to
+	// avoid a tailnet-wide recompute on every ordinary reconnect.
+	NodeNeedsPeerRecompute(node types.NodeView) bool
+
 	// ViaRoutesForPeer computes via grant effects for a viewer-peer pair.
 	// It returns which routes should be included (peer is via-designated for viewer)
 	// and excluded (steered to a different peer). When no via grants apply,

--- a/hscontrol/policy/v2/compiled.go
+++ b/hscontrol/policy/v2/compiled.go
@@ -594,6 +594,58 @@ func hasPerNodeGrants(grants []compiledGrant) bool {
 	return false
 }
 
+// collectRelayTargetIPs returns the set of IPs that are destinations of a
+// tailscale.com/cap/relay grant. A node whose IP is in this set is a relay
+// target: when it goes offline, peers holding a PeerRelay allocation through
+// it must recompute their netmap to drop the now-dead allocation. The relay
+// cap is carried on each grant's [tailcfg.CapGrant] with Dsts set to the
+// resolved relay destinations (see [Policy.compileOtherDests]); the reversed
+// companion rule carries [tailcfg.PeerCapabilityRelayTarget] instead and is
+// intentionally skipped.
+func collectRelayTargetIPs(grants []compiledGrant) (*netipx.IPSet, error) {
+	var b netipx.IPSetBuilder
+
+	for i := range grants {
+		for _, rule := range grants[i].rules {
+			for _, cg := range rule.CapGrant {
+				if _, ok := cg.CapMap[tailcfg.PeerCapabilityRelay]; !ok {
+					continue
+				}
+
+				for _, dst := range cg.Dsts {
+					b.AddPrefix(dst)
+				}
+			}
+		}
+	}
+
+	return b.IPSet()
+}
+
+// collectViaTargetTags returns the set of tags used as via targets across all
+// grants. A node carrying any of these tags is a via target: peers steering
+// traffic through it must recompute when it goes offline. Returns nil when no
+// via grants exist.
+func collectViaTargetTags(grants []compiledGrant) map[Tag]struct{} {
+	var tags map[Tag]struct{}
+
+	for i := range grants {
+		if grants[i].via == nil {
+			continue
+		}
+
+		for _, t := range grants[i].via.viaTags {
+			if tags == nil {
+				tags = make(map[Tag]struct{})
+			}
+
+			tags[t] = struct{}{}
+		}
+	}
+
+	return tags
+}
+
 // globalFilterRules extracts global filter rules from [compiledGrant]s.
 // Via grants produce no global rules (they are per-node only); regular
 // grants contribute their full pre-compiled ruleset; self grants

--- a/hscontrol/policy/v2/node_recompute_test.go
+++ b/hscontrol/policy/v2/node_recompute_test.go
@@ -1,0 +1,137 @@
+package v2
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"tailscale.com/tailcfg"
+)
+
+// TestNodeNeedsPeerRecompute pins which node roles force peers to recompute
+// their netmap when the node's online state changes. An ordinary node only
+// needs the lightweight online/offline peer patch; subnet routers, relay
+// targets, and via targets change what peers compute and therefore need a
+// full recompute. The predicate is keyed on the flipping node, so an ordinary
+// node in a tailnet that uses relay or via elsewhere must still be classified
+// as not needing a recompute.
+func TestNodeNeedsPeerRecompute(t *testing.T) {
+	users := types.Users{
+		{Model: gorm.Model{ID: 1}, Name: "user1", Email: "user1@headscale.net"},
+	}
+
+	const allowAll = `{"acls":[{"action":"accept","src":["*"],"dst":["*:*"]}]}`
+
+	relayPol := `{
+		"tagOwners": {"tag:relay": ["user1@"]},
+		"grants": [
+			{"src": ["*"], "dst": ["tag:relay"], "app": {"tailscale.com/cap/relay": [{}]}}
+		]
+	}`
+
+	viaPol := `{
+		"tagOwners": {"tag:via": ["user1@"]},
+		"grants": [
+			{"src": ["*"], "dst": ["10.0.0.0/24"], "ip": ["*"], "via": ["tag:via"]}
+		]
+	}`
+
+	taildrivePol := `{
+		"tagOwners": {"tag:drive": ["user1@"]},
+		"grants": [
+			{"src": ["*"], "dst": ["tag:drive"], "app": {"tailscale.com/cap/drive": [{}]}}
+		]
+	}`
+
+	ordinary := node("ordinary", "100.64.0.1", "fd7a:115c:a1e0::1", users[0])
+	ordinary.ID = 1
+
+	subnetRouter := node("subnet", "100.64.0.2", "fd7a:115c:a1e0::2", users[0])
+	subnetRouter.ID = 2
+	subnetRouter.Hostinfo = &tailcfg.Hostinfo{
+		RoutableIPs: []netip.Prefix{netip.MustParsePrefix("10.0.0.0/24")},
+	}
+	subnetRouter.ApprovedRoutes = []netip.Prefix{netip.MustParsePrefix("10.0.0.0/24")}
+
+	relayTarget := node("relay", "100.64.0.3", "fd7a:115c:a1e0::3", users[0])
+	relayTarget.ID = 3
+	relayTarget.Tags = []string{"tag:relay"}
+
+	viaTarget := node("via", "100.64.0.4", "fd7a:115c:a1e0::4", users[0])
+	viaTarget.ID = 4
+	viaTarget.Tags = []string{"tag:via"}
+
+	driveTarget := node("drive", "100.64.0.5", "fd7a:115c:a1e0::5", users[0])
+	driveTarget.ID = 5
+	driveTarget.Tags = []string{"tag:drive"}
+
+	tests := []struct {
+		name    string
+		pol     string
+		nodes   types.Nodes
+		subject *types.Node
+		want    bool
+	}{
+		{
+			name:    "ordinary node under allow-all does not need recompute",
+			pol:     allowAll,
+			nodes:   types.Nodes{ordinary},
+			subject: ordinary,
+			want:    false,
+		},
+		{
+			name:    "subnet router needs recompute",
+			pol:     allowAll,
+			nodes:   types.Nodes{subnetRouter},
+			subject: subnetRouter,
+			want:    true,
+		},
+		{
+			name:    "relay target needs recompute",
+			pol:     relayPol,
+			nodes:   types.Nodes{relayTarget, ordinary},
+			subject: relayTarget,
+			want:    true,
+		},
+		{
+			name:    "ordinary node in a relay-using tailnet does not need recompute",
+			pol:     relayPol,
+			nodes:   types.Nodes{relayTarget, ordinary},
+			subject: ordinary,
+			want:    false,
+		},
+		{
+			name:    "via target needs recompute",
+			pol:     viaPol,
+			nodes:   types.Nodes{viaTarget, ordinary},
+			subject: viaTarget,
+			want:    true,
+		},
+		{
+			name:    "ordinary node in a via-using tailnet does not need recompute",
+			pol:     viaPol,
+			nodes:   types.Nodes{viaTarget, ordinary},
+			subject: ordinary,
+			want:    false,
+		},
+		{
+			name:    "taildrive target does not need recompute",
+			pol:     taildrivePol,
+			nodes:   types.Nodes{driveTarget, ordinary},
+			subject: driveTarget,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm, err := NewPolicyManager([]byte(tt.pol), users, tt.nodes.ViewSlice())
+			require.NoError(t, err)
+
+			got := pm.NodeNeedsPeerRecompute(tt.subject.View())
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -45,6 +45,15 @@ type PolicyManager struct {
 	autoApproveMapHash deephash.Sum
 	autoApproveMap     map[netip.Prefix]*netipx.IPSet
 
+	// relayTargetIPs holds the IPs of nodes that are destinations of a
+	// tailscale.com/cap/relay grant; viaTargetTags holds the tags used as
+	// via targets. A node matching either, or that is a subnet router,
+	// forces peers to recompute their netmap when its online state changes
+	// (see [PolicyManager.NodeNeedsPeerRecompute]). Recomputed from the
+	// compiled grants on every policy/user/node change.
+	relayTargetIPs *netipx.IPSet
+	viaTargetTags  map[Tag]struct{}
+
 	// Lazy map of SSH policies
 	sshPolicyMap map[types.NodeID]*tailcfg.SSHPolicy
 
@@ -223,6 +232,14 @@ func (pm *PolicyManager) updateLocked() (bool, error) {
 	pm.compiledGrants = pm.pol.compileGrants(pm.users, pm.nodes)
 	pm.userNodeIdx = buildUserNodeIndex(pm.nodes)
 	pm.needsPerNodeFilter = hasPerNodeGrants(pm.compiledGrants)
+	pm.viaTargetTags = collectViaTargetTags(pm.compiledGrants)
+
+	relayTargetIPs, err := collectRelayTargetIPs(pm.compiledGrants)
+	if err != nil {
+		return false, fmt.Errorf("collecting relay target IPs: %w", err)
+	}
+
+	pm.relayTargetIPs = relayTargetIPs
 
 	var filter []tailcfg.FilterRule
 	if pm.pol == nil || (pm.pol.ACLs == nil && pm.pol.Grants == nil) {
@@ -358,6 +375,45 @@ func (pm *PolicyManager) updateLocked() (bool, error) {
 		Msg("Policy changes require node updates")
 
 	return true, nil
+}
+
+// NodeNeedsPeerRecompute reports whether peers must recompute their netmap
+// when node's online state changes. A plain node only needs the lightweight
+// online/offline peer patch; these roles change what peers compute when the
+// node goes up or down, so they require a full recompute:
+//   - subnet router: primary-route failover changes peers' AllowedIPs
+//   - relay target (tailscale.com/cap/relay): peers must drop a stale
+//     PeerRelay allocation
+//   - via target: peers steer traffic through this node
+//
+// The check is keyed on the node itself, so an ordinary node in a tailnet
+// that uses relay or via for other nodes is correctly classified as not
+// needing a recompute.
+func (pm *PolicyManager) NodeNeedsPeerRecompute(node types.NodeView) bool {
+	if !node.Valid() {
+		return false
+	}
+
+	// Subnet-router status is intrinsic to the node, so it needs no policy
+	// state and is checked without the lock.
+	if node.IsSubnetRouter() {
+		return true
+	}
+
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	if pm.relayTargetIPs != nil && node.InIPSet(pm.relayTargetIPs) {
+		return true
+	}
+
+	for tag := range pm.viaTargetTags {
+		if node.HasTag(string(tag)) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // SSHPolicy returns the [tailcfg.SSHPolicy] for node, compiling and

--- a/hscontrol/state/connect_test.go
+++ b/hscontrol/state/connect_test.go
@@ -1,0 +1,168 @@
+package state
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/juanfont/headscale/hscontrol/types/change"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"tailscale.com/tailcfg"
+)
+
+// runtimePeerComputationReasons returns the Reason of every change in cs that
+// carries RequiresRuntimePeerComputation. Each such change makes the batcher
+// rebuild a full netmap (packet filters, SSH policy, peer serialization) for
+// every connected node, so it is the expensive fan-out the issue is about.
+func runtimePeerComputationReasons(cs []change.Change) []string {
+	var reasons []string
+
+	for _, c := range cs {
+		if c.RequiresRuntimePeerComputation {
+			reasons = append(reasons, c.Reason)
+		}
+	}
+
+	return reasons
+}
+
+// hasPeerPatch reports whether any change carries a lightweight PeerChange
+// patch (e.g. the online/offline indicator). This is the cheap notification a
+// reconnect should produce instead of a full runtime recompute.
+func hasPeerPatch(cs []change.Change) bool {
+	for _, c := range cs {
+		if len(c.PeerPatches) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// forcesPeerRecompute reports whether any change makes peers rebuild a full
+// netmap, whether via a full update (subnet-router path) or a runtime peer
+// computation (relay/via path).
+func forcesPeerRecompute(cs []change.Change) bool {
+	for _, c := range cs {
+		if c.IsFull() || c.RequiresRuntimePeerComputation {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestConnectDisconnectOrdinaryNodeNoRuntimeRecompute asserts that an ordinary
+// node coming online or going offline only sends the lightweight online/offline
+// peer patch and does not trigger a runtime peer recompute.
+//
+// State.Connect and State.Disconnect gate change.PolicyChange() (which sets
+// RequiresRuntimePeerComputation, forcing the batcher to rebuild a full netmap
+// for every connected node) on NodeNeedsPeerRecompute. An ordinary node is
+// neither a subnet router, a relay target, nor a via target, so the gate is
+// false and no recompute is emitted.
+//
+// Emitting that recompute unconditionally turned each reconnect into O(N) full
+// netmap rebuilds (and a reconnect storm into O(N^2)), which saturated CPU
+// after the v0.28 -> v0.29 upgrade.
+func TestConnectDisconnectOrdinaryNodeNoRuntimeRecompute(t *testing.T) {
+	_, s, nodeID := persistTestSetup(t)
+	t.Cleanup(func() { _ = s.Close() })
+
+	t.Run("connect", func(t *testing.T) {
+		cs, epoch := s.Connect(nodeID)
+		require.NotZero(t, epoch, "Connect should return a session epoch")
+
+		assert.True(t, hasPeerPatch(cs),
+			"Connect should still emit a lightweight online peer patch")
+
+		reasons := runtimePeerComputationReasons(cs)
+		assert.Empty(t, reasons,
+			"ordinary node connect must not trigger a runtime peer recompute; "+
+				"got RequiresRuntimePeerComputation changes: %v", reasons)
+	})
+
+	t.Run("disconnect", func(t *testing.T) {
+		// Connect first so Disconnect's epoch check passes.
+		_, epoch := s.Connect(nodeID)
+
+		cs, err := s.Disconnect(nodeID, epoch)
+		require.NoError(t, err)
+
+		assert.True(t, hasPeerPatch(cs),
+			"Disconnect should still emit a lightweight offline peer patch")
+
+		reasons := runtimePeerComputationReasons(cs)
+		assert.Empty(t, reasons,
+			"ordinary node disconnect must not trigger a runtime peer recompute; "+
+				"got RequiresRuntimePeerComputation changes: %v", reasons)
+	})
+}
+
+// TestConnectDisconnectRelayTargetTriggersRecompute locks the cap/relay case:
+// a relay target is not a subnet router, so the only thing that makes its
+// connect/disconnect emit a runtime peer recompute is the
+// NodeNeedsPeerRecompute gate. Peers must still receive that recompute so they
+// drop a stale PeerRelay allocation when the relay goes offline.
+func TestConnectDisconnectRelayTargetTriggersRecompute(t *testing.T) {
+	_, s, nodeID := persistTestSetup(t)
+	t.Cleanup(func() { _ = s.Close() })
+
+	// A cap/relay grant whose destination resolves to the node's owning
+	// user makes the node a relay target without making it a subnet router.
+	relayPolicy := `{"grants":[{"src":["*"],"dst":["persist-user@"],"app":{"tailscale.com/cap/relay":[{}]}}]}`
+	_, err := s.SetPolicy([]byte(relayPolicy))
+	require.NoError(t, err)
+
+	t.Run("connect", func(t *testing.T) {
+		cs, epoch := s.Connect(nodeID)
+		require.NotZero(t, epoch)
+
+		assert.NotEmpty(t, runtimePeerComputationReasons(cs),
+			"relay-target node connect must trigger a runtime peer recompute")
+	})
+
+	t.Run("disconnect", func(t *testing.T) {
+		_, epoch := s.Connect(nodeID)
+
+		cs, err := s.Disconnect(nodeID, epoch)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, runtimePeerComputationReasons(cs),
+			"relay-target node disconnect must trigger a runtime peer recompute")
+	})
+}
+
+// TestConnectDisconnectSubnetRouterForcesRecompute guards that a subnet router
+// still forces peers to recompute on connect/disconnect (primary-route
+// failover changes their AllowedIPs), so the gate does not over-suppress.
+func TestConnectDisconnectSubnetRouterForcesRecompute(t *testing.T) {
+	_, s, nodeID := persistTestSetup(t)
+	t.Cleanup(func() { _ = s.Close() })
+
+	route := netip.MustParsePrefix("10.0.0.0/24")
+	_, ok := s.nodeStore.UpdateNode(nodeID, func(n *types.Node) {
+		n.Hostinfo = &tailcfg.Hostinfo{RoutableIPs: []netip.Prefix{route}}
+		n.ApprovedRoutes = []netip.Prefix{route}
+	})
+	require.True(t, ok)
+
+	t.Run("connect", func(t *testing.T) {
+		cs, epoch := s.Connect(nodeID)
+		require.NotZero(t, epoch)
+
+		assert.True(t, forcesPeerRecompute(cs),
+			"subnet router connect must force a peer recompute")
+	})
+
+	t.Run("disconnect", func(t *testing.T) {
+		_, epoch := s.Connect(nodeID)
+
+		cs, err := s.Disconnect(nodeID, epoch)
+		require.NoError(t, err)
+
+		assert.True(t, forcesPeerRecompute(cs),
+			"subnet router disconnect must force a peer recompute")
+	})
+}

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -594,9 +594,14 @@ func (s *State) Connect(id types.NodeID) ([]change.Change, uint64) {
 		c = append(c, change.NodeAdded(id))
 	}
 
-	// Coming online may re-enable cap/relay grants and identity-based
-	// aliases targeting this node, so peers need a fresh netmap.
-	c = append(c, change.PolicyChange())
+	// Only a node whose online state changes what peers compute (a subnet
+	// router, relay target, or via target) needs a full peer recompute.
+	// An ordinary node coming online just sends the lightweight online
+	// patch above; emitting a PolicyChange for it would force every peer
+	// to rebuild its netmap on every reconnect.
+	if s.polMan.NodeNeedsPeerRecompute(node) {
+		c = append(c, change.PolicyChange())
+	}
 
 	return c, epoch
 }
@@ -648,13 +653,15 @@ func (s *State) Disconnect(id types.NodeID, epoch uint64) ([]change.Change, erro
 		c = change.Change{}
 	}
 
-	// Going offline can affect policy compilation beyond subnet routes
-	// (cap/relay grants, tag/group aliases, via routes), so peers need
-	// a fresh netmap regardless of whether the primary moved.
-	//
-	// TODO(kradalby): fires one full netmap recompute per peer on
-	// every connect/disconnect. Coalesce in mapper/batcher.go:addToBatch.
-	cs := []change.Change{change.NodeOfflineFor(node), c, change.PolicyChange()}
+	// Only a node whose online state changes what peers compute (a subnet
+	// router, relay target, or via target) needs a full peer recompute.
+	// An ordinary node going offline just sends the lightweight offline
+	// patch; emitting a PolicyChange for it would force every peer to
+	// rebuild its netmap on every disconnect.
+	cs := []change.Change{change.NodeOfflineFor(node), c}
+	if s.polMan.NodeNeedsPeerRecompute(node) {
+		cs = append(cs, change.PolicyChange())
+	}
 
 	return cs, nil
 }


### PR DESCRIPTION
As part of making sure we handled every update correct as we implemented `via` and `relays` we made the policy upgrade and recompute very aggressive, triggering on every connect and disconnect.

This PR restores-and-extends the previous behaviour where we only recomputed it when it was a subnet router, but now adding relays and via nodes. 

Fixes #3293

Generated with the help of an AI assistant
