### PR TITLE
policy, types, state: add policy DNS profiles

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -282,6 +282,7 @@ jobs:
           - TestDERPVerifyEndpoint
           - TestResolveMagicDNS
           - TestResolveMagicDNSExtraRecordsPath
+          - TestPolicyDNSProfiles
           - TestDERPServerScenario
           - TestDERPServerWebsocketScenario
           - TestPingAllByIP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ to understand how the packet filter should be generated. We discovered a few dif
 overall our implementation was very close.
 [#3036](https://github.com/juanfont/headscale/pull/3036)
 
+### DNS profiles (per-tag / per-user / per-group) [#3012](https://github.com/juanfont/headscale/issues/3012)
+
+The policy file gains a top-level `dns:` block: an ordered list of DNS
+profiles that override fields of the tailnet-wide `dns:` config in
+`headscale.yaml` for matched nodes. Each profile carries an assignment
+list (`groups`, `users`, or `tags`); fields set on the profile replace
+the base, unset fields inherit. Nodes matching no profile receive the
+base unchanged. Matching is by tier (tag > user > group) and by
+profile list order within each tier. Hot-reloaded with the policy file.
+
 ### SSH check action
 
 SSH rules with `"action": "check"` are now supported. When a client initiates a SSH connection to a node

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -318,6 +318,12 @@ policy:
 #
 # If you want stop Headscale from managing the DNS configuration
 # all the fields under `dns` should be set to empty values.
+#
+# For per-identity DNS overrides (different resolvers / split DNS /
+# search domains for specific groups, users, or tagged nodes), use the
+# policy file's top-level `dns:` block — see
+# https://headscale.net/stable/ref/policy/#dns-profiles
+
 dns:
   # Whether to use MagicDNS
   magic_dns: true

--- a/docs/ref/dns.md
+++ b/docs/ref/dns.md
@@ -3,6 +3,10 @@
 Headscale supports [most DNS features](../about/features.md) from Tailscale. DNS related settings can be configured
 within the `dns` section of the [configuration file](configuration.md).
 
+For **per-identity DNS overrides** (different resolvers, override flags,
+or split-DNS routes for specific groups, users, or tagged nodes), see
+[DNS profiles in the policy file](policy.md#dns-profiles).
+
 ## Setting extra DNS records
 
 Headscale allows to set extra DNS records which are made available via

--- a/docs/ref/policy.md
+++ b/docs/ref/policy.md
@@ -226,6 +226,71 @@ configuration and attributes. At least the following node attributes are current
 }
 ```
 
+## DNS profiles
+
+The top-level `dns:` block in the policy file is an ordered list of
+DNS profiles that override fields of the tailnet-wide `dns:` config in
+`headscale.yaml`. Each profile carries an assignment list (`groups`,
+`users`, or `tags`) and an optional set of DNS fields; a matched node
+gets the profile's set fields, with unset fields inheriting from the
+base. A node matching no profile receives the base unchanged.
+
+### Profile shape
+
+| Field | Type | Effect |
+|---|---|---|
+| `nameservers` | `[]string` | Replaces the base nameservers (routed by `overrideLocalDNS` to either `Resolvers` or `FallbackResolvers`). |
+| `overrideLocalDNS` | `bool` | Sends nameservers to `Resolvers` (`true`) or `FallbackResolvers` (`false`). Set without `nameservers` to re-route the inherited nameservers between the two wire fields. |
+| `split` | `map[string][]string` | Per-domain restricted resolvers (`Routes`); replaces base `Routes`. |
+| `searchDomains` | `[]string` | DNS search suffixes; appended after the `base_domain` in `Domains`. |
+| `groups` | `[]Group` | Assignment list — matches nodes whose user is a member of any listed group (group tier). |
+| `users` | `[]Username` | Assignment list — matches nodes whose user is listed (user tier). |
+| `tags` | `[]Tag` | Assignment list — matches tagged nodes (tag tier). |
+
+Every profile must have at least one of `groups` / `users` / `tags`.
+
+### Resolution model
+
+For each node, the lookup walks tiers in this order and returns the
+first profile whose assignment list matches, with profile list order
+breaking ties within a tier:
+
+1. **Tag tier** — any of the node's tags appears in the profile's
+   `tags`. Tagged nodes consult ONLY the tag tier.
+2. **User tier** — the node's user appears in the profile's `users`.
+3. **Group tier** — the node's user is in a group that appears in the
+   profile's `groups`.
+
+A user in two assigned groups gets the profile listed first.
+
+A group, user, or tag may appear in at most one profile's assignment
+list — the validator rejects duplicates.
+
+### Example
+
+```hujson
+{
+  "groups": {
+    "group:admin": ["alice@"]
+  },
+  "dns": [
+    {
+      // Admins override their primary resolver.
+      "nameservers": ["192.168.4.2"],
+      "overrideLocalDNS": true,
+      "groups": ["group:admin"]
+    }
+  ]
+}
+```
+
+### Exempting principals from a group assignment
+
+A profile with an assignment list but **no body fields** matches without
+changing anything. Because the user tier always beats the group tier,
+listing a user on a body-less `users` profile exempts them from any
+group-level override.
+
 ## Network-wide policy options
 
 The following options are applied for the entire tailnet. Consider [node attributes](#node-attributes) for a more

--- a/hscontrol/mapper/builder.go
+++ b/hscontrol/mapper/builder.go
@@ -161,7 +161,14 @@ func (b *MapResponseBuilder) WithDNSConfig() *MapResponseBuilder {
 		return b
 	}
 
-	b.resp.DNSConfig = generateDNSConfig(b.mapper.cfg, node, b.mapper.state.NodeCapMap(node.ID()))
+	if b.mapper.cfg.TailcfgDNSConfig == nil {
+		return b
+	}
+
+	// Resolve the per-node DNS config against the policy here; mapper's
+	// generateDNSConfig then just applies the NextDNS rewrite layer.
+	dnsConfig := b.mapper.state.NodeDNSConfig(node, b.mapper.cfg.TailcfgDNSConfig)
+	b.resp.DNSConfig = generateDNSConfig(dnsConfig, node, b.mapper.state.NodeCapMap(node.ID()))
 
 	return b
 }

--- a/hscontrol/mapper/mapper.go
+++ b/hscontrol/mapper/mapper.go
@@ -130,16 +130,18 @@ const (
 // or `..` into the resolver URL via a crafted cap name.
 var nextDNSProfileRE = regexp.MustCompile(`^[A-Za-z0-9._-]{1,64}$`)
 
+// generateDNSConfig takes the per-node DNS config (already resolved
+// against the policy by the caller) and applies the NextDNS profile
+// rewriting and metadata, returning the final wire-ready DNSConfig.
+// Returns nil if the input is nil.
 func generateDNSConfig(
-	cfg *types.Config,
+	dnsConfig *tailcfg.DNSConfig,
 	node types.NodeView,
 	capMap tailcfg.NodeCapMap,
 ) *tailcfg.DNSConfig {
-	if cfg.TailcfgDNSConfig == nil {
+	if dnsConfig == nil {
 		return nil
 	}
-
-	dnsConfig := cfg.TailcfgDNSConfig.Clone()
 
 	profile := nextDNSProfileFromCapMap(capMap)
 	if profile != "" {

--- a/hscontrol/mapper/mapper_test.go
+++ b/hscontrol/mapper/mapper_test.go
@@ -64,9 +64,7 @@ func TestDNSConfigMapResponse(t *testing.T) {
 			nodeInShared1 := mach("test_get_shared_nodes_1", "shared1", 1)
 
 			got := generateDNSConfig(
-				&types.Config{
-					TailcfgDNSConfig: &dnsConfigOrig,
-				},
+				dnsConfigOrig.Clone(),
 				nodeInShared1.View(),
 				nil,
 			)
@@ -81,16 +79,14 @@ func TestDNSConfigMapResponse(t *testing.T) {
 func TestNextDNSCapMapRendering(t *testing.T) {
 	t.Parallel()
 
-	mkConfig := func(addrs ...string) *types.Config {
+	mkDNS := func(addrs ...string) *tailcfg.DNSConfig {
 		resolvers := make([]*dnstype.Resolver, len(addrs))
 		for i, a := range addrs {
 			resolvers[i] = &dnstype.Resolver{Addr: a}
 		}
 
-		return &types.Config{
-			TailcfgDNSConfig: &tailcfg.DNSConfig{
-				Resolvers: resolvers,
-			},
+		return &tailcfg.DNSConfig{
+			Resolvers: resolvers,
 		}
 	}
 
@@ -124,7 +120,7 @@ func TestNextDNSCapMapRendering(t *testing.T) {
 		t.Parallel()
 
 		got := generateDNSConfig(
-			mkConfig("https://dns.nextdns.io/abc"),
+			mkDNS("https://dns.nextdns.io/abc"),
 			mkNode(),
 			nil,
 		)
@@ -143,7 +139,7 @@ func TestNextDNSCapMapRendering(t *testing.T) {
 		}
 
 		got := generateDNSConfig(
-			mkConfig("https://dns.nextdns.io/global"),
+			mkDNS("https://dns.nextdns.io/global"),
 			mkNode(),
 			capMap,
 		)
@@ -163,7 +159,7 @@ func TestNextDNSCapMapRendering(t *testing.T) {
 		}
 
 		got := generateDNSConfig(
-			mkConfig("https://dns.nextdns.io/global"),
+			mkDNS("https://dns.nextdns.io/global"),
 			mkNode(),
 			capMap,
 		)
@@ -182,7 +178,7 @@ func TestNextDNSCapMapRendering(t *testing.T) {
 		}
 
 		got := generateDNSConfig(
-			mkConfig("https://dns.example.org/dns-query"),
+			mkDNS("https://dns.example.org/dns-query"),
 			mkNode(),
 			capMap,
 		)

--- a/hscontrol/policy/pm.go
+++ b/hscontrol/policy/pm.go
@@ -24,6 +24,11 @@ type PolicyManager interface {
 	// SSHCheckParams resolves the SSH check period for a (src, dst) pair
 	// from the current policy, avoiding trust of client-provided URL params.
 	SSHCheckParams(srcNodeID, dstNodeID types.NodeID) (time.Duration, bool)
+	// NodeDNSConfig returns the DNSConfig for the given node by applying
+	// the matched DNS profile from the policy's dns block on top of base.
+	// Returns base unchanged if no profile matches. baseDomain is the
+	// tailnet base_domain, preserved when a profile replaces SearchDomains.
+	NodeDNSConfig(node types.NodeView, base *tailcfg.DNSConfig, baseDomain string) *tailcfg.DNSConfig
 	SetPolicy(pol []byte) (bool, error)
 	SetUsers(users []types.User) (bool, error)
 	SetNodes(nodes views.Slice[types.NodeView]) (bool, error)

--- a/hscontrol/policy/v2/dns_test.go
+++ b/hscontrol/policy/v2/dns_test.go
@@ -1,0 +1,639 @@
+package v2
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/dnstype"
+)
+
+// boolp returns a pointer to b. Tests use it for *bool fields where
+// present-vs-absent semantics matter.
+func boolp(b bool) *bool { return &b }
+
+// nsList returns a pointer to a []string built from the given values.
+func nsList(s ...string) *[]string { x := []string(s); return &x }
+
+// splitMap returns a pointer to a map[string][]string.
+func splitMap(m map[string][]string) *map[string][]string { return &m }
+
+// TestNodeDNSConfig exercises the matcher across all three tiers
+// (tag > user > group), the within-tier list-order precedence, and
+// the "no match returns base unchanged" behavior.
+func TestNodeDNSConfig(t *testing.T) {
+	users := types.Users{
+		{Model: gorm.Model{ID: 1}, Name: "admin", Email: "admin@headscale.net"},
+		{Model: gorm.Model{ID: 2}, Name: "friend", Email: "friend@headscale.net"},
+		{Model: gorm.Model{ID: 3}, Name: "boss", Email: "boss@headscale.net"},
+		{Model: gorm.Model{ID: 4}, Name: "other", Email: "other@headscale.net"},
+	}
+	adminUser, friendUser, bossUser, otherUser := users[0], users[1], users[2], users[3]
+
+	splitRoutes := map[string][]*dnstype.Resolver{
+		"scoresby.cloud": {{Addr: "192.168.4.2"}},
+	}
+	base := &tailcfg.DNSConfig{
+		Routes:  splitRoutes,
+		Domains: []string{"ts.scoresby.cloud"},
+		Proxied: true,
+	}
+
+	// Profiles in list order:
+	//   [0] admin override — Resolvers, override=true. Both group:admin
+	//       and friend@ (user-tier) point at it. friend is also in
+	//       group:friend listed later, but user tier beats group tier so
+	//       this profile wins for friend.
+	//   [1] friend group override — used by group:friend members that
+	//       aren't overridden via user tier above.
+	//   [2] server tag — for tagged nodes.
+	pol := `{
+		"groups": {
+			"group:admin": ["admin@"],
+			"group:friend": ["friend@", "boss@"]
+		},
+		"tagOwners": {
+			"tag:server": ["admin@"]
+		},
+		"dns": [
+			{
+				"nameservers": ["192.168.4.2"],
+				"overrideLocalDNS": true,
+				"groups": ["group:admin"],
+				"users": ["friend@"]
+			},
+			{
+				"nameservers": ["1.1.1.1"],
+				"groups": ["group:friend"]
+			},
+			{
+				"nameservers": ["10.0.0.1"],
+				"overrideLocalDNS": true,
+				"tags": ["tag:server"]
+			}
+		]
+	}`
+
+	adminNode := node("admin-phone", "100.64.0.1", "fd7a:115c:a1e0::1", adminUser)
+	adminNode.ID = 1
+	friendNode := node("friend-laptop", "100.64.0.2", "fd7a:115c:a1e0::2", friendUser)
+	friendNode.ID = 2
+	bossNode := node("boss-laptop", "100.64.0.3", "fd7a:115c:a1e0::3", bossUser)
+	bossNode.ID = 3
+	otherNode := node("other-phone", "100.64.0.4", "fd7a:115c:a1e0::4", otherUser)
+	otherNode.ID = 4
+	taggedNode := node("server-1", "100.64.0.5", "fd7a:115c:a1e0::5", types.User{})
+	taggedNode.ID = 5
+	taggedNode.Tags = types.Strings{"tag:server"}
+	untaggedNode := node("other-router", "100.64.0.6", "fd7a:115c:a1e0::6", types.User{})
+	untaggedNode.ID = 6
+	untaggedNode.Tags = types.Strings{"tag:unrelated"}
+
+	nodes := types.Nodes{adminNode, friendNode, bossNode, otherNode, taggedNode, untaggedNode}
+	pm, err := NewPolicyManager([]byte(pol), users, nodes.ViewSlice())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		node types.NodeView
+		want *tailcfg.DNSConfig
+	}{
+		{
+			// Admin is in group:admin → profile [0], override=true → Resolvers.
+			name: "group-tier-admin",
+			node: adminNode.View(),
+			want: &tailcfg.DNSConfig{
+				Routes:    splitRoutes,
+				Domains:   []string{"ts.scoresby.cloud"},
+				Proxied:   true,
+				Resolvers: []*dnstype.Resolver{{Addr: "192.168.4.2"}},
+			},
+		},
+		{
+			// friend@ matches profile [0]'s Users (user tier > group tier);
+			// would otherwise match profile [1] via group:friend.
+			name: "user-tier-beats-group-tier",
+			node: friendNode.View(),
+			want: &tailcfg.DNSConfig{
+				Routes:    splitRoutes,
+				Domains:   []string{"ts.scoresby.cloud"},
+				Proxied:   true,
+				Resolvers: []*dnstype.Resolver{{Addr: "192.168.4.2"}},
+			},
+		},
+		{
+			// boss@ is in group:friend only → profile [1], override=false → FallbackResolvers.
+			name: "group-tier-fallback-only",
+			node: bossNode.View(),
+			want: &tailcfg.DNSConfig{
+				Routes:            splitRoutes,
+				Domains:           []string{"ts.scoresby.cloud"},
+				Proxied:           true,
+				FallbackResolvers: []*dnstype.Resolver{{Addr: "1.1.1.1"}},
+			},
+		},
+		{
+			// other@ matches no profile → base unchanged.
+			name: "no-match-returns-base",
+			node: otherNode.View(),
+			want: base.Clone(),
+		},
+		{
+			// Tagged node matches profile [2] via tag:server.
+			name: "tag-tier",
+			node: taggedNode.View(),
+			want: &tailcfg.DNSConfig{
+				Routes:    splitRoutes,
+				Domains:   []string{"ts.scoresby.cloud"},
+				Proxied:   true,
+				Resolvers: []*dnstype.Resolver{{Addr: "10.0.0.1"}},
+			},
+		},
+		{
+			// Tagged node whose tags aren't in any profile → base unchanged.
+			name: "tagged-no-match-returns-base",
+			node: untaggedNode.View(),
+			want: base.Clone(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pm.NodeDNSConfig(tt.node, base, "")
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("NodeDNSConfig() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestNodeDNSConfigListOrderWithinTier verifies that within the group
+// tier, the first profile to list a matching group wins — even if the
+// node's user is in multiple groups assigned to different profiles.
+func TestNodeDNSConfigListOrderWithinTier(t *testing.T) {
+	users := types.Users{{Model: gorm.Model{ID: 1}, Name: "u", Email: "u@headscale.net"}}
+	user := users[0]
+
+	// The user is in both groups; list order ⇒ profile [0] wins.
+	pol := `{
+		"groups": {
+			"group:first":  ["u@"],
+			"group:second": ["u@"]
+		},
+		"dns": [
+			{ "nameservers": ["1.1.1.1"], "overrideLocalDNS": true, "groups": ["group:first"] },
+			{ "nameservers": ["8.8.8.8"], "overrideLocalDNS": true, "groups": ["group:second"] }
+		]
+	}`
+
+	n := node("u-node", "100.64.0.1", "fd7a:115c:a1e0::1", user)
+	n.ID = 1
+	pm, err := NewPolicyManager([]byte(pol), users, types.Nodes{n}.ViewSlice())
+	require.NoError(t, err)
+
+	got := pm.NodeDNSConfig(n.View(), &tailcfg.DNSConfig{}, "")
+	require.NotNil(t, got)
+	want := []*dnstype.Resolver{{Addr: "1.1.1.1"}}
+	if diff := cmp.Diff(want, got.Resolvers); diff != "" {
+		t.Errorf("list-order should pick profile[0] (group:first); mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestNodeDNSConfigMultiTagProfileListOrder verifies the tag tier
+// matches by profile list order, not by the order tags appear on the
+// node. A node with [tag:b, tag:a] should match profile {tags:[a]} (the
+// first profile listed) even though tag:b appears first on the node.
+func TestNodeDNSConfigMultiTagProfileListOrder(t *testing.T) {
+	users := types.Users{{Model: gorm.Model{ID: 1}, Name: "owner", Email: "owner@headscale.net"}}
+	pol := `{
+		"tagOwners": {
+			"tag:a": ["owner@"],
+			"tag:b": ["owner@"]
+		},
+		"dns": [
+			{ "nameservers": ["1.1.1.1"], "overrideLocalDNS": true, "tags": ["tag:a"] },
+			{ "nameservers": ["8.8.8.8"], "overrideLocalDNS": true, "tags": ["tag:b"] }
+		]
+	}`
+
+	n := node("server", "100.64.0.1", "fd7a:115c:a1e0::1", types.User{})
+	n.ID = 1
+	n.Tags = types.Strings{"tag:b", "tag:a"} // node order: b, a
+
+	pm, err := NewPolicyManager([]byte(pol), users, types.Nodes{n}.ViewSlice())
+	require.NoError(t, err)
+
+	got := pm.NodeDNSConfig(n.View(), &tailcfg.DNSConfig{}, "")
+	require.NotNil(t, got)
+	want := []*dnstype.Resolver{{Addr: "1.1.1.1"}}
+	if diff := cmp.Diff(want, got.Resolvers); diff != "" {
+		t.Errorf("profile list order (tag:a) should win over node tag order (tag:b first); mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestNodeDNSConfigUntaggedNoValidUser: an untagged node whose user is
+// invalid (no user record attached) matches no profile and returns base.
+func TestNodeDNSConfigUntaggedNoValidUser(t *testing.T) {
+	users := types.Users{{Model: gorm.Model{ID: 1}, Name: "u", Email: "u@headscale.net"}}
+	pol := `{
+		"groups": { "group:x": ["u@"] },
+		"dns": [
+			{ "nameservers": ["9.9.9.9"], "groups": ["group:x"] }
+		]
+	}`
+
+	// Node with no user attached.
+	n := node("nouser", "100.64.0.1", "fd7a:115c:a1e0::1", types.User{})
+	n.ID = 1
+	pm, err := NewPolicyManager([]byte(pol), users, types.Nodes{n}.ViewSlice())
+	require.NoError(t, err)
+
+	base := &tailcfg.DNSConfig{Routes: map[string][]*dnstype.Resolver{"x.example": {{Addr: "base"}}}}
+	got := pm.NodeDNSConfig(n.View(), base, "")
+	if diff := cmp.Diff(base, got); diff != "" {
+		t.Errorf("node with no valid user should return base unchanged; mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestNodeDNSConfigEmptyDNSPolicy: a policy with no dns block returns
+// base unchanged.
+func TestNodeDNSConfigEmptyDNSPolicy(t *testing.T) {
+	users := types.Users{{Model: gorm.Model{ID: 1}, Name: "u", Email: "u@headscale.net"}}
+	user := users[0]
+	pol := `{}`
+	n := node("u-node", "100.64.0.1", "fd7a:115c:a1e0::1", user)
+	n.ID = 1
+	pm, err := NewPolicyManager([]byte(pol), users, types.Nodes{n}.ViewSlice())
+	require.NoError(t, err)
+
+	base := &tailcfg.DNSConfig{Routes: map[string][]*dnstype.Resolver{"x.example": {{Addr: "base"}}}}
+	got := pm.NodeDNSConfig(n.View(), base, "")
+	if diff := cmp.Diff(base, got); diff != "" {
+		t.Errorf("empty DNS policy should return base unchanged; mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestNodeDNSConfigNilBase: a nil base passes through as nil.
+func TestNodeDNSConfigNilBase(t *testing.T) {
+	users := types.Users{{Model: gorm.Model{ID: 1}, Name: "u", Email: "u@headscale.net"}}
+	pol := `{}`
+	n := node("u-node", "100.64.0.1", "fd7a:115c:a1e0::1", users[0])
+	n.ID = 1
+	pm, err := NewPolicyManager([]byte(pol), users, types.Nodes{n}.ViewSlice())
+	require.NoError(t, err)
+	if got := pm.NodeDNSConfig(n.View(), nil, ""); got != nil {
+		t.Errorf("nil base should produce nil; got %v", got)
+	}
+}
+
+// TestNodeDNSConfigSplitAndSearchDomains: a profile can override Split
+// (Routes) and SearchDomains on top of base.
+func TestNodeDNSConfigSplitAndSearchDomains(t *testing.T) {
+	users := types.Users{{Model: gorm.Model{ID: 1}, Name: "eng", Email: "eng@headscale.net"}}
+	user := users[0]
+
+	pol := `{
+		"groups": { "group:eng": ["eng@"] },
+		"dns": [
+			{
+				"nameservers": ["192.168.4.2"],
+				"overrideLocalDNS": true,
+				"split": { "internal.example": ["10.0.0.1"] },
+				"searchDomains": ["internal.example"],
+				"groups": ["group:eng"]
+			}
+		]
+	}`
+
+	n := node("eng-node", "100.64.0.1", "fd7a:115c:a1e0::1", user)
+	n.ID = 1
+	pm, err := NewPolicyManager([]byte(pol), users, types.Nodes{n}.ViewSlice())
+	require.NoError(t, err)
+
+	base := &tailcfg.DNSConfig{
+		Routes:  map[string][]*dnstype.Resolver{"old.example": {{Addr: "base-res"}}},
+		Domains: []string{"base.example"},
+		Proxied: true,
+	}
+	got := pm.NodeDNSConfig(n.View(), base, "base.example")
+	require.NotNil(t, got)
+
+	// Split replaces Routes; SearchDomains is appended after base_domain.
+	wantRoutes := map[string][]*dnstype.Resolver{"internal.example": {{Addr: "10.0.0.1"}}}
+	if diff := cmp.Diff(wantRoutes, got.Routes); diff != "" {
+		t.Errorf("Routes mismatch (-want +got):\n%s", diff)
+	}
+	wantDomains := []string{"base.example", "internal.example"}
+	if diff := cmp.Diff(wantDomains, got.Domains); diff != "" {
+		t.Errorf("Domains mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// ---- Validation tests ----
+
+// TestPolicyValidateDNSProfileNoAssignmentList: a profile with no
+// Groups, Users, or Tags is rejected — it could never match any node.
+func TestPolicyValidateDNSProfileNoAssignmentList(t *testing.T) {
+	pol := `{
+		"dns": [
+			{ "nameservers": ["9.9.9.9"] }
+		]
+	}`
+	users := types.Users{{Model: gorm.Model{ID: 1}, Name: "u", Email: "u@headscale.net"}}
+	_, err := NewPolicyManager([]byte(pol), users, types.Nodes{}.ViewSlice())
+	if err == nil {
+		t.Fatal("expected validation error for profile with no assignment list, got nil")
+	}
+	if !errors.Is(err, ErrDNSProfileHasNoAssignmentList) {
+		t.Errorf("expected ErrDNSProfileHasNoAssignmentList, got: %v", err)
+	}
+}
+
+// TestPolicyValidateDNSDuplicatePrincipal: a group / user / tag may
+// appear in at most one profile's assignment list.
+func TestPolicyValidateDNSDuplicatePrincipal(t *testing.T) {
+	cases := map[string]string{
+		"group-in-two-profiles": `{
+			"groups": { "group:x": ["u@"] },
+			"dns": [
+				{ "nameservers": ["9.9.9.9"], "groups": ["group:x"] },
+				{ "nameservers": ["1.1.1.1"], "groups": ["group:x"] }
+			]
+		}`,
+		"user-in-two-profiles": `{
+			"dns": [
+				{ "nameservers": ["9.9.9.9"], "users": ["u@"] },
+				{ "nameservers": ["1.1.1.1"], "users": ["u@"] }
+			]
+		}`,
+		"tag-in-two-profiles": `{
+			"tagOwners": { "tag:t": ["u@"] },
+			"dns": [
+				{ "nameservers": ["9.9.9.9"], "tags": ["tag:t"] },
+				{ "nameservers": ["1.1.1.1"], "tags": ["tag:t"] }
+			]
+		}`,
+	}
+	users := types.Users{{Model: gorm.Model{ID: 1}, Name: "u", Email: "u@headscale.net"}}
+	for name, pol := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewPolicyManager([]byte(pol), users, types.Nodes{}.ViewSlice())
+			if err == nil {
+				t.Fatal("expected validation error for duplicate principal across profiles, got nil")
+			}
+			if !errors.Is(err, ErrDNSPrincipalAssignedTwice) {
+				t.Errorf("expected ErrDNSPrincipalAssignedTwice, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestPolicyValidateDNSUndefinedReference: every referenced group must
+// exist in the policy's top-level groups; every tag must exist in
+// tagOwners; every username must be syntactically valid.
+func TestPolicyValidateDNSUndefinedReference(t *testing.T) {
+	cases := map[string]string{
+		"undefined-group": `{
+			"groups": { "group:defined": ["u@"] },
+			"dns": [
+				{ "nameservers": ["9.9.9.9"], "groups": ["group:undefined"] }
+			]
+		}`,
+		"undefined-tag": `{
+			"tagOwners": { "tag:defined": ["u@"] },
+			"dns": [
+				{ "nameservers": ["9.9.9.9"], "tags": ["tag:undefined"] }
+			]
+		}`,
+		"bad-username": `{
+			"dns": [
+				{ "nameservers": ["9.9.9.9"], "users": ["no-at-sign"] }
+			]
+		}`,
+	}
+	users := types.Users{{Model: gorm.Model{ID: 1}, Name: "u", Email: "u@headscale.net"}}
+	for name, pol := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewPolicyManager([]byte(pol), users, types.Nodes{}.ViewSlice())
+			if err == nil {
+				t.Fatal("expected validation error for undefined reference, got nil")
+			}
+		})
+	}
+}
+
+// TestSetUsersForcesChangeWhenDNSProfilesExist verifies that a user
+// update on a policy that has DNS profiles always reports change=true,
+// even when the filter / tag-owner / auto-approver hashes are stable.
+// A user create / rename can shift which DNS profile a node matches
+// (e.g., a new user landing in a group an existing profile assigns) —
+// without this carve-out, affected nodes would keep stale DNS until
+// the next unrelated policy event.
+func TestSetUsersForcesChangeWhenDNSProfilesExist(t *testing.T) {
+	// Policy has only DNS profiles, no ACLs / grants / SSH — so the
+	// filter and tag-owner hashes are empty/stable across SetUsers.
+	pol := `{
+		"groups": { "group:eng": ["eng@"] },
+		"dns": [
+			{ "nameservers": ["9.9.9.9"], "groups": ["group:eng"] }
+		]
+	}`
+	users := types.Users{{Model: gorm.Model{ID: 1}, Name: "u", Email: "u@headscale.net"}}
+	pm, err := NewPolicyManager([]byte(pol), users, types.Nodes{}.ViewSlice())
+	require.NoError(t, err)
+
+	// Add a new user. With no DNS carve-out, SetUsers would return
+	// false (filter/tag/autoapprove hashes haven't moved). With the
+	// carve-out, it returns true so map responses get rebroadcast.
+	newUsers := append(users, types.User{Model: gorm.Model{ID: 2}, Name: "eng", Email: "eng@headscale.net"})
+	changed, err := pm.SetUsers(newUsers)
+	require.NoError(t, err)
+	if !changed {
+		t.Error("SetUsers should report change=true when the policy has DNS profiles, even if other hashes are stable")
+	}
+}
+
+// ---- applyDNSProfile direct unit tests ----
+
+func TestApplyDNSProfileFieldHandoff(t *testing.T) {
+	base := &tailcfg.DNSConfig{
+		Resolvers:         []*dnstype.Resolver{{Addr: "base-res"}},
+		FallbackResolvers: []*dnstype.Resolver{{Addr: "base-fb"}},
+		Routes:            map[string][]*dnstype.Resolver{"old.example": {{Addr: "old-res"}}},
+		Domains:           []string{"base.example"},
+	}
+
+	t.Run("override-true-clears-fallback", func(t *testing.T) {
+		got := applyDNSProfile(base, "base.example", DNSProfile{
+			Nameservers:      nsList("1.1.1.1"),
+			OverrideLocalDNS: boolp(true),
+		})
+		if got.Resolvers[0].Addr != "1.1.1.1" {
+			t.Errorf("Resolvers should be set to profile.Nameservers")
+		}
+		if got.FallbackResolvers != nil {
+			t.Errorf("FallbackResolvers should be cleared when override=true; got %v", got.FallbackResolvers)
+		}
+	})
+
+	t.Run("override-false-clears-resolvers", func(t *testing.T) {
+		got := applyDNSProfile(base, "base.example", DNSProfile{
+			Nameservers:      nsList("8.8.8.8"),
+			OverrideLocalDNS: boolp(false),
+		})
+		if got.FallbackResolvers[0].Addr != "8.8.8.8" {
+			t.Errorf("FallbackResolvers should be set to profile.Nameservers")
+		}
+		if got.Resolvers != nil {
+			t.Errorf("Resolvers should be cleared when override=false; got %v", got.Resolvers)
+		}
+	})
+
+	t.Run("absent-nameservers-inherits-both", func(t *testing.T) {
+		got := applyDNSProfile(base, "base.example", DNSProfile{})
+		if diff := cmp.Diff(base.Resolvers, got.Resolvers); diff != "" {
+			t.Errorf("absent nameservers should leave Resolvers inherited; mismatch (-want +got):\n%s", diff)
+		}
+		if diff := cmp.Diff(base.FallbackResolvers, got.FallbackResolvers); diff != "" {
+			t.Errorf("absent nameservers should leave FallbackResolvers inherited; mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("present-empty-nameservers-clears-both", func(t *testing.T) {
+		got := applyDNSProfile(base, "base.example", DNSProfile{
+			Nameservers:      nsList(),
+			OverrideLocalDNS: boolp(true),
+		})
+		if got.Resolvers != nil {
+			t.Errorf("present-empty Nameservers with override=true should clear Resolvers; got %v", got.Resolvers)
+		}
+		if got.FallbackResolvers != nil {
+			t.Errorf("FallbackResolvers should be cleared; got %v", got.FallbackResolvers)
+		}
+	})
+
+	t.Run("override-only-reroutes-inherited-from-fallback-to-resolvers", func(t *testing.T) {
+		fbBase := &tailcfg.DNSConfig{
+			FallbackResolvers: []*dnstype.Resolver{{Addr: "fb"}},
+		}
+		got := applyDNSProfile(fbBase, "", DNSProfile{
+			OverrideLocalDNS: boolp(true),
+		})
+		if got.Resolvers == nil || got.Resolvers[0].Addr != "fb" {
+			t.Errorf("inherited FallbackResolvers should re-route to Resolvers; got Resolvers=%v", got.Resolvers)
+		}
+		if got.FallbackResolvers != nil {
+			t.Errorf("FallbackResolvers should be cleared after re-route; got %v", got.FallbackResolvers)
+		}
+	})
+
+	t.Run("override-only-reroutes-inherited-from-resolvers-to-fallback", func(t *testing.T) {
+		resBase := &tailcfg.DNSConfig{
+			Resolvers: []*dnstype.Resolver{{Addr: "res"}},
+		}
+		got := applyDNSProfile(resBase, "", DNSProfile{
+			OverrideLocalDNS: boolp(false),
+		})
+		if got.FallbackResolvers == nil || got.FallbackResolvers[0].Addr != "res" {
+			t.Errorf("inherited Resolvers should re-route to FallbackResolvers; got FallbackResolvers=%v", got.FallbackResolvers)
+		}
+		if got.Resolvers != nil {
+			t.Errorf("Resolvers should be cleared after re-route; got %v", got.Resolvers)
+		}
+	})
+
+	t.Run("split-replaces-routes", func(t *testing.T) {
+		got := applyDNSProfile(base, "base.example", DNSProfile{
+			Split: splitMap(map[string][]string{"new.example": {"new-res"}}),
+		})
+		want := map[string][]*dnstype.Resolver{"new.example": {{Addr: "new-res"}}}
+		if diff := cmp.Diff(want, got.Routes); diff != "" {
+			t.Errorf("Split should replace Routes; mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("absent-split-inherits-routes", func(t *testing.T) {
+		got := applyDNSProfile(base, "base.example", DNSProfile{})
+		if diff := cmp.Diff(base.Routes, got.Routes); diff != "" {
+			t.Errorf("absent Split should leave Routes inherited; mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("present-empty-split-clears-routes", func(t *testing.T) {
+		got := applyDNSProfile(base, "base.example", DNSProfile{
+			Split: splitMap(map[string][]string{}),
+		})
+		if len(got.Routes) != 0 {
+			t.Errorf("present-empty Split should clear Routes; got %v", got.Routes)
+		}
+	})
+
+	t.Run("search-domains-replaces-preserving-base-domain", func(t *testing.T) {
+		got := applyDNSProfile(base, "base.example", DNSProfile{
+			SearchDomains: &[]string{"new.example"},
+		})
+		want := []string{"base.example", "new.example"}
+		if diff := cmp.Diff(want, got.Domains); diff != "" {
+			t.Errorf("SearchDomains should replace Domains[1:] preserving Domains[0]; mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("search-domains-no-base-domain-fully-replaces-domains", func(t *testing.T) {
+		// When base_domain is unset (yaml has dns.base_domain: "") but
+		// dns.search_domains is set, base.Domains contains only search
+		// domains. SearchDomains on a profile should fully replace those —
+		// NOT promote the first inherited search domain to a "base_domain"
+		// slot.
+		searchOnlyBase := &tailcfg.DNSConfig{
+			Domains: []string{"inherited-search1", "inherited-search2"},
+		}
+		got := applyDNSProfile(searchOnlyBase, "", DNSProfile{
+			SearchDomains: &[]string{"profile-search"},
+		})
+		want := []string{"profile-search"}
+		if diff := cmp.Diff(want, got.Domains); diff != "" {
+			t.Errorf("with no base_domain, SearchDomains should fully replace Domains; mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("absent-search-domains-leaves-domains-untouched", func(t *testing.T) {
+		got := applyDNSProfile(base, "base.example", DNSProfile{})
+		if diff := cmp.Diff(base.Domains, got.Domains); diff != "" {
+			t.Errorf("absent SearchDomains should leave Domains untouched; mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("present-empty-search-domains-clears-search-portion", func(t *testing.T) {
+		// SearchDomains: &[]string{} is the "present-but-empty" case —
+		// it explicitly clears the search-domain portion of Domains,
+		// preserving only baseDomain.
+		got := applyDNSProfile(base, "base.example", DNSProfile{
+			SearchDomains: &[]string{},
+		})
+		want := []string{"base.example"}
+		if diff := cmp.Diff(want, got.Domains); diff != "" {
+			t.Errorf("present-empty SearchDomains with baseDomain should yield [baseDomain]; mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("present-empty-search-domains-no-base-domain-clears-all", func(t *testing.T) {
+		// SearchDomains: &[]string{} with empty baseDomain → no Domains.
+		got := applyDNSProfile(base, "", DNSProfile{
+			SearchDomains: &[]string{},
+		})
+		if len(got.Domains) != 0 {
+			t.Errorf("present-empty SearchDomains with no baseDomain should yield empty Domains; got %v", got.Domains)
+		}
+	})
+
+	t.Run("fully-empty-profile-equals-base", func(t *testing.T) {
+		got := applyDNSProfile(base, "base.example", DNSProfile{})
+		if diff := cmp.Diff(base, got); diff != "" {
+			t.Errorf("a fully-empty profile should produce base.Clone(); mismatch (-want +got):\n%s", diff)
+		}
+	})
+}

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -19,6 +19,7 @@ import (
 	"go4.org/netipx"
 	"tailscale.com/net/tsaddr"
 	"tailscale.com/tailcfg"
+	"tailscale.com/types/dnstype"
 	"tailscale.com/types/views"
 	"tailscale.com/util/deephash"
 	"tailscale.com/util/multierr"
@@ -32,6 +33,10 @@ type PolicyManager struct {
 	pol   *Policy
 	users []types.User
 	nodes views.Slice[types.NodeView]
+
+	dnsProfileByTag   map[Tag]int
+	dnsProfileByUser  map[types.UserID]int
+	dnsProfileByGroup map[types.UserID]int
 
 	filterHash deephash.Sum
 	filter     []tailcfg.FilterRule
@@ -176,6 +181,12 @@ func validateUserReferences(pol *Policy, users types.Users) error {
 		}
 	}
 
+	for _, profile := range pol.DNS {
+		for i := range profile.Users {
+			check(&profile.Users[i])
+		}
+	}
+
 	return multierr.New(errs...)
 }
 
@@ -240,6 +251,8 @@ func (pm *PolicyManager) updateLocked() (bool, error) {
 	}
 
 	pm.relayTargetIPs = relayTargetIPs
+
+	pm.buildDNSProfileIndexesLocked()
 
 	var filter []tailcfg.FilterRule
 	if pm.pol == nil || (pm.pol.ACLs == nil && pm.pol.Grants == nil) {
@@ -518,6 +531,185 @@ func (pm *PolicyManager) SSHCheckParams(
 	}
 
 	return 0, false
+}
+
+// NodeDNSConfig returns the DNSConfig for the given node by applying
+// the matched DNS profile from the policy's dns block on top of base.
+// Returns base unchanged if no profile matches; returns nil if base is
+// nil. baseDomain is the tailnet base_domain, preserved when a profile
+// replaces SearchDomains.
+func (pm *PolicyManager) NodeDNSConfig(node types.NodeView, base *tailcfg.DNSConfig, baseDomain string) *tailcfg.DNSConfig {
+	if base == nil {
+		return nil
+	}
+
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	if pm.pol == nil || len(pm.pol.DNS) == 0 {
+		return base.Clone()
+	}
+
+	matchIdx := pm.matchProfile(node)
+	if matchIdx < 0 {
+		return base.Clone()
+	}
+	return applyDNSProfile(base, baseDomain, pm.pol.DNS[matchIdx])
+}
+
+// matchProfile returns the index of the DNS profile chosen for the
+// given node, or -1 if no profile matches. Caller must hold pm.mu.
+func (pm *PolicyManager) matchProfile(node types.NodeView) int {
+	if node.IsTagged() {
+		// Tag tier (tagged nodes only); min over tags = list-order winner.
+		best := -1
+		for _, tagStr := range node.Tags().AsSlice() {
+			if idx, ok := pm.dnsProfileByTag[Tag(tagStr)]; ok {
+				if best < 0 || idx < best {
+					best = idx
+				}
+			}
+		}
+		return best
+	}
+
+	nodeUserID := node.TypedUserID()
+	if nodeUserID == 0 {
+		return -1
+	}
+
+	// User tier.
+	if idx, ok := pm.dnsProfileByUser[nodeUserID]; ok {
+		return idx
+	}
+
+	// Group tier.
+	if idx, ok := pm.dnsProfileByGroup[nodeUserID]; ok {
+		return idx
+	}
+
+	return -1
+}
+
+// buildDNSProfileIndexesLocked rebuilds the DNS profile lookup maps
+// from the current policy + users. Caller must hold pm.mu.
+func (pm *PolicyManager) buildDNSProfileIndexesLocked() {
+	pm.dnsProfileByTag = nil
+	pm.dnsProfileByUser = nil
+	pm.dnsProfileByGroup = nil
+
+	if pm.pol == nil || len(pm.pol.DNS) == 0 {
+		return
+	}
+
+	pm.dnsProfileByTag = make(map[Tag]int)
+	pm.dnsProfileByUser = make(map[types.UserID]int)
+	pm.dnsProfileByGroup = make(map[types.UserID]int)
+
+	setIfLower := func(m map[types.UserID]int, uid types.UserID, idx int) {
+		if prev, ok := m[uid]; !ok || idx < prev {
+			m[uid] = idx
+		}
+	}
+
+	for i, profile := range pm.pol.DNS {
+		for _, t := range profile.Tags {
+			if _, ok := pm.dnsProfileByTag[t]; !ok {
+				pm.dnsProfileByTag[t] = i
+			}
+		}
+		for _, username := range profile.Users {
+			user, err := username.resolveUser(pm.users)
+			if err != nil {
+				continue
+			}
+			setIfLower(pm.dnsProfileByUser, types.UserID(user.ID), i)
+		}
+		for _, groupName := range profile.Groups {
+			members, ok := pm.pol.Groups[groupName]
+			if !ok {
+				continue
+			}
+			for _, member := range members {
+				user, err := member.resolveUser(pm.users)
+				if err != nil {
+					continue
+				}
+				setIfLower(pm.dnsProfileByGroup, types.UserID(user.ID), i)
+			}
+		}
+	}
+}
+
+// applyDNSProfile returns a clone of base with the profile's set fields
+// substituted in. Pointer-typed body fields use present-vs-absent
+// semantics: a present field (even if empty) replaces the inherited
+// value; an absent field inherits. baseDomain is preserved at
+// Domains[0] when SearchDomains is replaced.
+func applyDNSProfile(base *tailcfg.DNSConfig, baseDomain string, profile DNSProfile) *tailcfg.DNSConfig {
+	cfg := base.Clone()
+
+	// Inherit override state from base (Resolvers populated => override;
+	// neither populated => default false), unless the profile says otherwise.
+	override := cfg.Resolvers != nil
+	if profile.OverrideLocalDNS != nil {
+		override = *profile.OverrideLocalDNS
+	}
+
+	var nameservers []*dnstype.Resolver
+	switch {
+	case profile.Nameservers != nil:
+		nameservers = stringsToResolvers(*profile.Nameservers)
+	case cfg.Resolvers != nil:
+		nameservers = cfg.Resolvers
+	default:
+		nameservers = cfg.FallbackResolvers
+	}
+
+	// Only re-emit wire fields if the profile said something about resolvers.
+	if profile.Nameservers != nil || profile.OverrideLocalDNS != nil {
+		cfg.Resolvers = nil
+		cfg.FallbackResolvers = nil
+		if override {
+			cfg.Resolvers = nameservers
+		} else {
+			cfg.FallbackResolvers = nameservers
+		}
+	}
+
+	if profile.Split != nil {
+		cfg.Routes = make(map[string][]*dnstype.Resolver, len(*profile.Split))
+		for domain, addrs := range *profile.Split {
+			cfg.Routes[domain] = stringsToResolvers(addrs)
+		}
+	}
+	if profile.SearchDomains != nil {
+		// Preserve baseDomain at Domains[0]; when empty, omit so we
+		// don't promote a stale Domains[0] as a search domain.
+		var head []string
+		if baseDomain != "" {
+			head = []string{baseDomain}
+		}
+		cfg.Domains = append(head, (*profile.SearchDomains)...)
+	}
+	return cfg
+}
+
+// stringsToResolvers converts a list of address strings (IPs or DoH URLs)
+// into the wire-protocol resolver slice. Mirrors the leniency of
+// (*types.DNSConfig).globalResolvers: invalid entries are not rejected
+// here but simply will not resolve at runtime.
+func stringsToResolvers(addrs []string) []*dnstype.Resolver {
+	if len(addrs) == 0 {
+		return nil
+	}
+
+	resolvers := make([]*dnstype.Resolver, 0, len(addrs))
+	for _, a := range addrs {
+		resolvers = append(resolvers, &dnstype.Resolver{Addr: a})
+	}
+
+	return resolvers
 }
 
 func (pm *PolicyManager) SetPolicy(polB []byte) (bool, error) {
@@ -800,6 +992,12 @@ func (pm *PolicyManager) SetUsers(users []types.User) (bool, error) {
 	// If SSH policies exist, force a policy change when users are updated
 	// This ensures nodes get updated SSH policies even if other policy hashes didn't change
 	if pm.pol != nil && pm.pol.SSHs != nil && len(pm.pol.SSHs) > 0 {
+		return true, nil
+	}
+
+	// Same for DNS profiles: a user change can shift profile resolution
+	// without moving the filter / tag-owner / auto-approver hashes.
+	if pm.pol != nil && len(pm.pol.DNS) > 0 {
 		return true, nil
 	}
 

--- a/hscontrol/policy/v2/policy_test.go
+++ b/hscontrol/policy/v2/policy_test.go
@@ -2220,6 +2220,12 @@ func TestValidateUserReferences_AllSites(t *testing.T) {
   "ssh": [{"action":"accept","src":["dup@"],"dst":["dup@"],"users":["root"]}]
 }`,
 		},
