### PR TITLE
hscontrol: add libdns certificate challenges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 **Minimum supported Tailscale client version: v1.xx.0**
 
+### Tailscale Serve HTTPS certificates
+
+Headscale can now advertise per-node certificate domains and handle the
+`/machine/set-dns` endpoint used by `tailscale cert` and `tailscale serve
+--https`. Nodes publish ACME DNS-01 TXT challenges through Headscale, which
+validates the request belongs to the authenticated node and writes the TXT RRset
+through a registered `libdns` provider.
+
+Headscale does not run an authoritative DNS server for this feature and does
+not store issued certificates or private keys. A concrete `libdns` provider
+must be registered in the Headscale build and configured under
+`dns.certificates`.
+
 ## 0.29.0 (2026-06-17)
 
 **Minimum supported Tailscale client version: v1.80.0**

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -329,6 +329,28 @@ dns:
   # `hostname.base_domain` (e.g., _myhost.example.com_).
   base_domain: example.com
 
+  # Per-node HTTPS certificates for `tailscale cert` and
+  # `tailscale serve --https`.
+  #
+  # When enabled, Headscale advertises each node's FQDN in DNSConfig.CertDomains
+  # and accepts ACME DNS-01 TXT updates from authenticated nodes on
+  # /machine/set-dns. The TXT records are published through a registered libdns
+  # provider; Headscale does not run an authoritative DNS server for this.
+  certificates:
+    enabled: false
+    # Name of a registered libdns provider factory.
+    provider: ""
+    # DNS zone passed to libdns. Empty defaults to dns.base_domain.
+    zone: ""
+    # TXT record TTL. Empty or 0 uses the provider default.
+    ttl: 0s
+    # Optional delay after libdns accepts the record, useful for eventually
+    # consistent DNS provider APIs.
+    propagation_wait: 0s
+    # Provider-specific settings passed unchanged to the registered provider
+    # factory. Exact keys depend on the provider package used in your build.
+    provider_config: {}
+
   # Whether to use the local DNS settings of a node or override the local DNS
   # settings (default) and force the use of Headscale's DNS configuration.
   override_local_dns: true

