### PR TITLE
hscontrol: keep an invalid node name from breaking map delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@ keys remain all-access.
 
 - Fix map generation serializing on the policy lock, so a mass reconnect on `autogroup:self`, via or relay policies no longer stalls clients into `unexpected EOF` retry loops [#3358](https://github.com/juanfont/headscale/pull/3358)
 
+A node whose stored name could not be turned into a valid FQDN — empty, or long
+enough that the full hostname exceeded 255 characters once the base domain was
+applied — broke map delivery for itself and for every peer that could see it.
+Affected clients looped on `PollNetMap: unexpected EOF` and reported being
+unable to reach the coordination server, while other clients were unaffected.
+The mapper now drops such a node from its peers' maps instead of failing the
+whole response, the long-poll handler returns an explicit error rather than an
+empty response, node renames that would exceed the hostname limit are rejected,
+and startup logs each node whose stored name needs fixing together with the
+command to fix it.
+
+[#3349](https://github.com/juanfont/headscale/pull/3349)
+
 ## 0.29.1 (2026-06-18)
 
 **Minimum supported Tailscale client version: v1.80.0**

--- a/hscontrol/mapper/builder.go
+++ b/hscontrol/mapper/builder.go
@@ -9,6 +9,8 @@ import (
 	"github.com/juanfont/headscale/hscontrol/policy"
 	policyv2 "github.com/juanfont/headscale/hscontrol/policy/v2"
 	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/juanfont/headscale/hscontrol/util/zlog/zf"
+	"github.com/rs/zerolog/log"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/views"
 	"tailscale.com/util/multierr"
@@ -152,7 +154,15 @@ func (b *MapResponseBuilder) WithSSHPolicy() *MapResponseBuilder {
 
 	sshPolicy, err := b.mapper.state.SSHPolicy(node)
 	if err != nil {
-		b.addError(err)
+		// SSH policy is optional for a node to function. Rather than fail the
+		// whole map (leaving the node unable to connect), log and continue
+		// without it; the node still receives a usable netmap.
+		log.Warn().Caller().
+			Err(err).
+			Uint64(zf.NodeID, node.ID().Uint64()).
+			Str(zf.NodeHostname, node.Hostname()).
+			Msg("building map response: skipping SSH policy for node; node will receive a map without SSH rules")
+
 		return b
 	}
 
@@ -284,7 +294,19 @@ func (b *MapResponseBuilder) buildTailPeers(peers views.Slice[types.NodeView]) (
 			return b.mapper.state.RoutesForPeer(node, peer, matchers)
 		}, b.mapper.cfg, allCapMaps[peer.ID()])
 		if err != nil {
-			return nil, err
+			// One peer with invalid data (e.g. an empty or over-long
+			// GivenName that fails GetFQDN) must not blank out the map for
+			// every node that can see it. Drop the offending peer, log it
+			// with the identity an operator needs to fix it, and keep
+			// building from the remaining valid peers.
+			log.Warn().Caller().
+				Err(err).
+				Uint64(zf.NodeID, peer.ID().Uint64()).
+				Str(zf.NodeHostname, peer.Hostname()).
+				Uint64("map.viewer.node.id", b.nodeID.Uint64()).
+				Msgf("dropping peer %d from map response: invalid node data; fix with `headscale nodes rename %d <name>`", peer.ID(), peer.ID())
+
+			continue
 		}
 
 		// [tailcfg.Node.CapMap] on a peer carries the small set of

--- a/hscontrol/mapper/mapper_test.go
+++ b/hscontrol/mapper/mapper_test.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	"fmt"
 	"net/netip"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -532,6 +533,94 @@ func TestBuildFromChangeVisibilityMatchesFullMap(t *testing.T) {
 			// Cross-user profile (user2) must appear iff n2 is visible to n1.
 			assert.Equalf(t, full[n2.ID.NodeID()], profileReaches(t, n2, user2.TailscaleUserProfile().ID),
 				"%s: user2 profile must be sent iff n2 is visible to n1", tt.name)
+		})
+	}
+}
+
+// TestFullMapResponseSurvivesPeerWithInvalidName proves a single node with an
+// FQDN-invalid GivenName must not break map generation for its peers.
+//
+// A node whose stored GivenName is empty (ErrNodeHasNoGivenName) or yields an
+// FQDN longer than MaxHostnameLength (ErrHostnameTooLong) makes GetFQDN, and
+// therefore TailNode, return an error. buildTailPeers used to abort the entire
+// peer list on the first such error, so MapResponseBuilder.Build() failed for
+// every node that could see the bad peer; on the initial-connection path that
+// surfaced as "PollNetMap: ... unexpected EOF" and the "Unable to connect to
+// the Tailscale coordination server" health warning. A legacy DB row loads
+// verbatim (NewNodeStore reads db.ListNodes() without re-sanitising names), so
+// the bad peer persists across restart. The build for an unaffected viewer
+// must succeed: the bad peer is dropped, valid peers and self survive.
+func TestFullMapResponseSurvivesPeerWithInvalidName(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		badName string
+	}{
+		{"empty given name", ""},
+		{"over-long fqdn", strings.Repeat("a", types.MaxHostnameLength+1)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			p4 := netip.MustParsePrefix("100.64.0.0/10")
+			p6 := netip.MustParsePrefix("fd7a:115c:a1e0::/48")
+			cfg := &types.Config{
+				Database: types.DatabaseConfig{
+					Type:   types.DatabaseSqlite,
+					Sqlite: types.SqliteConfig{Path: tmp + "/h.db"},
+				},
+				PrefixV4:     &p4,
+				PrefixV6:     &p6,
+				IPAllocation: types.IPAllocationStrategySequential,
+				BaseDomain:   "headscale.test",
+				Policy:       types.PolicyConfig{Mode: types.PolicyModeDB},
+				DERP: types.DERPConfig{
+					DERPMap: &tailcfg.DERPMap{
+						Regions: map[int]*tailcfg.DERPRegion{999: {RegionID: 999}},
+					},
+				},
+				Tuning: types.Tuning{
+					NodeStoreBatchSize:    state.TestBatchSize,
+					NodeStoreBatchTimeout: state.TestBatchTimeout,
+				},
+			}
+
+			database, err := db.NewHeadscaleDatabase(cfg)
+			require.NoError(t, err)
+
+			user := database.CreateUserForTest("u1")
+			n1 := database.CreateRegisteredNodeForTest(user, "n1")     // viewer, valid
+			bad := database.CreateRegisteredNodeForTest(user, "bad")   // peer, name corrupted below
+			good := database.CreateRegisteredNodeForTest(user, "good") // peer, valid control
+
+			// Simulate a legacy/corrupt row that v29 loads verbatim.
+			require.NoError(t, database.DB.
+				Model(&types.Node{}).
+				Where("id = ?", bad.ID).
+				Update("given_name", tt.badName).Error)
+			require.NoError(t, database.Close())
+
+			s, err := state.NewState(cfg)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = s.Close() })
+
+			// Allow-all so n1 sees both peers; the bad one must still be dropped.
+			_, err = s.SetPolicy([]byte(`{"acls":[{"action":"accept","src":["*"],"dst":["*:*"]}]}`))
+			require.NoError(t, err)
+
+			m := &mapper{state: s, cfg: cfg}
+			capVer := tailcfg.CurrentCapabilityVersion
+
+			resp, err := m.fullMapResponse(n1.ID, capVer)
+			require.NoError(t, err, "n1's map must build despite a peer with an invalid name")
+			require.NotNil(t, resp)
+			require.NotNil(t, resp.Node, "n1 must receive its own self node")
+
+			peers := map[tailcfg.NodeID]bool{}
+			for _, p := range resp.Peers {
+				peers[p.ID] = true
+			}
+
+			assert.False(t, peers[bad.ID.NodeID()], "the peer with an invalid name must be dropped")
+			assert.True(t, peers[good.ID.NodeID()], "valid peers must remain in the map")
 		})
 	}
 }

