### PR TITLE
build: bump Go toolchain to 1.26.5

### DIFF
--- a/Dockerfile.derper
+++ b/Dockerfile.derper
@@ -1,6 +1,6 @@
 # For testing purposes only
 
-FROM golang:1.26.4-alpine AS build-env
+FROM golang:1.26.5-alpine AS build-env
 
 WORKDIR /go/src
 

--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -2,7 +2,7 @@
 # and are in no way endorsed by Headscale's maintainers as an
 # official nor supported release or distribution.
 
-FROM docker.io/golang:1.26.4-trixie AS builder
+FROM docker.io/golang:1.26.5-trixie AS builder
 ARG VERSION=dev
 ENV GOPATH /go
 WORKDIR /go/src/headscale

--- a/Dockerfile.tailscale-HEAD
+++ b/Dockerfile.tailscale-HEAD
@@ -4,7 +4,7 @@
 # This Dockerfile is more or less lifted from tailscale/tailscale
 # to ensure a similar build process when testing the HEAD of tailscale.
 
-FROM golang:1.26.4-alpine AS build-env
+FROM golang:1.26.5-alpine AS build-env
 
 WORKDIR /go/src
 

--- a/Dockerfile.wasmclient
+++ b/Dockerfile.wasmclient
@@ -7,7 +7,7 @@
 # to drive a real browser-style WebSocket GET against headscale's /ts2021,
 # guarding the regression in issue #3357.
 
-FROM golang:1.26.4-alpine AS build
+FROM golang:1.26.5-alpine AS build
 
 WORKDIR /src
 

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1781951072,
-        "narHash": "sha256-hA9u6hB4QzpReP8hudxqiaa4vLhoRvtXi6YmUgJRGEs=",
+        "lastModified": 1783015821,
+        "narHash": "sha256-vmzYTZxIAy3OYXwkRL5GQYk8fNnh8TLWcxQRIO3ywOU=",
         "owner": "kradalby",
         "repo": "flake-checks",
-        "rev": "3d2882efec5cf10f8b5a8a035d93ba6ba9f21717",
+        "rev": "3c821706eb0bd07f515f9a7726b650ccae927433",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781153106,
-        "narHash": "sha256-yzsroLCcuRG4KdGMxWt0eXKOrRSgQT8/xjYngeq9ujU=",
+        "lastModified": 1784421286,
+        "narHash": "sha256-YKn3t7FvaargtyNHbrOw+qzDM+93q5kSCREUPNxeZQs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ee75f111a06d7ab2b2f729698a8eff53d54e070",
+        "rev": "62eaae30cd05c04718500ddb44e7ef85cd45ddd5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,12 @@
   description = "headscale - Open Source Tailscale Control server";
 
   inputs = {
-    # Pinned to staging-next-26.05 for Go 1.26.4 (security fix GO-2026-5037/5039):
-    # nixpkgs-unstable still ships 1.26.3 — the bump is merged to nixpkgs staging
-    # but the large-rebuild staging->unstable pipeline lags. The 26.05 line is
-    # otherwise current (dev tools match unstable). Switch back to nixpkgs-unstable
-    # once it ships go_1_26 >= 1.26.4.
+    # Pinned to staging-next-26.05 for Go 1.26.5: the Tailscale HEAD build
+    # (Dockerfile.tailscale-HEAD) requires go >= 1.26.5, and nixpkgs-unstable
+    # still ships 1.26.4 — the bump is merged to nixpkgs staging but the
+    # large-rebuild staging->unstable pipeline lags. The 26.05 line is otherwise
+    # current (dev tools match unstable). Switch back to nixpkgs-unstable once it
+    # ships go_1_26 >= 1.26.5.
     nixpkgs.url = "github:NixOS/nixpkgs/staging-next-26.05";
     flake-utils.url = "github:numtide/flake-utils";
     # Reusable Go flake checks (build/test/lint/format); CI runs them via
@@ -36,7 +37,7 @@
       overlays.default = _: prev:
         let
           pkgs = nixpkgs.legacyPackages.${prev.stdenv.hostPlatform.system};
-          # Go 1.26 builder; resolves to Go 1.26.4 from the pinned nixpkgs.
+          # Go 1.26 builder; resolves to Go 1.26.5 from the pinned nixpkgs.
           buildGo = pkgs.buildGo126Module;
           vendorHash = (builtins.fromJSON (builtins.readFile ./flakehashes.json)).vendor.sri;
         in
@@ -72,7 +73,7 @@
           };
 
           # Build golangci-lint with stock Go 1.26 (upstream uses hardcoded Go
-          # version); it does not build against the pinned 1.26.4.
+          # version); it does not build against the pinned 1.26.5.
           golangci-lint = buildGo rec {
             pname = "golangci-lint";
             version = "2.12.2";

--- a/flakehashes.json
+++ b/flakehashes.json
@@ -1,6 +1,6 @@
 {
   "vendor": {
-    "goModSum": "sha256-SJml8RXGmb2p0g1nOsHn86FA1hwgd5ZffLSkUj5zek8=",
+    "goModSum": "sha256-t1RAYi36JEii5nGldY546oWGD/3SwxQU09/pTrDadIk=",
     "sri": "sha256-pjGNuVtgFFzWNq/2cK7a4iyF13AfcHz098nk92a9Ido="
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juanfont/headscale
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/arl/statsviz v0.8.0


### PR DESCRIPTION
Integration CI builds upstream tailscale from source via `Dockerfile.tailscale-HEAD`. Tailscale's `go.mod` now requires `go >= 1.26.5`, but the build images pinned `golang:1.26.4`, so the build fails with `go.mod requires go >= 1.26.5 (running go 1.26.4)`.

Bump the toolchain everywhere: `go.mod`, the four Go Dockerfiles, and the nixpkgs pin. `staging-next-26.05` ships `go_1_26` 1.26.5; `nixpkgs-unstable` still lags at 1.26.4, so the pin stays.

`nix flake check`, `nix build`, and `go test` pass on 1.26.5.

> Generated with the help of an AI assistant
