### PR TITLE
docs: add Headtower to the list of web interfaces

### DIFF
--- a/docs/ref/integration/web-ui.md
+++ b/docs/ref/integration/web-ui.md
@@ -11,8 +11,7 @@ Headscale doesn't provide a built-in web interface but users may pick one from t
   coordination server
 - [HeadscaleUi](https://github.com/simcu/headscale-ui) - A static headscale admin ui, no backend environment required
 - [Headplane](https://github.com/tale/headplane) - An advanced Tailscale inspired frontend for headscale
-- [Headtower](https://github.com/rnihesh/headtower) - A polished headscale dashboard with audit logging, an
-  ACL reachability tester, and device version/OS insights
+- [Headtower](https://github.com/rnihesh/headtower) - A polished headscale dashboard with SSO, audit logs, and ACL tooling
 - [headscale-admin](https://github.com/GoodiesHQ/headscale-admin) - Headscale-Admin is meant to be a simple, modern web
   interface for headscale
 - [ouroboros](https://github.com/yellowsink/ouroboros) - Ouroboros is designed for users to manage their own devices,

--- a/docs/ref/integration/web-ui.md
+++ b/docs/ref/integration/web-ui.md
@@ -11,6 +11,8 @@ Headscale doesn't provide a built-in web interface but users may pick one from t
   coordination server
 - [HeadscaleUi](https://github.com/simcu/headscale-ui) - A static headscale admin ui, no backend environment required
 - [Headplane](https://github.com/tale/headplane) - An advanced Tailscale inspired frontend for headscale
+- [Headtower](https://github.com/rnihesh/headtower) - A polished headscale dashboard with audit logging, an
+  ACL reachability tester, and device version/OS insights
 - [headscale-admin](https://github.com/GoodiesHQ/headscale-admin) - Headscale-Admin is meant to be a simple, modern web
   interface for headscale
 - [ouroboros](https://github.com/yellowsink/ouroboros) - Ouroboros is designed for users to manage their own devices,


### PR DESCRIPTION
Headtower is a community-maintained web UI for headscale: a polished, extended fork of Headplane with an audit log, an ACL reachability tester, route and exit-node approvals, and device version/OS insights.

Following the contribution note on this page, this PR adds Headtower to the list of web interfaces.

- Repo: https://github.com/rnihesh/headtower
- Docs: https://headtower.niheshr.com