--- a/hscontrol/poll.go
+++ b/hscontrol/poll.go
@@ -230,6 +230,11 @@ func (m *mapSession) serveLongPoll() {
 	mapReqChange, err := m.h.state.UpdateNodeFromMapRequest(m.node.ID, m.req)
 	if err != nil {
 		m.log.Error().Caller().Err(err).Msg("failed to update node from initial MapRequest")
+		// Write an explicit error rather than returning silently: a bare
+		// return leaves net/http to send an empty 200, which the client
+		// reads as "unexpected EOF" and retries forever (issue #3346).
+		httpError(m.w, err)
+
 		return
 	}
 
@@ -252,6 +257,11 @@ func (m *mapSession) serveLongPoll() {
 	// time between the node connecting and the batcher being ready.
 	if err := m.h.mapBatcher.AddNode(m.node.ID, m.ch, m.capVer, m.stopFromBatcher); err != nil { //nolint:noinlineerr
 		m.log.Error().Caller().Err(err).Msg("failed to add node to batcher")
+		// Write an explicit error rather than returning silently: a bare
+		// return leaves net/http to send an empty 200, which the client
+		// reads as "unexpected EOF" and retries forever (issue #3346).
+		httpError(m.w, err)
+
 		return
 	}
 

--- a/hscontrol/poll_test.go
+++ b/hscontrol/poll_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/juanfont/headscale/hscontrol/db"
 	"github.com/juanfont/headscale/hscontrol/mapper"
 	"github.com/juanfont/headscale/hscontrol/state"
+	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/types/change"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -87,6 +89,131 @@ func (w *delayedSuccessResponseWriter) WriteCount() int {
 	defer w.mu.Unlock()
 
 	return w.writeCount
+}
+
+// recordingResponseWriter records the status code and whether anything was
+// written, so a test can tell an explicit error response apart from a handler
+// that returned without writing (which net/http turns into an empty 200 the
+// client reads as "unexpected EOF").
+type recordingResponseWriter struct {
+	mu     sync.Mutex
+	header http.Header
+	status int
+	writes int
+}
+
+func (w *recordingResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+
+	return w.header
+}
+
+func (w *recordingResponseWriter) WriteHeader(code int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.status == 0 {
+		w.status = code
+	}
+}
+
+func (w *recordingResponseWriter) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+
+	w.writes++
+
+	return len(data), nil
+}
+
+func (w *recordingResponseWriter) Flush() {}
+
+func (w *recordingResponseWriter) statusCode() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.status
+}
+
+// TestServeLongPollWritesErrorWhenInitialMapFails proves that when the initial
+// map cannot be generated (here: the node's own GivenName is invalid, so
+// WithSelfNode fails and AddNode errors), serveLongPoll writes an explicit HTTP
+// error instead of returning with no body. Returning empty leaves net/http to
+// send an empty 200, which the Tailscale client reports as
+// "PollNetMap: ... unexpected EOF" and retries forever (issue #3346).
+func TestServeLongPollWritesErrorWhenInitialMapFails(t *testing.T) {
+	app := createTestApp(t)
+	user := app.state.CreateUserForTest("self-bad-name-user")
+	createdNode := app.state.CreateRegisteredNodeForTest(user, "self-bad-name-node")
+
+	// Corrupt the node's stored name to empty so GetFQDN fails for itself,
+	// then reload state so the bad row enters the NodeStore verbatim.
+	app.mapBatcher.Close()
+	require.NoError(t, app.state.Close())
+
+	database, err := db.NewHeadscaleDatabase(app.cfg)
+	require.NoError(t, err)
+	require.NoError(t, database.DB.
+		Model(&types.Node{}).
+		Where("id = ?", createdNode.ID).
+		Update("given_name", "").Error)
+	require.NoError(t, database.Close())
+
+	app.state, err = state.NewState(app.cfg)
+	require.NoError(t, err)
+
+	app.mapBatcher = mapper.NewBatcherAndMapper(app.cfg, app.state)
+	app.mapBatcher.Start()
+
+	t.Cleanup(func() {
+		app.mapBatcher.Close()
+		require.NoError(t, app.state.Close())
+	})
+
+	nodeView, ok := app.state.GetNodeByID(createdNode.ID)
+	require.True(t, ok)
+
+	node := nodeView.AsStruct()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	writer := &recordingResponseWriter{}
+	session := app.newMapSession(ctx, tailcfg.MapRequest{
+		Stream:  true,
+		Version: tailcfg.CapabilityVersion(100),
+	}, writer, node)
+
+	serveDone := make(chan struct{})
+
+	go func() {
+		session.serveLongPoll()
+		close(serveDone)
+	}()
+
+	t.Cleanup(func() {
+		// Break the post-disconnect reconnect wait so the goroutine exits.
+		dummyCh := make(chan *tailcfg.MapResponse, 1)
+		_ = app.mapBatcher.AddNode(node.ID, dummyCh, tailcfg.CapabilityVersion(100), nil)
+
+		cancel()
+
+		select {
+		case <-serveDone:
+		case <-time.After(2 * time.Second):
+		}
+
+		_ = app.mapBatcher.RemoveNode(node.ID, dummyCh)
+	})
+
+	assert.Eventually(t, func() bool {
+		return writer.statusCode() >= http.StatusInternalServerError
+	}, 2*time.Second, 10*time.Millisecond,
+		"serveLongPoll must write an HTTP error response when the initial map cannot be built, not an empty 200")
 }
 
 // TestGitHubIssue3129_TransientlyBlockedWriteDoesNotLeaveLiveStaleSession

