### PR TITLE
auth: check machine key on the followup registration path

### DIFF
--- a/hscontrol/auth.go
+++ b/hscontrol/auth.go
@@ -311,6 +311,18 @@ func (h *Headscale) waitForFollowup(
 					return h.reqToNewRegisterResponse(req, machineKey)
 				}
 
+				// The followup poll is only authenticated by the auth ID in the
+				// URL, so fail closed unless the Noise session asking for the
+				// result was started with the same machine key that opened the
+				// registration. [State.HandleNodeFromAuthPath] resolves the node
+				// from the cached [types.RegistrationData.MachineKey], so the two
+				// match on the normal path. [Headscale.handleRegister] and
+				// [Headscale.handleLogout] apply the same check.
+				err := machineKeyMismatch(verdict.Node, machineKey)
+				if err != nil {
+					return nil, err
+				}
+
 				return nodeToRegisterResponse(verdict.Node), nil
 			}
 		}

--- a/hscontrol/auth_test.go
+++ b/hscontrol/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"testing"
@@ -692,6 +693,11 @@ func TestAuthenticationFlows(t *testing.T) {
 					user := app.state.CreateUserForTest("followup-user")
 
 					node := app.state.CreateNodeForTest(user, "followup-success-node")
+					// [State.HandleNodeFromAuthPath] resolves the node from the
+					// machine key cached when the registration was opened, so on
+					// the real path the node carries the polling session's
+					// machine key. CreateNodeForTest picks a random one.
+					node.MachineKey = machineKey1.Public()
 					nodeToRegister.FinishAuth(types.AuthVerdict{Node: node.View()})
 				}()
 
@@ -4100,4 +4106,80 @@ func TestHandleNodeFromAuthPath_OldUserNil_NoPanic(t *testing.T) {
 	require.True(t, node.Valid())
 	assert.NotEqual(t, types.NodeID(99002), node.ID(), "new node, not orphan")
 	assert.Equal(t, userB.ID, node.UserID().Get(), "new node belongs to userB")
+}
+
+// TestWaitForFollowupMachineKeyMismatch covers the followup poll in
+// [Headscale.waitForFollowup]. That poll is authenticated only by the auth ID
+// embedded in the followup URL, so without a machine-key check anyone who
+// learns an ID gets the registering user's User/Login back in the
+// [tailcfg.RegisterResponse].
+//
+// [Headscale.handleRegister] and [Headscale.handleLogout] already fail closed
+// here; see the "existing_node_machine_key_mismatch" case in
+// [TestAuthenticationFlows] for the equivalent assertion on that path.
+//
+// The nodes are given the registering session's machine key because that is
+// what production produces: [State.HandleNodeFromAuthPath] resolves the node
+// from the machine key cached in [types.RegistrationData] when the
+// registration was opened.
+func TestWaitForFollowupMachineKeyMismatch(t *testing.T) {
+	app := createTestApp(t)
+
+	victimMachineKey := key.NewMachine()
+	attackerMachineKey := key.NewMachine()
+
+	// Park a completed registration in the auth cache, as a node that is
+	// already polling for its verdict would see it.
+	newPendingFollowup := func(hostname string) string {
+		authID := types.MustAuthID()
+		regEntry := types.NewRegisterAuthRequest(&types.RegistrationData{
+			MachineKey: victimMachineKey.Public(),
+			NodeKey:    key.NewNode().Public(),
+			Hostname:   hostname,
+		})
+		app.state.SetAuthCacheEntry(authID, regEntry)
+
+		user := app.state.CreateUserForTest(hostname + "-user")
+		node := app.state.CreateNodeForTest(user, hostname)
+		node.MachineKey = victimMachineKey.Public()
+		// CreateNodeForTest only sets UserID, but nodeToRegisterResponse reads
+		// the owner, and the owner's identity is exactly what must not leak.
+		node.User = user
+		regEntry.FinishAuth(types.AuthVerdict{Node: node.View()})
+
+		return fmt.Sprintf("http://localhost:8080/register/%s", authID)
+	}
+
+	followup := func(url string, machineKey key.MachinePublic) (*tailcfg.RegisterResponse, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		return app.handleRegister(ctx, tailcfg.RegisterRequest{
+			Followup: url,
+			NodeKey:  key.NewNode().Public(),
+		}, machineKey)
+	}
+
+	t.Run("mismatched machine key is rejected", func(t *testing.T) {
+		resp, err := followup(newPendingFollowup("followup-mismatch"), attackerMachineKey.Public())
+
+		require.Error(t, err, "followup with a foreign machine key must not succeed")
+		assert.Nil(t, resp, "no registration details should be returned")
+
+		var httpErr HTTPError
+		require.ErrorAs(t, err, &httpErr)
+		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
+	})
+
+	// Positive control. Without it a regression that stops the poll from
+	// finding the cache entry at all would still pass the case above, because
+	// waitForFollowup falls back to handing out a fresh AuthURL.
+	t.Run("matching machine key still completes", func(t *testing.T) {
+		resp, err := followup(newPendingFollowup("followup-match"), victimMachineKey.Public())
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.True(t, resp.MachineAuthorized)
+		assert.NotEmpty(t, resp.User.DisplayName, "the owner's identity is returned on the legitimate path")
+	})
 }


