### PR TITLE
hscontrol: read Apple platform via chi.URLParam, not mux.Vars

### DIFF
--- a/flakehashes.json
+++ b/flakehashes.json
@@ -1,6 +1,6 @@
 {
   "vendor": {
-    "goModSum": "sha256-xos6ixeJRMrEengGJaRiSsrm+3S3R0OEsnv1e85Sqhw=",
-    "sri": "sha256-bZod9sUUyQ67x/HzZrQ7SK+o5gAUxJhx7Rr6VdIUj1I="
+    "goModSum": "sha256-RjKl/xIblVgslZs9kl7KUgeiOQpJ+gKqCnhml1U+MOg=",
+    "sri": "sha256-4YiDhywnBPNLV7W5QffjJdOeDzEJW3zLWf7PHOWmYrE="
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/go-json-experiment/json v0.0.0-20260520185125-572e7c383686
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/google/go-cmp v0.7.0
-	github.com/gorilla/mux v1.8.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jagottsicher/termcolor v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -254,8 +254,6 @@ github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQ
 github.com/gookit/color v1.5.0/go.mod h1:43aQb+Zerm/BWh2GnrgOQm7ffz7tvQXEKV6BFMl7wAo=
 github.com/gookit/color v1.6.0 h1:JjJXBTk1ETNyqyilJhkTXJYYigHG24TM9Xa2M1xAhRA=
 github.com/gookit/color v1.6.0/go.mod h1:9ACFc7/1IpHGBW8RwuDm/0YEnhg3dwwXpoMsmtyHfjs=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=

--- a/hscontrol/platform_config.go
+++ b/hscontrol/platform_config.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	textTemplate "text/template"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/gofrs/uuid/v5"
-	"github.com/gorilla/mux"
 	"github.com/juanfont/headscale/hscontrol/templates"
 )
 
@@ -36,10 +36,8 @@ func (h *Headscale) ApplePlatformConfig(
 	writer http.ResponseWriter,
 	req *http.Request,
 ) {
-	vars := mux.Vars(req)
-
-	platform, ok := vars["platform"]
-	if !ok {
+	platform := chi.URLParam(req, "platform")
+	if platform == "" {
 		httpError(writer, NewHTTPError(http.StatusBadRequest, "no platform specified", nil))
 		return
 	}

--- a/hscontrol/platform_config_test.go
+++ b/hscontrol/platform_config_test.go
@@ -1,0 +1,110 @@
+package hscontrol
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplePlatformConfig_ServesProfilesViaChiRouter is the regression
+// guard for issue juanfont/headscale#3296.
+//
+// The Apple profile download endpoints (`/apple/macos-app-store`,
+// `/apple/macos-standalone`, `/apple/ios`) are registered on the chi
+// router (see hscontrol/app.go: `r.Get("/apple/{platform}", ...)`).
+// Before the fix, `ApplePlatformConfig` extracted the `{platform}` URL
+// parameter via `mux.Vars(req)` from gorilla/mux; because the request
+// never passed through a gorilla router, the lookup always missed and
+// every download returned HTTP 400 `no platform specified`.
+//
+// This test mounts the route on a chi router exactly as production
+// does so the assertion exercises the real router + handler wiring,
+// not a hand-crafted chi context. It fails if the handler ever again
+// reads URL parameters via an API the production router does not
+// populate.
+func TestApplePlatformConfig_ServesProfilesViaChiRouter(t *testing.T) {
+	t.Parallel()
+
+	h := &Headscale{
+		cfg: &types.Config{
+			ServerURL: "https://headscale.example.com",
+		},
+	}
+
+	// Mirror the production mount in hscontrol/app.go so this test
+	// covers the actual router + handler wiring, not a hand-crafted
+	// chi context.
+	r := chi.NewRouter()
+	r.Get("/apple/{platform}", h.ApplePlatformConfig)
+
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	platforms := []string{"macos-app-store", "macos-standalone", "ios"}
+	for _, platform := range platforms {
+		t.Run(platform, func(t *testing.T) {
+			t.Parallel()
+
+			//nolint:noctx // test fixture
+			resp, err := http.Get(srv.URL + "/apple/" + platform)
+			require.NoError(t, err)
+			t.Cleanup(func() { resp.Body.Close() })
+
+			bodyBytes, _ := io.ReadAll(resp.Body)
+			body := string(bodyBytes)
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode,
+				"expected 200 for /apple/%s, got %d: %s",
+				platform, resp.StatusCode, body)
+			assert.Equal(t,
+				"application/x-apple-aspen-config; charset=utf-8",
+				resp.Header.Get("Content-Type"),
+				"profile must be served as an Apple aspen config")
+			assert.Contains(t, body,
+				"https://headscale.example.com",
+				"rendered profile must embed the configured ServerURL")
+		})
+	}
+}
+
+// TestApplePlatformConfig_RejectsUnknownPlatform locks the contract for
+// the `default:` branch of `ApplePlatformConfig`: an otherwise-valid
+// request whose `{platform}` segment is none of the three known values
+// must return HTTP 400 with the documented message. This catches both
+// silent fallthrough (e.g. a future template registered under a new
+// name without adding a case) and accidental message drift.
+func TestApplePlatformConfig_RejectsUnknownPlatform(t *testing.T) {
+	t.Parallel()
+
+	h := &Headscale{
+		cfg: &types.Config{
+			ServerURL: "https://headscale.example.com",
+		},
+	}
+
+	r := chi.NewRouter()
+	r.Get("/apple/{platform}", h.ApplePlatformConfig)
+
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	//nolint:noctx // test fixture
+	resp, err := http.Get(srv.URL + "/apple/windows-phone")
+	require.NoError(t, err)
+	t.Cleanup(func() { resp.Body.Close() })
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	body := string(bodyBytes)
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"unknown platform must be rejected with 400")
+	assert.Contains(t, body,
+		"platform must be ios, macos-app-store or macos-standalone",
+		"error body must list the supported platforms")
+}


### PR DESCRIPTION
ApplePlatformConfig still used gorilla mux.Vars after the chi
migration in 3033844, so every /apple/{platform} request returned
400 "no platform specified". Read the param via chi and add tests.

Fixes #3296