--- a/hscontrol/state/node_health.go
+++ b/hscontrol/state/node_health.go
@@ -1,0 +1,92 @@
+package state
+
+import (
+	"fmt"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/juanfont/headscale/hscontrol/util/zlog/zf"
+	"github.com/rs/zerolog/log"
+)
+
+// nodeHealthCheck names a class of stored-node-data defect that breaks normal
+// operation and explains how to fix it. ok == true means the node passes the
+// check. This is the extension point for node-data validation: add a check
+// here as new corrupt-data classes surface (nil hostinfo, invalid IPs,
+// tags-XOR-user violations, ...) and both the boot scan and any future caller
+// run the whole set.
+type nodeHealthCheck struct {
+	name  string
+	check func(nv types.NodeView, cfg *types.Config) (problem, fixHint string, ok bool)
+}
+
+// nodeHealthChecks is the registry of node-data health checks. Today it carries
+// the one issue #3346 needs; append to it rather than reshaping callers.
+var nodeHealthChecks = []nodeHealthCheck{givenNameMapsToValidFQDN}
+
+// givenNameMapsToValidFQDN flags a node whose stored GivenName cannot produce a
+// valid FQDN (empty, or longer than MaxHostnameLength once base_domain is
+// applied). Such a node cannot be rendered into a netmap — neither its own nor
+// any peer's — so it must be renamed to recover.
+var givenNameMapsToValidFQDN = nodeHealthCheck{
+	name: "given-name-maps-to-valid-fqdn",
+	check: func(nv types.NodeView, cfg *types.Config) (string, string, bool) {
+		err := types.ValidateGivenName(nv.GivenName(), cfg.BaseDomain)
+		if err != nil {
+			return err.Error(), fmt.Sprintf("headscale nodes rename %d <name>", nv.ID()), false
+		}
+
+		return "", "", true
+	},
+}
+
+// nodeHealthFinding is a single failed check for a single node.
+type nodeHealthFinding struct {
+	nodeID   types.NodeID
+	hostname string
+	check    string
+	problem  string
+	fixHint  string
+}
+
+// scanNodeHealth runs every registered check against every node in the store
+// and returns one finding per failure. It only reports — it never mutates a
+// node — so an operator can repair the underlying data without the server
+// silently rewriting a user-visible name.
+func (s *State) scanNodeHealth() []nodeHealthFinding {
+	var findings []nodeHealthFinding
+
+	for _, nv := range s.nodeStore.ListNodes().All() {
+		for _, c := range nodeHealthChecks {
+			problem, fixHint, ok := c.check(nv, s.cfg)
+			if ok {
+				continue
+			}
+
+			findings = append(findings, nodeHealthFinding{
+				nodeID:   nv.ID(),
+				hostname: nv.Hostname(),
+				check:    c.name,
+				problem:  problem,
+				fixHint:  fixHint,
+			})
+		}
+	}
+
+	return findings
+}
+
+// logNodeHealth scans the store once and logs an actionable warning per
+// finding. Called at startup so an operator learns — by node id and fix
+// command — about stored data that will break map generation, without the
+// server changing anything itself.
+func (s *State) logNodeHealth() {
+	for _, f := range s.scanNodeHealth() {
+		log.Warn().
+			Uint64(zf.NodeID, f.nodeID.Uint64()).
+			Str(zf.NodeHostname, f.hostname).
+			Str("check", f.check).
+			Str("problem", f.problem).
+			Str("fix", f.fixHint).
+			Msg("node has invalid data that breaks map generation; rename it to restore connectivity")
+	}
+}

