### PR TITLE
ci: bump Mic92/hestia/action to v1.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
               - 'config-example.yaml'
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
         if: steps.changed-files.outputs.files == 'true'
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
         if: steps.changed-files.outputs.files == 'true'
 
       - name: Check vendor hash
@@ -82,7 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
 
       - name: Run go cross compile
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
               - 'config-example.yaml'
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
         if: steps.changed-files.outputs.files == 'true'
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
         if: steps.changed-files.outputs.files == 'true'
 
       - name: Check vendor hash
@@ -82,7 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
 
       - name: Run go cross compile
         env:

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -35,7 +35,7 @@ jobs:
               - 'tools/**'
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
         if: steps.changed-files.outputs.files == 'true'
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
         if: steps.changed-files.outputs.files == 'true'
 
       - name: Run make generate

--- a/.github/workflows/check-generated.yml
+++ b/.github/workflows/check-generated.yml
@@ -35,7 +35,7 @@ jobs:
               - 'tools/**'
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
         if: steps.changed-files.outputs.files == 'true'
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
         if: steps.changed-files.outputs.files == 'true'
 
       - name: Run make generate

--- a/.github/workflows/check-tests.yaml
+++ b/.github/workflows/check-tests.yaml
@@ -30,7 +30,7 @@ jobs:
               - 'config-example.yaml'
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
         if: steps.changed-files.outputs.files == 'true'
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
         if: steps.changed-files.outputs.files == 'true'
 
       - name: Generate and check integration tests

--- a/.github/workflows/check-tests.yaml
+++ b/.github/workflows/check-tests.yaml
@@ -30,7 +30,7 @@ jobs:
               - 'config-example.yaml'
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
         if: steps.changed-files.outputs.files == 'true'
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
         if: steps.changed-files.outputs.files == 'true'
 
       - name: Generate and check integration tests

--- a/.github/workflows/container-main.yml
+++ b/.github/workflows/container-main.yml
@@ -45,7 +45,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
 
       - name: Set commit timestamp
         run: echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> $GITHUB_ENV
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
 
       - name: Build binary
         env:

--- a/.github/workflows/container-main.yml
+++ b/.github/workflows/container-main.yml
@@ -45,7 +45,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
 
       - name: Set commit timestamp
         run: echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> $GITHUB_ENV
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
 
       - name: Build binary
         env:

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
       - name: Run garbage collection
         run: '"${HESTIA_BIN}" gc ${{ inputs.dry-run && ''--dry-run'' || '''' }}'
         env:

--- a/.github/workflows/gc.yml
+++ b/.github/workflows/gc.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
       - name: Run garbage collection
         run: '"${HESTIA_BIN}" gc ${{ inputs.dry-run && ''--dry-run'' || '''' }}'
         env:

--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
       - name: build
         run: nix build -L .#checks.x86_64-linux.build
 
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
       - name: gotest
         run: nix build -L .#checks.x86_64-linux.gotest
 
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
       - name: golangci-lint
         run: nix build -L .#checks.x86_64-linux.golangci-lint
 
@@ -51,6 +51,6 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
       - name: formatting
         run: nix build -L .#checks.x86_64-linux.formatting

--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
       - name: build
         run: nix build -L .#checks.x86_64-linux.build
 
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
       - name: gotest
         run: nix build -L .#checks.x86_64-linux.gotest
 
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
       - name: golangci-lint
         run: nix build -L .#checks.x86_64-linux.golangci-lint
 
@@ -51,6 +51,6 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
       - name: formatting
         run: nix build -L .#checks.x86_64-linux.formatting

--- a/.github/workflows/nix-module-test.yml
+++ b/.github/workflows/nix-module-test.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
         if: steps.changed-files.outputs.nix == 'true' || steps.changed-files.outputs.go == 'true'
 
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
         if: steps.changed-files.outputs.nix == 'true' || steps.changed-files.outputs.go == 'true'
 
       - name: Run NixOS module tests

--- a/.github/workflows/nix-module-test.yml
+++ b/.github/workflows/nix-module-test.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
         if: steps.changed-files.outputs.nix == 'true' || steps.changed-files.outputs.go == 'true'
 
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
         if: steps.changed-files.outputs.nix == 'true' || steps.changed-files.outputs.go == 'true'
 
       - name: Run NixOS module tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
 
       - name: Run goreleaser
         run: goreleaser release --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
 
       - name: Run goreleaser
         run: goreleaser release --clean

--- a/.github/workflows/servertest.yml
+++ b/.github/workflows/servertest.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
 
       - name: go test ./hscontrol/servertest
         env:

--- a/.github/workflows/servertest.yml
+++ b/.github/workflows/servertest.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
 
       - name: go test ./hscontrol/servertest
         env:

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -41,7 +41,7 @@ jobs:
               - 'Dockerfile.*'
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
         if: steps.changed-files.outputs.files == 'true'
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
         if: steps.changed-files.outputs.files == 'true'
       - name: Build binaries and warm Go cache
         if: steps.changed-files.outputs.files == 'true'
@@ -160,7 +160,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
+      - uses: Mic92/hestia@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
       - name: Force overlay2 storage driver
         run: |
           sudo mkdir -p /etc/docker

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -41,7 +41,7 @@ jobs:
               - 'Dockerfile.*'
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
         if: steps.changed-files.outputs.files == 'true'
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
         if: steps.changed-files.outputs.files == 'true'
       - name: Build binaries and warm Go cache
         if: steps.changed-files.outputs.files == 'true'
@@ -160,7 +160,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
-      - uses: Mic92/hestia/action@ff07bb902a9968ac0c3d0e51d90a606662a375d8 # main
+      - uses: Mic92/hestia/action@7ae4509d1c3cacd4a31b91d9ad308d74e0b5a053 # v1.0.2
       - name: Force overlay2 storage driver
         run: |
           sudo mkdir -p /etc/docker


### PR DESCRIPTION
Hestia [v1.0.2](https://github.com/Mic92/hestia/releases/tag/v1.0.2) is out, the first stable release line. Bumps the pinned commit SHA; no workflow changes needed since the action interface is unchanged from the previous `main` pin.