### PR TITLE
oidc: fix NewProvider ignoring caller context timeout

### DIFF
--- a/hscontrol/oidc.go
+++ b/hscontrol/oidc.go
@@ -87,7 +87,7 @@ func NewAuthProviderOIDC(
 ) (*AuthProviderOIDC, error) {
 	var err error
 	// grab oidc config if it hasn't been already
-	oidcProvider, err := oidc.NewProvider(context.Background(), cfg.Issuer) //nolint:contextcheck
+	oidcProvider, err := oidc.NewProvider(ctx, cfg.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("creating OIDC provider from issuer config: %w", err)
 	}


### PR DESCRIPTION
NewAuthProviderOIDC received a context with a 30-second timeout from its caller, but immediately discarded it by passing context.Background() to oidc.NewProvider. This caused both `headscale serve` and `headscale configtest` to hang indefinitely if the OIDC issuer was unreachable, rather than timing out and returning an error.

Fix by passing the caller's ctx to oidc.NewProvider and remove the nolint:contextcheck annotation that was suppressing the linter warning about this bug. The annotation was introduced in ce580f82 as part of a bulk lint-suppression pass without addressing the underlying issue.

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