--- a/hscontrol/state/node_health_test.go
+++ b/hscontrol/state/node_health_test.go
@@ -1,0 +1,67 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/db"
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGivenNameMapsToValidFQDNCheck(t *testing.T) {
+	cfg := &types.Config{BaseDomain: "example.com"}
+
+	_, _, ok := givenNameMapsToValidFQDN.check((&types.Node{ID: 1, GivenName: "valid"}).View(), cfg)
+	require.True(t, ok, "a valid given name must pass the check")
+
+	problem, fixHint, ok := givenNameMapsToValidFQDN.check((&types.Node{ID: 7, GivenName: ""}).View(), cfg)
+	require.False(t, ok, "an empty given name must fail the check")
+	require.NotEmpty(t, problem)
+	require.Contains(t, fixHint, "rename 7", "fix hint must name the offending node")
+}
+
+// TestScanNodeHealthReportsInvalidNameWithoutMutating proves the boot scan
+// reports a node whose stored name would break map generation (issue #3346)
+// with an actionable fix, and that it never rewrites the stored name — the
+// maintainer's decision is log-only, no silent mutation.
+func TestScanNodeHealthReportsInvalidNameWithoutMutating(t *testing.T) {
+	dbPath := t.TempDir() + "/headscale.db"
+	cfg := persistTestConfig(dbPath)
+
+	database, err := db.NewHeadscaleDatabase(cfg)
+	require.NoError(t, err)
+
+	user := database.CreateUserForTest("scan-user")
+	bad := database.CreateRegisteredNodeForTest(user, "scan-bad")
+	good := database.CreateRegisteredNodeForTest(user, "scan-good")
+
+	require.NoError(t, database.DB.
+		Model(&types.Node{}).
+		Where("id = ?", bad.ID).
+		Update("given_name", "").Error)
+	require.NoError(t, database.Close())
+
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	findings := s.scanNodeHealth()
+
+	var badFinding *nodeHealthFinding
+
+	for i := range findings {
+		require.NotEqual(t, good.ID, findings[i].nodeID, "a valid node must not be reported")
+
+		if findings[i].nodeID == bad.ID {
+			badFinding = &findings[i]
+		}
+	}
+
+	require.NotNil(t, badFinding, "a node with an invalid name must be reported")
+	require.Contains(t, badFinding.fixHint, "rename", "finding must carry an actionable fix")
+
+	// Log-only: neither the scan nor boot may rewrite the stored name.
+	nv, ok := s.GetNodeByID(bad.ID)
+	require.True(t, ok)
+	require.Empty(t, nv.GivenName(), "boot scan must not mutate the stored name")
+}