+		{
+			name: "dns",
+			pol: `{
+  "dns": [{"users":["dup@"]}]
+}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/hscontrol/policy/v2/types.go
+++ b/hscontrol/policy/v2/types.go
@@ -36,6 +36,12 @@ var ErrAutogroupSelfRequiresPerNodeResolution = errors.New("autogroup:self requi
 
 var ErrUndefinedTagReference = errors.New("references undefined tag")
 
+// DNS validation errors.
+var (
+	ErrDNSProfileHasNoAssignmentList = errors.New("DNS profile has no assignment list")
+	ErrDNSPrincipalAssignedTwice     = errors.New("DNS principal assigned to two profiles")
+)
+
 // SSH validation errors.
 var (
 	ErrSSHTagSourceToUserDest             = errors.New("tags in SSH source cannot access user-owned devices")
@@ -2097,6 +2103,27 @@ type Policy struct {
 	Tests               []PolicyTest       `json:"tests,omitempty"`
 	SSHTests            []SSHPolicyTest    `json:"sshTests,omitempty"`
 	RandomizeClientPort bool               `json:"randomizeClientPort,omitempty"`
+	DNS                 PolicyDNS          `json:"dns,omitempty"`
+}
+
+// PolicyDNS is an ordered list of DNS profile overrides applied on top
+// of the tailnet-wide DNS config in headscale.yaml. See docs/ref/policy.md.
+type PolicyDNS []DNSProfile
+
+// DNSProfile is one DNS override assignable by tag, user, or group. Body
+// fields are pointer-typed: a present field (even empty) replaces the
+// inherited value; absent fields inherit. Every profile must set at
+// least one of Groups, Users, or Tags; a principal may appear in at
+// most one profile.
+type DNSProfile struct {
+	Nameservers      *[]string            `json:"nameservers,omitempty"`
+	OverrideLocalDNS *bool                `json:"overrideLocalDNS,omitempty"`
+	Split            *map[string][]string `json:"split,omitempty"`
+	SearchDomains    *[]string            `json:"searchDomains,omitempty"`
+
+	Groups []Group    `json:"groups,omitempty"`
+	Users  []Username `json:"users,omitempty"`
+	Tags   []Tag      `json:"tags,omitempty"`
 }
 
 // MarshalJSON is deliberately not implemented for [Policy].
@@ -2905,6 +2932,62 @@ func (p *Policy) validate() error {
 
 	if err := validateSSHTests(p, p.SSHTests); err != nil { //nolint:noinlineerr
 		errs = append(errs, err)
+	}
+
+	for i, profile := range p.DNS {
+		if len(profile.Groups) == 0 && len(profile.Users) == 0 && len(profile.Tags) == 0 {
+			errs = append(errs, fmt.Errorf("dns[%d]: %w", i, ErrDNSProfileHasNoAssignmentList))
+		}
+		for _, u := range profile.Users {
+			uCopy := u
+			if err := uCopy.Validate(); err != nil {
+				errs = append(errs, fmt.Errorf("dns[%d].users: %w", i, err))
+			}
+		}
+		for _, g := range profile.Groups {
+			gCopy := g
+			if err := p.Groups.Contains(&gCopy); err != nil {
+				errs = append(errs, fmt.Errorf("dns[%d].groups: %w", i, err))
+			}
+		}
+		for _, t := range profile.Tags {
+			tCopy := t
+			if err := p.TagOwners.Contains(&tCopy); err != nil {
+				errs = append(errs, fmt.Errorf("dns[%d].tags: %w", i, err))
+			}
+		}
+	}
+	seenGroup := make(map[Group]int)
+	seenUser := make(map[Username]int)
+	seenTag := make(map[Tag]int)
+	for i, profile := range p.DNS {
+		for _, g := range profile.Groups {
+			if prev, ok := seenGroup[g]; ok {
+				errs = append(errs, fmt.Errorf(
+					"group %q in dns[%d] and dns[%d]: %w",
+					g, prev, i, ErrDNSPrincipalAssignedTwice))
+			} else {
+				seenGroup[g] = i
+			}
+		}
+		for _, u := range profile.Users {
+			if prev, ok := seenUser[u]; ok {
+				errs = append(errs, fmt.Errorf(
+					"user %q in dns[%d] and dns[%d]: %w",
+					u, prev, i, ErrDNSPrincipalAssignedTwice))
+			} else {
+				seenUser[u] = i
+			}
+		}
+		for _, t := range profile.Tags {
+			if prev, ok := seenTag[t]; ok {
+				errs = append(errs, fmt.Errorf(
+					"tag %q in dns[%d] and dns[%d]: %w",
+					t, prev, i, ErrDNSPrincipalAssignedTwice))
+			} else {
+				seenTag[t] = i
+			}
+		}
 	}
 
 	if len(errs) > 0 {

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -1052,6 +1052,12 @@ func (s *State) SSHPolicy(node types.NodeView) (*tailcfg.SSHPolicy, error) {
 	return s.polMan.SSHPolicy(s.cfg.ServerURL, node)
 }
 
+// NodeDNSConfig returns the DNSConfig for a node, applying the matched
+// DNS profile from the policy on top of base.
+func (s *State) NodeDNSConfig(node types.NodeView, base *tailcfg.DNSConfig) *tailcfg.DNSConfig {
+	return s.polMan.NodeDNSConfig(node, base, s.cfg.BaseDomain)
+}
+
 // SSHCheckParams resolves the SSH check period for a source-destination
 // node pair from the current policy.
 func (s *State) SSHCheckParams(

--- a/integration/dns_test.go
+++ b/integration/dns_test.go
@@ -7,12 +7,14 @@ import (
 	"testing"
 	"time"
 
+	policyv2 "github.com/juanfont/headscale/hscontrol/policy/v2"
 	"github.com/juanfont/headscale/integration/hsic"
 	"github.com/juanfont/headscale/integration/integrationutil"
 	"github.com/juanfont/headscale/integration/tsic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"tailscale.com/tailcfg"
+	"tailscale.com/types/dnstype"
 )
 
 func TestResolveMagicDNS(t *testing.T) {
@@ -220,5 +222,160 @@ func TestResolveMagicDNSExtraRecordsPath(t *testing.T) {
 
 	for _, client := range allClients {
 		assertCommandOutputContains(t, client, []string{"dig", "copy.myvpn.example.com"}, "8.8.8.8")
+	}
+}
+
+// hasResolverAddr returns true if any entry in resolvers has the given
+// Addr. Used by the integration test to assert presence / absence of
+// an override resolver across either Resolvers or FallbackResolvers.
+func hasResolverAddr(resolvers []*dnstype.Resolver, addr string) bool {
+	for _, r := range resolvers {
+		if r != nil && r.Addr == addr {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPolicyDNSProfiles exercises the policy DNS profiles feature
+// end-to-end across two configurations and a hot-reload between them:
+//
+//	Phase 1 (no policy DNS overrides): both admin and guest clients
+//	get the base DNS config from headscale.yaml's `dns:` block.
+//
+//	Phase 2 (hot reload → add group:admin override): the policy is
+//	updated via SetPolicy to add a profile that overrides Resolvers
+//	for group:admin. SetPolicy is the same downstream entry point
+//	that the file-mode reload path (systemctl reload / SIGHUP) hits,
+//	so this exercises the hot-reload propagation mechanism even
+//	though the trigger is the API rather than a signal.
+//
+//	Phase 3 (post-reload): admin's netmap carries the override
+//	Resolvers; guest's netmap is unchanged (no override resolver in
+//	either Resolvers or FallbackResolvers).
+func TestPolicyDNSProfiles(t *testing.T) {
+	IntegrationSkip(t)
+
+	const (
+		adminUser     = "admin-user"
+		guestUser     = "guest-user"
+		overrideNS    = "10.99.0.42"
+		adminGroup    = "group:admin"
+		splitDomain   = "internal.example"
+		splitResolver = "10.99.0.99"
+	)
+
+	// Initial policy: no dns block. Everyone gets the yaml base.
+	initialPolicy := &policyv2.Policy{
+		Groups: policyv2.Groups{
+			policyv2.Group(adminGroup): []policyv2.Username{
+				policyv2.Username(adminUser + "@"),
+			},
+		},
+	}
+
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{adminUser, guestUser},
+		Versions:     []string{"head"},
+	}
+
+	scenario, err := NewScenario(spec)
+	require.NoError(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv(
+		[]tsic.Option{tsic.WithNetfilter("off")},
+		hsic.WithACLPolicy(initialPolicy),
+		hsic.WithTestName("dnsreload"),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	err = scenario.WaitForTailscaleSync()
+	requireNoErrSync(t, err)
+
+	adminClients, err := scenario.ListTailscaleClients(adminUser)
+	requireNoErrListClients(t, err)
+	require.NotEmpty(t, adminClients)
+	guestClients, err := scenario.ListTailscaleClients(guestUser)
+	requireNoErrListClients(t, err)
+	require.NotEmpty(t, guestClients)
+
+	// Phase 1: no policy.dns overrides — neither client should have
+	// the override resolver set in Resolvers OR FallbackResolvers.
+	for _, client := range append(adminClients, guestClients...) {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			nm, err := client.Netmap()
+			if !assert.NoError(ct, err) || !assert.NotNil(ct, nm) || !assert.NotNil(ct, nm.DNS) {
+				return
+			}
+			assert.False(ct, hasResolverAddr(nm.DNS.Resolvers, overrideNS),
+				"initial: %s should not have the override in Resolvers yet", client.Hostname())
+			assert.False(ct, hasResolverAddr(nm.DNS.FallbackResolvers, overrideNS),
+				"initial: %s should not have the override in FallbackResolvers yet", client.Hostname())
+		}, integrationutil.StatusReadyTimeout, 1*time.Second)
+	}
+
+	// Phase 2: hot-reload the policy to add a group:admin override.
+	// The override profile exercises three body fields at once:
+	//   Nameservers + OverrideLocalDNS → Resolvers populated on the wire
+	//   Split → Routes populated on the wire (split-DNS coverage)
+	overrideNSList := []string{overrideNS}
+	overrideTrue := true
+	splitMap := map[string][]string{splitDomain: {splitResolver}}
+	updatedPolicy := &policyv2.Policy{
+		Groups: initialPolicy.Groups,
+		DNS: policyv2.PolicyDNS{
+			{
+				Nameservers:      &overrideNSList,
+				OverrideLocalDNS: &overrideTrue,
+				Split:            &splitMap,
+				Groups:           []policyv2.Group{policyv2.Group(adminGroup)},
+			},
+		},
+	}
+
+	headscale, err := scenario.Headscale()
+	require.NoError(t, err)
+	require.NoError(t, headscale.SetPolicy(updatedPolicy),
+		"hot-reloading the policy should succeed")
+
+	// Phase 3: admin now receives the override Resolver; guest is
+	// unchanged. EventuallyWithT bounds the wait so the netmap update
+	// can propagate to the clients.
+	for _, client := range adminClients {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			nm, err := client.Netmap()
+			if !assert.NoError(ct, err) || !assert.NotNil(ct, nm) || !assert.NotNil(ct, nm.DNS) {
+				return
+			}
+			if assert.Len(ct, nm.DNS.Resolvers, 1, "admin should have one Resolver after reload") {
+				assert.Equal(ct, overrideNS, nm.DNS.Resolvers[0].Addr,
+					"admin's Resolvers should be the override after reload")
+			}
+			if assert.Contains(ct, nm.DNS.Routes, splitDomain,
+				"admin's Routes should carry the profile's Split entry") {
+				if assert.Len(ct, nm.DNS.Routes[splitDomain], 1) {
+					assert.Equal(ct, splitResolver, nm.DNS.Routes[splitDomain][0].Addr,
+						"split resolver should be the profile's value")
+				}
+			}
+		}, integrationutil.PolicyPropagationTimeout, 2*time.Second,
+			"admin %s should receive override + split DNS after hot-reload", client.Hostname())
+	}
+	for _, client := range guestClients {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			nm, err := client.Netmap()
+			if !assert.NoError(ct, err) || !assert.NotNil(ct, nm) || !assert.NotNil(ct, nm.DNS) {
+				return
+			}
+			assert.False(ct, hasResolverAddr(nm.DNS.Resolvers, overrideNS),
+				"guest should not have the override in Resolvers")
+			assert.False(ct, hasResolverAddr(nm.DNS.FallbackResolvers, overrideNS),
+				"guest should not have the override in FallbackResolvers")
+			assert.NotContains(ct, nm.DNS.Routes, splitDomain,
+				"guest should not have the admin profile's Split entry")
+		}, integrationutil.PolicyPropagationTimeout, 2*time.Second,
+			"guest %s should stay on base after hot-reload", client.Hostname())
 	}
 }


### PR DESCRIPTION

This PR adds a per-identity DNS override mechanism to the policy file.

## Background

I've wanted this feature for a while, and it appears others have too:

- **#3012** — tracking issue: "Assign global DNS based on IP address or machine name."
- **#3127** — alternative draft PR by IdanKoblik.

I've implemented and run variations of this on my own tailnet for a couple of months. I didn't realize #3127 existed until I was getting ready to submit my own PR. It's encouraging to find we'd arrived at similar ideas independently.

#3127 proposes a minimal IP-based implementation: a `dns.profiles` block in `headscale.yaml` keyed by tailnet IP, replacing `Resolvers` on the wire for matched nodes. Narrow scope, ~200 lines added. This PR takes a broader shape: identity-based instead of IP-based.

## Description

The policy file gains a top-level `dns:` block: an ordered list of DNS
profiles that override the corresponding fields in `headscale.yaml`'s
tailnet-wide `dns:` block for matched nodes. Each profile carries an
assignment list (`groups`, `users`, or `tags`) and an optional set of
body fields (`nameservers`, `overrideLocalDNS`, `split`,
`searchDomains`).

When a node matches a profile, the profile's set fields replace the
corresponding fields from `headscale.yaml`'s tailnet-wide `dns:` block;
unset fields inherit from the yaml. A node that matches no profile
receives the yaml config unchanged. Profile changes are hot-reloaded
with the policy file.

Matching is by tier — **tag > user > group** — and by profile list
order within each tier. Tagged nodes consult only the tag tier.

```hujson
{
  "groups": {
    "group:admin": ["alice@"]
  },
  "dns": [
    {
      // Admins override their primary resolver.
      "nameservers": ["192.168.4.2"],
      "overrideLocalDNS": true,
      "groups": ["group:admin"]
    }
  ]
}
```

Result on the wire:

| User | Resolvers | from |
|---|---|---|
| `alice@` (admin) | `[192.168.4.2]` | profile match |
| anyone else | (base) | unchanged from `headscale.yaml` |

## Design decisions

### DNS Profiles in policy

Putting DNS in the policy file felt natural for a couple of reasons:

- DNS config can be assigned per node, and the ACL identity definitions (groups, users, tags)
  in the policy file are a great fit for that.
- There's no reason DNS config can't be reassigned at runtime — and the policy file already
  has the hot-reload plumbing.

Putting it in `headscale.yaml` instead would require restarting the server to change DNS for
even a single node. It would also create a coupling problem: the base config would need to
reference identities defined in the policy file, but those identities change on policy
reload, which could leave dangling references in the yaml.

I initially tried to move DNS out of the yaml entirely (with MagicDNS settings becoming their
own block), which I think is cleaner — it keeps all DNS config in one spot, and the first
profile can serve as the default. But the backwards-compatibility footguns were a nightmare.
This diff is much simpler.

### Pointer-typed body fields

The body fields (`Nameservers`, `Split`, `SearchDomains`,
`OverrideLocalDNS`) are pointer-typed so the schema can distinguish
three states:

- **Absent** (field omitted in JSON) — inherits from base
- **Present and non-empty** — replaces base
- **Present but empty** (e.g. `"searchDomains": []`) — explicitly clears
  the inherited value

### `Nameservers` + `OverrideLocalDNS` matrix

The wire protocol has two slots: `Resolvers` (primary) and
`FallbackResolvers` (only when OS has no DNS). The base has nameservers
in one or the other depending on `OverrideLocalDNS`. Profiles set or
omit `Nameservers` and `OverrideLocalDNS` independently:

| Profile sets... | Effect |
|---|---|
| Both `Nameservers` and `OverrideLocalDNS` | New nameservers go to whichever wire field the explicit `OverrideLocalDNS` selects; the other wire field is cleared |
| Only `Nameservers` (not `OverrideLocalDNS`) | New nameservers go to whichever wire field base was using |
| Only `OverrideLocalDNS` (not `Nameservers`) | The inherited nameservers move from one wire field to the other per the explicit value |
| Neither | Both wire fields inherit from base unchanged |

Unit tests in `TestApplyDNSProfileFieldHandoff` cover all four cells.

### Why threading `baseDomain` explicitly

`tailcfg.DNSConfig.Domains` is a flat list — by convention `Domains[0]`
is the tailnet `base_domain` followed by search domains, but the type
itself doesn't distinguish them. When a profile replaces
`SearchDomains`, we want to preserve `base_domain` and replace the
rest. If we read `Domains[0]` heuristically that works in the common
case, but breaks when `base_domain` is unset (e.g. MagicDNS off + search
domains set in yaml) — `Domains[0]` is then a search domain and
preserving it would be wrong.

So `baseDomain string` is threaded through `NodeDNSConfig` →
`applyDNSProfile` explicitly. The state layer passes
`s.cfg.BaseDomain`; the mapper doesn't need to know. The
`search-domains-no-base-domain-fully-replaces-domains` subtest of
`TestApplyDNSProfileFieldHandoff` covers the edge case.

### `SetUsers` force-change carve-out

A policy can list a username in a Groups definition before that user
exists in the DB — validation doesn't reject it. So when the user is
later created (or renamed / deleted), the DNS profile resolution for
their node shifts. `SetUsers` normally returns `changed=true` only when
a tracked hash moves (filter / tag-owner / auto-approver / SSH), and
none of those catch DNS resolution. Without a carve-out the new DNS
mapping wouldn't be broadcast until something else triggered a map
response.

Mirrors the existing SSH carve-out:

```go
if pm.pol != nil && len(pm.pol.DNS) > 0 {
    return true, nil
}
```

`TestSetUsersForcesChangeWhenDNSProfilesExist` is the regression guard.

### Validation choices

The validator rejects:

- **Profiles with no assignment list.** A profile with no `groups` /
  `users` / `tags` would never match — it's almost certainly a
  misconfiguration. The opposite — a profile *with* an assignment
  list but no body fields — is allowed; it's the exemption pattern
  documented in `docs/ref/policy.md`.
- **Duplicate principals across profiles.** A group / user / tag may
  appear in at most one profile's assignment list. Each principal
  belongs to exactly one profile; list order only resolves ties within
  a tier, never which profile a principal is assigned to.
- **Undefined references.** Group references must exist in the policy's
  top-level `groups` map; tag references must be in `tagOwners`;
  usernames must contain `@`. Same conventions as ACL / SSH / TagOwners
  validation.
- **Ambiguous usernames** (multi-user resolution). `validateUserReferences`
  now walks `pol.DNS` alongside `Groups`, `TagOwners`, `AutoApprovers`,
  `ACLs`, and `SSH`. Without this, an ambiguous username in a DNS
  profile's `Users` list would silently fail to match at lookup time.

---

## Backwards compatibility

The yaml `dns:` block is unchanged. Operators who don't use
`policy.dns` see identical behavior to today — no deprecation warnings,
no migration path, no cross-file checks.

DB-mode policies are unaffected. Both file and db modes converge on
`hsdb.PolicyBytes` → `polMan.SetPolicy(pol)`; the DNS feature lives
entirely downstream of that fork.

---

## Maintenance surface

The feature is bounded and localized: `policy/v2/policy.go` matcher,
`policy/v2/types.go` schema + validation, a thin passthrough in
`state.go`. No new external dependencies, no new long-running
goroutines, no new lock layers. The tests I added should catch
regressions.

I'll engage with review comments and plan to run headscale with this
feature for the foreseeable future. I won't be offended if the PR
isn't accepted — I'll be maintaining this fork for myself either way,
so I figured I'd throw it out there for anyone else that might
benefit. No hard maintenance commitments, but if anything ever breaks
my setup, I'll be fixing it.

---

## Tests

### Unit (`hscontrol/policy/v2/dns_test.go`, 11 functions)

- Tier precedence (tag > user > group)
- List order within tier (group + user)
- Multi-tag profile list order — regression guard for an earlier bug
  where iterating node tags first picked the wrong profile
- No match returns base unchanged
- Empty DNS policy returns base
- Nil base returns nil
- Split + SearchDomains override applied to base
- `applyDNSProfile` field handoff matrix:
  - `Nameservers` + `OverrideLocalDNS` four-cell matrix
  - Re-route on `OverrideLocalDNS`-only profile (both directions)
  - Present-empty `Nameservers` clears both wire fields
  - Absent fields inherit base
  - Split replace / inherit / present-empty-clear
  - SearchDomains with `base_domain` / without `base_domain` /
    present-empty (with and without `base_domain`)
- Validation: profile with no assignment list rejected
- Validation: duplicate principal across profiles rejected (groups,
  users, tags)
- Validation: undefined group / tag / malformed username rejected
- `TestSetUsersForcesChangeWhenDNSProfilesExist` — the SetUsers
  carve-out

### Existing validation test parity

`TestValidateUserReferences_AllSites` (`policy_test.go`) gains a `dns`
case for symmetry with `groups`, `tagOwners`, `autoApprovers.routes`,
`autoApprovers.exitNode`, `acls.src`, `acls.dst`, `ssh.src`, `ssh.dst`.

### Mapper

`hscontrol/mapper/mapper_test.go` updated for the
`generateDNSConfig` signature change. Tests now construct
`*tailcfg.DNSConfig` directly (no test stub for the dropped
`dnsConfigStater` interface).

### Integration (`integration/dns_test.go`, `TestPolicyDNSProfiles`)

Three phases against real Tailscale clients on a real headscale
server:

1. **No policy.dns overrides** → neither admin nor guest has the
   override resolver in `Resolvers` or `FallbackResolvers`.
2. **Hot-reload via `SetPolicy`** to add a `group:admin` profile with
   `Nameservers` + `OverrideLocalDNS` + `Split`.
3. **Post-reload** — admin gets the override `Resolvers` AND the split
   `Routes`; guest stays clean on `Resolvers`, `FallbackResolvers`, and
   `Routes`.

Verified passing locally.

---

## Checklist (from PR template)

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand — #3012
- [x] added unit tests
- [x] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md

---