### PR DESCRIPTION
`waitForFollowup` hands back `nodeToRegisterResponse(verdict.Node)` for a completed registration without checking the machine key of the Noise session that is asking. That response carries the registering user's `User` and `Login`, so the auth ID in the followup URL is the only thing in front of it.

The other two paths that return a node already guard this. `handleRegister` calls `machineKeyMismatch` before the tailscaled-restart fast path (auth.go:90) and `handleLogout` calls it on entry (auth.go:165). This is the third one and it does not.

The key is already there to check against. `State.HandleNodeFromAuthPath` resolves the node from the `MachineKey` cached in `RegistrationData` when the registration was opened, so on a normal registration the node and the polling session carry the same key and the check does nothing.

On how much this is worth: the auth ID is 96 bits of randomness, so nobody is guessing one. It does get logged at info level when a registration is created, so log access is the realistic way to come by an ID. I would call this consistency rather than a live hole, which is why it is a PR and not a security report. Happy to be told it is not worth the branch.

### Tests

`existing_node_machine_key_mismatch` in `TestAuthenticationFlows` already asserts this property for the `handleRegister` path, so the new test is the followup equivalent. The table runner returns early on `wantError`, which means a case there cannot assert the status code or that nothing came back, so I wrote it as a standalone test instead.

It has a positive control alongside the rejection case. Without one the test passes for the wrong reason if the poll ever stops finding the cache entry, since `waitForFollowup` then falls through and hands out a fresh AuthURL rather than erroring.

Reverting just the guard:

```
--- FAIL: TestWaitForFollowupMachineKeyMismatch (0.18s)
    --- FAIL: TestWaitForFollowupMachineKeyMismatch/mismatched_machine_key_is_rejected (0.08s)
        auth_test.go:4166:
            Error:      An error is expected but got nil.
            Messages:   followup with a foreign machine key must not succeed
FAIL
```

With it:

```
--- PASS: TestWaitForFollowupMachineKeyMismatch (0.18s)
    --- PASS: TestWaitForFollowupMachineKeyMismatch/mismatched_machine_key_is_rejected (0.09s)
    --- PASS: TestWaitForFollowupMachineKeyMismatch/matching_machine_key_still_completes (0.08s)
```

Full package: `go test ./hscontrol/ -count=1` gives `ok github.com/juanfont/headscale/hscontrol 182.676s`. `go build ./...` and `gofmt` are clean. I could not run `hscontrol/servertest` or the integration tests here, they need `tofu` from the nix shell.

One change to an existing test: `followup_registration_success` built its node with `CreateNodeForTest`, which picks a random machine key that no real registration would ever produce, so it fails against the guard. I set the registering machine key on it so the fixture matches what `HandleNodeFromAuthPath` produces. It also only sets `UserID` and leaves `User` nil, so I populate the owner in the new test, otherwise the response has no user on it and the thing being protected is not actually in the assertion.

### Note on overlap

This touches the same lines as #3392. That one is about the select picking a timeout over a completed verdict, so the two are independent, but they will conflict textually. Mine is an insert just above the `nodeToRegisterResponse` return, which survives the restructure in #3392 with a re-indent. Happy to rebase on top of it, or to hold this until it lands.

I have not raised an issue for this one. CONTRIBUTING says bug fixes are open without discussion, but say the word if you would rather discuss it first.