--- a/hscontrol/state/rename_test.go
+++ b/hscontrol/state/rename_test.go
@@ -1,0 +1,40 @@
+package state
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRenameNodeRejectsNameExceedingFQDNLimit proves RenameNode rejects a name
+// that is a valid DNS label but whose FQDN, under the configured base_domain,
+// exceeds MaxHostnameLength. Without the FQDN-length gate such a name persists
+// and then breaks map generation for the node and its peers (issue #3346):
+// admin-facing writes must not be able to introduce an unmappable name.
+func TestRenameNodeRejectsNameExceedingFQDNLimit(t *testing.T) {
+	dbPath := t.TempDir() + "/headscale.db"
+	cfg := persistTestConfig(dbPath)
+	// A long base domain so a 63-char label overflows the 255-char FQDN bound.
+	cfg.BaseDomain = strings.Repeat("b", 200) + ".example.com"
+
+	database, err := db.NewHeadscaleDatabase(cfg)
+	require.NoError(t, err)
+
+	user := database.CreateUserForTest("rename-user")
+	node := database.CreateRegisteredNodeForTest(user, "rename-node")
+	require.NoError(t, database.Close())
+
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Valid 63-char DNS label, but the resulting FQDN exceeds 255 chars.
+	_, _, err = s.RenameNode(node.ID, strings.Repeat("a", 63))
+	require.Error(t, err, "rename to a name whose FQDN exceeds the limit must be rejected")
+
+	// A short, valid name is still accepted.
+	_, _, err = s.RenameNode(node.ID, "short")
+	require.NoError(t, err)
+}

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -277,7 +277,7 @@ func NewState(cfg *types.Config) (*State, error) {
 	)
 	nodeStore.Start()
 