--- a/docs/about/features.md
+++ b/docs/about/features.md
@@ -41,5 +41,7 @@ provides on overview of Headscale's feature and compatibility with the Tailscale
     - [x] Update user profile from identity provider
     - [ ] OIDC groups cannot be used in ACLs
 - [ ] [Funnel](https://tailscale.com/docs/features/tailscale-funnel) ([#1040](https://github.com/juanfont/headscale/issues/1040))
-- [ ] [Serve](https://tailscale.com/docs/features/tailscale-serve) ([#1234](https://github.com/juanfont/headscale/issues/1921))
+- [x] [Serve](https://tailscale.com/docs/features/tailscale-serve) ([#1921](https://github.com/juanfont/headscale/issues/1921))
+    - [x] HTTP Serve with MagicDNS
+    - [x] [HTTPS Serve and `tailscale cert`](../ref/serve.md) with `dns.certificates` and a registered `libdns` provider
 - [ ] [Network flow logs](https://tailscale.com/docs/features/logging/network-flow-logs) ([#1687](https://github.com/juanfont/headscale/issues/1687))

--- a/docs/ref/serve.md
+++ b/docs/ref/serve.md
@@ -1,0 +1,104 @@
+# Tailscale Serve and certificates
+
+[Tailscale Serve](https://tailscale.com/docs/features/tailscale-serve) is a
+client-side feature: the Serve configuration and TLS private keys live on the
+node, not on Headscale.
+
+Plain HTTP Serve works with MagicDNS. HTTPS Serve and `tailscale cert` require
+Headscale to advertise the node's MagicDNS name as certificate-eligible and to
+publish ACME DNS-01 TXT challenge records for the node.
+
+## Certificate flow
+
+1. Headscale advertises the node's FQDN in `DNSConfig.CertDomains`.
+   This is the client signal that avoids:
+
+   ```console
+   HTTPS cert support is not enabled/configured for your tailnet.
+   ```
+
+2. The node runs `tailscale cert <node>.<base_domain>` or
+   `tailscale serve --https`.
+3. The node starts an ACME order locally. Headscale never sees the ACME account
+   key, certificate private key, or issued certificate.
+4. The node calls Headscale's Noise endpoint `/machine/set-dns` with a
+   `TXT` record for `_acme-challenge.<node>.<base_domain>`.
+5. Headscale validates that the Noise machine key owns the node key and that
+   the requested TXT name belongs to that node's own FQDN.
+6. Headscale publishes the TXT RRset through the configured `libdns`
+   `RecordSetter`.
+7. The client asks the ACME CA to validate DNS-01 and stores the issued
+   certificate locally.
+
+## Configuration
+
+```yaml
+dns:
+  magic_dns: true
+  base_domain: example.com
+
+  certificates:
+    enabled: true
+    provider: "provider-name"
+    zone: "example.com"
+    ttl: 2m
+    propagation_wait: 10s
+    provider_config:
+      token: "provider-api-token"
+```
+
+`dns.certificates.enabled` requires:
+
+- `dns.magic_dns: true`
+- `dns.base_domain` set
+- `dns.certificates.provider` set
+- a Headscale build that registers a matching `libdns` provider factory
+
+`zone` defaults to `dns.base_domain` when empty. `provider_config` is passed
+unchanged to the registered provider factory and is omitted from JSON debug
+configuration output because it commonly contains API credentials.
+
+## Provider registration
+
+Headscale's core implementation is provider-neutral. It imports only
+`github.com/libdns/libdns`; it does not import Cloudflare, Hetzner, Route53, or
+any other provider package directly.
+
+A concrete provider package must be included in the build and register a
+factory with:
+
+```go
+hscontrol.RegisterDNSCertificateProvider("provider-name", func(config map[string]string) (libdns.RecordSetter, error) {
+    // Construct and return the provider-specific libdns RecordSetter.
+})
+```
+
+The factory receives `dns.certificates.provider_config`.
+
+## Security properties
+
+- Nodes can only publish `TXT` records.
+- Nodes can only publish `_acme-challenge.<their-node-fqdn>`.
+- The Noise machine key must match the node key in the request.
+- Concurrent TXT values for the same challenge name are preserved in the RRset
+  so overlapping ACME validations do not replace each other.
+- Challenge values are retained in memory only for a short period and then
+  dropped from Headscale's local RRset cache.
+
+## Usage
+
+After enabling the config and restarting Headscale, clients need a fresh netmap
+containing `DNSConfig.CertDomains`. This normally happens automatically; if a
+client still says certificate support is not enabled, restart or reconnect the
+client and check that the node's map response contains its FQDN in
+`CertDomains`.
+
+Then run:
+
+```console
+tailscale cert <node>.<base_domain>
+tailscale serve --https=443 localhost:8080
+```
+
+Funnel remains unsupported because it depends on Tailscale's public ingress
+infrastructure.

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jagottsicher/termcolor v1.0.2
+	github.com/libdns/libdns v1.1.1
 	github.com/oauth2-proxy/mockoidc v0.0.0-20240214162133-caebfff84d25
 	github.com/ory/dockertest/v3 v3.12.0
 	github.com/philip-bui/grpc-zerolog v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -310,6 +310,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
 github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
+github.com/libdns/libdns v1.1.1 h1:wPrHrXILoSHKWJKGd0EiAVmiJbFShguILTg9leS/P/U=
+github.com/libdns/libdns v1.1.1/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
 github.com/lithammer/fuzzysearch v1.1.8 h1:/HIuJnjHuXS8bKaiTMeeDlW2/AyIWk2brx1V8LFgLN4=
 github.com/lithammer/fuzzysearch v1.1.8/go.mod h1:IdqeyBClc3FFqSzYq/MXESsS4S0FsZ5ajtkr5xPLts4=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=

--- a/hscontrol/app.go
+++ b/hscontrol/app.go
@@ -107,6 +107,7 @@ type Headscale struct {
 	extraRecordMan *dns.ExtraRecordsMan
 	authProvider   AuthProvider
 	mapBatcher     *mapper.Batcher
+	dnsCertManager *dnsCertificateManager
 
 	clientStreamsOpen sync.WaitGroup
 }
@@ -234,6 +235,13 @@ func NewHeadscale(cfg *types.Config) (*Headscale, error) {
 			// (tailscale.com/ipn/ipnlocal/node_backend.go:869 documents the
 			// empty-resolver Routes form for Issue 2706).
 			app.cfg.TailcfgDNSConfig.Routes[d.WithoutTrailingDot()] = []*dnstype.Resolver{}
+		}
+	}
+
+	if cfg.DNSConfig.Certificates.Enabled {
+		app.dnsCertManager, err = newDNSCertificateManager(cfg.DNSConfig.Certificates)
+		if err != nil {
+			return nil, fmt.Errorf("creating DNS certificate manager: %w", err)
 		}
 	}
 

--- a/hscontrol/mapper/mapper.go
+++ b/hscontrol/mapper/mapper.go
@@ -147,6 +147,12 @@ func generateDNSConfig(
 		}
 	}
 
+	if cfg.DNSConfig.Certificates.Enabled {
+		if fqdn, err := node.GetFQDN(cfg.BaseDomain); err == nil {
+			dnsConfig.CertDomains = []string{strings.TrimSuffix(fqdn, ".")}
+		}
+	}
+
 	return dnsConfig
 }
 

--- a/hscontrol/mapper/mapper_test.go
+++ b/hscontrol/mapper/mapper_test.go
@@ -199,6 +199,47 @@ func TestNextDNSCapMapRendering(t *testing.T) {
 	})
 }
 
