### PR TITLE
dns: add scoped nameservers.use_with_exit_node selectors

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -319,6 +319,7 @@ jobs:
           - TestExitRoutesWithAutogroupInternetACL
           - TestSubnetRouterMultiNetwork
           - TestSubnetRouterMultiNetworkExitNode
+          - TestExitNodeUseWithExitNodeDNS
           - TestAutoApproveMultiNetwork/authkey-tag.*
           - TestAutoApproveMultiNetwork/authkey-user.*
           - TestAutoApproveMultiNetwork/authkey-group.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ keys remain all-access.
 
 - Expiring or deleting a non-existent pre-auth key now returns an error instead of silently succeeding [#3324](https://github.com/juanfont/headscale/pull/3324)
 - Improve systemd service file hardening [#3341](https://github.com/juanfont/headscale/pull/3341)
-- Add `dns.nameservers.use_with_exit_node` to keep selected resolvers active when a client uses an exit node, so a self-hosted resolver can be reached without routing DNS through the exit node (requires Tailscale v1.88+) [#2816](https://github.com/juanfont/headscale/issues/2816)
+- Add `dns.nameservers.use_with_exit_node` to keep selected resolvers active when a client uses an exit node, so a self-hosted resolver can be reached without routing DNS through the exit node (requires Tailscale v1.88+) [#3376](https://github.com/juanfont/headscale/pull/3376)
 
 ## 0.29.2 (2026-07-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ keys remain all-access.
 
 - Expiring or deleting a non-existent pre-auth key now returns an error instead of silently succeeding [#3324](https://github.com/juanfont/headscale/pull/3324)
 - Improve systemd service file hardening [#3341](https://github.com/juanfont/headscale/pull/3341)
+- Add `dns.nameservers.use_with_exit_node` to keep selected resolvers active when a client uses an exit node, so a self-hosted resolver can be reached without routing DNS through the exit node (requires Tailscale v1.88+) [#2816](https://github.com/juanfont/headscale/issues/2816)
 
 ## 0.29.2 (2026-07-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ keys remain all-access.
 
 - Expiring or deleting a non-existent pre-auth key now returns an error instead of silently succeeding [#3324](https://github.com/juanfont/headscale/pull/3324)
 - Improve systemd service file hardening [#3341](https://github.com/juanfont/headscale/pull/3341)
-- Add `dns.nameservers.use_with_exit_node` to keep selected resolvers active when a client uses an exit node, so a self-hosted resolver can be reached without routing DNS through the exit node (requires Tailscale v1.88+) [#3376](https://github.com/juanfont/headscale/pull/3376)
+- Add scoped `dns.nameservers.use_with_exit_node` selectors so configured resolvers remain active when a client uses an exit node (requires Tailscale v1.88.1+) [#3376](https://github.com/juanfont/headscale/pull/3376)
 
 ## 0.29.2 (2026-07-01)
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -337,6 +337,18 @@ dns:
       #   - 1.1.1.1
       #   - 8.8.8.8
 
+    # By default, when a client selects an exit node, Tailscale routes all of
+    # that client's DNS through the exit node and ignores the nameservers
+    # above. List the nameserver addresses here (from `global` or `split`) that
+    # should keep being used even while an exit node is selected. This is useful
+    # to reach a self-hosted resolver (e.g. Pi-hole on the tailnet) directly,
+    # without the round trip through the exit node.
+    #
+    # Requires a Tailscale client from v1.88 or newer (capability version 125);
+    # older clients silently ignore this setting.
+    use_with_exit_node: []
+      # - 100.64.0.53
+
   # Set custom DNS search domains. With MagicDNS enabled,
   # your tailnet base_domain is always the first search domain.
   search_domains: []

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -337,17 +337,15 @@ dns:
       #   - 1.1.1.1
       #   - 8.8.8.8
 
-    # By default, when a client selects an exit node, Tailscale routes all of
-    # that client's DNS through the exit node and ignores the nameservers
-    # above. List the nameserver addresses here (from `global` or `split`) that
-    # should keep being used even while an exit node is selected. This is useful
-    # to reach a self-hosted resolver (e.g. Pi-hole on the tailnet) directly,
-    # without the round trip through the exit node.
-    #
-    # Requires a Tailscale client from v1.88 or newer (capability version 125);
-    # older clients silently ignore this setting.
-    use_with_exit_node: []
-      # - 100.64.0.53
+    # Nameservers to keep using while an exit node is selected. Global entries
+    # must also be in `global` and require `override_local_dns: true`. Split
+    # entries must also be under the same domain in `split`.
+    use_with_exit_node:
+      global: []
+        # - 1.1.1.1
+      split: {}
+        # foo.bar.com:
+        #   - 1.1.1.1
 
   # Set custom DNS search domains. With MagicDNS enabled,
   # your tailnet base_domain is always the first search domain.

--- a/docs/ref/dns.md
+++ b/docs/ref/dns.md
@@ -3,6 +3,34 @@
 Headscale supports [most DNS features](../about/features.md) from Tailscale. DNS related settings can be configured
 within the `dns` section of the [configuration file](configuration.md).
 
+## Keeping nameservers active when using an exit node
+
+By default, when a client selects an exit node, Tailscale sends **all** of that client's DNS through the exit node and
+ignores the nameservers configured in Headscale. This is usually desirable, but it prevents reaching a self-hosted
+resolver (for example a Pi-hole running on the tailnet) directly: the query has to take the round trip through the exit
+node first.
+
+The `dns.nameservers.use_with_exit_node` option lists the nameserver addresses that should keep being used even while an
+exit node is selected. Listed addresses must also appear in `dns.nameservers.global` or `dns.nameservers.split`.
+
+```yaml title="config.yaml"
+dns:
+  nameservers:
+    global:
+      - 100.64.0.53
+    use_with_exit_node:
+      - 100.64.0.53
+```
+
+When the listed resolver is reachable within the tailnet (such as `100.64.0.53`), the client talks to it directly
+instead of routing the query through the exit node.
+
+!!! warning "Requires a recent Tailscale client"
+
+    This maps to Tailscale's [`UseWithExitNode`](https://tailscale.com/kb/1054/dns#nameservers-and-exit-nodes) resolver
+    flag, added in **capability version 125 (Tailscale v1.88)**. Older clients silently ignore the setting and continue
+    to send DNS through the exit node.
+
 ## Setting extra DNS records
 
 Headscale allows to set extra DNS records which are made available via

--- a/docs/ref/dns.md
+++ b/docs/ref/dns.md
@@ -10,25 +10,39 @@ ignores the nameservers configured in Headscale. This is usually desirable, but 
 resolver (for example a Pi-hole running on the tailnet) directly: the query has to take the round trip through the exit
 node first.
 
-The `dns.nameservers.use_with_exit_node` option lists the nameserver addresses that should keep being used even while an
-exit node is selected. Listed addresses must also appear in `dns.nameservers.global` or `dns.nameservers.split`.
+List a global or split nameserver under `dns.nameservers.use_with_exit_node` to keep using that resolver while an exit
+node is selected. Each selected address must also appear in the corresponding `global` list or under the same domain in
+`split`.
 
 ```yaml title="config.yaml"
 dns:
+  override_local_dns: true
   nameservers:
     global:
       - 100.64.0.53
+    split:
+      homelab.example.com:
+        - 100.64.0.54
     use_with_exit_node:
-      - 100.64.0.53
+      global:
+        - 100.64.0.53
+      split:
+        homelab.example.com:
+          - 100.64.0.54
 ```
 
-When the listed resolver is reachable within the tailnet (such as `100.64.0.53`), the client talks to it directly
-instead of routing the query through the exit node.
+Global nameservers require `dns.override_local_dns: true`. Split nameservers can use this option regardless of that
+setting. Global and split selections are independent, so the same address can be enabled for one split domain without
+enabling its global entry.
+
+This option controls which resolver receives a query, not how packets are routed. A resolver at a tailnet address or
+behind an advertised subnet route is normally reached directly because that route is more specific than the exit-node
+default route. Traffic to a public resolver normally still travels through the exit node.
 
 !!! warning "Requires a recent Tailscale client"
 
     This maps to Tailscale's [`UseWithExitNode`](https://tailscale.com/kb/1054/dns#nameservers-and-exit-nodes) resolver
-    flag, added in **capability version 125 (Tailscale v1.88)**. Older clients silently ignore the setting and continue
+    flag, added in **capability version 125 (Tailscale v1.88.1)**. Older clients silently ignore the setting and continue
     to send DNS through the exit node.
 
 ## Setting extra DNS records

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -167,6 +167,12 @@ type DNSConfig struct {
 type Nameservers struct {
 	Global []string
 	Split  map[string][]string
+	// UseWithExitNode lists nameserver addresses (from Global or Split)
+	// that should keep being used even when a client selects an exit node.
+	// Without this, Tailscale clients delegate all DNS to the exit node,
+	// ignoring the configured resolvers. Requires client capability version
+	// 125 (Tailscale v1.88 or newer); older clients ignore the flag.
+	UseWithExitNode []string `mapstructure:"use_with_exit_node"`
 }
 
 type SqliteConfig struct {
@@ -446,6 +452,7 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("dns.override_local_dns", true)
 	viper.SetDefault("dns.nameservers.global", []string{})
 	viper.SetDefault("dns.nameservers.split", map[string]string{})
+	viper.SetDefault("dns.nameservers.use_with_exit_node", []string{})
 	viper.SetDefault("dns.search_domains", []string{})
 
 	viper.SetDefault("derp.server.enabled", false)
@@ -914,6 +921,9 @@ func dns() (DNSConfig, error) {
 	dns.OverrideLocalDNS = viper.GetBool("dns.override_local_dns")
 	dns.Nameservers.Global = viper.GetStringSlice("dns.nameservers.global")
 	dns.Nameservers.Split = viper.GetStringMapStringSlice("dns.nameservers.split")
+	dns.Nameservers.UseWithExitNode = viper.GetStringSlice(
+		"dns.nameservers.use_with_exit_node",
+	)
 	dns.SearchDomains = viper.GetStringSlice("dns.search_domains")
 	dns.ExtraRecordsPath = viper.GetString("dns.extra_records_path")
 
@@ -936,13 +946,20 @@ func dns() (DNSConfig, error) {
 // If a nameserver is a valid URL, it will be used as a DoH resolver.
 // If a nameserver is neither a valid URL nor a valid IP, it will be ignored.
 // When domain is non-empty, it is included in the warning for invalid entries.
-func parseResolvers(nameservers []string, domain string) []*dnstype.Resolver {
+// Resolvers whose address is present in useWithExitNode are marked so Tailscale
+// clients keep using them even when an exit node is selected.
+func parseResolvers(
+	nameservers []string,
+	domain string,
+	useWithExitNode map[string]bool,
+) []*dnstype.Resolver {
 	var resolvers []*dnstype.Resolver
 
 	for _, nsStr := range nameservers {
 		if _, err := netip.ParseAddr(nsStr); err == nil { //nolint:noinlineerr
 			resolvers = append(resolvers, &dnstype.Resolver{
-				Addr: nsStr,
+				Addr:            nsStr,
+				UseWithExitNode: useWithExitNode[nsStr],
 			})
 
 			continue
@@ -950,7 +967,8 @@ func parseResolvers(nameservers []string, domain string) []*dnstype.Resolver {
 
 		if _, err := url.Parse(nsStr); err == nil { //nolint:noinlineerr
 			resolvers = append(resolvers, &dnstype.Resolver{
-				Addr: nsStr,
+				Addr:            nsStr,
+				UseWithExitNode: useWithExitNode[nsStr],
 			})
 
 			continue
@@ -967,18 +985,34 @@ func parseResolvers(nameservers []string, domain string) []*dnstype.Resolver {
 	return resolvers
 }
 
+// useWithExitNodeSet returns the set of nameserver addresses that should keep
+// being used when an exit node is selected.
+func (d *DNSConfig) useWithExitNodeSet() map[string]bool {
+	if len(d.Nameservers.UseWithExitNode) == 0 {
+		return nil
+	}
+
+	set := make(map[string]bool, len(d.Nameservers.UseWithExitNode))
+	for _, ns := range d.Nameservers.UseWithExitNode {
+		set[ns] = true
+	}
+
+	return set
+}
+
 // globalResolvers returns the global DNS resolvers
 // defined in the config file.
 func (d *DNSConfig) globalResolvers() []*dnstype.Resolver {
-	return parseResolvers(d.Nameservers.Global, "")
+	return parseResolvers(d.Nameservers.Global, "", d.useWithExitNodeSet())
 }
 
 // splitResolvers returns a map of domain to DNS resolvers.
 func (d *DNSConfig) splitResolvers() map[string][]*dnstype.Resolver {
 	routes := make(map[string][]*dnstype.Resolver)
 
+	useWithExitNode := d.useWithExitNodeSet()
 	for domain, nameservers := range d.Nameservers.Split {
-		routes[domain] = parseResolvers(nameservers, domain)
+		routes[domain] = parseResolvers(nameservers, domain, useWithExitNode)
 	}
 
 	return routes

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -7,6 +7,7 @@ import (
 	"net/netip"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -32,16 +33,18 @@ const (
 )
 
 var (
-	errOidcMutuallyExclusive     = errors.New("oidc_client_secret and oidc_client_secret_path are mutually exclusive")
-	errOIDCIssuerInvalid         = errors.New("oidc.issuer must be a valid http(s) URL")
-	errOIDCClientIDRequired      = errors.New("oidc.client_id is required when oidc.issuer is set")
-	errOIDCClientSecretRequired  = errors.New("oidc.client_secret or oidc.client_secret_path is required when oidc.issuer is set")
-	errServerURLSuffix           = errors.New("server_url cannot be part of base_domain in a way that could make the DERP and headscale server unreachable")
-	errServerURLSame             = errors.New("server_url cannot use the same domain as base_domain in a way that could make the DERP and headscale server unreachable")
-	errInvalidPKCEMethod         = errors.New("pkce.method must be either 'plain' or 'S256'")
-	errTrustedProxyZeroRange     = errors.New("0.0.0.0/0 and ::/0 are not allowed")
-	ErrNoPrefixConfigured        = errors.New("no IPv4 or IPv6 prefix configured, minimum one prefix is required")
-	ErrInvalidAllocationStrategy = errors.New("invalid prefix allocation strategy")
+	errOidcMutuallyExclusive         = errors.New("oidc_client_secret and oidc_client_secret_path are mutually exclusive")
+	errOIDCIssuerInvalid             = errors.New("oidc.issuer must be a valid http(s) URL")
+	errOIDCClientIDRequired          = errors.New("oidc.client_id is required when oidc.issuer is set")
+	errOIDCClientSecretRequired      = errors.New("oidc.client_secret or oidc.client_secret_path is required when oidc.issuer is set")
+	errServerURLSuffix               = errors.New("server_url cannot be part of base_domain in a way that could make the DERP and headscale server unreachable")
+	errServerURLSame                 = errors.New("server_url cannot use the same domain as base_domain in a way that could make the DERP and headscale server unreachable")
+	errInvalidPKCEMethod             = errors.New("pkce.method must be either 'plain' or 'S256'")
+	errTrustedProxyZeroRange         = errors.New("0.0.0.0/0 and ::/0 are not allowed")
+	errNameserverNotConfigured       = errors.New("use_with_exit_node nameserver is not configured")
+	errNameserverGlobalNeedsOverride = errors.New("dns.nameservers.use_with_exit_node.global requires dns.override_local_dns to be true")
+	ErrNoPrefixConfigured            = errors.New("no IPv4 or IPv6 prefix configured, minimum one prefix is required")
+	ErrInvalidAllocationStrategy     = errors.New("invalid prefix allocation strategy")
 )
 
 type IPAllocationStrategy string
@@ -167,12 +170,12 @@ type DNSConfig struct {
 type Nameservers struct {
 	Global []string
 	Split  map[string][]string
-	// UseWithExitNode lists nameserver addresses (from Global or Split)
-	// that should keep being used even when a client selects an exit node.
-	// Without this, Tailscale clients delegate all DNS to the exit node,
-	// ignoring the configured resolvers. Requires client capability version
-	// 125 (Tailscale v1.88 or newer); older clients ignore the flag.
-	UseWithExitNode []string `mapstructure:"use_with_exit_node"`
+}
+
+type parsedDNSConfig struct {
+	dns                   DNSConfig
+	globalUseWithExitNode map[string]bool
+	splitUseWithExitNode  map[string]map[string]bool
 }
 
 type SqliteConfig struct {
@@ -452,7 +455,8 @@ func LoadConfig(path string, isFile bool) error {
 	viper.SetDefault("dns.override_local_dns", true)
 	viper.SetDefault("dns.nameservers.global", []string{})
 	viper.SetDefault("dns.nameservers.split", map[string]string{})
-	viper.SetDefault("dns.nameservers.use_with_exit_node", []string{})
+	viper.SetDefault("dns.nameservers.use_with_exit_node.global", []string{})
+	viper.SetDefault("dns.nameservers.use_with_exit_node.split", map[string]string{})
 	viper.SetDefault("dns.search_domains", []string{})
 
 	viper.SetDefault("derp.server.enabled", false)
@@ -906,8 +910,10 @@ func databaseConfig() DatabaseConfig {
 	}
 }
 
-func dns() (DNSConfig, error) {
-	var dns DNSConfig
+func dns() (parsedDNSConfig, error) {
+	var result parsedDNSConfig
+
+	dns := &result.dns
 
 	// TODO: Use this instead of manually getting settings when
 	// UnmarshalKey is compatible with Environment Variables.
@@ -919,11 +925,62 @@ func dns() (DNSConfig, error) {
 	dns.MagicDNS = viper.GetBool("dns.magic_dns")
 	dns.BaseDomain = viper.GetString("dns.base_domain")
 	dns.OverrideLocalDNS = viper.GetBool("dns.override_local_dns")
+
 	dns.Nameservers.Global = viper.GetStringSlice("dns.nameservers.global")
 	dns.Nameservers.Split = viper.GetStringMapStringSlice("dns.nameservers.split")
-	dns.Nameservers.UseWithExitNode = viper.GetStringSlice(
-		"dns.nameservers.use_with_exit_node",
+
+	globalUseWithExitNode := viper.GetStringSlice(
+		"dns.nameservers.use_with_exit_node.global",
 	)
+	if len(globalUseWithExitNode) > 0 && !dns.OverrideLocalDNS {
+		return parsedDNSConfig{}, errNameserverGlobalNeedsOverride
+	}
+
+	result.globalUseWithExitNode = make(map[string]bool, len(globalUseWithExitNode))
+	for _, address := range globalUseWithExitNode {
+		if !slices.Contains(dns.Nameservers.Global, address) {
+			return parsedDNSConfig{}, fmt.Errorf(
+				"%w in dns.nameservers.global: %q",
+				errNameserverNotConfigured,
+				address,
+			)
+		}
+
+		result.globalUseWithExitNode[address] = true
+	}
+
+	splitUseWithExitNode := viper.GetStringMapStringSlice(
+		"dns.nameservers.use_with_exit_node.split",
+	)
+
+	result.splitUseWithExitNode = make(map[string]map[string]bool, len(splitUseWithExitNode))
+	for domain, addresses := range splitUseWithExitNode {
+		configured, ok := dns.Nameservers.Split[domain]
+		if !ok {
+			return parsedDNSConfig{}, fmt.Errorf(
+				"%w for split domain %q",
+				errNameserverNotConfigured,
+				domain,
+			)
+		}
+
+		selected := make(map[string]bool, len(addresses))
+		for _, address := range addresses {
+			if !slices.Contains(configured, address) {
+				return parsedDNSConfig{}, fmt.Errorf(
+					"%w for split domain %q: %q",
+					errNameserverNotConfigured,
+					domain,
+					address,
+				)
+			}
+
+			selected[address] = true
+		}
+
+		result.splitUseWithExitNode[domain] = selected
+	}
+
 	dns.SearchDomains = viper.GetStringSlice("dns.search_domains")
 	dns.ExtraRecordsPath = viper.GetString("dns.extra_records_path")
 
@@ -932,13 +989,13 @@ func dns() (DNSConfig, error) {
 
 		err := viper.UnmarshalKey("dns.extra_records", &extraRecords)
 		if err != nil {
-			return DNSConfig{}, fmt.Errorf("unmarshalling dns extra records: %w", err)
+			return parsedDNSConfig{}, fmt.Errorf("unmarshalling dns extra records: %w", err)
 		}
 
 		dns.ExtraRecords = extraRecords
 	}
 
-	return dns, nil
+	return result, nil
 }
 
 // parseResolvers converts nameserver strings into DNS resolvers.
@@ -946,8 +1003,6 @@ func dns() (DNSConfig, error) {
 // If a nameserver is a valid URL, it will be used as a DoH resolver.
 // If a nameserver is neither a valid URL nor a valid IP, it will be ignored.
 // When domain is non-empty, it is included in the warning for invalid entries.
-// Resolvers whose address is present in useWithExitNode are marked so Tailscale
-// clients keep using them even when an exit node is selected.
 func parseResolvers(
 	nameservers []string,
 	domain string,
@@ -985,41 +1040,34 @@ func parseResolvers(
 	return resolvers
 }
 
-// useWithExitNodeSet returns the set of nameserver addresses that should keep
-// being used when an exit node is selected.
-func (d *DNSConfig) useWithExitNodeSet() map[string]bool {
-	if len(d.Nameservers.UseWithExitNode) == 0 {
-		return nil
-	}
-
-	set := make(map[string]bool, len(d.Nameservers.UseWithExitNode))
-	for _, ns := range d.Nameservers.UseWithExitNode {
-		set[ns] = true
-	}
-
-	return set
-}
-
 // globalResolvers returns the global DNS resolvers
 // defined in the config file.
-func (d *DNSConfig) globalResolvers() []*dnstype.Resolver {
-	return parseResolvers(d.Nameservers.Global, "", d.useWithExitNodeSet())
+func (d *parsedDNSConfig) globalResolvers() []*dnstype.Resolver {
+	return parseResolvers(
+		d.dns.Nameservers.Global,
+		"",
+		d.globalUseWithExitNode,
+	)
 }
 
 // splitResolvers returns a map of domain to DNS resolvers.
-func (d *DNSConfig) splitResolvers() map[string][]*dnstype.Resolver {
+func (d *parsedDNSConfig) splitResolvers() map[string][]*dnstype.Resolver {
 	routes := make(map[string][]*dnstype.Resolver)
 
-	useWithExitNode := d.useWithExitNodeSet()
-	for domain, nameservers := range d.Nameservers.Split {
-		routes[domain] = parseResolvers(nameservers, domain, useWithExitNode)
+	for domain, nameservers := range d.dns.Nameservers.Split {
+		routes[domain] = parseResolvers(
+			nameservers,
+			domain,
+			d.splitUseWithExitNode[domain],
+		)
 	}
 
 	return routes
 }
 
-func dnsToTailcfgDNS(dns DNSConfig) *tailcfg.DNSConfig {
+func dnsToTailcfgDNS(parsed parsedDNSConfig) *tailcfg.DNSConfig {
 	cfg := tailcfg.DNSConfig{}
+	dns := parsed.dns
 
 	if dns.BaseDomain == "" && dns.MagicDNS {
 		log.Fatal().Msg("dns.base_domain must be set when using MagicDNS (dns.magic_dns)")
@@ -1029,12 +1077,12 @@ func dnsToTailcfgDNS(dns DNSConfig) *tailcfg.DNSConfig {
 
 	cfg.ExtraRecords = dns.ExtraRecords
 	if dns.OverrideLocalDNS {
-		cfg.Resolvers = dns.globalResolvers()
+		cfg.Resolvers = parsed.globalResolvers()
 	} else {
-		cfg.FallbackResolvers = dns.globalResolvers()
+		cfg.FallbackResolvers = parsed.globalResolvers()
 	}
 
-	routes := dns.splitResolvers()
+	routes := parsed.splitResolvers()
 
 	cfg.Routes = routes
 	if dns.BaseDomain != "" {
@@ -1241,8 +1289,8 @@ func LoadServerConfig() (*Config, error) {
 	// - DERP run on their own domains
 	// - Control plane runs on login.tailscale.com/controlplane.tailscale.com
 	// - MagicDNS (BaseDomain) for users is on a *.ts.net domain per tailnet (e.g. tail-scale.ts.net)
-	if dnsConfig.BaseDomain != "" {
-		err := isSafeServerURL(serverURL, dnsConfig.BaseDomain)
+	if dnsConfig.dns.BaseDomain != "" {
+		err := isSafeServerURL(serverURL, dnsConfig.dns.BaseDomain)
 		if err != nil {
 			return nil, err
 		}
@@ -1262,7 +1310,7 @@ func LoadServerConfig() (*Config, error) {
 		NoisePrivateKeyPath: util.AbsolutePathFromConfigPath(
 			viper.GetString("noise.private_key_path"),
 		),
-		BaseDomain: dnsConfig.BaseDomain,
+		BaseDomain: dnsConfig.dns.BaseDomain,
 
 		DERP: derpConfig,
 
@@ -1287,7 +1335,7 @@ func LoadServerConfig() (*Config, error) {
 
 		TLS: tlsConfig(),
 
-		DNSConfig:        dnsConfig,
+		DNSConfig:        dnsConfig.dns,
 		TailcfgDNSConfig: dnsToTailcfgDNS(dnsConfig),
 
 		ACMEEmail: viper.GetString("acme_email"),

--- a/hscontrol/types/config_test.go
+++ b/hscontrol/types/config_test.go
@@ -262,7 +262,8 @@ func TestReadConfig(t *testing.T) {
 					{Addr: "1.0.0.1"},
 				},
 				Routes: map[string][]*dnstype.Resolver{
-					"foo.bar.com": {{Addr: "8.8.8.8", UseWithExitNode: true}},
+					"foo.bar.com":     {{Addr: "8.8.8.8", UseWithExitNode: true}},
+					"baz.example.com": {{Addr: "9.9.9.9"}},
 				},
 			},
 		},

--- a/hscontrol/types/config_test.go
+++ b/hscontrol/types/config_test.go
@@ -52,10 +52,15 @@ func TestReadConfig(t *testing.T) {
 						"darp.headscale.net": {"1.1.1.1", "8.8.8.8"},
 						"foo.bar.com":        {"1.1.1.1"},
 					},
+					UseWithExitNode: []string{},
 				},
 				ExtraRecords: []tailcfg.DNSRecord{
 					{Name: "grafana.myvpn.example.com", Type: "A", Value: "100.64.0.3"},
-					{Name: "prometheus.myvpn.example.com", Type: "A", Value: "100.64.0.4"},
+					{
+						Name:  "prometheus.myvpn.example.com",
+						Type:  "A",
+						Value: "100.64.0.4",
+					},
 				},
 				SearchDomains: []string{"test.com", "bar.com"},
 			},
@@ -87,7 +92,11 @@ func TestReadConfig(t *testing.T) {
 				},
 				ExtraRecords: []tailcfg.DNSRecord{
 					{Name: "grafana.myvpn.example.com", Type: "A", Value: "100.64.0.3"},
-					{Name: "prometheus.myvpn.example.com", Type: "A", Value: "100.64.0.4"},
+					{
+						Name:  "prometheus.myvpn.example.com",
+						Type:  "A",
+						Value: "100.64.0.4",
+					},
 				},
 			},
 		},
@@ -118,10 +127,15 @@ func TestReadConfig(t *testing.T) {
 						"darp.headscale.net": {"1.1.1.1", "8.8.8.8"},
 						"foo.bar.com":        {"1.1.1.1"},
 					},
+					UseWithExitNode: []string{},
 				},
 				ExtraRecords: []tailcfg.DNSRecord{
 					{Name: "grafana.myvpn.example.com", Type: "A", Value: "100.64.0.3"},
-					{Name: "prometheus.myvpn.example.com", Type: "A", Value: "100.64.0.4"},
+					{
+						Name:  "prometheus.myvpn.example.com",
+						Type:  "A",
+						Value: "100.64.0.4",
+					},
 				},
 				SearchDomains: []string{"test.com", "bar.com"},
 			},
@@ -153,7 +167,11 @@ func TestReadConfig(t *testing.T) {
 				},
 				ExtraRecords: []tailcfg.DNSRecord{
 					{Name: "grafana.myvpn.example.com", Type: "A", Value: "100.64.0.3"},
-					{Name: "prometheus.myvpn.example.com", Type: "A", Value: "100.64.0.4"},
+					{
+						Name:  "prometheus.myvpn.example.com",
+						Type:  "A",
+						Value: "100.64.0.4",
+					},
 				},
 			},
 		},
@@ -217,6 +235,34 @@ func TestReadConfig(t *testing.T) {
 				Resolvers: []*dnstype.Resolver{
 					{Addr: "1.1.1.1"},
 					{Addr: "1.0.0.1"},
+				},
+			},
+		},
+		{
+			name:       "dns-use-with-exit-node",
+			configPath: "testdata/dns-use-with-exit-node.yaml",
+			setup: func(t *testing.T) (any, error) { //nolint:thelper
+				_, err := LoadServerConfig()
+				if err != nil {
+					return nil, err
+				}
+
+				dns, err := dns()
+				if err != nil {
+					return nil, err
+				}
+
+				return dnsToTailcfgDNS(dns), nil
+			},
+			want: &tailcfg.DNSConfig{
+				Proxied: true,
+				Domains: []string{"derp2.no"},
+				Resolvers: []*dnstype.Resolver{
+					{Addr: "1.1.1.1", UseWithExitNode: true},
+					{Addr: "1.0.0.1"},
+				},
+				Routes: map[string][]*dnstype.Resolver{
+					"foo.bar.com": {{Addr: "8.8.8.8", UseWithExitNode: true}},
 				},
 			},
 		},
@@ -495,7 +541,10 @@ dns:
   override_local_dns: false
 oidc:` + tt.oidcBlock + "\n")
 
-			require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "config.yaml"), configYaml, 0o600))
+			require.NoError(
+				t,
+				os.WriteFile(filepath.Join(tmpDir, "config.yaml"), configYaml, 0o600),
+			)
 			require.NoError(t, LoadConfig(tmpDir, false))
 
 			err := validateServerConfig()
@@ -735,7 +784,11 @@ func TestTrustedProxies(t *testing.T) {
 
 			require.NoError(t, err)
 
-			if diff := cmp.Diff(tt.want, got, cmpopts.EquateComparable(netip.Prefix{})); diff != "" {
+			if diff := cmp.Diff(
+				tt.want,
+				got,
+				cmpopts.EquateComparable(netip.Prefix{}),
+			); diff != "" {
 				t.Errorf("trustedProxies() mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/hscontrol/types/config_test.go
+++ b/hscontrol/types/config_test.go
@@ -34,7 +34,7 @@ func TestReadConfig(t *testing.T) {
 					return nil, err
 				}
 
-				return dns, nil
+				return dns.dns, nil
 			},
 			want: DNSConfig{
 				MagicDNS:         true,
@@ -52,7 +52,6 @@ func TestReadConfig(t *testing.T) {
 						"darp.headscale.net": {"1.1.1.1", "8.8.8.8"},
 						"foo.bar.com":        {"1.1.1.1"},
 					},
-					UseWithExitNode: []string{},
 				},
 				ExtraRecords: []tailcfg.DNSRecord{
 					{Name: "grafana.myvpn.example.com", Type: "A", Value: "100.64.0.3"},
@@ -109,7 +108,7 @@ func TestReadConfig(t *testing.T) {
 					return nil, err
 				}
 
-				return dns, nil
+				return dns.dns, nil
 			},
 			want: DNSConfig{
 				MagicDNS:         false,
@@ -127,7 +126,6 @@ func TestReadConfig(t *testing.T) {
 						"darp.headscale.net": {"1.1.1.1", "8.8.8.8"},
 						"foo.bar.com":        {"1.1.1.1"},
 					},
-					UseWithExitNode: []string{},
 				},
 				ExtraRecords: []tailcfg.DNSRecord{
 					{Name: "grafana.myvpn.example.com", Type: "A", Value: "100.64.0.3"},
@@ -258,12 +256,15 @@ func TestReadConfig(t *testing.T) {
 				Proxied: true,
 				Domains: []string{"derp2.no"},
 				Resolvers: []*dnstype.Resolver{
-					{Addr: "1.1.1.1", UseWithExitNode: true},
-					{Addr: "1.0.0.1"},
+					{Addr: "100.64.0.1"},
+					{Addr: "100.64.0.2", UseWithExitNode: true},
 				},
 				Routes: map[string][]*dnstype.Resolver{
-					"foo.bar.com":     {{Addr: "8.8.8.8", UseWithExitNode: true}},
-					"baz.example.com": {{Addr: "9.9.9.9"}},
+					"foo.bar.com": {
+						{Addr: "100.64.0.1", UseWithExitNode: true},
+						{Addr: "100.64.0.2"},
+					},
+					"baz.example.com": {{Addr: "100.64.0.1"}},
 				},
 			},
 		},
@@ -308,6 +309,78 @@ func TestReadConfig(t *testing.T) {
 			if diff := cmp.Diff(tt.want, conf); diff != "" {
 				t.Errorf("ReadConfig() mismatch (-want +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+func TestUseWithExitNodeConfigValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   string
+		override bool
+		wantErr  string
+	}{
+		{
+			name: "global-without-override",
+			config: `    global:
+      - 1.1.1.1
+    use_with_exit_node:
+      global:
+        - 1.1.1.1`,
+			wantErr: "dns.nameservers.use_with_exit_node.global requires " +
+				"dns.override_local_dns to be true",
+		},
+		{
+			name:     "global-not-configured",
+			override: true,
+			config: `    global:
+      - 1.1.1.1
+    use_with_exit_node:
+      global:
+        - 8.8.8.8`,
+			wantErr: `use_with_exit_node nameserver is not configured in dns.nameservers.global: "8.8.8.8"`,
+		},
+		{
+			name: "split-domain-not-configured",
+			config: `    split:
+      internal.example.com:
+        - 1.1.1.1
+    use_with_exit_node:
+      split:
+        other.example.com:
+          - 1.1.1.1`,
+			wantErr: `use_with_exit_node nameserver is not configured for split domain "other.example.com"`,
+		},
+		{
+			name: "split-address-not-configured",
+			config: `    split:
+      internal.example.com:
+        - 1.1.1.1
+    use_with_exit_node:
+      split:
+        internal.example.com:
+          - 8.8.8.8`,
+			wantErr: `use_with_exit_node nameserver is not configured for split domain "internal.example.com": "8.8.8.8"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+
+			config := fmt.Sprintf(`noise:
+  private_key_path: noise_private.key
+dns:
+  override_local_dns: %t
+  nameservers:
+%s
+`, tt.override, tt.config)
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			require.NoError(t, os.WriteFile(path, []byte(config), 0o600))
+			require.NoError(t, LoadConfig(path, true))
+
+			_, err := dns()
+			require.ErrorContains(t, err, tt.wantErr)
 		})
 	}
 }
@@ -358,7 +431,7 @@ func TestReadConfigFromEnv(t *testing.T) {
 					return nil, err
 				}
 
-				return dns, nil
+				return dns.dns, nil
 			},
 			want: DNSConfig{
 				MagicDNS:         true,
@@ -374,6 +447,32 @@ func TestReadConfigFromEnv(t *testing.T) {
 				// 	{Name: "prometheus.myvpn.example.com", Type: "A", Value: "100.64.0.4"},
 				// },
 				SearchDomains: []string{"test.com", "bar.com"},
+			},
+		},
+		{
+			name: "use-with-exit-node-global",
+			configEnv: map[string]string{
+				"HEADSCALE_DNS_BASE_DOMAIN":                           "example.com",
+				"HEADSCALE_DNS_OVERRIDE_LOCAL_DNS":                    "true",
+				"HEADSCALE_DNS_NAMESERVERS_GLOBAL":                    "1.1.1.1 8.8.8.8",
+				"HEADSCALE_DNS_NAMESERVERS_USE_WITH_EXIT_NODE_GLOBAL": "1.1.1.1",
+			},
+			setup: func(t *testing.T) (any, error) { //nolint:thelper
+				dns, err := dns()
+				if err != nil {
+					return nil, err
+				}
+
+				return dnsToTailcfgDNS(dns), nil
+			},
+			want: &tailcfg.DNSConfig{
+				Proxied: true,
+				Domains: []string{"example.com"},
+				Resolvers: []*dnstype.Resolver{
+					{Addr: "1.1.1.1", UseWithExitNode: true},
+					{Addr: "8.8.8.8"},
+				},
+				Routes: map[string][]*dnstype.Resolver{},
 			},
 		},
 	}
@@ -392,7 +491,11 @@ func TestReadConfigFromEnv(t *testing.T) {
 			conf, err := tt.setup(t)
 			require.NoError(t, err)
 
-			if diff := cmp.Diff(tt.want, conf, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(
+				tt.want,
+				conf,
+				cmpopts.EquateEmpty(),
+			); diff != "" {
 				t.Errorf("ReadConfig() mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/hscontrol/types/testdata/dns-use-with-exit-node.yaml
+++ b/hscontrol/types/testdata/dns-use-with-exit-node.yaml
@@ -1,0 +1,26 @@
+noise:
+  private_key_path: "private_key.pem"
+
+prefixes:
+  v6: fd7a:115c:a1e0::/48
+  v4: 100.64.0.0/10
+
+database:
+  type: sqlite3
+
+server_url: "https://server.derp.no"
+
+dns:
+  magic_dns: true
+  base_domain: derp2.no
+  override_local_dns: true
+  nameservers:
+    global:
+      - 1.1.1.1
+      - 1.0.0.1
+    split:
+      foo.bar.com:
+        - 8.8.8.8
+    use_with_exit_node:
+      - 1.1.1.1
+      - 8.8.8.8

--- a/hscontrol/types/testdata/dns-use-with-exit-node.yaml
+++ b/hscontrol/types/testdata/dns-use-with-exit-node.yaml
@@ -21,6 +21,8 @@ dns:
     split:
       foo.bar.com:
         - 8.8.8.8
+      baz.example.com:
+        - 9.9.9.9
     use_with_exit_node:
       - 1.1.1.1
       - 8.8.8.8

--- a/hscontrol/types/testdata/dns-use-with-exit-node.yaml
+++ b/hscontrol/types/testdata/dns-use-with-exit-node.yaml
@@ -16,13 +16,17 @@ dns:
   override_local_dns: true
   nameservers:
     global:
-      - 1.1.1.1
-      - 1.0.0.1
+      - 100.64.0.1
+      - 100.64.0.2
     split:
       foo.bar.com:
-        - 8.8.8.8
+        - 100.64.0.1
+        - 100.64.0.2
       baz.example.com:
-        - 9.9.9.9
+        - 100.64.0.1
     use_with_exit_node:
-      - 1.1.1.1
-      - 8.8.8.8
+      global:
+        - 100.64.0.2
+      split:
+        foo.bar.com:
+          - 100.64.0.1

--- a/integration/route_test.go
+++ b/integration/route_test.go
@@ -27,6 +27,7 @@ import (
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/net/tsaddr"
 	"tailscale.com/tailcfg"
+	"tailscale.com/types/dnstype"
 	"tailscale.com/types/ipproto"
 	"tailscale.com/types/views"
 	"tailscale.com/util/must"
@@ -2149,6 +2150,160 @@ func TestSubnetRouterMultiNetworkExitNode(t *testing.T) {
 
 		assertTracerouteViaIPWithCollect(c, tr, ip)
 	}, 10*time.Second, 200*time.Millisecond, "user2 traceroute should go through user1 exit node")
+}
+
+// TestExitNodeUseWithExitNodeDNS verifies that nameservers listed in
+// dns.nameservers.use_with_exit_node keep their UseWithExitNode flag when sent
+// to clients, so a client that selects an exit node still resolves via the
+// configured resolver instead of having all DNS delegated to the exit node.
+// Nameservers not in the list must not carry the flag. See issue #2816.
+func TestExitNodeUseWithExitNodeDNS(t *testing.T) {
+	IntegrationSkip(t)
+
+	// The UseWithExitNode resolver flag requires Tailscale capability version
+	// 125 (v1.88+); older clients ignore it. Pin to head so the netmap carries
+	// the flag.
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{"user1", "user2"},
+		Versions:     []string{"head"},
+	}
+
+	scenario, err := NewScenario(spec)
+	require.NoErrorf(t, err, "failed to create scenario: %s", err)
+
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	// keepResolver is reachable within the tailnet and should keep being used
+	// when an exit node is selected. dropResolver is configured but not listed,
+	// so it must not carry the flag.
+	const (
+		keepResolver = "100.64.0.53"
+		dropResolver = "1.1.1.1"
+	)
+
+	err = scenario.CreateHeadscaleEnv(
+		[]tsic.Option{},
+		hsic.WithTestName("rt-exitdns"),
+		hsic.WithConfigEnv(map[string]string{
+			"HEADSCALE_DNS_OVERRIDE_LOCAL_DNS":             "true",
+			"HEADSCALE_DNS_NAMESERVERS_GLOBAL":             keepResolver + " " + dropResolver,
+			"HEADSCALE_DNS_NAMESERVERS_USE_WITH_EXIT_NODE": keepResolver,
+		}),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	allClients, err := scenario.ListTailscaleClients()
+	requireNoErrListClients(t, err)
+
+	err = scenario.WaitForTailscaleSync()
+	requireNoErrSync(t, err)
+
+	headscale, err := scenario.Headscale()
+	requireNoErrGetHeadscale(t, err)
+	assert.NotNil(t, headscale)
+
+	var user1c, user2c TailscaleClient
+
+	for _, c := range allClients {
+		s := c.MustStatus()
+		switch s.User[s.Self.UserID].LoginName {
+		case "user1@test.no":
+			user1c = c
+		case "user2@test.no":
+			user2c = c
+		}
+	}
+
+	require.NotNil(t, user1c)
+	require.NotNil(t, user2c)
+
+	// Advertise the exit node on user1c.
+	_, _, err = user1c.Execute([]string{
+		"tailscale", "set", "--advertise-exit-node",
+	})
+	require.NoErrorf(t, err, "failed to advertise exit node: %s", err)
+
+	// headscale should see the two exit routes announced.
+	var nodes []*clientv1.Node
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err = headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 2)
+		requireNodeRouteCountWithCollect(c, nodes[0], 2, 0, 0)
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "exit routes should be announced")
+
+	// Approve the exit routes.
+	_, err = headscale.ApproveRoutes(
+		mustParseID(nodes[0].Id),
+		[]netip.Prefix{tsaddr.AllIPv4(), tsaddr.AllIPv6()},
+	)
+	require.NoError(t, err)
+
+	// The exit node becomes an option for user2c.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		status, err := user2c.Status()
+		assert.NoError(c, err)
+
+		for _, peerKey := range status.Peers() {
+			assert.True(
+				c,
+				status.Peer[peerKey].ExitNodeOption,
+				"peer should be an exit node option",
+			)
+		}
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "exit node should be visible to client")
+
+	// user2c selects user1c as its exit node.
+	_, _, err = user2c.Execute([]string{
+		"tailscale", "set", "--exit-node", user1c.Hostname(),
+	})
+	require.NoErrorf(t, err, "failed to set exit node: %s", err)
+
+	// The exit node becomes active.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		status, err := user2c.Status()
+		assert.NoError(c, err)
+		assert.NotNil(c, status.ExitNodeStatus, "exit node should be active")
+	}, 30*time.Second, 500*time.Millisecond, "exit node activation")
+
+	// The netmap DNS config carries the UseWithExitNode flag per resolver. The
+	// listed resolver must keep it; the unlisted one must not, regardless of
+	// the active exit node.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nm, err := user2c.Netmap()
+		assert.NoError(c, err)
+
+		var keep, drop *dnstype.Resolver
+
+		for _, r := range nm.DNS.Resolvers {
+			switch r.Addr {
+			case keepResolver:
+				keep = r
+			case dropResolver:
+				drop = r
+			}
+		}
+
+		if assert.NotNil(c, keep, "resolver %s should be present", keepResolver) {
+			assert.True(
+				c,
+				keep.UseWithExitNode,
+				"resolver %s should keep UseWithExitNode under an exit node",
+				keepResolver,
+			)
+		}
+
+		if assert.NotNil(c, drop, "resolver %s should be present", dropResolver) {
+			assert.False(
+				c,
+				drop.UseWithExitNode,
+				"resolver %s should not have UseWithExitNode set",
+				dropResolver,
+			)
+		}
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "configured resolver should stay active under exit node")
 }
 
 func MustFindNode(hostname string, nodes []*clientv1.Node) *clientv1.Node {

--- a/integration/route_test.go
+++ b/integration/route_test.go
@@ -27,7 +27,6 @@ import (
 	"tailscale.com/ipn/ipnstate"
 	"tailscale.com/net/tsaddr"
 	"tailscale.com/tailcfg"
-	"tailscale.com/types/dnstype"
 	"tailscale.com/types/ipproto"
 	"tailscale.com/types/views"
 	"tailscale.com/util/must"
@@ -2152,21 +2151,15 @@ func TestSubnetRouterMultiNetworkExitNode(t *testing.T) {
 	}, 10*time.Second, 200*time.Millisecond, "user2 traceroute should go through user1 exit node")
 }
 
-// TestExitNodeUseWithExitNodeDNS verifies that nameservers listed in
-// dns.nameservers.use_with_exit_node keep their UseWithExitNode flag when sent
-// to clients, so a client that selects an exit node still resolves via the
-// configured resolver instead of having all DNS delegated to the exit node.
-// Nameservers not in the list must not carry the flag. See issue #2816.
+// TestExitNodeUseWithExitNodeDNS verifies that a resolver marked for use with
+// exit nodes remains the client's effective resolver after selecting one.
 func TestExitNodeUseWithExitNodeDNS(t *testing.T) {
 	IntegrationSkip(t)
 
-	// The UseWithExitNode resolver flag requires Tailscale capability version
-	// 125 (v1.88+); older clients ignore it. Pin to head so the netmap carries
-	// the flag.
 	spec := ScenarioSpec{
 		NodesPerUser: 1,
 		Users:        []string{"user1", "user2"},
-		Versions:     []string{"head"},
+		Versions:     []string{"1.98"},
 	}
 
 	scenario, err := NewScenario(spec)
@@ -2174,27 +2167,28 @@ func TestExitNodeUseWithExitNodeDNS(t *testing.T) {
 
 	defer scenario.ShutdownAssertNoPanics(t)
 
-	// keepResolver is reachable within the tailnet and should keep being used
-	// when an exit node is selected. dropResolver is configured but not listed,
-	// so it must not carry the flag.
-	const (
-		keepResolver = "100.64.0.53"
-		dropResolver = "1.1.1.1"
-	)
+	const keepResolver = "127.0.0.11"
 
 	err = scenario.CreateHeadscaleEnv(
 		[]tsic.Option{},
 		hsic.WithTestName("rt-exitdns"),
 		hsic.WithConfigEnv(map[string]string{
-			"HEADSCALE_DNS_OVERRIDE_LOCAL_DNS":             "true",
-			"HEADSCALE_DNS_NAMESERVERS_GLOBAL":             keepResolver + " " + dropResolver,
-			"HEADSCALE_DNS_NAMESERVERS_USE_WITH_EXIT_NODE": keepResolver,
+			"HEADSCALE_DNS_OVERRIDE_LOCAL_DNS":                    "true",
+			"HEADSCALE_DNS_NAMESERVERS_GLOBAL":                    keepResolver,
+			"HEADSCALE_DNS_NAMESERVERS_USE_WITH_EXIT_NODE_GLOBAL": keepResolver,
 		}),
 	)
 	requireNoErrHeadscaleEnv(t, err)
 
-	allClients, err := scenario.ListTailscaleClients()
+	user1Clients, err := scenario.ListTailscaleClients("user1")
 	requireNoErrListClients(t, err)
+	require.Len(t, user1Clients, 1)
+	user1c := user1Clients[0]
+
+	user2Clients, err := scenario.ListTailscaleClients("user2")
+	requireNoErrListClients(t, err)
+	require.Len(t, user2Clients, 1)
+	user2c := user2Clients[0]
 
 	err = scenario.WaitForTailscaleSync()
 	requireNoErrSync(t, err)
@@ -2203,21 +2197,6 @@ func TestExitNodeUseWithExitNodeDNS(t *testing.T) {
 	requireNoErrGetHeadscale(t, err)
 	assert.NotNil(t, headscale)
 
-	var user1c, user2c TailscaleClient
-
-	for _, c := range allClients {
-		s := c.MustStatus()
-		switch s.User[s.Self.UserID].LoginName {
-		case "user1@test.no":
-			user1c = c
-		case "user2@test.no":
-			user2c = c
-		}
-	}
-
-	require.NotNil(t, user1c)
-	require.NotNil(t, user2c)
-
 	// Advertise the exit node on user1c.
 	_, _, err = user1c.Execute([]string{
 		"tailscale", "set", "--advertise-exit-node",
@@ -2225,35 +2204,67 @@ func TestExitNodeUseWithExitNodeDNS(t *testing.T) {
 	require.NoErrorf(t, err, "failed to advertise exit node: %s", err)
 
 	// headscale should see the two exit routes announced.
-	var nodes []*clientv1.Node
+	var exitNode *clientv1.Node
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		nodes, err = headscale.ListNodes()
-		assert.NoError(c, err)
-		assert.Len(c, nodes, 2)
-		requireNodeRouteCountWithCollect(c, nodes[0], 2, 0, 0)
+		nodes, err := headscale.ListNodes()
+		if !assert.NoError(c, err) || !assert.Len(c, nodes, 2) {
+			return
+		}
+
+		exitNode = nil
+
+		for _, node := range nodes {
+			if node.Name == user1c.Hostname() {
+				exitNode = node
+				break
+			}
+		}
+
+		if !assert.NotNil(c, exitNode, "exit node should be registered") {
+			return
+		}
+
+		requireNodeRouteCountWithCollect(c, exitNode, 2, 0, 0)
 	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "exit routes should be announced")
+	require.NotNil(t, exitNode)
 
 	// Approve the exit routes.
 	_, err = headscale.ApproveRoutes(
-		mustParseID(nodes[0].Id),
+		mustParseID(exitNode.Id),
 		[]netip.Prefix{tsaddr.AllIPv4(), tsaddr.AllIPv6()},
 	)
 	require.NoError(t, err)
 
 	// The exit node becomes an option for user2c.
+	var exitNodeID tailcfg.StableNodeID
+
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		status, err := user2c.Status()
-		assert.NoError(c, err)
+		if !assert.NoError(c, err) {
+			return
+		}
+
+		var peer *ipnstate.PeerStatus
 
 		for _, peerKey := range status.Peers() {
-			assert.True(
-				c,
-				status.Peer[peerKey].ExitNodeOption,
-				"peer should be an exit node option",
-			)
+			if status.Peer[peerKey].HostName == user1c.Hostname() {
+				peer = status.Peer[peerKey]
+				break
+			}
 		}
+
+		if !assert.NotNil(c, peer, "exit node peer should be visible") {
+			return
+		}
+
+		if !assert.True(c, peer.ExitNodeOption, "peer should be an exit node option") {
+			return
+		}
+
+		exitNodeID = peer.ID
 	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "exit node should be visible to client")
+	require.NotEmpty(t, exitNodeID)
 
 	// user2c selects user1c as its exit node.
 	_, _, err = user2c.Execute([]string{
@@ -2264,46 +2275,62 @@ func TestExitNodeUseWithExitNodeDNS(t *testing.T) {
 	// The exit node becomes active.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		status, err := user2c.Status()
-		assert.NoError(c, err)
-		assert.NotNil(c, status.ExitNodeStatus, "exit node should be active")
-	}, 30*time.Second, 500*time.Millisecond, "exit node activation")
+		if !assert.NoError(c, err) ||
+			!assert.NotNil(c, status.ExitNodeStatus, "exit node should be active") {
+			return
+		}
 
-	// The netmap DNS config carries the UseWithExitNode flag per resolver. The
-	// listed resolver must keep it; the unlisted one must not, regardless of
-	// the active exit node.
+		assert.Equal(c, exitNodeID, status.ExitNodeStatus.ID)
+		assert.True(c, status.ExitNodeStatus.Online)
+	}, integrationutil.ScaledTimeout(30*time.Second), integrationutil.SlowPoll, "exit node activation")
+
+	// Query a real name in Docker's embedded DNS. The resolver reported by the
+	// client distinguishes direct use from the exit node's DoH proxy.
+	type dnsQueryResult struct {
+		Resolvers []struct {
+			Addr string
+		}
+		ResponseCode string
+		Answers      []struct {
+			Type string
+			Body string
+		}
+	}
+
+	network := scenario.Networks()[0]
+	queryName := headscale.GetHostname()
+	wantAnswer := headscale.GetIPInNetwork(network)
+
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		nm, err := user2c.Netmap()
-		assert.NoError(c, err)
+		stdout, stderr, err := user2c.Execute([]string{
+			"tailscale", "dns", "query", "--json", queryName, "A",
+		})
+		if !assert.NoError(c, err, "DNS query failed: %s", stderr) {
+			return
+		}
 
-		var keep, drop *dnstype.Resolver
+		var result dnsQueryResult
+		if !assert.NoError(c, json.Unmarshal([]byte(stdout), &result)) {
+			return
+		}
 
-		for _, r := range nm.DNS.Resolvers {
-			switch r.Addr {
-			case keepResolver:
-				keep = r
-			case dropResolver:
-				drop = r
+		assert.Equal(c, "RCodeSuccess", result.ResponseCode)
+
+		if assert.Len(c, result.Resolvers, 1) {
+			assert.Equal(c, keepResolver, result.Resolvers[0].Addr)
+		}
+
+		foundAnswer := false
+
+		for _, answer := range result.Answers {
+			if answer.Type == "TypeA" && answer.Body == wantAnswer {
+				foundAnswer = true
+				break
 			}
 		}
 
-		if assert.NotNil(c, keep, "resolver %s should be present", keepResolver) {
-			assert.True(
-				c,
-				keep.UseWithExitNode,
-				"resolver %s should keep UseWithExitNode under an exit node",
-				keepResolver,
-			)
-		}
-
-		if assert.NotNil(c, drop, "resolver %s should be present", dropResolver) {
-			assert.False(
-				c,
-				drop.UseWithExitNode,
-				"resolver %s should not have UseWithExitNode set",
-				dropResolver,
-			)
-		}
-	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "configured resolver should stay active under exit node")
+		assert.True(c, foundAnswer, "expected A answer %s, got %+v", wantAnswer, result.Answers)
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.SlowPoll, "DNS should use the configured resolver directly under an exit node")
 }
 
 func MustFindNode(hostname string, nodes []*clientv1.Node) *clientv1.Node {


### PR DESCRIPTION
Fixes #2816

## What

Add scoped `dns.nameservers.use_with_exit_node` selectors for global and split DNS resolvers:

```yaml
dns:
  override_local_dns: true
  nameservers:
    global:
      - 100.64.0.53
    split:
      homelab.example.com:
        - 100.64.0.54
    use_with_exit_node:
      global:
        - 100.64.0.53
      split:
        homelab.example.com:
          - 100.64.0.54
```

Selected resolvers are sent with Tailscale `dnstype.Resolver.UseWithExitNode`, so supported clients keep using them after selecting an exit node.

## Compatibility

- Existing stable scalar YAML for `global` and `split` is unchanged.
- The exported `Nameservers.Global` and `Nameservers.Split` Go fields retain their existing types.
- Global and split selections are independent, so one address can be enabled for a split domain without enabling its global occurrence.
- Selectors are validated against the matching configured resolver scope.
- Global selectors require `dns.override_local_dns: true`; split selectors do not.
- Clients older than capability version 125 ignore the wire field.

## Why

By default, a Tailscale client delegates DNS to the selected exit node. That can add an unnecessary round trip for a resolver reachable through a tailnet or subnet route. This option preserves selected global or split resolvers while normal routing still determines how resolver traffic travels.

## Testing

- Unit coverage verifies global and split propagation, including the same address with different scoped behavior.
- Validation coverage rejects unmatched selectors and ineffective global selectors without DNS override.
- Environment-variable coverage verifies the global selector form.
- `TestExitNodeUseWithExitNodeDNS` uses Tailscale 1.98, activates an exit node, performs a real `tailscale dns query --json`, and asserts both the effective direct resolver and returned DNS answer.
- `go test ./hscontrol/types ./integration`
- `go vet ./...`
- `golangci-lint run --new-from-rev=048308511c72fa77da103e932f9b857a6e5247b9 --timeout=5m`
- `nix flake check --no-build`
- Integration workflow generation is clean.

Local Docker execution was unavailable: `go run ./cmd/hi doctor` reported that no Docker daemon was running. The integration scenario is registered in CI. A repository-wide `go test ./...` run timed out after 10 minutes in existing `TestLogoutReloginWithPollChurn`; that test passed alone in 64 seconds, and all changed packages passed.

---

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand (#2816)
- [x] added unit tests
- [x] added integration tests
- [x] updated documentation
- [x] updated CHANGELOG.md