-	return &State{
+	s := &State{
 		cfg: cfg,
 
 		db:        db,
@@ -289,7 +289,14 @@ func NewState(cfg *types.Config) (*State, error) {
 
 		sshCheckAuth:  make(map[sshCheckPair]time.Time),
 		registerLocks: xsync.NewMap[key.MachinePublic, *sync.Mutex](),
-	}, nil
+	}
+
+	// Surface nodes whose stored data would break map generation (e.g. an
+	// invalid given name from a legacy row) so an operator can fix them. This
+	// only logs; it never mutates a node's stored name at boot.
+	s.logNodeHealth()
+
+	return s, nil
 }
 
 // Close gracefully shuts down the [State] instance and releases all resources.

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -1032,7 +1032,10 @@ func (s *State) SetApprovedRoutes(nodeID types.NodeID, routes []netip.Prefix) (t
 // auto-sanitisation) and collisions error out rather than silently
 // bumping a user-facing label. See HOSTNAME.md for the CLI contract.
 func (s *State) RenameNode(nodeID types.NodeID, newName string) (types.NodeView, change.Change, error) {
-	err := dnsname.ValidLabel(newName)
+	// Validate the label AND that the resulting FQDN fits MaxHostnameLength:
+	// a valid 63-char label can still overflow under a long base_domain, and
+	// an unmappable name would break this node and its peers (issue #3346).
+	err := types.ValidateGivenName(newName, s.cfg.BaseDomain)
 	if err != nil {
 		return types.NodeView{}, change.Change{}, fmt.Errorf("%w: %w", ErrGivenNameInvalid, err)
 	}

--- a/hscontrol/types/node.go
+++ b/hscontrol/types/node.go
@@ -19,6 +19,7 @@ import (
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 	"tailscale.com/types/views"
+	"tailscale.com/util/dnsname"
 )
 
 var (
@@ -515,6 +516,28 @@ func (node *Node) GetFQDN(baseDomain string) (string, error) {
 	}
 
 	return hostname, nil
+}
+
+// ValidateGivenName reports whether givenName is usable as a node's DNS label:
+// a valid DNS label that, combined with baseDomain, yields an FQDN within
+// MaxHostnameLength. Admin-facing write paths (e.g. node rename) reject names
+// that fail this, since the mapper cannot build a map for a node — or any of
+// its peers — whose GetFQDN fails. Derived paths sanitise/coerce instead.
+func ValidateGivenName(givenName, baseDomain string) error {
+	err := dnsname.ValidLabel(givenName)
+	if err != nil {
+		return fmt.Errorf("%q is not a valid DNS label: %w", givenName, err)
+	}
+
+	// Reuse GetFQDN so the length bound stays identical to what the mapper
+	// enforces; a valid 63-char label can still overflow under a long
+	// base_domain.
+	_, err = (&Node{GivenName: givenName}).GetFQDN(baseDomain)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // AnnouncedRoutes returns the list of routes the node announces, as

--- a/hscontrol/types/node_test.go
+++ b/hscontrol/types/node_test.go
@@ -417,6 +417,33 @@ func TestNodeFQDN(t *testing.T) {
 	}
 }
 
+func TestValidateGivenName(t *testing.T) {
+	tests := []struct {
+		name       string
+		givenName  string
+		baseDomain string
+		wantErr    bool
+	}{
+		{"valid", "test", "example.com", false},
+		{"empty", "", "example.com", true},
+		{"invalid label chars", "not valid", "example.com", true},
+		{"label too long", strings.Repeat("a", 64), "example.com", true},
+		// A valid 63-char label whose FQDN overflows only because the base
+		// domain is long: ValidLabel passes, the FQDN-length bound rejects it.
+		{"fqdn too long under long base domain", strings.Repeat("a", 63), strings.Repeat("b", 200) + ".example.com", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateGivenName(tc.givenName, tc.baseDomain)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ValidateGivenName(%q, %q) error = %v, wantErr %v",
+					tc.givenName, tc.baseDomain, err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestPeerChangeFromMapRequest(t *testing.T) {
 	nKeys := []key.NodePublic{
 		key.NewNode().Public(),


### PR DESCRIPTION
A node whose stored `GivenName` can't form a valid FQDN — empty, or over 255 characters once `base_domain` is applied — used to abort the whole `MapResponse` for itself and every peer that could see it. Affected clients looped on `PollNetMap: ... unexpected EOF` and reported being unable to reach the coordination server, while unrelated clients were fine, so it looked random. The fragility predates 0.29; the hostname/given-name rework in that release made invalid names reachable.

`buildTailPeers` now drops an unrenderable peer and keeps going instead of failing the response, and `serveLongPoll` returns a real HTTP error rather than the empty `200` the client read as EOF. To keep bad names out, a node rename whose FQDN would exceed the limit is rejected. To surface names already stored, startup logs each offending node with the `headscale nodes rename` command to fix it — log-only, nothing is rewritten.

Aimed at a `0.29.2` backport; this branch is the same change on `main`.

Fixes #3346

> Generated with the help of an AI assistant