+func TestGenerateDNSConfigCertDomains(t *testing.T) {
+	t.Parallel()
+
+	node := (&types.Node{
+		ID:        1,
+		Hostname:  "node1",
+		GivenName: "node1",
+		IPv4:      iap("100.64.0.1"),
+		Hostinfo:  &tailcfg.Hostinfo{OS: "linux"},
+	}).View()
+
+	mkConfig := func(enabled bool) *types.Config {
+		return &types.Config{
+			BaseDomain: "tailnet.example.com",
+			DNSConfig: types.DNSConfig{
+				Certificates: types.DNSCertificatesConfig{
+					Enabled: enabled,
+				},
+			},
+			TailcfgDNSConfig: &tailcfg.DNSConfig{
+				Domains: []string{"tailnet.example.com"},
+				Proxied: true,
+			},
+		}
+	}
+
+	t.Run("enabled", func(t *testing.T) {
+		t.Parallel()
+
+		got := generateDNSConfig(mkConfig(true), node, nil)
+		require.Equal(t, []string{"node1.tailnet.example.com"}, got.CertDomains)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		t.Parallel()
+
+		got := generateDNSConfig(mkConfig(false), node, nil)
+		require.Empty(t, got.CertDomains)
+	})
+}
+
 // TestBuildFromChangeFiltersPeerPatchesByVisibility proves that incremental
 // peer-change patches (online/offline, endpoint, key-expiry) are restricted to
 // the recipient's ACL-visible peer set, the same way buildTailPeers filters

