### PR TITLE
docs(routes): note exit nodes are selected only via autogroup:internet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ keys remain all-access.
 
 - Expiring or deleting a non-existent pre-auth key now returns an error instead of silently succeeding [#3324](https://github.com/juanfont/headscale/pull/3324)
 - Improve systemd service file hardening [#3341](https://github.com/juanfont/headscale/pull/3341)
+- Document that exit-node access is granted only through `autogroup:internet`; subnet-style CIDR destinations carried over from older ACLs do not select an exit node [#3368](https://github.com/juanfont/headscale/pull/3368)
 
 ## 0.29.2 (2026-07-01)
 

--- a/docs/ref/routes.md
+++ b/docs/ref/routes.md
@@ -222,6 +222,10 @@ available exit nodes.
 }
 ```
 
+!!! warning "Exit nodes are selected only via `autogroup:internet`"
+
+    Exit-node access is granted through `autogroup:internet`, not through a regular CIDR destination. Broad public-internet ranges — such as the split set (`0.0.0.0/5` through `208.0.0.0/4`) that some older ACLs used to represent the internet — are treated as ordinary subnet-route destinations and do **not** authorize exit-node use. When migrating a policy from ACLs to grants, replace those destinations with `autogroup:internet`.
+
 ### Restrict access to exit nodes per user or group
 
 A user can use _any_ of the available exit nodes with `autogroup:internet`. Alternatively, the policy snippet below


### PR DESCRIPTION
Follows up on #3361. When a policy is migrated from ACLs to grants, exit-node selection silently stops working if the policy relied on the split public-internet CIDR ranges that older ACLs used. Those ranges are treated as ordinary subnet-route destinations; only `autogroup:internet` authorizes an exit node (`compiled.go`: `hasAutoGroupInternet && node.IsExitNode()`). The reporter asked for this to be documented.

Adds a note to the exit-node policy section of `docs/ref/routes.md` plus a CHANGELOG entry. Documentation only, no code change.

- [x] have read the CONTRIBUTING.md file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand (#3361)
- [ ] added unit tests (n/a, documentation only)
- [ ] added integration tests (n/a, documentation only)
- [x] updated documentation if needed
- [x] updated CHANGELOG.md