--- a/hscontrol/noise.go
+++ b/hscontrol/noise.go
@@ -172,17 +172,15 @@ func (h *Headscale) NoiseUpgradeHandler(
 		// SSH Check mode endpoint, consulted to validate if a given SSH connection should be accepted or rejected.
 		r.Get("/ssh/action/{src_node_id}/to/{dst_node_id}", ns.SSHActionHandler)
 
-		// Not implemented yet
-		//
 		// /whoami is a debug endpoint to validate that the client can communicate over the connection,
 		// not clear if there is a specific response, it looks like it is just logged.
 		// https://github.com/tailscale/tailscale/blob/dfba01ca9bd8c4df02c3c32f400d9aeb897c5fc7/cmd/tailscale/cli/debug.go#L1138
 		r.Get("/whoami", ns.NotImplementedHandler)
 
-		// client sends a [tailcfg.SetDNSRequest] to this endpoints and expect
+		// client sends a [tailcfg.SetDNSRequest] to this endpoint and expects
 		// the server to create or update this DNS record "somewhere".
 		// It is typically a TXT record for an ACME challenge.
-		r.Post("/set-dns", ns.NotImplementedHandler)
+		r.Post("/set-dns", ns.SetDNSHandler)
 
 		// A patch of [tailcfg.SetDeviceAttributesRequest] to update device attributes.
 		// We currently do not support device attributes.
@@ -706,7 +704,7 @@ func (ns *noiseServer) PollNetMapHandler(
 		return
 	}
 
-	nv, err := ns.getAndValidateNode(mapRequest)
+	nv, err := ns.getAndValidateNode(mapRequest.NodeKey)
 	if err != nil {
 		httpError(writer, err)
 		return
@@ -785,8 +783,8 @@ func (ns *noiseServer) RegistrationHandler(
 
 // getAndValidateNode retrieves the node from the database using the NodeKey
 // and validates that it matches the MachineKey from the Noise session.
-func (ns *noiseServer) getAndValidateNode(mapRequest tailcfg.MapRequest) (types.NodeView, error) {
-	nv, ok := ns.headscale.state.GetNodeByNodeKey(mapRequest.NodeKey)
+func (ns *noiseServer) getAndValidateNode(nodeKey key.NodePublic) (types.NodeView, error) {
+	nv, ok := ns.headscale.state.GetNodeByNodeKey(nodeKey)
 	if !ok {
 		return types.NodeView{}, NewHTTPError(http.StatusNotFound, "node not found", nil)
 	}
@@ -797,4 +795,56 @@ func (ns *noiseServer) getAndValidateNode(mapRequest tailcfg.MapRequest) (types.
 	}
 
 	return nv, nil
+}
+
+// SetDNSHandler handles ACME DNS-01 TXT updates from Tailscale clients for
+// `tailscale cert` and `tailscale serve --https`.
+func (ns *noiseServer) SetDNSHandler(writer http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		httpError(writer, errMethodNotAllowed)
+
+		return
+	}
+
+	if ns.headscale.dnsCertManager == nil {
+		httpError(writer, NewHTTPError(http.StatusNotImplemented, "DNS certificates are not enabled", nil))
+
+		return
+	}
+
+	var dnsReq tailcfg.SetDNSRequest
+	if err := json.NewDecoder(req.Body).Decode(&dnsReq); err != nil {
+		httpError(writer, NewHTTPError(http.StatusBadRequest, "invalid SetDNSRequest body", err))
+
+		return
+	}
+
+	if rejectUnsupported(writer, dnsReq.Version, ns.machineKey, dnsReq.NodeKey) {
+		return
+	}
+
+	nv, err := ns.getAndValidateNode(dnsReq.NodeKey)
+	if err != nil {
+		httpError(writer, err)
+
+		return
+	}
+
+	if err := ns.headscale.dnsCertManager.setDNS(
+		req.Context(),
+		nv,
+		ns.headscale.cfg.BaseDomain,
+		dnsReq,
+	); err != nil {
+		httpError(writer, NewHTTPError(http.StatusBadRequest, "invalid DNS record update", err))
+
+		return
+	}
+
+	writer.Header().Set("Content-Type", "application/json; charset=utf-8")
+	writer.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(writer).Encode(tailcfg.SetDNSResponse{}); err != nil {
+		log.Error().Caller().Err(err).Msg("noise set-dns handler: failed to encode SetDNSResponse")
+	}
 }

--- a/hscontrol/noise_test.go
+++ b/hscontrol/noise_test.go
@@ -10,10 +10,12 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/libdns/libdns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"tailscale.com/tailcfg"
@@ -396,6 +398,101 @@ func TestOverrideRemoteAddr(t *testing.T) {
 	r.ServeHTTP(httptest.NewRecorder(), req)
 
 	assert.Equal(t, clientAddr, observed)
+}
+
+func TestSetDNSHandlerPublishesTXTRecord(t *testing.T) {
+	t.Parallel()
+
+	app := createTestApp(t)
+	user := app.state.CreateUserForTest("cert-user")
+	node := putTestNodeInStore(t, app, user, "cert-node")
+	node.GivenName = "cert-node"
+	app.state.PutNodeInStoreForTest(*node)
+	app.cfg.BaseDomain = "example.com"
+	fqdn, err := node.GetFQDN(app.cfg.BaseDomain)
+	require.NoError(t, err)
+	challengeName := "_acme-challenge." + strings.TrimSuffix(fqdn, ".")
+
+	setter := &fakeRecordSetter{}
+	app.dnsCertManager = newDNSCertificateManagerForSetter(types.DNSCertificatesConfig{
+		Zone: "example.com",
+	}, setter)
+
+	ns := &noiseServer{
+		headscale:  app,
+		machineKey: node.MachineKey,
+	}
+
+	reqBody := tailcfg.SetDNSRequest{
+		Version: tailcfg.CurrentCapabilityVersion,
+		NodeKey: node.NodeKey,
+		Name:    challengeName,
+		Type:    "TXT",
+		Value:   "challenge-token",
+	}
+	payload, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/machine/set-dns",
+		bytes.NewReader(payload),
+	)
+	rec := httptest.NewRecorder()
+
+	ns.SetDNSHandler(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	require.Equal(t, "example.com", setter.zone)
+	require.Len(t, setter.records, 1)
+
+	txt, ok := setter.records[0].(libdns.TXT)
+	require.True(t, ok, "record = %T, want libdns.TXT", setter.records[0])
+	require.Equal(t, strings.TrimSuffix(challengeName, ".example.com"), txt.Name)
+	require.Equal(t, "challenge-token", txt.Text)
+}
+
+func TestSetDNSHandlerRejectsOtherNodeRecord(t *testing.T) {
+	t.Parallel()
+
+	app := createTestApp(t)
+	user := app.state.CreateUserForTest("cert-user")
+	node := putTestNodeInStore(t, app, user, "cert-node")
+	node.GivenName = "cert-node"
+	app.state.PutNodeInStoreForTest(*node)
+	app.cfg.BaseDomain = "example.com"
+	app.dnsCertManager = newDNSCertificateManagerForSetter(
+		types.DNSCertificatesConfig{Zone: "example.com"},
+		&fakeRecordSetter{},
+	)
+
+	ns := &noiseServer{
+		headscale:  app,
+		machineKey: node.MachineKey,
+	}
+
+	reqBody := tailcfg.SetDNSRequest{
+		Version: tailcfg.CurrentCapabilityVersion,
+		NodeKey: node.NodeKey,
+		Name:    "_acme-challenge.other.example.com",
+		Type:    "TXT",
+		Value:   "challenge-token",
+	}
+	payload, err := json.Marshal(reqBody)
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"/machine/set-dns",
+		bytes.NewReader(payload),
+	)
+	rec := httptest.NewRecorder()
+
+	ns.SetDNSHandler(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 // TestSSHActionHoldAndDelegate_PersistsAuthSession guards the happy path: the

--- a/hscontrol/tlscert.go
+++ b/hscontrol/tlscert.go
@@ -1,0 +1,228 @@
+package hscontrol
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/libdns/libdns"
+	"tailscale.com/tailcfg"
+)
+
+const (
+	dnsCertRecordRetention = 10 * time.Minute
+	maxTXTValueLength      = 255
+)
+
+var (
+	errDNSCertProviderExists = errors.New("DNS certificate provider already registered")
+	errDNSCertProviderUnset  = errors.New("DNS certificate provider is not registered")
+	errDNSCertRecordType     = errors.New("only TXT records are supported")
+	errDNSCertRecordName     = errors.New("DNS record name is not allowed")
+	errDNSCertRecordValue    = errors.New("invalid TXT record value")
+)
+
+// DNSCertificateProviderFactory constructs a libdns RecordSetter from the
+// provider_config map in config.yaml.
+type DNSCertificateProviderFactory func(map[string]string) (libdns.RecordSetter, error)
+
+var (
+	dnsCertProviderMu        sync.RWMutex
+	dnsCertProviderFactories = map[string]DNSCertificateProviderFactory{}
+)
+
+// RegisterDNSCertificateProvider registers a provider-neutral libdns factory.
+// Concrete provider packages should call this from init and return a
+// libdns.RecordSetter built from providerConfig.
+func RegisterDNSCertificateProvider(
+	name string,
+	factory DNSCertificateProviderFactory,
+) error {
+	name = strings.TrimSpace(strings.ToLower(name))
+	if name == "" {
+		return fmt.Errorf("provider name is empty")
+	}
+	if factory == nil {
+		return fmt.Errorf("provider factory is nil")
+	}
+
+	dnsCertProviderMu.Lock()
+	defer dnsCertProviderMu.Unlock()
+
+	if _, ok := dnsCertProviderFactories[name]; ok {
+		return fmt.Errorf("%w: %s", errDNSCertProviderExists, name)
+	}
+
+	dnsCertProviderFactories[name] = factory
+
+	return nil
+}
+
+func newDNSCertificateManager(
+	cfg types.DNSCertificatesConfig,
+) (*dnsCertificateManager, error) {
+	providerName := strings.TrimSpace(strings.ToLower(cfg.Provider))
+
+	dnsCertProviderMu.RLock()
+	factory := dnsCertProviderFactories[providerName]
+	dnsCertProviderMu.RUnlock()
+
+	if factory == nil {
+		return nil, fmt.Errorf("%w: %s", errDNSCertProviderUnset, providerName)
+	}
+
+	setter, err := factory(cfg.ProviderConfig)
+	if err != nil {
+		return nil, fmt.Errorf("creating DNS certificate provider %q: %w", providerName, err)
+	}
+	if setter == nil {
+		return nil, fmt.Errorf("creating DNS certificate provider %q: nil provider", providerName)
+	}
+
+	return newDNSCertificateManagerForSetter(cfg, setter), nil
+}
+
+func newDNSCertificateManagerForSetter(
+	cfg types.DNSCertificatesConfig,
+	setter libdns.RecordSetter,
+) *dnsCertificateManager {
+	return &dnsCertificateManager{
+		zone:            strings.TrimSuffix(strings.ToLower(cfg.Zone), "."),
+		ttl:             cfg.TTL,
+		propagationWait: cfg.PropagationWait,
+		setter:          setter,
+		records:         make(map[string]map[string]time.Time),
+	}
+}
+
+type dnsCertificateManager struct {
+	zone            string
+	ttl             time.Duration
+	propagationWait time.Duration
+	setter          libdns.RecordSetter
+
+	mu      sync.Mutex
+	records map[string]map[string]time.Time
+}
+
+func (m *dnsCertificateManager) setDNS(
+	ctx context.Context,
+	node types.NodeView,
+	baseDomain string,
+	req tailcfg.SetDNSRequest,
+) error {
+	if m == nil {
+		return errDNSCertProviderUnset
+	}
+
+	if err := validateSetDNSRequest(node, baseDomain, req); err != nil {
+		return err
+	}
+
+	name := canonicalDNSName(req.Name)
+	value := strings.TrimSpace(req.Value)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	m.purgeExpiredLocked(now)
+
+	values := m.records[name]
+	if values == nil {
+		values = make(map[string]time.Time)
+		m.records[name] = values
+	}
+
+	retention := dnsCertRecordRetention
+	if m.ttl > retention {
+		retention = m.ttl
+	}
+	expires := now.Add(retention)
+	values[value] = expires
+
+	records := make([]libdns.Record, 0, len(values))
+	for txt := range values {
+		records = append(records, libdns.TXT{
+			Name: m.relativeRecordName(name),
+			TTL:  m.ttl,
+			Text: txt,
+		})
+	}
+
+	if _, err := m.setter.SetRecords(ctx, m.zone, records); err != nil {
+		return fmt.Errorf("setting ACME DNS-01 TXT record: %w", err)
+	}
+
+	if m.propagationWait > 0 {
+		timer := time.NewTimer(m.propagationWait)
+		defer timer.Stop()
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	return nil
+}
+
+func (m *dnsCertificateManager) purgeExpiredLocked(now time.Time) {
+	for name, values := range m.records {
+		for value, expires := range values {
+			if !expires.IsZero() && now.After(expires) {
+				delete(values, value)
+			}
+		}
+
+		if len(values) == 0 {
+			delete(m.records, name)
+		}
+	}
+}
+
+func (m *dnsCertificateManager) relativeRecordName(name string) string {
+	zone := canonicalDNSName(m.zone)
+	if name == zone {
+		return "@"
+	}
+
+	return strings.TrimSuffix(strings.TrimSuffix(name, "."), "."+strings.TrimSuffix(zone, "."))
+}
+
+func validateSetDNSRequest(
+	node types.NodeView,
+	baseDomain string,
+	req tailcfg.SetDNSRequest,
+) error {
+	if !strings.EqualFold(req.Type, "TXT") {
+		return errDNSCertRecordType
+	}
+
+	value := strings.TrimSpace(req.Value)
+	if value == "" || len(value) > maxTXTValueLength {
+		return fmt.Errorf("%w: TXT value length must be 1..%d", errDNSCertRecordValue, maxTXTValueLength)
+	}
+
+	fqdn, err := node.GetFQDN(baseDomain)
+	if err != nil {
+		return fmt.Errorf("determining node FQDN: %w", err)
+	}
+
+	want := canonicalDNSName("_acme-challenge." + strings.TrimSuffix(fqdn, "."))
+	got := canonicalDNSName(req.Name)
+	if got != want {
+		return fmt.Errorf("%w: got %q, want %q", errDNSCertRecordName, got, want)
+	}
+
+	return nil
+}
+
+func canonicalDNSName(name string) string {
+	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(name), ".") + ".")
+}

--- a/hscontrol/tlscert_test.go
+++ b/hscontrol/tlscert_test.go
@@ -1,0 +1,124 @@
+package hscontrol
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/libdns/libdns"
+	"github.com/stretchr/testify/require"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/key"
+)
+
+type fakeRecordSetter struct {
+	zone    string
+	records []libdns.Record
+}
+
+func (f *fakeRecordSetter) SetRecords(
+	_ context.Context,
+	zone string,
+	records []libdns.Record,
+) ([]libdns.Record, error) {
+	f.zone = zone
+	f.records = append([]libdns.Record(nil), records...)
+
+	return records, nil
+}
+
+func testCertNode() types.NodeView {
+	nodeKey := key.NewNode()
+	machineKey := key.NewMachine()
+
+	return (&types.Node{
+		ID:         1,
+		Hostname:   "node1",
+		GivenName:  "node1",
+		NodeKey:    nodeKey.Public(),
+		MachineKey: machineKey.Public(),
+	}).View()
+}
+
+func TestDNSCertificateManagerSetDNS(t *testing.T) {
+	t.Parallel()
+
+	setter := &fakeRecordSetter{}
+	manager := newDNSCertificateManagerForSetter(types.DNSCertificatesConfig{
+		Zone: "example.com",
+		TTL:  time.Minute,
+	}, setter)
+
+	req := tailcfg.SetDNSRequest{
+		NodeKey: testCertNode().NodeKey(),
+		Name:    "_acme-challenge.node1.example.com",
+		Type:    "TXT",
+		Value:   "challenge-token",
+	}
+
+	require.NoError(t, manager.setDNS(t.Context(), testCertNode(), "example.com", req))
+	require.Equal(t, "example.com", setter.zone)
+	require.Len(t, setter.records, 1)
+
+	txt, ok := setter.records[0].(libdns.TXT)
+	require.True(t, ok, "record = %T, want libdns.TXT", setter.records[0])
+	require.Equal(t, "_acme-challenge.node1", txt.Name)
+	require.Equal(t, "challenge-token", txt.Text)
+	require.Equal(t, time.Minute, txt.TTL)
+}
+
+func TestDNSCertificateManagerKeepsConcurrentTXTValues(t *testing.T) {
+	t.Parallel()
+
+	setter := &fakeRecordSetter{}
+	manager := newDNSCertificateManagerForSetter(types.DNSCertificatesConfig{
+		Zone: "example.com",
+		TTL:  time.Minute,
+	}, setter)
+	node := testCertNode()
+
+	req := tailcfg.SetDNSRequest{
+		NodeKey: node.NodeKey(),
+		Name:    "_acme-challenge.node1.example.com",
+		Type:    "TXT",
+		Value:   "token-1",
+	}
+	require.NoError(t, manager.setDNS(t.Context(), node, "example.com", req))
+
+	req.Value = "token-2"
+	require.NoError(t, manager.setDNS(t.Context(), node, "example.com", req))
+
+	require.Len(t, setter.records, 2)
+}
+
+func TestValidateSetDNSRequestRejectsWrongRecord(t *testing.T) {
+	t.Parallel()
+
+	node := testCertNode()
+
+	tests := []tailcfg.SetDNSRequest{
+		{
+			NodeKey: node.NodeKey(),
+			Name:    "_acme-challenge.node1.example.com",
+			Type:    "A",
+			Value:   "challenge-token",
+		},
+		{
+			NodeKey: node.NodeKey(),
+			Name:    "_acme-challenge.other.example.com",
+			Type:    "TXT",
+			Value:   "challenge-token",
+		},
+		{
+			NodeKey: node.NodeKey(),
+			Name:    "_acme-challenge.node1.example.com",
+			Type:    "TXT",
+			Value:   "",
+		},
+	}
+
+	for _, req := range tests {
+		require.Error(t, validateSetDNSRequest(node, "example.com", req))
+	}
+}

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -152,6 +152,34 @@ type DNSConfig struct {
 	SearchDomains    []string            `mapstructure:"search_domains"`
 	ExtraRecords     []tailcfg.DNSRecord `mapstructure:"extra_records"`
 	ExtraRecordsPath string              `mapstructure:"extra_records_path"`
+
+	Certificates DNSCertificatesConfig `mapstructure:"certificates"`
+}
+
+// DNSCertificatesConfig configures per-node HTTPS/TLS certificate support for
+// `tailscale cert` and `tailscale serve --https`.
+type DNSCertificatesConfig struct {
+	Enabled bool
+
+	// Provider names a registered libdns provider factory. Headscale's core
+	// certificate path is provider-neutral; concrete providers register a
+	// factory that returns a libdns.RecordSetter.
+	Provider string
+
+	// ProviderConfig is passed unchanged to the registered provider factory.
+	ProviderConfig map[string]string `mapstructure:"provider_config" json:"-"`
+
+	// Zone is the DNS zone passed to libdns. Empty defaults to dns.base_domain.
+	Zone string
+
+	// TTL is the TXT record TTL sent to libdns. Zero uses libdns/provider
+	// defaults.
+	TTL time.Duration
+
+	// PropagationWait optionally delays the SetDNS response after libdns
+	// accepts the TXT record, giving eventually-consistent providers time to
+	// publish the record before the client asks ACME to validate it.
+	PropagationWait time.Duration `mapstructure:"propagation_wait"`
 }
 
 type Nameservers struct {
@@ -408,6 +436,7 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("dns.nameservers.global", []string{})
 	viper.SetDefault("dns.nameservers.split", map[string]string{})
 	viper.SetDefault("dns.search_domains", []string{})
+	viper.SetDefault("dns.certificates.enabled", false)
 
 	viper.SetDefault("derp.server.enabled", false)
 	viper.SetDefault("derp.server.verify_clients", true)
@@ -880,6 +909,18 @@ func dns() (DNSConfig, error) {
 	dns.Nameservers.Split = viper.GetStringMapStringSlice("dns.nameservers.split")
 	dns.SearchDomains = viper.GetStringSlice("dns.search_domains")
 	dns.ExtraRecordsPath = viper.GetString("dns.extra_records_path")
+	dns.Certificates.Enabled = viper.GetBool("dns.certificates.enabled")
+	dns.Certificates.Provider = viper.GetString("dns.certificates.provider")
+	if viper.IsSet("dns.certificates.provider_config") {
+		dns.Certificates.ProviderConfig = viper.GetStringMapString(
+			"dns.certificates.provider_config",
+		)
+	}
+	dns.Certificates.Zone = viper.GetString("dns.certificates.zone")
+	dns.Certificates.TTL = viper.GetDuration("dns.certificates.ttl")
+	dns.Certificates.PropagationWait = viper.GetDuration(
+		"dns.certificates.propagation_wait",
+	)
 
 	if viper.IsSet("dns.extra_records") {
 		var extraRecords []tailcfg.DNSRecord
@@ -1175,6 +1216,24 @@ func LoadServerConfig() (*Config, error) {
 		err := isSafeServerURL(serverURL, dnsConfig.BaseDomain)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	if dnsConfig.Certificates.Enabled {
+		if !dnsConfig.MagicDNS {
+			return nil, errors.New("dns.certificates.enabled requires dns.magic_dns to be enabled")
+		}
+
+		if dnsConfig.BaseDomain == "" {
+			return nil, errors.New("dns.certificates.enabled requires dns.base_domain to be set")
+		}
+
+		if dnsConfig.Certificates.Provider == "" {
+			return nil, errors.New("dns.certificates.enabled requires dns.certificates.provider to be set")
+		}
+
+		if dnsConfig.Certificates.Zone == "" {
+			dnsConfig.Certificates.Zone = dnsConfig.BaseDomain
 		}
 	}
 

--- a/hscontrol/types/config_test.go
+++ b/hscontrol/types/config_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -444,6 +445,111 @@ oidc:
 	assert.Contains(t, err.Error(), errInvalidPKCEMethod.Error())
 }
 
+func TestDNSCertificateConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		dnsYAML string
+		want    DNSCertificatesConfig
+		wantErr string
+	}{
+		{
+			name: "enabled-defaults-zone-to-base-domain",
+			dnsYAML: `
+  magic_dns: true
+  base_domain: example.com
+  override_local_dns: false
+  certificates:
+    enabled: true
+    provider: test-provider
+    ttl: 2m
+    propagation_wait: 3s
+    provider_config:
+      token: secret-token
+`,
+			want: DNSCertificatesConfig{
+				Enabled:         true,
+				Provider:        "test-provider",
+				ProviderConfig:  map[string]string{"token": "secret-token"},
+				Zone:            "example.com",
+				TTL:             2 * time.Minute,
+				PropagationWait: 3 * time.Second,
+			},
+		},
+		{
+			name: "requires-magic-dns",
+			dnsYAML: `
+  magic_dns: false
+  base_domain: example.com
+  override_local_dns: false
+  certificates:
+    enabled: true
+    provider: test-provider
+`,
+			wantErr: "dns.certificates.enabled requires dns.magic_dns to be enabled",
+		},
+		{
+			name: "requires-base-domain",
+			dnsYAML: `
+  magic_dns: true
+  override_local_dns: false
+  certificates:
+    enabled: true
+    provider: test-provider
+`,
+			wantErr: "dns.certificates.enabled requires dns.base_domain to be set",
+		},
+		{
+			name: "requires-provider",
+			dnsYAML: `
+  magic_dns: true
+  base_domain: example.com
+  override_local_dns: false
+  certificates:
+    enabled: true
+`,
+			wantErr: "dns.certificates.enabled requires dns.certificates.provider to be set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configYaml := []byte(`---
+server_url: https://headscale.example.net
+noise:
+  private_key_path: noise_private.key
+prefixes:
+  v4: 100.64.0.0/10
+  v6: fd7a:115c:a1e0::/48
+database:
+  type: sqlite3
+  sqlite:
+    path: "` + filepath.Join(tmpDir, "db.sqlite") + `"
+dns:
+` + tt.dnsYAML)
+
+			configFilePath := filepath.Join(tmpDir, "config.yaml")
+			err := os.WriteFile(configFilePath, configYaml, 0o600)
+			require.NoError(t, err)
+
+			viper.Reset()
+			err = LoadConfig(tmpDir, false)
+			require.NoError(t, err)
+
+			cfg, err := LoadServerConfig()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantErr, err.Error())
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cfg.DNSConfig.Certificates)
+		})
+	}
+}
+
 // OK
 // server_url: headscale.com, base: clients.headscale.com
 // server_url: headscale.com, base: headscale.net
@@ -559,6 +665,7 @@ func TestConfigJSONOmitsSecrets(t *testing.T) {
 		secretPostgresPass = "p0stgres-secret-marker"
 		secretClientSecret = "oidc-client-secret-marker"    //nolint:gosec // test marker, not a real credential
 		secretAPIKey       = "headscale-cli-api-key-marker" //nolint:gosec // test marker, not a real credential
+		secretDNSProvider  = "dns-provider-secret-marker"   //nolint:gosec // test marker, not a real credential
 	)
 
 	cfg := &Config{
@@ -573,13 +680,25 @@ func TestConfigJSONOmitsSecrets(t *testing.T) {
 		CLI: CLIConfig{
 			APIKey: secretAPIKey,
 		},
+		DNSConfig: DNSConfig{
+			Certificates: DNSCertificatesConfig{
+				ProviderConfig: map[string]string{
+					"token": secretDNSProvider,
+				},
+			},
+		},
 	}
 
 	out, err := json.Marshal(cfg)
 	require.NoError(t, err)
 
 	body := string(out)
-	for _, secret := range []string{secretPostgresPass, secretClientSecret, secretAPIKey} {
+	for _, secret := range []string{
+		secretPostgresPass,
+		secretClientSecret,
+		secretAPIKey,
+		secretDNSProvider,
+	} {
 		assert.NotContains(t, body, secret,
 			"marshalled Config must not contain secret %q", secret)
 	}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,6 +187,7 @@ nav:
       - TLS: ref/tls.md
       - Policy: ref/policy.md
       - DNS: ref/dns.md
+      - Serve and certificates: ref/serve.md
       - DERP: ref/derp.md
       - API: ref/api.md
       - Tags: ref/tags.md


### PR DESCRIPTION
## What changed

Adds provider-neutral support for `tailscale cert` and `tailscale serve --https` by advertising per-node `DNSConfig.CertDomains` and implementing the Noise `/machine/set-dns` endpoint. The endpoint validates that the authenticated node can only publish its own `_acme-challenge.<node>.<base_domain>` TXT record, then writes the TXT RRset through a registered `libdns.RecordSetter`.

The implementation does not run an authoritative DNS server and does not import any provider-specific DNS package in Headscale core. Concrete libdns providers register a factory with `RegisterDNSCertificateProvider`.

## User impact

Operators can enable `dns.certificates` to let clients obtain certificates for their MagicDNS names. Clients learn support is enabled through `DNSConfig.CertDomains`; without that signal, `tailscale cert` reports HTTPS certificate support as not configured.

## Safety

- Only TXT records are accepted.
- Nodes can only update their own ACME challenge name.
- Noise machine key and node key are validated before DNS updates.
- Concurrent challenge values for the same name are preserved in the RRset.
- Provider credentials in `provider_config` are omitted from JSON config output.

## Docs

Adds config example coverage, a Serve/certificate reference page, mkdocs navigation, feature matrix updates, and changelog entry.

## Tests

- `go test ./hscontrol ./hscontrol/mapper ./hscontrol/types`
- `git diff --check`