### PR TITLE
state: fix authkey reregistration issues

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -379,6 +379,8 @@ jobs:
           - TestTagsAuthKeyWithoutUserInheritsTags
           - TestTagsAuthKeyWithoutUserRejectsAdvertisedTags
           - TestTagsAuthKeyConvertToUserViaCLIRegister
+          - TestTaggedNodeLogoutReloginSingleUseKeyOnline
+          - TestTaggedNodeLogoutReloginReusableKeyOnline
           - TestTS2021WebSocketGET
           - TestTS2021WASMClientUnderNode
           - TestTailscaleRustAxum

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -383,6 +383,8 @@ jobs:
           - TestTagsAuthKeyConvertToUserViaCLIRegister
           - TestTaggedNodeLogoutReloginSingleUseKeyOnline
           - TestTaggedNodeLogoutReloginReusableKeyOnline
+          - TestTagsOIDCReauthAddOwnedTag
+          - TestTagsReauthEmptyTagsReturnsToUserSurvives
           - TestTS2021WebSocketGET
           - TestTS2021WASMClientUnderNode
           - TestTailscaleRustAxum

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -352,6 +352,8 @@ jobs:
           - TestTagsAuthKeyWithTagCannotAddViaCLI
           - TestTagsAuthKeyWithTagCannotChangeViaCLI
           - TestTagsAuthKeyWithTagAdminOverrideReauthPreserves
+          - TestTagsReauthDifferentKeyRetagsNode
+          - TestTagsReauthDifferentKeyRemovesTag
           - TestTagsAuthKeyWithTagCLICannotModifyAdminTags
           - TestTagsAuthKeyWithoutTagCannotRequestTags
           - TestTagsAuthKeyWithoutTagRegisterNoTags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ keys remain all-access.
 
 - Fix tagged node stuck expired after `tailscale logout`, unable to re-authenticate [#3394](https://github.com/juanfont/headscale/pull/3394)
 - Re-registering a tagged node with a different pre-auth key now applies the new key's tags instead of silently keeping the old ones [#3394](https://github.com/juanfont/headscale/pull/3394)
+- Fix re-authenticating an already-tagged node with `--advertise-tags` being rejected when the authenticating user owns the tags [#3394](https://github.com/juanfont/headscale/pull/3394)
 
 ## 0.29.2 (2026-07-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ keys remain all-access.
 ### Changes
 
 - Fix tagged node stuck expired after `tailscale logout`, unable to re-authenticate [#3394](https://github.com/juanfont/headscale/pull/3394)
+- Re-registering a tagged node with a different pre-auth key now applies the new key's tags instead of silently keeping the old ones [#3394](https://github.com/juanfont/headscale/pull/3394)
 
 ## 0.29.2 (2026-07-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ keys remain all-access.
 - Expiring or deleting a non-existent pre-auth key now returns an error instead of silently succeeding [#3324](https://github.com/juanfont/headscale/pull/3324)
 - Improve systemd service file hardening [#3341](https://github.com/juanfont/headscale/pull/3341)
 
+## 0.29.3 (202x-xx-xx)
+
+**Minimum supported Tailscale client version: v1.80.0**
+
+### Changes
+
+- Fix tagged node stuck expired after `tailscale logout`, unable to re-authenticate [#3394](https://github.com/juanfont/headscale/pull/3394)
+
 ## 0.29.2 (2026-07-01)
 
 **Minimum supported Tailscale client version: v1.80.0**

--- a/hscontrol/auth.go
+++ b/hscontrol/auth.go
@@ -233,6 +233,20 @@ func (h *Headscale) handleLogout(
 			Msg("Node is not ephemeral, setting expiry instead of deleting")
 	}
 
+	// Tagged nodes have key expiry permanently disabled (they are owned by
+	// their tags, not a user, and never expire - KB 1068). Logging one out has
+	// no expiry semantics, so do not stamp an expiry on it: doing so leaves the
+	// node IsExpired() forever and it can never re-authenticate (#3371). The
+	// admin path `headscale nodes expire` remains free to set a deliberate
+	// expiry via SetNodeExpiry; only the logout path is guarded here.
+	if node.IsTagged() {
+		log.Debug().
+			EmbedObject(node).
+			Msg("Tagged node logout: not stamping expiry (tagged nodes never expire)")
+
+		return nodeToRegisterResponse(node), nil
+	}
+
 	// Update the internal state with the nodes new expiry, meaning it is
 	// logged out.
 	//

--- a/hscontrol/auth_tags_test.go
+++ b/hscontrol/auth_tags_test.go
@@ -1337,3 +1337,392 @@ func TestReregistrationZeroExpiryStaysNil(t *testing.T) {
 	assert.False(t, node2.Expiry().Valid(),
 		"re-registration with zero client expiry and no default should leave expiry nil, not pointer to zero time")
 }
+
+// tsLogoutSentinelExpiry is the past expiry a real tailscale client sends on
+// `tailscale logout`: time.Unix(123, 0) (controlclient/direct.go). The issue
+// #3371 trace shows it verbatim as `expiry=123`. Using it here (rather than a
+// generic time.Now().Add(-1h)) keeps the reproduction faithful to the wire
+// behaviour: handleRegister must classify this as a logout, and handleLogout
+// must clamp it to now.
+func tsLogoutSentinelExpiry() time.Time {
+	return time.Unix(123, 0)
+}
+
+// TestIssue3371_TaggedNodeLogoutReloginSingleUseKey reproduces
+// https://github.com/juanfont/headscale/issues/3371 through the real
+// register/logout HTTP-handler path (handleRegister -> handleLogout ->
+// handleRegister), not by poking SetNodeExpiry directly.
+//
+// Root cause (a): `tailscale logout` sends a past expiry; handleLogout stamps
+// it on the node via SetNodeExpiry with no IsTagged guard, so a tagged node —
+// which must have key-expiry disabled — becomes Expired.
+//
+// Root cause (b): on the next `tailscale up --auth-key <fresh key>`,
+// HandleNodeFromPreAuthKey sees an expired node, takes the expired-node
+// validation path, consumes the fresh single-use key on the in-place
+// re-registration, yet leaves the node expired (the expiry-refresh block is
+// gated `!node.IsTagged()`). The response carries NodeKeyExpired=true, so the
+// client rotates its node key and retries with the now-spent key, which is
+// rejected with "authkey already used" forever.
+//
+// Faithful to the artifacts: the client rotates its NodeKey on relogin, the
+// logout carries BOTH a past expiry AND an auth key, and a BRAND NEW key is
+// presented for the relogin (the trace shows tag:tag2 keys burned while the
+// node kept tag:tag1).
+func TestIssue3371_TaggedNodeLogoutReloginSingleUseKey(t *testing.T) {
+	app := createTestApp(t)
+
+	user := app.state.CreateUserForTest("tag-logout-user")
+	tags := []string{"tag:tag1"}
+
+	// `headscale preauthkeys create --tags tag:tag1` (single-use).
+	pak, err := app.state.CreatePreAuthKey(user.TypedID(), false, false, nil, tags)
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	nodeKey := key.NewNode()
+
+	// `tailscale up --auth-key $KEY1`: initial join.
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey:  nodeKey.Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "headscale-debug"},
+	}
+
+	resp, err := app.handleRegister(context.Background(), regReq, machineKey.Public())
+	require.NoError(t, err)
+	require.True(t, resp.MachineAuthorized)
+	require.False(t, resp.NodeKeyExpired)
+
+	node, found := app.state.GetNodeByNodeKey(nodeKey.Public())
+	require.True(t, found)
+	require.True(t, node.IsTagged(), "precondition: node is tagged")
+	require.False(t, node.Expiry().Valid(), "precondition: tagged node has expiry disabled")
+
+	// `tailscale logout`: client sends a past-expiry register with the auth key
+	// still attached (handleRegister must treat past expiry as logout regardless
+	// of Auth). Reuse the same node key: logout does not rotate it.
+	logoutReq := tailcfg.RegisterRequest{
+		Auth:    &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey: nodeKey.Public(),
+		Expiry:  tsLogoutSentinelExpiry(),
+	}
+
+	_, err = app.handleRegister(context.Background(), logoutReq, machineKey.Public())
+	require.NoError(t, err)
+
+	// A tagged node must NOT be expired by logout — tagged nodes never expire.
+	// This is root cause (a); it fails before the fix.
+	nodeAfterLogout, found := app.state.GetNodeByNodeKey(nodeKey.Public())
+	require.True(t, found)
+	assert.False(t, nodeAfterLogout.IsExpired(),
+		"issue #3371 root cause (a): logout must not expire a tagged node")
+	assert.False(t, nodeAfterLogout.Expiry().Valid(),
+		"issue #3371 root cause (a): tagged node must keep key-expiry disabled after logout")
+
+	// `tailscale up --auth-key $KEY2`: a BRAND NEW single-use key, and the client
+	// rotates its node key (as the real client does on relogin).
+	pak2, err := app.state.CreatePreAuthKey(user.TypedID(), false, false, nil, tags)
+	require.NoError(t, err)
+
+	nodeKey2 := key.NewNode()
+	reloginReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak2.Key},
+		NodeKey:  nodeKey2.Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "headscale-debug"},
+	}
+
+	reloginResp, err := app.handleRegister(context.Background(), reloginReq, machineKey.Public())
+	require.NoError(t, err,
+		"issue #3371: a fresh valid key must re-authenticate the tagged node after logout")
+	require.NotNil(t, reloginResp)
+
+	// The whole point: the node comes back online, not stuck expired.
+	assert.False(t, reloginResp.NodeKeyExpired,
+		"issue #3371: relogin response must not report the node key as expired")
+	assert.True(t, reloginResp.MachineAuthorized)
+
+	relogged, found := app.state.GetNodeByNodeKey(nodeKey2.Public())
+	require.True(t, found)
+	assert.True(t, relogged.IsTagged(), "node stays tagged after relogin")
+	assert.False(t, relogged.IsExpired(),
+		"issue #3371: tagged node must be online (not expired) after relogin")
+	assert.False(t, relogged.Expiry().Valid(),
+		"issue #3371: tagged node must have key-expiry disabled after relogin")
+	assert.Equal(t, node.ID(), relogged.ID(), "must re-use the same node, not duplicate")
+	assert.Equal(t, 1, app.state.ListNodes().Len(), "machine maps to exactly one node")
+}
+
+// TestIssue3371_TaggedNodeLogoutReloginReusableKey is the reusable-key variant
+// from the issue ("tailscale up then hangs indefinitely instead of erroring").
+// With a reusable key the relogin does not hit "authkey already used", but the
+// node still stays expired without the fix — so the client never observes a
+// non-expired node and hangs. The observable failure here is the persisted
+// expired state after relogin.
+func TestIssue3371_TaggedNodeLogoutReloginReusableKey(t *testing.T) {
+	app := createTestApp(t)
+
+	user := app.state.CreateUserForTest("tag-logout-reusable")
+	tags := []string{"tag:tag1"}
+
+	// `headscale preauthkeys create --reusable --tags tag:tag1`.
+	pak, err := app.state.CreatePreAuthKey(user.TypedID(), true, false, nil, tags)
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	nodeKey := key.NewNode()
+
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey:  nodeKey.Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "reusable-tagged"},
+	}
+
+	_, err = app.handleRegister(context.Background(), regReq, machineKey.Public())
+	require.NoError(t, err)
+
+	node, found := app.state.GetNodeByNodeKey(nodeKey.Public())
+	require.True(t, found)
+	require.True(t, node.IsTagged())
+	require.False(t, node.Expiry().Valid())
+
+	// Logout.
+	logoutReq := tailcfg.RegisterRequest{
+		Auth:    &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey: nodeKey.Public(),
+		Expiry:  tsLogoutSentinelExpiry(),
+	}
+	_, err = app.handleRegister(context.Background(), logoutReq, machineKey.Public())
+	require.NoError(t, err)
+
+	// Relogin with the same reusable key, rotating the node key.
+	nodeKey2 := key.NewNode()
+	reloginReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey:  nodeKey2.Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "reusable-tagged"},
+	}
+	reloginResp, err := app.handleRegister(context.Background(), reloginReq, machineKey.Public())
+	require.NoError(t, err)
+	require.NotNil(t, reloginResp)
+
+	assert.False(t, reloginResp.NodeKeyExpired,
+		"issue #3371: reusable-key relogin must not report node key expired")
+
+	relogged, found := app.state.GetNodeByNodeKey(nodeKey2.Public())
+	require.True(t, found)
+	assert.True(t, relogged.IsTagged())
+	assert.False(t, relogged.IsExpired(),
+		"issue #3371: tagged node must be online (not expired) after reusable-key relogin")
+	assert.False(t, relogged.Expiry().Valid(),
+		"issue #3371: tagged node must have key-expiry disabled after reusable-key relogin")
+}
+
+// TestIssue3371_TaggedNodeLogoutDoesNotSetExpiry pins the deepest root cause
+// (a) in isolation: `tailscale logout` on a tagged node must not stamp an
+// expiry at all. This is the assertion PR #3372 does not make — it leaves
+// handleLogout expiring tagged nodes and only unwinds the damage on the next
+// registration. Keeping this separate from the relogin tests means a
+// regression that re-introduces logout-sets-expiry is caught even if the
+// re-registration cleanup masks it.
+func TestIssue3371_TaggedNodeLogoutDoesNotSetExpiry(t *testing.T) {
+	app := createTestApp(t)
+
+	user := app.state.CreateUserForTest("tag-logout-noexpiry")
+	tags := []string{"tag:tag1"}
+
+	pak, err := app.state.CreatePreAuthKey(user.TypedID(), true, false, nil, tags)
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	nodeKey := key.NewNode()
+
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey:  nodeKey.Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "noexpiry-tagged"},
+	}
+	_, err = app.handleRegister(context.Background(), regReq, machineKey.Public())
+	require.NoError(t, err)
+
+	logoutReq := tailcfg.RegisterRequest{
+		Auth:    &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey: nodeKey.Public(),
+		Expiry:  tsLogoutSentinelExpiry(),
+	}
+	_, err = app.handleRegister(context.Background(), logoutReq, machineKey.Public())
+	require.NoError(t, err)
+
+	nodeAfterLogout, found := app.state.GetNodeByNodeKey(nodeKey.Public())
+	require.True(t, found)
+	assert.True(t, nodeAfterLogout.IsTagged(), "node stays tagged through logout")
+	assert.False(t, nodeAfterLogout.Expiry().Valid(),
+		"issue #3371 root cause (a): logout must not set an expiry on a tagged node")
+	assert.False(t, nodeAfterLogout.IsExpired(),
+		"issue #3371 root cause (a): tagged node must not be expired by logout")
+
+	// The database column must be NULL, not a clamped 'now' timestamp — a
+	// persisted expiry survives restart and re-triggers the lockout.
+	var dbNode types.Node
+	require.NoError(t,
+		app.state.DB().DB.First(&dbNode, nodeAfterLogout.ID().Uint64()).Error)
+	assert.Nil(t, dbNode.Expiry,
+		"issue #3371 root cause (a): tagged node's DB expiry must remain NULL after logout")
+}
+
+// TestIssue3371_UserOwnedNodeLogoutStillExpires is the guard rail: the fix for
+// tagged nodes must not change logout for ordinary user-owned nodes. A
+// user-owned node that logs out MUST still be expired (that is what logout
+// means for it).
+func TestIssue3371_UserOwnedNodeLogoutStillExpires(t *testing.T) {
+	app := createTestApp(t)
+
+	user := app.state.CreateUserForTest("user-logout")
+
+	pak, err := app.state.CreatePreAuthKey(user.TypedID(), true, false, nil, nil)
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	nodeKey := key.NewNode()
+
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey:  nodeKey.Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "user-node"},
+		Expiry:   time.Now().Add(24 * time.Hour),
+	}
+	_, err = app.handleRegister(context.Background(), regReq, machineKey.Public())
+	require.NoError(t, err)
+
+	node, found := app.state.GetNodeByNodeKey(nodeKey.Public())
+	require.True(t, found)
+	require.False(t, node.IsTagged(), "precondition: user-owned node")
+
+	logoutReq := tailcfg.RegisterRequest{
+		Auth:    &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey: nodeKey.Public(),
+		Expiry:  tsLogoutSentinelExpiry(),
+	}
+	logoutResp, err := app.handleRegister(context.Background(), logoutReq, machineKey.Public())
+	require.NoError(t, err)
+	require.NotNil(t, logoutResp)
+
+	nodeAfterLogout, found := app.state.GetNodeByNodeKey(nodeKey.Public())
+	require.True(t, found)
+	assert.True(t, nodeAfterLogout.IsExpired(),
+		"user-owned node must still be expired by logout (fix must not regress this)")
+	assert.True(t, logoutResp.NodeKeyExpired,
+		"logout response for a user-owned node must report the key expired")
+}
+
+// TestIssue3371_TaggedNodeFutureExpirySurvivesRelogin is the discriminator
+// guard rail for the fix. A tagged node may carry a DELIBERATE future expiry
+// set by an admin (`headscale nodes expire`); TestTaggedNodeCanHaveKeyExpiry
+// establishes that is legal. The #3371 fix clears only a STALE PAST expiry (the
+// logout stamp) on re-registration — it must NOT wipe a future expiry. This
+// test locks that boundary: without care, a "tagged => clear expiry" fix would
+// silently destroy the admin's setting.
+//
+// Passes before the fix (re-registration currently never touches a tagged
+// node's expiry) and must keep passing after.
+func TestIssue3371_TaggedNodeFutureExpirySurvivesRelogin(t *testing.T) {
+	app := createTestApp(t)
+
+	user := app.state.CreateUserForTest("tag-future-expiry")
+	tags := []string{"tag:tag1"}
+
+	pak, err := app.state.CreatePreAuthKey(user.TypedID(), true, false, nil, tags)
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	nodeKey := key.NewNode()
+
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey:  nodeKey.Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "future-expiry-tagged"},
+	}
+	_, err = app.handleRegister(context.Background(), regReq, machineKey.Public())
+	require.NoError(t, err)
+
+	node, found := app.state.GetNodeByNodeKey(nodeKey.Public())
+	require.True(t, found)
+	require.True(t, node.IsTagged())
+
+	// Admin sets a deliberate future expiry (`headscale nodes expire`).
+	future := time.Now().Add(24 * time.Hour)
+	_, _, err = app.state.SetNodeExpiry(node.ID(), &future)
+	require.NoError(t, err)
+
+	withFuture, found := app.state.GetNodeByNodeKey(nodeKey.Public())
+	require.True(t, found)
+	require.True(t, withFuture.Expiry().Valid(), "precondition: future expiry set")
+	require.False(t, withFuture.IsExpired(), "precondition: future expiry is not expired")
+
+	// Node re-registers (rotating its node key). The future expiry must survive.
+	nodeKey2 := key.NewNode()
+	reregReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey:  nodeKey2.Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "future-expiry-tagged"},
+	}
+	_, err = app.handleRegister(context.Background(), reregReq, machineKey.Public())
+	require.NoError(t, err)
+
+	after, found := app.state.GetNodeByNodeKey(nodeKey2.Public())
+	require.True(t, found)
+	require.True(t, after.IsTagged(), "node stays tagged")
+	assert.True(t, after.Expiry().Valid(),
+		"deliberate future expiry must survive re-registration (not cleared by #3371 fix)")
+	assert.WithinDuration(t, future, after.Expiry().Get(), 5*time.Second,
+		"the surviving expiry must be the admin-set future value, unchanged")
+}
+
+// TestIssue3371_EphemeralTaggedNodeLogoutDeletes is a regression guard for the
+// ephemeral+tagged combination. A tagged pre-auth key can also be ephemeral.
+// handleLogout deletes ephemeral nodes (before any expiry stamp), so the #3371
+// fix (which suppresses the expiry stamp for tagged nodes) must not divert an
+// ephemeral tagged node away from deletion.
+//
+// Passes before the fix and must keep passing after.
+func TestIssue3371_EphemeralTaggedNodeLogoutDeletes(t *testing.T) {
+	app := createTestApp(t)
+
+	user := app.state.CreateUserForTest("tag-ephemeral")
+	tags := []string{"tag:tag1"}
+
+	// Ephemeral + tagged key.
+	pak, err := app.state.CreatePreAuthKey(user.TypedID(), true, true, nil, tags)
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	nodeKey := key.NewNode()
+
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey:  nodeKey.Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "ephemeral-tagged"},
+	}
+	_, err = app.handleRegister(context.Background(), regReq, machineKey.Public())
+	require.NoError(t, err)
+
+	node, found := app.state.GetNodeByNodeKey(nodeKey.Public())
+	require.True(t, found)
+	require.True(t, node.IsTagged(), "precondition: node is tagged")
+	require.True(t, node.IsEphemeral(), "precondition: node is ephemeral")
+
+	// Logout: an ephemeral node is deleted, not expired.
+	logoutReq := tailcfg.RegisterRequest{
+		Auth:    &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey: nodeKey.Public(),
+		Expiry:  tsLogoutSentinelExpiry(),
+	}
+	_, err = app.handleRegister(context.Background(), logoutReq, machineKey.Public())
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, stillThere := app.state.GetNodeByNodeKey(nodeKey.Public())
+		assert.False(c, stillThere,
+			"ephemeral tagged node must be deleted on logout, not expired")
+	}, 2*time.Second, 50*time.Millisecond, "waiting for ephemeral node deletion")
+}

--- a/hscontrol/db/db.go
+++ b/hscontrol/db/db.go
@@ -900,6 +900,33 @@ WHERE user_id IS NULL
 				},
 				Rollback: func(db *gorm.DB) error { return nil },
 			},
+			{
+				// Clear stale key expiry on tagged nodes. A tagged node is
+				// owned by its tags and never expires (KB 1068), but a buggy
+				// handleLogout stamped a past expiry on it, leaving it
+				// permanently Expired and unable to re-authenticate. The
+				// buggy writer is fixed, so this only repairs rows written
+				// before the upgrade; a fixed server cannot recreate them.
+				// Match the tagged-node predicate the earlier
+				// clear-tagged-node-user-id migration uses (a nil tags slice
+				// marshals to 'null', so exclude it).
+				// Fixes: https://github.com/juanfont/headscale/issues/3371
+				ID: "202607241200-clear-tagged-node-expiry",
+				Migrate: func(tx *gorm.DB) error {
+					err := tx.Exec(`
+UPDATE nodes
+SET expiry = NULL
+WHERE tags IS NOT NULL AND tags != '[]' AND tags != '' AND tags != 'null'
+	AND expiry IS NOT NULL;
+						`).Error
+					if err != nil {
+						return fmt.Errorf("clearing expiry on tagged nodes: %w", err)
+					}
+
+					return nil
+				},
+				Rollback: func(db *gorm.DB) error { return nil },
+			},
 		},
 	)
 

--- a/hscontrol/db/db_test.go
+++ b/hscontrol/db/db_test.go
@@ -295,6 +295,64 @@ func TestSQLiteMigrationAndDataValidation(t *testing.T) {
 				assert.Equal(t, uint(1), *node4.UserID, "node4 should still belong to user1")
 			},
 		},
+		// Test for the clear-tagged-node-expiry migration
+		// (202607241200-clear-tagged-node-expiry). A buggy handleLogout stamped
+		// a key expiry on tagged nodes, which never expire (KB 1068), leaving
+		// them permanently Expired. The migration clears expiry on tagged rows
+		// only, preserving user-owned nodes' expiry.
+		// Fixes: https://github.com/juanfont/headscale/issues/3371
+		{
+			dbPath: "testdata/sqlite/clear_tagged_node_expiry_migration_test.sql",
+			wantFunc: func(t *testing.T, hsdb *HSDatabase) {
+				t.Helper()
+
+				nodes, err := Read(hsdb.DB, func(rx *gorm.DB) (types.Nodes, error) {
+					return ListNodes(rx)
+				})
+				require.NoError(t, err)
+				require.Len(t, nodes, 5, "should have all 5 nodes")
+
+				byHostname := make(map[string]*types.Node, len(nodes))
+				for _, n := range nodes {
+					byHostname[n.Hostname] = n
+				}
+
+				// Node 1: tagged with a stale PAST expiry (the bug). Cleared.
+				node1 := byHostname["node1"]
+				require.NotNil(t, node1, "node1 should exist")
+				assert.True(t, node1.IsTagged(), "node1 should be tagged")
+				assert.Nil(t, node1.Expiry, "node1 (tagged) stale expiry should be cleared")
+				assert.False(t, node1.IsExpired(), "node1 must not be reported expired")
+
+				// Node 2: tagged with a FUTURE expiry. Tagged nodes never expire,
+				// so this is cleared too.
+				node2 := byHostname["node2"]
+				require.NotNil(t, node2, "node2 should exist")
+				assert.True(t, node2.IsTagged(), "node2 should be tagged")
+				assert.Nil(t, node2.Expiry, "node2 (tagged) expiry should be cleared")
+
+				// Node 3: tagged, expiry already NULL. Stays NULL.
+				node3 := byHostname["node3"]
+				require.NotNil(t, node3, "node3 should exist")
+				assert.True(t, node3.IsTagged(), "node3 should be tagged")
+				assert.Nil(t, node3.Expiry, "node3 (tagged) NULL expiry should be preserved")
+
+				// Node 4: untagged (tags='null') with a PAST expiry. PRESERVED —
+				// the migration must not touch user-owned nodes.
+				node4 := byHostname["node4"]
+				require.NotNil(t, node4, "node4 should exist")
+				assert.False(t, node4.IsTagged(), "node4 (tags='null') should be untagged")
+				require.NotNil(t, node4.Expiry, "node4 (user-owned) expiry must be preserved")
+				assert.Equal(t, 2020, node4.Expiry.UTC().Year(), "node4 past expiry preserved")
+
+				// Node 5: untagged (tags='[]') with a FUTURE expiry. PRESERVED.
+				node5 := byHostname["node5"]
+				require.NotNil(t, node5, "node5 should exist")
+				assert.False(t, node5.IsTagged(), "node5 (tags='[]') should be untagged")
+				require.NotNil(t, node5.Expiry, "node5 (user-owned) expiry must be preserved")
+				assert.Equal(t, 2099, node5.Expiry.UTC().Year(), "node5 future expiry preserved")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/hscontrol/db/testdata/sqlite/clear_tagged_node_expiry_migration_test.sql
+++ b/hscontrol/db/testdata/sqlite/clear_tagged_node_expiry_migration_test.sql
@@ -1,0 +1,85 @@
+-- Test SQL dump for the clear-tagged-node-expiry migration
+-- (202607241200-clear-tagged-node-expiry)
+--
+-- A buggy handleLogout stamped a past key expiry on tagged nodes. Tagged
+-- nodes are owned by their tags and never expire (KB 1068), so such a row is
+-- reported as permanently Expired and can never re-authenticate. The migration
+-- clears expiry on tagged rows while leaving user-owned nodes untouched.
+-- Fixes: https://github.com/juanfont/headscale/issues/3371
+
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+
+-- Migrations table: entries applied up to (but not including) the fix. The
+-- intervening expiry migrations (clear-zero-time) also run against this dump;
+-- their predicates (expiry < 1900) do not match the post-2000 dates below, so
+-- they leave these rows for the new migration to handle.
+CREATE TABLE `migrations` (`id` text,PRIMARY KEY (`id`));
+INSERT INTO migrations VALUES('202312101416');
+INSERT INTO migrations VALUES('202312101430');
+INSERT INTO migrations VALUES('202402151347');
+INSERT INTO migrations VALUES('2024041121742');
+INSERT INTO migrations VALUES('202406021630');
+INSERT INTO migrations VALUES('202409271400');
+INSERT INTO migrations VALUES('202407191627');
+INSERT INTO migrations VALUES('202408181235');
+INSERT INTO migrations VALUES('202501221827');
+INSERT INTO migrations VALUES('202501311657');
+INSERT INTO migrations VALUES('202502070949');
+INSERT INTO migrations VALUES('202502131714');
+INSERT INTO migrations VALUES('202502171819');
+INSERT INTO migrations VALUES('202505091439');
+INSERT INTO migrations VALUES('202505141324');
+INSERT INTO migrations VALUES('202507021200');
+INSERT INTO migrations VALUES('202510311551');
+INSERT INTO migrations VALUES('202511101554-drop-old-idx');
+INSERT INTO migrations VALUES('202511011637-preauthkey-bcrypt');
+INSERT INTO migrations VALUES('202511122344-remove-newline-index');
+INSERT INTO migrations VALUES('202511131445-node-forced-tags-to-tags');
+INSERT INTO migrations VALUES('202601121700-migrate-hostinfo-request-tags');
+INSERT INTO migrations VALUES('202602201200-clear-tagged-node-user-id');
+
+-- Users table
+CREATE TABLE `users` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`updated_at` datetime,`deleted_at` datetime,`name` text,`display_name` text,`email` text,`provider_identifier` text,`provider` text,`profile_pic_url` text);
+INSERT INTO users VALUES(1,'2024-01-01 00:00:00+00:00','2024-01-01 00:00:00+00:00',NULL,'user1','User One','user1@example.com',NULL,NULL,NULL);
+
+-- Pre-auth keys table
+CREATE TABLE `pre_auth_keys` (`id` integer PRIMARY KEY AUTOINCREMENT,`key` text,`user_id` integer,`reusable` numeric,`ephemeral` numeric DEFAULT false,`used` numeric DEFAULT false,`tags` text,`created_at` datetime,`expiration` datetime,`prefix` text,`hash` blob,CONSTRAINT `fk_pre_auth_keys_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE SET NULL);
+
+-- API keys table
+CREATE TABLE `api_keys` (`id` integer PRIMARY KEY AUTOINCREMENT,`prefix` text,`hash` blob,`created_at` datetime,`expiration` datetime,`last_seen` datetime);
+
+-- Nodes table - current schema (after the tags rename + last_seen/expiry reordering)
+CREATE TABLE IF NOT EXISTS "nodes" (`id` integer PRIMARY KEY AUTOINCREMENT,`machine_key` text,`node_key` text,`disco_key` text,`endpoints` text,`host_info` text,`ipv4` text,`ipv6` text,`hostname` text,`given_name` varchar(63),`user_id` integer,`register_method` text,`tags` text,`auth_key_id` integer,`last_seen` datetime,`expiry` datetime,`approved_routes` text,`created_at` datetime,`updated_at` datetime,`deleted_at` datetime,CONSTRAINT `fk_nodes_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE,CONSTRAINT `fk_nodes_auth_key` FOREIGN KEY (`auth_key_id`) REFERENCES `pre_auth_keys`(`id`));
+
+-- Node 1: TAGGED, user_id NULL, stale PAST expiry (the #3371 bug). After migration: expiry NULL.
+INSERT INTO nodes VALUES(1,'mkey:a0ab77456320823945ae0331823e3c0d516fae9585bd42698dfa1ac3d7679e01','nodekey:7c84167ab68f494942de14deb83587fd841843de2bac105b6c670048c1605501','discokey:53075b3c6cad3b62a2a29caea61beeb93f66b8c75cb89dac465236a5bbf57701','[]','{}','100.64.0.1','fd7a:115c:a1e0::1','node1','node1',NULL,'authkey','["tag:foo"]',NULL,'2024-01-01 00:00:00+00:00','2020-06-01 00:00:00+00:00','[]','2024-01-01 00:00:00+00:00','2024-01-01 00:00:00+00:00',NULL);
+
+-- Node 2: TAGGED, user_id NULL, FUTURE expiry. Tagged nodes never expire, so cleared to NULL too.
+INSERT INTO nodes VALUES(2,'mkey:a0ab77456320823945ae0331823e3c0d516fae9585bd42698dfa1ac3d7679e02','nodekey:7c84167ab68f494942de14deb83587fd841843de2bac105b6c670048c1605502','discokey:53075b3c6cad3b62a2a29caea61beeb93f66b8c75cb89dac465236a5bbf57702','[]','{}','100.64.0.2','fd7a:115c:a1e0::2','node2','node2',NULL,'authkey','["tag:foo"]',NULL,'2024-01-01 00:00:00+00:00','2099-01-01 00:00:00+00:00','[]','2024-01-01 00:00:00+00:00','2024-01-01 00:00:00+00:00',NULL);
+
+-- Node 3: TAGGED, user_id NULL, expiry already NULL. After migration: still NULL.
+INSERT INTO nodes VALUES(3,'mkey:a0ab77456320823945ae0331823e3c0d516fae9585bd42698dfa1ac3d7679e03','nodekey:7c84167ab68f494942de14deb83587fd841843de2bac105b6c670048c1605503','discokey:53075b3c6cad3b62a2a29caea61beeb93f66b8c75cb89dac465236a5bbf57703','[]','{}','100.64.0.3','fd7a:115c:a1e0::3','node3','node3',NULL,'authkey','["tag:foo"]',NULL,'2024-01-01 00:00:00+00:00',NULL,'[]','2024-01-01 00:00:00+00:00','2024-01-01 00:00:00+00:00',NULL);
+
+-- Node 4: UNTAGGED user-owned (tags='null'), PAST expiry. Must be PRESERVED (guard against
+-- the #3323-class over-match: a nil tags slice marshals to the literal 'null').
+INSERT INTO nodes VALUES(4,'mkey:a0ab77456320823945ae0331823e3c0d516fae9585bd42698dfa1ac3d7679e04','nodekey:7c84167ab68f494942de14deb83587fd841843de2bac105b6c670048c1605504','discokey:53075b3c6cad3b62a2a29caea61beeb93f66b8c75cb89dac465236a5bbf57704','[]','{}','100.64.0.4','fd7a:115c:a1e0::4','node4','node4',1,'cli','null',NULL,'2024-01-01 00:00:00+00:00','2020-06-01 00:00:00+00:00','[]','2024-01-01 00:00:00+00:00','2024-01-01 00:00:00+00:00',NULL);
+
+-- Node 5: UNTAGGED user-owned (tags='[]'), FUTURE expiry. Must be PRESERVED.
+INSERT INTO nodes VALUES(5,'mkey:a0ab77456320823945ae0331823e3c0d516fae9585bd42698dfa1ac3d7679e05','nodekey:7c84167ab68f494942de14deb83587fd841843de2bac105b6c670048c1605505','discokey:53075b3c6cad3b62a2a29caea61beeb93f66b8c75cb89dac465236a5bbf57705','[]','{}','100.64.0.5','fd7a:115c:a1e0::5','node5','node5',1,'cli','[]',NULL,'2024-01-01 00:00:00+00:00','2099-01-01 00:00:00+00:00','[]','2024-01-01 00:00:00+00:00','2024-01-01 00:00:00+00:00',NULL);
+
+-- Policies table (empty)
+CREATE TABLE `policies` (`id` integer PRIMARY KEY AUTOINCREMENT,`created_at` datetime,`updated_at` datetime,`deleted_at` datetime,`data` text);
+
+DELETE FROM sqlite_sequence;
+INSERT INTO sqlite_sequence VALUES('users',1);
+INSERT INTO sqlite_sequence VALUES('nodes',5);
+CREATE INDEX idx_users_deleted_at ON users(deleted_at);
+CREATE UNIQUE INDEX idx_api_keys_prefix ON api_keys(prefix);
+CREATE INDEX idx_policies_deleted_at ON policies(deleted_at);
+CREATE UNIQUE INDEX idx_provider_identifier ON users(provider_identifier) WHERE provider_identifier IS NOT NULL;
+CREATE UNIQUE INDEX idx_name_provider_identifier ON users(name, provider_identifier);
+CREATE UNIQUE INDEX idx_name_no_provider_identifier ON users(name) WHERE provider_identifier IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pre_auth_keys_prefix ON pre_auth_keys(prefix) WHERE prefix IS NOT NULL AND prefix != '';
+
+COMMIT;

--- a/hscontrol/policy/pm.go
+++ b/hscontrol/policy/pm.go
@@ -30,6 +30,12 @@ type PolicyManager interface {
 	// NodeCanHaveTag reports whether the given node can have the given tag.
 	NodeCanHaveTag(node types.NodeView, tag string) bool
 
+	// UserCanHaveTag reports whether the given user owns the given tag, i.e.
+	// is listed (directly or via a group) in the tag's tagOwners. This is the
+	// user half of NodeCanHaveTag, used to authorise re-auth tag changes
+	// against the authenticating user rather than the node's stale ownership.
+	UserCanHaveTag(user types.UserView, tag string) bool
+
 	// TagExists reports whether the given tag is defined in the policy.
 	TagExists(tag string) bool
 

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -972,6 +972,37 @@ func (pm *PolicyManager) NodeCanHaveTag(node types.NodeView, tag string) bool {
 	return false
 }
 
+// UserCanHaveTag reports whether the given user is one of the tag's owners
+// (directly or via a group). It is the user half of [PolicyManager.NodeCanHaveTag]:
+// re-authentication authorises requested tags against the authenticating user,
+// because a tag-owned node carries no user and its IP is not in any owner set,
+// so only the user presenting the credential can prove ownership.
+func (pm *PolicyManager) UserCanHaveTag(user types.UserView, tag string) bool {
+	if pm == nil || !user.Valid() {
+		return false
+	}
+
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	if pm.pol == nil {
+		return false
+	}
+
+	owners, exists := pm.pol.TagOwners[Tag(tag)]
+	if !exists {
+		return false
+	}
+
+	for _, owner := range owners {
+		if pm.userMatchesOwner(user, owner) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // TagOwnedByTags reports whether a credential holding ownerTags is authorised to
 // apply tag. It is true when tag is one of ownerTags, or when tag's tagOwners
 // chain (tag-to-tag ownership) transitively includes one of ownerTags. This is

--- a/hscontrol/state/auth_tagged_expiry_test.go
+++ b/hscontrol/state/auth_tagged_expiry_test.go
@@ -408,6 +408,151 @@ func TestAuthPathRejectsTaggedAndUserCoexistence(t *testing.T) {
 	require.ErrorIs(t, err, ErrAmbiguousNodeOwnership)
 }
 
+// TestIssue3371_TaggedNodeInteractiveReloginAfterLogout reproduces the
+// interactive/OIDC arm of https://github.com/juanfont/headscale/issues/3371
+// ("With no key (interactive): the register URL is printed and the login never
+// completes").
+//
+// A logout stamps a stale PAST expiry on a tagged node. When the node
+// re-authenticates through the auth path (HandleNodeFromAuthPath ->
+// applyAuthNodeUpdate), the tagged->tagged branch keeps the existing expiry
+// ("Tagged → Tagged: keep existing expiry (nil) - no action needed",
+// state.go). That comment assumes the existing expiry is nil; after a logout it
+// is a past timestamp, so the node stays expired. The fix must clear a stale
+// past expiry on a node that remains tagged (scoped to IsExpired(), so a
+// deliberate future expiry is preserved).
+func TestIssue3371_TaggedNodeInteractiveReloginAfterLogout(t *testing.T) {
+	dbPath := t.TempDir() + "/headscale.db"
+	cfg := persistTestConfig(dbPath)
+
+	database, err := db.NewHeadscaleDatabase(cfg)
+	require.NoError(t, err)
+
+	user := database.CreateUserForTest("interactive-user")
+	node := database.CreateRegisteredNodeForTest(user, "interactive-tagged")
+	machineKey := node.MachineKey
+	nodeID := node.ID
+	discoKey := node.DiscoKey
+
+	require.NoError(t, database.Close())
+
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Make the node tagged with a stale PAST expiry (the state a `tailscale
+	// logout` leaves behind). Leaving UserID nil but retaining User routes the
+	// re-auth through the convert-from-tag branch and lets the tag
+	// re-advertisement be permitted (mirrors TestTaggedReauthKeepsNilExpiry,
+	// which seeds Expiry=nil; here the only change is a past expiry).
+	past := time.Now().Add(-1 * time.Hour)
+	seeded, ok := s.nodeStore.UpdateNode(nodeID, func(n *types.Node) {
+		n.Tags = []string{"tag:foo"}
+		n.UserID = nil
+		n.User = user
+		n.Expiry = &past
+	})
+	require.True(t, ok)
+	require.True(t, seeded.IsTagged(), "precondition: node is tagged")
+	require.True(t, seeded.IsExpired(), "precondition: logout left the tagged node expired")
+
+	policy := fmt.Sprintf(`{"tagOwners":{"tag:foo":["%s@"]}}`, user.Name)
+	_, err = s.SetPolicy([]byte(policy))
+	require.NoError(t, err)
+	require.True(t, s.NodeCanHaveTag(seeded, "tag:foo"),
+		"precondition: tagged node is permitted to re-advertise tag:foo")
+
+	// Interactive/OIDC relogin: the client re-advertises the same tag (rotating
+	// its node key, as a real client does). The node must come back not-expired.
+	regData := &types.RegistrationData{
+		MachineKey: machineKey,
+		NodeKey:    key.NewNode().Public(),
+		DiscoKey:   discoKey,
+		Hostname:   "interactive-tagged",
+		Hostinfo: &tailcfg.Hostinfo{
+			Hostname:    "interactive-tagged",
+			RequestTags: []string{"tag:foo"},
+		},
+	}
+	authID := types.MustAuthID()
+	s.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(regData))
+
+	relogged, _, err := s.HandleNodeFromAuthPath(
+		authID, types.UserID(user.ID), nil, util.RegisterMethodOIDC,
+	)
+	require.NoError(t, err)
+	require.True(t, relogged.Valid())
+
+	require.True(t, relogged.IsTagged(), "node stays tagged after interactive relogin")
+	require.False(t, relogged.IsExpired(),
+		"issue #3371: interactive relogin must clear the stale logout expiry")
+	require.Nil(t, relogged.AsStruct().Expiry,
+		"issue #3371: tagged node must have key-expiry disabled after interactive relogin")
+}
+
+// TestIssue3371_TaggedNodePastExpirySelfHealsOnReregister covers the 0.29.x
+// upgrade path: a tagged node broken by an OLDER headscale carries a past
+// expiry persisted in its DB row. After a restart (State reloads the row) it
+// comes back expired, and its next auth-key re-registration must self-heal it
+// by clearing the stale past expiry. This is the "part b" defensive clear.
+func TestIssue3371_TaggedNodePastExpirySelfHealsOnReregister(t *testing.T) {
+	dbPath := t.TempDir() + "/headscale.db"
+	cfg := persistTestConfig(dbPath)
+
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+
+	_, err = s.SetPolicy([]byte(`{"tagOwners":{"tag:foo":["tagger@"]}}`))
+	require.NoError(t, err)
+
+	pak, err := s.CreatePreAuthKey(nil, true, false, nil, []string{"tag:foo"})
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	nodeKey := key.NewNode()
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey:  nodeKey.Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "broken-tagged"},
+	}
+	node, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err)
+
+	nodeID := node.ID()
+
+	// A prior (buggy) version persisted a past expiry on this tagged node.
+	past := time.Now().Add(-1 * time.Hour)
+	err = s.DB().NodeSetExpiry(nodeID, &past)
+	require.NoError(t, err)
+
+	// Restart: reload State from the same database file.
+	require.NoError(t, s.Close())
+
+	s2, err := NewState(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s2.Close() })
+
+	reloaded, ok := s2.GetNodeByID(nodeID)
+	require.True(t, ok)
+	require.True(t, reloaded.IsExpired(),
+		"precondition: a persisted past expiry survives restart and re-triggers the lockout")
+
+	// Re-register (rotating the node key). The stale past expiry must be cleared.
+	reregReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey:  key.NewNode().Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "broken-tagged"},
+	}
+	healed, _, err := s2.HandleNodeFromPreAuthKey(reregReq, machineKey.Public())
+	require.NoError(t, err)
+	require.True(t, healed.IsTagged(), "node stays tagged")
+	require.False(t, healed.IsExpired(),
+		"issue #3371: re-registration must self-heal a tagged node broken by an older version")
+	require.Nil(t, healed.AsStruct().Expiry,
+		"issue #3371: self-healed tagged node must have key-expiry disabled (DB NULL)")
+	require.Equal(t, nodeID, healed.ID(), "must be the same node")
+}
+
 // TestTaggedNodeCanHaveKeyExpiry matches Tailscale: a tagged node has key
 // expiry disabled by default, but it can still be set explicitly (e.g. via
 // `headscale nodes expire`).

--- a/hscontrol/state/auth_tagged_expiry_test.go
+++ b/hscontrol/state/auth_tagged_expiry_test.go
@@ -553,6 +553,558 @@ func TestIssue3371_TaggedNodePastExpirySelfHealsOnReregister(t *testing.T) {
 	require.Equal(t, nodeID, healed.ID(), "must be the same node")
 }
 
+// TestIssue3371_ExpiredTaggedNodeSameSpentKeyNotRevalidated is the gating test
+// for the isExpired-gate exclusion (state.go: `&& !existingNodeSameUser.IsTagged()`).
+// A tagged node carrying a stale PAST expiry, re-registering with the SAME
+// single-use key and the SAME node key (no rotation), must take the
+// skip-validation fast path — otherwise the spent key is re-validated and
+// rejected with "authkey already used", the exact lockout #3371 fixes. Without
+// the tagged exclusion this fails; with it the node self-heals. The neighbours
+// all rotate the node key or use a reusable key, so validation runs regardless
+// and none probes this fast-path exclusion.
+func TestIssue3371_ExpiredTaggedNodeSameSpentKeyNotRevalidated(t *testing.T) {
+	s := newRetagTestState(t)
+
+	// Single-use tagged key.
+	pak, err := s.CreatePreAuthKey(nil, false, false, nil, []string{"tag:foo"})
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	nodeKey := key.NewNode()
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey:  nodeKey.Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "spent-tagged"},
+	}
+	node, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err)
+	require.True(t, node.IsTagged())
+
+	// Stale past (logout) expiry, and the single-use key is now spent.
+	past := time.Now().Add(-1 * time.Hour)
+	_, ok := s.nodeStore.UpdateNode(node.ID(), func(n *types.Node) {
+		n.Expiry = &past
+	})
+	require.True(t, ok)
+
+	// Re-register with the SAME key and the SAME node key (no rotation). The
+	// tagged exclusion from the isExpired gate must let this skip validation, so
+	// the spent single-use key is not rejected.
+	healed, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err,
+		"a tagged node with a stale past expiry must skip re-validation of its spent key")
+	require.False(t, healed.IsExpired(), "stale expiry cleared")
+	require.Nil(t, healed.AsStruct().Expiry, "tagged node key-expiry disabled")
+	require.Equal(t, node.ID(), healed.ID())
+}
+
+// TestTaggedPAKReauthRetagsExistingTaggedNode reproduces issue #3370: an
+// already-tagged node re-authenticating with a *fresh, valid* tagged pre-auth
+// key carrying *different* tags has that key validated and consumed, but its
+// tags are silently discarded — the node keeps its old tags.
+//
+// Root cause: the in-place re-registration path in HandleNodeFromPreAuthKey
+// only applies a key's tags when a tagged key converts a user-owned node
+// (`pak.IsTagged() && !node.IsTagged()`). An already-tagged node fails
+// `!node.IsTagged()`, so a differently-tagged key leaves the tags unchanged —
+// while the single-use key is still marked used below (hsdb.UsePreAuthKey).
+//
+// Tagged-PAK tags are authorised by possession of the key (only syntactic
+// `tag:` validation at creation; no tagOwners policy is required — the bug
+// reproduces with an empty policy). Re-keying is Tailscale's documented method
+// for changing an auth-key device's tags, so a fresh key's tags must be
+// applied on re-registration.
+//
+// https://github.com/juanfont/headscale/issues/3370
+func TestTaggedPAKReauthRetagsExistingTaggedNode(t *testing.T) {
+	dbPath := t.TempDir() + "/headscale.db"
+	cfg := persistTestConfig(dbPath)
+
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Empty policy: tagged-PAK tags need no tagOwners entry (issue reproduces
+	// with a completely empty policy).
+
+	// KEY1: single-use tags-only key carrying tag:tag1.
+	key1, err := s.CreatePreAuthKey(nil, false, false, nil, []string{"tag:tag1"})
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: key1.Key},
+		NodeKey:  key.NewNode().Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "retag-node"},
+	}
+
+	// Initial registration: node comes up tagged tag:tag1.
+	first, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err)
+	require.True(t, first.IsTagged(), "precondition: node registered tagged")
+	require.Equal(t, []string{"tag:tag1"}, first.Tags().AsSlice())
+	nodeID := first.ID()
+	firstIPv4 := first.IPv4()
+	firstIPv6 := first.IPv6()
+
+	// KEY2: fresh single-use tags-only key carrying tag:tag2.
+	key2, err := s.CreatePreAuthKey(nil, false, false, nil, []string{"tag:tag2"})
+	require.NoError(t, err)
+
+	// `tailscale up --force-reauth --auth-key KEY2`: same machine, rotated node
+	// key, fresh valid key. This validates and consumes KEY2.
+	reReg := regReq
+	reReg.Auth = &tailcfg.RegisterResponseAuth{AuthKey: key2.Key}
+	reReg.NodeKey = key.NewNode().Public()
+
+	second, _, err := s.HandleNodeFromPreAuthKey(reReg, machineKey.Public())
+	require.NoError(t, err)
+	require.Equal(t, nodeID, second.ID(), "must update in place, not duplicate")
+	require.Equal(t, 1, s.ListNodes().Len(), "machine must map to exactly one node")
+	require.True(t, second.IsTagged(), "node must remain tagged")
+
+	// KEY2 was validated and consumed regardless of the outcome.
+	consumed, err := s.GetPreAuthKeyByID(key2.ID)
+	require.NoError(t, err)
+	require.True(t, consumed.Used, "single-use key was consumed by the re-auth")
+
+	// The consumed key's tags must be applied: re-keying retags the device
+	// (Tailscale's documented behaviour). This is the assertion that fails
+	// before the fix — the node keeps ["tag:tag1"].
+	require.Equal(t, []string{"tag:tag2"}, second.Tags().AsSlice(),
+		"re-authenticating with a differently-tagged key must retag the node, "+
+			"not silently discard the tags of the consumed key")
+
+	// Identity continuity: the reporter stresses "same node, same IP". The
+	// re-auth updates in place, so the machine key and both Tailscale IPs are
+	// preserved while the node key rotates. A retag must not re-allocate IPs or
+	// duplicate the node.
+	require.Equal(t, machineKey.Public(), second.MachineKey(),
+		"machine key is the stable identity across re-auth")
+	require.Equal(t, firstIPv4, second.IPv4(), "IPv4 preserved across retag")
+	require.Equal(t, firstIPv6, second.IPv6(), "IPv6 preserved across retag")
+	require.NotEqual(t, first.NodeKey(), second.NodeKey(),
+		"--force-reauth rotates the node key")
+
+	// A retagged node stays a tagged node: user-less and key-expiry disabled.
+	require.Nil(t, second.AsStruct().Expiry, "tagged node keeps nil key expiry")
+}
+
+// TestTaggedPAKReauthSameKeyPreservesTags is the counterpart constraint to
+// #3370: re-authenticating with the *same* tagged key must NOT clobber the
+// node's current tags, even after an admin retagged it via
+// `headscale nodes tag`. This is the unit-level guard for the integration
+// test TestTagsAuthKeyWithTagAdminOverrideReauthPreserves (admin decisions are
+// authoritative), and it is why the retag discriminator must key on the
+// pre-auth key's *identity* (a different key) rather than on "validation ran"
+// (a --force-reauth with the same key also runs validation). This test passes
+// today and must keep passing after the #3370 fix.
+func TestTaggedPAKReauthSameKeyPreservesTags(t *testing.T) {
+	dbPath := t.TempDir() + "/headscale.db"
+	cfg := persistTestConfig(dbPath)
+
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	// tag:admin must be permitted for the admin SetNodeTags call.
+	_, err = s.SetPolicy([]byte(`{"tagOwners":{"tag:admin":["admin@"]}}`))
+	require.NoError(t, err)
+
+	// Reusable tagged key (the shape used by the admin-override integration
+	// test) so the same key can be presented twice.
+	pak, err := s.CreatePreAuthKey(nil, true, false, nil, []string{"tag:orig"})
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey:  key.NewNode().Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "sticky-node"},
+	}
+
+	first, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err)
+	require.Equal(t, []string{"tag:orig"}, first.Tags().AsSlice())
+	nodeID := first.ID()
+
+	// Admin retags the node out-of-band.
+	tagged, _, err := s.SetNodeTags(nodeID, []string{"tag:admin"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"tag:admin"}, tagged.Tags().AsSlice())
+
+	// `--force-reauth` with the SAME key: rotate the node key so validation
+	// runs, exactly like the client does.
+	reReg := regReq
+	reReg.NodeKey = key.NewNode().Public()
+
+	second, _, err := s.HandleNodeFromPreAuthKey(reReg, machineKey.Public())
+	require.NoError(t, err)
+	require.Equal(t, nodeID, second.ID())
+	require.Equal(t, []string{"tag:admin"}, second.Tags().AsSlice(),
+		"re-authenticating with the same key must preserve the admin-assigned tags")
+}
+
+// TestTaggedPAKReauthSpentKeySameNodeKeyRejected pins the authorization boundary
+// the retag must respect: presenting a *spent* single-use tagged key to retag an
+// already-tagged node must be rejected, even when the client reuses its node key
+// (the skip-validation fast path). Without forcing validation on a retag, a
+// used/revoked/expired tagged credential could still apply its tags — replaying
+// a dead key to escalate a machine onto a tag, and defeating key revocation. The
+// existing isExpired comment already declares the boundary "must not depend on
+// the client rotating its key"; retag must honour the same rule.
+func TestTaggedPAKReauthSpentKeySameNodeKeyRejected(t *testing.T) {
+	s := newRetagTestState(t)
+
+	// KEY1: single-use tag:tag1, used to register.
+	key1, err := s.CreatePreAuthKey(nil, false, false, nil, []string{"tag:tag1"})
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	nodeKey := key.NewNode()
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: key1.Key},
+		NodeKey:  nodeKey.Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "retag-node"},
+	}
+	first, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err)
+	require.Equal(t, []string{"tag:tag1"}, first.Tags().AsSlice())
+
+	// KEY2: single-use tag:tag2, spent elsewhere so it is already Used.
+	key2, err := s.CreatePreAuthKey(nil, false, false, nil, []string{"tag:tag2"})
+	require.NoError(t, err)
+	_, _, err = s.HandleNodeFromPreAuthKey(tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: key2.Key},
+		NodeKey:  key.NewNode().Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "other-node"},
+	}, key.NewMachine().Public())
+	require.NoError(t, err)
+
+	// Re-register the FIRST node with the now-spent KEY2, REUSING its node key
+	// (no rotation) so it targets the skip-validation fast path. A spent key must
+	// be rejected, and the node's tags must be unchanged.
+	reReg := regReq
+	reReg.Auth = &tailcfg.RegisterResponseAuth{AuthKey: key2.Key}
+	// reReg.NodeKey stays nodeKey (same) -> fast path.
+
+	_, _, err = s.HandleNodeFromPreAuthKey(reReg, machineKey.Public())
+	require.Error(t, err, "a spent tagged key must not be able to retag on the fast path")
+	require.Contains(t, err.Error(), "authkey already used")
+
+	after, ok := s.GetNodeByID(first.ID())
+	require.True(t, ok)
+	require.Equal(t, []string{"tag:tag1"}, after.Tags().AsSlice(),
+		"a rejected spent key must not have applied its tags")
+}
+
+// retagReauthCase drives the #3370 retag scenario with configurable key shapes
+// so the sibling cases below stay a few lines each. It registers a node with
+// key1, then re-registers the same machine with key2, and returns the
+// re-registered node. rotateNodeKey mirrors --force-reauth (the client rotates
+// its node key); when false the client reuses its node key.
+func retagReauthCase(
+	t *testing.T,
+	s *State,
+	key1Tags, key2Tags []string,
+	key1User, key2User *types.UserID,
+	reusable, rotateNodeKey bool,
+) (types.NodeView, types.NodeView) {
+	t.Helper()
+
+	key1, err := s.CreatePreAuthKey(key1User, reusable, false, nil, key1Tags)
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	nodeKey := key.NewNode()
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: key1.Key},
+		NodeKey:  nodeKey.Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "retag-node"},
+	}
+
+	first, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err)
+
+	key2, err := s.CreatePreAuthKey(key2User, reusable, false, nil, key2Tags)
+	require.NoError(t, err)
+
+	reReg := regReq
+
+	reReg.Auth = &tailcfg.RegisterResponseAuth{AuthKey: key2.Key}
+	if rotateNodeKey {
+		reReg.NodeKey = key.NewNode().Public()
+	}
+
+	second, _, err := s.HandleNodeFromPreAuthKey(reReg, machineKey.Public())
+	require.NoError(t, err)
+	require.Equal(t, first.ID(), second.ID(), "must update in place, not duplicate")
+
+	return first, second
+}
+
+// TestTaggedPAKReauthReusableKeyRetags: a *reusable* differently-tagged key
+// must retag too. The retag must key on key identity, not on the single-use
+// `Used` flag, so it cannot be coupled to single-use semantics.
+func TestTaggedPAKReauthReusableKeyRetags(t *testing.T) {
+	s := newRetagTestState(t)
+	_, second := retagReauthCase(t, s,
+		[]string{"tag:tag1"}, []string{"tag:tag2"}, nil, nil, true /*reusable*/, true)
+	require.Equal(t, []string{"tag:tag2"}, second.Tags().AsSlice())
+}
+
+// TestTaggedPAKReauthDifferentKeySameNodeKey: retag must fire even when the
+// client reuses its node key (no rotation). The trigger is key identity,
+// decoupled from NodeKey rotation.
+func TestTaggedPAKReauthDifferentKeySameNodeKey(t *testing.T) {
+	s := newRetagTestState(t)
+	_, second := retagReauthCase(t, s,
+		[]string{"tag:tag1"}, []string{"tag:tag2"}, nil, nil, false, false /*same node key*/)
+	require.Equal(t, []string{"tag:tag2"}, second.Tags().AsSlice())
+}
+
+// TestTaggedPAKReauthSameSingleUseKeySameNodeKeyPreservesTags guards the #2830
+// container-restart permutation for a tags-only single-use key: presenting the
+// SAME (already-used) single-use key with the SAME node key must take the
+// skip-validation fast path, succeed, and keep the node's tags — not reject
+// with "authkey already used" and not spuriously retag. This confirms the
+// keyChanged/isRetag additions never fire for a same-key restart, the exact
+// property #2830/#3312 depend on. (The existing #3312 test uses a user-owned
+// one-shot key; this covers the tags-only single-use key.)
+func TestTaggedPAKReauthSameSingleUseKeySameNodeKeyPreservesTags(t *testing.T) {
+	s := newRetagTestState(t)
+
+	pak, err := s.CreatePreAuthKey(nil, false /*single-use*/, false, nil, []string{"tag:tag1"})
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+		NodeKey:  key.NewNode().Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "restart-node"},
+	}
+
+	first, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err)
+	require.Equal(t, []string{"tag:tag1"}, first.Tags().AsSlice())
+
+	// Container restart: same key, same node key, same machine. The single-use
+	// key is already consumed, so re-validation would reject it.
+	second, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err,
+		"same-key restart of a tagged node must skip validation, not reject a spent single-use key")
+	require.Equal(t, first.ID(), second.ID(), "must update in place")
+	require.Equal(t, []string{"tag:tag1"}, second.Tags().AsSlice(),
+		"same-key restart must preserve tags (no spurious retag)")
+	require.Equal(t, 1, s.ListNodes().Len(), "no duplicate node")
+}
+
+// TestTaggedPAKReauthUserScopedKeyRetags: a user-scoped tagged key
+// (User != nil, the `headscale preauthkeys create -u <user> --tags` shape)
+// exercises the pak.User != nil branch of findExistingNodeForPAK, a different
+// lookup path from tags-only keys. It must still retag.
+func TestTaggedPAKReauthUserScopedKeyRetags(t *testing.T) {
+	s := newRetagTestState(t)
+	user := s.CreateUserForTest("owner")
+	uid := user.TypedID()
+	_, second := retagReauthCase(t, s,
+		[]string{"tag:tag1"}, []string{"tag:tag2"}, uid, uid, false, true)
+	require.Equal(t, []string{"tag:tag2"}, second.Tags().AsSlice())
+	require.True(t, second.IsTagged())
+}
+
+// TestTaggedPAKReauthReplacesNotMerges pins the Tailscale KB 1068 rule that
+// re-keying *replaces* the tag set (it does not union). Re-keying a
+// {tag1,tag2} node with a {tag1} key must drop tag2.
+func TestTaggedPAKReauthReplacesNotMerges(t *testing.T) {
+	s := newRetagTestState(t)
+	_, second := retagReauthCase(t, s,
+		[]string{"tag:tag1", "tag:tag2"}, []string{"tag:tag1"}, nil, nil, false, true)
+	require.Equal(t, []string{"tag:tag1"}, second.Tags().AsSlice(),
+		"re-keying replaces the tag set; tag:tag2 must be removed, not merged")
+}
+
+// TestExpiredTaggedNodeReauthRetags: a tagged node that looks expired (a stale
+// logout stamp — see #3371) re-authenticating with a fresh differently-tagged
+// key must still retag. Combines the isExpired validation path with the retag.
+func TestExpiredTaggedNodeReauthRetags(t *testing.T) {
+	s := newRetagTestState(t)
+
+	key1, err := s.CreatePreAuthKey(nil, false, false, nil, []string{"tag:tag1"})
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: key1.Key},
+		NodeKey:  key.NewNode().Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "retag-node"},
+	}
+	first, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err)
+
+	// Force a stale past expiry onto the tagged node.
+	past := time.Now().Add(-1 * time.Hour)
+	_, ok := s.nodeStore.UpdateNode(first.ID(), func(n *types.Node) {
+		n.Expiry = &past
+	})
+	require.True(t, ok)
+
+	key2, err := s.CreatePreAuthKey(nil, false, false, nil, []string{"tag:tag2"})
+	require.NoError(t, err)
+
+	reReg := regReq
+	reReg.Auth = &tailcfg.RegisterResponseAuth{AuthKey: key2.Key}
+	reReg.NodeKey = key.NewNode().Public()
+
+	second, _, err := s.HandleNodeFromPreAuthKey(reReg, machineKey.Public())
+	require.NoError(t, err)
+	require.Equal(t, []string{"tag:tag2"}, second.Tags().AsSlice(),
+		"an expired (stale logout stamp) tagged node must retag on fresh-key re-auth")
+	require.Nil(t, second.AsStruct().Expiry,
+		"retag must clear a stale expiry: the node is tagged and tagged nodes never expire")
+	require.False(t, second.IsExpired(),
+		"a retagged node must not remain expired")
+}
+
+// TestTaggedPAKReauthRetagPreservesFutureAdminExpiry pins the composition
+// decision between #3370 (retag) and #3371 (never wrongly expire a tagged
+// node): a deliberate FUTURE expiry set by an admin via `headscale nodes expire`
+// is a node property, not tied to the auth key, so re-keying an already-tagged
+// node with a different key must retag it WITHOUT wiping that future expiry.
+// Only a stale PAST expiry is cleared (see TestExpiredTaggedNodeReauthRetags).
+// Symmetric with the same-key relogin path.
+func TestTaggedPAKReauthRetagPreservesFutureAdminExpiry(t *testing.T) {
+	s := newRetagTestState(t)
+
+	key1, err := s.CreatePreAuthKey(nil, false, false, nil, []string{"tag:tag1"})
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: key1.Key},
+		NodeKey:  key.NewNode().Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "retag-node"},
+	}
+	first, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err)
+
+	// Admin sets a deliberate future expiry on the tagged node
+	// (`headscale nodes expire`), which SetNodeExpiry permits.
+	future := time.Now().Add(30 * 24 * time.Hour)
+	_, _, err = s.SetNodeExpiry(first.ID(), &future)
+	require.NoError(t, err)
+
+	// Re-key with a different tagged key.
+	key2, err := s.CreatePreAuthKey(nil, false, false, nil, []string{"tag:tag2"})
+	require.NoError(t, err)
+
+	reReg := regReq
+	reReg.Auth = &tailcfg.RegisterResponseAuth{AuthKey: key2.Key}
+	reReg.NodeKey = key.NewNode().Public()
+
+	second, _, err := s.HandleNodeFromPreAuthKey(reReg, machineKey.Public())
+	require.NoError(t, err)
+	require.Equal(t, []string{"tag:tag2"}, second.Tags().AsSlice(), "node retags")
+	require.NotNil(t, second.AsStruct().Expiry,
+		"a deliberate future admin expiry must survive a different-key retag")
+	require.Equal(t, future.Unix(), second.AsStruct().Expiry.Unix(),
+		"the admin expiry value must be unchanged")
+}
+
+// newRetagTestState builds a State with an empty policy (tagged-PAK tags need
+// no tagOwners entry).
+func newRetagTestState(t *testing.T) *State {
+	t.Helper()
+
+	cfg := persistTestConfig(t.TempDir() + "/headscale.db")
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	return s
+}
+
+// TestPreAuthKeyReauthPersistsAuthKeyID pins the root cause behind the
+// ephemeral-flag revert bug found while auditing #3370: on re-registration
+// with a *different* key, HandleNodeFromPreAuthKey updates node.AuthKeyID in
+// the NodeStore (state.go, in the in-place closure) but AuthKeyID is excluded
+// from nodeUpdateColumns (added for #2862 to avoid persisting a *deleted* key's
+// stale reference on MapRequest). The exclusion is correct for MapRequest, but
+// on the re-registration path the presented key is freshly loaded and valid, so
+// the new auth_key_id must be persisted. Otherwise a control-plane restart
+// reloads the OLD key, and any key-scoped property (notably Ephemeral) silently
+// reverts — an ephemeral->non-ephemeral re-auth leaves a node that looks
+// persistent in memory but is ephemeral again after restart and can be GC'd.
+//
+// Drives the real handler twice, then reopens the DB to prove the association
+// survives the reload.
+func TestPreAuthKeyReauthPersistsAuthKeyID(t *testing.T) {
+	dbPath := t.TempDir() + "/headscale.db"
+	cfg := persistTestConfig(dbPath)
+
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+
+	user := s.CreateUserForTest("rekey-user")
+
+	// KEY A: ephemeral, single-use.
+	keyA, err := s.CreatePreAuthKey(user.TypedID(), false, true /*ephemeral*/, nil, nil)
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: keyA.Key},
+		NodeKey:  key.NewNode().Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "rekey-node"},
+		Expiry:   time.Now().Add(24 * time.Hour),
+	}
+
+	first, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err)
+
+	nodeID := first.ID()
+	require.True(t, first.IsEphemeral(), "precondition: registered with an ephemeral key")
+
+	// KEY B: non-ephemeral, single-use, same user. `--force-reauth` rotates the
+	// node key so this is a genuine re-registration that consumes KEY B.
+	keyB, err := s.CreatePreAuthKey(user.TypedID(), false, false /*non-ephemeral*/, nil, nil)
+	require.NoError(t, err)
+
+	reReg := regReq
+	reReg.Auth = &tailcfg.RegisterResponseAuth{AuthKey: keyB.Key}
+	reReg.NodeKey = key.NewNode().Public()
+
+	second, _, err := s.HandleNodeFromPreAuthKey(reReg, machineKey.Public())
+	require.NoError(t, err)
+	require.Equal(t, nodeID, second.ID(), "must update in place")
+
+	// In-memory, the node now tracks KEY B (non-ephemeral).
+	require.NotNil(t, second.AuthKeyID().Get())
+	require.Equal(t, keyB.ID, second.AuthKeyID().Get(),
+		"NodeStore must reference the key just used to re-authenticate")
+	require.False(t, second.IsEphemeral(),
+		"re-auth with a non-ephemeral key must make the node non-ephemeral")
+
+	// Restart the control plane: reload state from the database only.
+	require.NoError(t, s.Close())
+
+	s2, err := NewState(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s2.Close() })
+
+	reloaded, ok := s2.GetNodeByID(nodeID)
+	require.True(t, ok, "node must reload from DB after restart")
+
+	// This is the assertion that fails today: auth_key_id was never persisted on
+	// re-registration, so the reload resurrects KEY A and the node is ephemeral
+	// again — at risk of GC on the next disconnect.
+	require.NotNil(t, reloaded.AuthKeyID().Get())
+	require.Equal(t, keyB.ID, reloaded.AuthKeyID().Get(),
+		"auth_key_id must persist across restart, not revert to the old key")
+	require.False(t, reloaded.IsEphemeral(),
+		"ephemerality must not silently revert after a control-plane restart")
+}
+
 // TestTaggedNodeCanHaveKeyExpiry matches Tailscale: a tagged node has key
 // expiry disabled by default, but it can still be set explicitly (e.g. via
 // `headscale nodes expire`).

--- a/hscontrol/state/auth_tagged_expiry_test.go
+++ b/hscontrol/state/auth_tagged_expiry_test.go
@@ -408,6 +408,445 @@ func TestAuthPathRejectsTaggedAndUserCoexistence(t *testing.T) {
 	require.ErrorIs(t, err, ErrAmbiguousNodeOwnership)
 }
 
+// seededTaggedNode holds the identity of a node seeded into the genuinely
+// tag-owned state, so re-auth tests can drive HandleNodeFromAuthPath and then
+// re-read the node to assert its post-conditions.
+type seededTaggedNode struct {
+	s       *State
+	regData *types.RegistrationData
+	id      types.NodeID
+	cfg     *types.Config
+}
+
+// seedTagOwnedNode registers a node under a seed user, then rewrites it into the
+// genuinely tag-owned state that `tailscale up --advertise-tags` produces:
+// tagged, with neither UserID nor User set. This is the shape the issue #3374
+// DB dump shows (`user_id: None`), and the shape that CreateRegisteredNodeForTest
+// alone does not produce (it leaves a real user attached).
+//
+// createdByName controls the retained "created by" user: "" reproduces the pure
+// tag-owned state (issue #3374); a non-empty name reproduces a node that kept a
+// created-by User (UserID still nil) — used to prove authorisation keys off the
+// authenticating user, not the created-by user. When set, that user is created
+// in the DB so it resolves in policy.
+func seedTagOwnedNode(t *testing.T, tags []string, createdByName string) seededTaggedNode {
+	t.Helper()
+
+	dbPath := t.TempDir() + "/headscale.db"
+	cfg := persistTestConfig(dbPath)
+
+	database, err := db.NewHeadscaleDatabase(cfg)
+	require.NoError(t, err)
+
+	seedUser := database.CreateUserForTest("seed")
+	node := database.CreateRegisteredNodeForTest(seedUser, "tagged-node")
+
+	var createdBy *types.User
+	if createdByName != "" {
+		createdBy = database.CreateUserForTest(createdByName)
+	}
+
+	regData := &types.RegistrationData{
+		MachineKey: node.MachineKey,
+		NodeKey:    node.NodeKey,
+		DiscoKey:   node.DiscoKey,
+		Hostname:   "tagged-node",
+	}
+
+	require.NoError(t, database.Close())
+
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Genuinely tag-owned: tags set, UserID nil. UserID nil indexes the node
+	// under userID 0, so HandleNodeFromAuthPath takes the convert-from-tag
+	// branch — the path the issue exercises. User mirrors createdBy.
+	seeded, ok := s.nodeStore.UpdateNode(node.ID, func(n *types.Node) {
+		n.Tags = tags
+		n.UserID = nil
+		n.User = createdBy
+		n.Expiry = nil
+	})
+	require.True(t, ok)
+	require.True(t, seeded.IsTagged(), "precondition: node must be tagged")
+
+	return seededTaggedNode{s: s, regData: regData, id: node.ID, cfg: cfg}
+}
+
+// reopen closes the current State and reloads it from the same database, so a
+// test can assert that a mutation was actually persisted (not just applied to
+// the in-memory NodeStore). Returns the reloaded node view.
+func (n seededTaggedNode) reopen(t *testing.T) types.NodeView {
+	t.Helper()
+
+	require.NoError(t, n.s.Close())
+
+	s2, err := NewState(n.cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s2.Close() })
+
+	v, ok := s2.GetNodeByID(n.id)
+	require.True(t, ok, "node must reload from DB after restart")
+
+	return v
+}
+
+// reauth replays an interactive re-auth (OIDC/CLI) of the seeded tag-owned
+// machine as authUser, advertising requestTags. clientExpiry is the expiry the
+// tailscale client requests (nil for none); it must be ignored while the node
+// stays tagged.
+func (n seededTaggedNode) reauth(t *testing.T, authUser *types.User, requestTags []string, clientExpiry *time.Time) (types.NodeView, error) {
+	t.Helper()
+
+	// Sync the policy manager's user cache. Production keeps it current because
+	// State.CreateUser refreshes it on every user creation; the CreateUserForTest
+	// DB helper does not, so tests that create the authenticating user after
+	// NewState must sync before tag authorisation can resolve them as a tag owner.
+	require.NoError(t, n.s.UpdatePolicyManagerUsersForTest())
+
+	rd := *n.regData
+	rd.Hostinfo = &tailcfg.Hostinfo{
+		Hostname:    n.regData.Hostname,
+		RequestTags: requestTags,
+	}
+	rd.Expiry = clientExpiry
+
+	authID := types.MustAuthID()
+	n.s.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(&rd))
+
+	node, _, err := n.s.HandleNodeFromAuthPath(
+		authID,
+		types.UserID(authUser.ID),
+		nil,
+		util.RegisterMethodOIDC,
+	)
+
+	return node, err
+}
+
+// get re-reads the seeded node from the store.
+func (n seededTaggedNode) get(t *testing.T) types.NodeView {
+	t.Helper()
+
+	v, ok := n.s.GetNodeByID(n.id)
+	require.True(t, ok, "seeded node must still exist")
+
+	return v
+}
+
+// TestTaggedReauthAddTagAsOwner reproduces issue #3374 with the issue's own
+// scenario: a tag-owned node holding tag:tag1 re-authenticates with
+// --advertise-tags=tag:tag1,tag:tag2, and the authenticating user (ci-admin,
+// via group:ci) owns BOTH tags. Today headscale rejects the whole set as
+// "invalid or not permitted", leaving the re-keyed node logged out.
+//
+// This is stronger than re-advertising the already-held set: it exercises BOTH
+// authorization checks on the reauth path, which both ask "can this NODE have
+// the tag" instead of "can the authenticating USER apply it":
+//
+//  1. the pre-check validateRequestTags (state.go, before NodeStore.UpdateNode);
+//  2. the apply-time re-check inside processReauthTags (state.go), whose
+//     rejection return is discarded (`_ =`) on the assumption that the
+//     pre-check already passed.
+//
+// A fix that only addresses (1) makes the call return success while
+// processReauthTags silently drops the newly-requested tag — so this test
+// asserts on the resulting tag SET, not merely on the absence of an error.
+//
+// https://github.com/juanfont/headscale/issues/3374
+func TestTaggedReauthAddTagAsOwner(t *testing.T) {
+	n := seedTagOwnedNode(t, []string{"tag:tag1"}, "")
+
+	admin := n.s.CreateUserForTest("ci-admin")
+
+	// Mirror the issue's acl.json: group:ci = [ci-admin], and group:ci owns
+	// both tags. Ownership through a group is part of the reported scenario.
+	policy := fmt.Sprintf(
+		`{"groups":{"group:ci":["%s@"]},"tagOwners":{"tag:tag1":["group:ci"],"tag:tag2":["group:ci"]}}`,
+		admin.Name,
+	)
+	_, err := n.s.SetPolicy([]byte(policy))
+	require.NoError(t, err)
+
+	// Client requests an expiry; a node that stays tagged must ignore it.
+	clientExpiry := time.Now().Add(180 * 24 * time.Hour)
+	finalNode, err := n.reauth(t, admin, []string{"tag:tag1", "tag:tag2"}, &clientExpiry)
+	require.NoError(t, err,
+		"tag owner re-authenticating a tagged node with owned tags must be permitted (issue #3374)")
+	require.True(t, finalNode.Valid())
+	require.True(t, finalNode.IsTagged(), "node must remain tagged")
+
+	// The whole point of the re-auth: the node must actually carry both tags.
+	// A fix that only silences the pre-check leaves tag:tag2 dropped here.
+	require.ElementsMatch(t, []string{"tag:tag1", "tag:tag2"}, finalNode.Tags().AsSlice(),
+		"node must hold the full re-advertised owned tag set, not a silently truncated one")
+
+	// Tag ownership invariants matching the issue's DB dump (user_id None,
+	// expiry None): a tagged node stays user-less and never expires.
+	require.False(t, finalNode.User().Valid(), "tagged node must carry no user (user_id None)")
+	require.Nil(t, finalNode.AsStruct().Expiry,
+		"tagged node keeps nil key expiry; the client-requested expiry must be ignored")
+}
+
+// TestTaggedReauthSameTagAsOwner covers the issue's minimal claim: "at minimum,
+// a device should be able to re-authenticate with the same tag set it already
+// holds, which is also rejected today." Node is tag-owned (no user), tagger owns
+// the tag, re-auth re-advertises exactly the held tag.
+func TestTaggedReauthSameTagAsOwner(t *testing.T) {
+	n := seedTagOwnedNode(t, []string{"tag:foo"}, "")
+
+	tagger := n.s.CreateUserForTest("tagger")
+	_, err := n.s.SetPolicy(fmt.Appendf(nil, `{"tagOwners":{"tag:foo":["%s@"]}}`, tagger.Name))
+	require.NoError(t, err)
+
+	finalNode, err := n.reauth(t, tagger, []string{"tag:foo"}, nil)
+	require.NoError(t, err,
+		"tagged node re-advertising the same owned tag must be permitted (issue #3374)")
+	require.True(t, finalNode.IsTagged(), "node must remain tagged")
+	require.ElementsMatch(t, []string{"tag:foo"}, finalNode.Tags().AsSlice())
+	require.False(t, finalNode.User().Valid(), "tagged node must carry no user")
+	require.Nil(t, finalNode.AsStruct().Expiry, "tagged node keeps nil key expiry")
+}
+
+// TestTaggedReauthRemoveTagAsOwner is a P0 silent-data-loss guard: a tag-owned
+// node holding [tag:tag1, tag:tag2] re-auths advertising only [tag:tag1]. The
+// dropped tag must actually be removed. A fix that only relaxes the pre-check
+// leaves processReauthTags rejecting every tag, so the node silently retains
+// both — a success return with the wrong tag set.
+func TestTaggedReauthRemoveTagAsOwner(t *testing.T) {
+	n := seedTagOwnedNode(t, []string{"tag:tag1", "tag:tag2"}, "")
+
+	owner := n.s.CreateUserForTest("owner")
+	policy := fmt.Sprintf(
+		`{"tagOwners":{"tag:tag1":["%s@"],"tag:tag2":["%s@"]}}`,
+		owner.Name, owner.Name,
+	)
+	_, err := n.s.SetPolicy([]byte(policy))
+	require.NoError(t, err)
+
+	finalNode, err := n.reauth(t, owner, []string{"tag:tag1"}, nil)
+	require.NoError(t, err, "owner narrowing an owned tag set must be permitted")
+	require.True(t, finalNode.IsTagged(), "node still tagged (tag:tag1 remains)")
+	require.ElementsMatch(t, []string{"tag:tag1"}, finalNode.Tags().AsSlice(),
+		"tag:tag2 must be removed, not silently retained")
+	require.Nil(t, finalNode.AsStruct().Expiry, "tagged node keeps nil key expiry")
+	require.Equal(t, 1, n.s.ListNodes().Len(), "machine must map to exactly one node")
+}
+
+// TestTaggedReauthReplaceTagSetAsOwner is a P0 silent-data-loss guard: a
+// tag-owned node holding [tag:tag1] re-auths advertising an entirely different
+// owned tag [tag:tag2]. The node must end up on tag:tag2 only, not silently keep
+// tag:tag1.
+func TestTaggedReauthReplaceTagSetAsOwner(t *testing.T) {
+	n := seedTagOwnedNode(t, []string{"tag:tag1"}, "")
+
+	owner := n.s.CreateUserForTest("owner")
+	policy := fmt.Sprintf(
+		`{"tagOwners":{"tag:tag1":["%s@"],"tag:tag2":["%s@"]}}`,
+		owner.Name, owner.Name,
+	)
+	_, err := n.s.SetPolicy([]byte(policy))
+	require.NoError(t, err)
+
+	finalNode, err := n.reauth(t, owner, []string{"tag:tag2"}, nil)
+	require.NoError(t, err, "owner replacing one owned tag with another must be permitted")
+	require.True(t, finalNode.IsTagged())
+	require.ElementsMatch(t, []string{"tag:tag2"}, finalNode.Tags().AsSlice(),
+		"node must switch to tag:tag2 only, not silently keep tag:tag1")
+}
+
+// TestTaggedReauthAuthUserOwnsNotCreatedBy is the purest statement of the bug:
+// the node retains a created-by User who does NOT own the tag, while the
+// authenticating user DOES. Authorisation must key off the authenticating user,
+// so this must be permitted. (Before the fix, NodeCanHaveTag consults the
+// created-by user and rejects.)
+func TestTaggedReauthAuthUserOwnsNotCreatedBy(t *testing.T) {
+	n := seedTagOwnedNode(t, []string{"tag:foo"}, "creator")
+
+	admin := n.s.CreateUserForTest("admin")
+
+	// Only admin owns tag:foo; the created-by "creator" does not.
+	_, err := n.s.SetPolicy(fmt.Appendf(nil, `{"tagOwners":{"tag:foo":["%s@"]}}`, admin.Name))
+	require.NoError(t, err)
+
+	finalNode, err := n.reauth(t, admin, []string{"tag:foo"}, nil)
+	require.NoError(t, err,
+		"authorisation must key off the authenticating user, not the created-by user")
+	require.True(t, finalNode.IsTagged())
+	require.ElementsMatch(t, []string{"tag:foo"}, finalNode.Tags().AsSlice())
+}
+
+// TestTaggedReauthUntagReturnsToAuthUser covers tagged->user: re-auth with empty
+// RequestTags untags the node and returns ownership to the authenticating user,
+// with the client-requested expiry now applied (tagged nodes have no expiry;
+// user-owned nodes do). The untagging user need not own the tag.
+func TestTaggedReauthUntagReturnsToAuthUser(t *testing.T) {
+	n := seedTagOwnedNode(t, []string{"tag:foo"}, "")
+
+	alice := n.s.CreateUserForTest("alice")
+	// alice does not own tag:foo; untagging (empty RequestTags) is always allowed.
+	_, err := n.s.SetPolicy([]byte(`{"tagOwners":{"tag:foo":["someone-else@"]}}`))
+	require.NoError(t, err)
+
+	clientExpiry := time.Now().Add(90 * 24 * time.Hour)
+	finalNode, err := n.reauth(t, alice, []string{}, &clientExpiry)
+	require.NoError(t, err, "untagging via empty RequestTags must always be permitted")
+	require.False(t, finalNode.IsTagged(), "node must become user-owned")
+	require.Empty(t, finalNode.Tags().AsSlice())
+	require.True(t, finalNode.User().Valid(), "ownership returns to a user")
+	require.Equal(t, alice.ID, finalNode.User().ID(),
+		"ownership returns to the authenticating user")
+	require.NotNil(t, finalNode.AsStruct().Expiry,
+		"a now-user-owned node takes the client-requested expiry")
+}
+
+// TestTaggedReauthUntagClearsEphemeralAuthKey guards the interactive-path mirror
+// of the #3370 ephemeral bug: a node created by a tagged *ephemeral* pre-auth
+// key, then untagged via an interactive re-auth, must not keep the ephemeral key
+// reference. Otherwise it stays IsEphemeral() and is garbage-collected on its
+// next disconnect, silently deleting the user's just-claimed device — and the
+// stale reference survives a control-plane restart via the reloaded AuthKeyID.
+func TestTaggedReauthUntagClearsEphemeralAuthKey(t *testing.T) {
+	n := seedTagOwnedNode(t, []string{"tag:foo"}, "")
+
+	alice := n.s.CreateUserForTest("alice")
+	_, err := n.s.SetPolicy([]byte(`{"tagOwners":{"tag:foo":["someone-else@"]}}`))
+	require.NoError(t, err)
+
+	// Attach a tagged, ephemeral auth key to the seeded node (the shape a
+	// `tailscale up --authkey <ephemeral tagged key>` node has).
+	ephKey, err := n.s.CreatePreAuthKey(nil, false, true /*ephemeral*/, nil, []string{"tag:foo"})
+	require.NoError(t, err)
+	pak, err := n.s.GetPreAuthKeyByID(ephKey.ID)
+	require.NoError(t, err)
+
+	seeded, ok := n.s.nodeStore.UpdateNode(n.id, func(nd *types.Node) {
+		nd.AuthKey = pak
+		nd.AuthKeyID = &pak.ID
+	})
+	require.True(t, ok)
+	require.True(t, seeded.IsEphemeral(), "precondition: node is ephemeral (tagged ephemeral key)")
+
+	// Untag via interactive re-auth (empty RequestTags).
+	finalNode, err := n.reauth(t, alice, []string{}, nil)
+	require.NoError(t, err)
+	require.False(t, finalNode.IsTagged(), "node must become user-owned")
+	require.False(t, finalNode.IsEphemeral(),
+		"untagged node must not keep the ephemeral auth-key reference")
+	require.False(t, finalNode.AuthKeyID().Valid(),
+		"auth key reference must be cleared when a node is untagged")
+
+	// Confirm the cleared reference is PERSISTED, not just applied in memory:
+	// reload the State from the database and assert the node is still
+	// non-ephemeral. This is what fails if AuthKeyID is not written on the
+	// untag path — the node reloads as ephemeral and gets GC-deleted.
+	reloaded := n.reopen(t)
+	require.False(t, reloaded.IsEphemeral(),
+		"untagged node must remain non-ephemeral after a control-plane restart")
+	require.False(t, reloaded.AuthKeyID().Valid(),
+		"cleared auth key reference must persist across restart")
+}
+
+// TestTaggedReauthRejectsUnownedTag pins the security boundary: the fix
+// authorises the authenticating user, it must not skip authorisation. A tag the
+// authenticating user does not own is still rejected, and the node is left
+// byte-for-byte unchanged — same tags, same node key (NOT rotated), no user,
+// nil expiry — matching the issue's post-rejection DB/nodes-list state.
+func TestTaggedReauthRejectsUnownedTag(t *testing.T) {
+	n := seedTagOwnedNode(t, []string{"tag:foo"}, "")
+
+	tagger := n.s.CreateUserForTest("tagger")
+	other := n.s.CreateUserForTest("other")
+
+	// tagger owns tag:foo; tag:bar is owned by a different user.
+	policy := fmt.Sprintf(
+		`{"tagOwners":{"tag:foo":["%s@"],"tag:bar":["%s@"]}}`,
+		tagger.Name, other.Name,
+	)
+	_, err := n.s.SetPolicy([]byte(policy))
+	require.NoError(t, err)
+
+	before := n.get(t)
+	beforeKey := before.NodeKey()
+
+	_, err = n.reauth(t, tagger, []string{"tag:foo", "tag:bar"}, nil)
+	require.Error(t, err,
+		"a tag the authenticating user does not own must still be rejected")
+	require.ErrorIs(t, err, ErrRequestedTagsInvalidOrNotPermitted)
+
+	// The rejected re-auth must not have mutated the node. Validation runs before
+	// NodeStore.UpdateNode, so tags, ownership, expiry and the node key are all
+	// preserved (issue's nodes-list-after-failed-reauth still shows the old key).
+	after := n.get(t)
+	require.ElementsMatch(t, []string{"tag:foo"}, after.Tags().AsSlice(), "tags unchanged")
+	require.True(t, after.IsTagged())
+	require.False(t, after.User().Valid(), "still no user (user_id None)")
+	require.Nil(t, after.AsStruct().Expiry, "expiry unchanged")
+	require.Equal(t, beforeKey, after.NodeKey(),
+		"node key must not be rotated on a rejected re-auth")
+	require.Equal(t, 1, n.s.ListNodes().Len())
+}
+
+// TestTaggedReauthUndefinedTagRejected covers the distinct NodeCanHaveTag branch
+// where a requested tag is not defined in the policy at all (vs. defined but
+// owned by another user). The owned tag alone would pass; the undefined tag must
+// force rejection of the whole set.
+func TestTaggedReauthUndefinedTagRejected(t *testing.T) {
+	n := seedTagOwnedNode(t, []string{"tag:foo"}, "")
+
+	owner := n.s.CreateUserForTest("owner")
+	_, err := n.s.SetPolicy(fmt.Appendf(nil, `{"tagOwners":{"tag:foo":["%s@"]}}`, owner.Name))
+	require.NoError(t, err)
+
+	_, err = n.reauth(t, owner, []string{"tag:foo", "tag:undefined"}, nil)
+	require.Error(t, err, "a tag not defined in policy must be rejected")
+	require.ErrorIs(t, err, ErrRequestedTagsInvalidOrNotPermitted)
+
+	after := n.get(t)
+	require.ElementsMatch(t, []string{"tag:foo"}, after.Tags().AsSlice(), "node unchanged on rejection")
+}
+
+// TestTaggedReauthDuplicateTagsDeduped guards the slices.Compact in
+// processReauthTags: an owner re-advertising the same tag twice must succeed and
+// the node must hold a single copy.
+func TestTaggedReauthDuplicateTagsDeduped(t *testing.T) {
+	n := seedTagOwnedNode(t, []string{"tag:foo"}, "")
+
+	owner := n.s.CreateUserForTest("owner")
+	_, err := n.s.SetPolicy(fmt.Appendf(nil, `{"tagOwners":{"tag:foo":["%s@"]}}`, owner.Name))
+	require.NoError(t, err)
+
+	finalNode, err := n.reauth(t, owner, []string{"tag:foo", "tag:foo"}, nil)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"tag:foo"}, finalNode.Tags().AsSlice(),
+		"duplicate requested tags must be deduped to a single tag")
+}
+
+// TestTaggedReauthPreservesOnlineAndLastSeen pins the reauth side-effect
+// invariants documented at applyAuthNodeUpdate: online status is owned by the
+// poll lifecycle and must not be reset here, and LastSeen is refreshed.
+func TestTaggedReauthPreservesOnlineAndLastSeen(t *testing.T) {
+	n := seedTagOwnedNode(t, []string{"tag:foo"}, "")
+
+	owner := n.s.CreateUserForTest("owner")
+	_, err := n.s.SetPolicy(fmt.Appendf(nil, `{"tagOwners":{"tag:foo":["%s@"]}}`, owner.Name))
+	require.NoError(t, err)
+
+	// Mark the node online before reauth.
+	_, ok := n.s.nodeStore.UpdateNode(n.id, func(nd *types.Node) {
+		nd.IsOnline = new(true)
+	})
+	require.True(t, ok)
+
+	finalNode, err := n.reauth(t, owner, []string{"tag:foo"}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, finalNode.IsOnline().Get())
+	require.True(t, finalNode.IsOnline().Get(),
+		"re-auth must not reset online status (owned by the poll lifecycle)")
+	require.NotNil(t, finalNode.LastSeen().Get(), "LastSeen must be set on reauth")
+}
+
 // TestIssue3371_TaggedNodeInteractiveReloginAfterLogout reproduces the
 // interactive/OIDC arm of https://github.com/juanfont/headscale/issues/3371
 // ("With no key (interactive): the register URL is printed and the login never

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -2443,7 +2443,17 @@ func (s *State) HandleNodeFromPreAuthKey(
 	isOwnershipConversion := existsSameUser && existingNodeSameUser.Valid() &&
 		pak.IsTagged() && !existingNodeSameUser.IsTagged()
 
-	if isExistingNodeReregistering && !isNodeKeyRotation && !isExpired && !isOwnershipConversion {
+	// A tagged key that differs from the one the node last authed with retags
+	// the node (see the in-place update below). Applying a key's tags is an
+	// authorisation decision, so the key must be validated rather than ride the
+	// skip-validation fast-path; otherwise a spent, revoked or expired tagged
+	// key could still retag a node that reuses its node key. Like isExpired,
+	// this boundary must not depend on the client rotating its key.
+	isRetag := existsSameUser && existingNodeSameUser.Valid() &&
+		pak.IsTagged() && existingNodeSameUser.IsTagged() &&
+		(!existingNodeSameUser.AuthKeyID().Valid() || existingNodeSameUser.AuthKeyID().Get() != pak.ID)
+
+	if isExistingNodeReregistering && !isNodeKeyRotation && !isExpired && !isOwnershipConversion && !isRetag {
 		// Existing, still-valid node re-registering with same NodeKey: skip
 		// validation. Pre-auth keys are only needed for initial authentication.
 		// Critical for containers that run "tailscale up --authkey=KEY" on every
@@ -2491,8 +2501,10 @@ func (s *State) HandleNodeFromPreAuthKey(
 
 	var finalNode types.NodeView
 
-	// If this node exists for this user, update the node in place.
-	// Note: For tags-only keys (pak.User == nil), existsSameUser is always false.
+	// If this node exists for this user, update the node in place. For a
+	// tags-only key (pak.User == nil) this is true when the machine already has
+	// a tagged node (findExistingNodeForPAK matches it under UserID 0); for a
+	// user-owned key it is true when the same user already has the node.
 	if existsSameUser && existingNodeSameUser.Valid() {
 		log.Trace().
 			Caller().
@@ -2534,17 +2546,37 @@ func (s *State) HandleNodeFromPreAuthKey(
 
 			node.RegisterMethod = util.RegisterMethodAuthKey
 
-			// Tags from PreAuthKey are only applied during initial registration.
-			// On re-registration the node keeps its existing tags and ownership,
-			// except when a tagged key converts a user-owned node: that adopts
-			// the key's tags and drops user ownership (tagged nodes are
-			// user-less and never expire). Only update AuthKey reference
-			// otherwise.
-			if pak.IsTagged() && !node.IsTagged() {
+			// Tags from a PreAuthKey are applied on initial registration and
+			// re-applied whenever a *different* key is presented on
+			// re-registration: re-keying is Tailscale's documented way to change
+			// an auth-key device's tags (KB 1068 - "generate a new auth key with
+			// the new set of tags ... doing so replaces the device's existing
+			// tags"). Presenting the SAME key again (container restart,
+			// #2830/#3312) preserves the node's current tags and any admin
+			// override. A tagged key presented for a user-owned node also converts
+			// it, dropping user ownership.
+			//
+			// node.AuthKeyID still holds the prior key's ID here (it is reassigned
+			// below), and SetNodeTags leaves AuthKeyID intact, so an admin retag
+			// cannot masquerade as a new key.
+			keyChanged := node.AuthKeyID == nil || *node.AuthKeyID != pak.ID
+			if pak.IsTagged() && (!node.IsTagged() || keyChanged) {
+				wasUserOwned := !node.IsTagged()
+
 				node.Tags = pak.Tags
 				node.UserID = nil
 				node.User = nil
-				node.Expiry = nil
+
+				// Converting a user-owned node to tagged drops the user's key
+				// expiry (tagged nodes never expire). But retagging an
+				// already-tagged node must preserve a deliberate FUTURE expiry
+				// set via `headscale nodes expire` - that is a node property, not
+				// tied to the auth key - and only clear a stale PAST expiry. This
+				// keeps the retag path symmetric with the same-key relogin path
+				// (#3371) rather than silently overriding an admin decision.
+				if wasUserOwned || node.IsExpired() {
+					node.Expiry = nil
+				}
 			}
 
 			node.AuthKey = pak
@@ -2586,8 +2618,14 @@ func (s *State) HandleNodeFromPreAuthKey(
 
 		_, err = hsdb.Write(s.db.DB, func(tx *gorm.DB) (*types.Node, error) {
 			// Explicitly select all node columns so GORM includes nil/zero-value fields
-			// (see nodeUpdateColumns comment).
-			err := tx.Select(nodeUpdateColumns).Updates(updatedNodeView.AsStruct()).Error
+			// (see nodeUpdateColumns comment). AuthKeyID is normally excluded to
+			// avoid persisting a deleted key's stale reference on MapRequest
+			// (#2862), but re-registration presents a freshly-validated key, so
+			// its ID must be persisted here — otherwise a restart reloads the old
+			// key and any key-scoped property (e.g. Ephemeral) silently reverts.
+			reregColumns := append(slices.Clone(nodeUpdateColumns), "AuthKeyID")
+
+			err := tx.Select(reregColumns).Updates(updatedNodeView.AsStruct()).Error
 			if err != nil {
 				return nil, fmt.Errorf("saving node: %w", err)
 			}

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -1707,7 +1707,17 @@ func (s *State) applyAuthNodeUpdate(params authNodeUpdateParams) (types.NodeView
 	// Validate tags BEFORE calling [NodeStore.UpdateNode] to ensure we don't modify
 	// [NodeStore] if validation fails. This maintains consistency between [NodeStore]
 	// and database.
-	rejectedTags := s.validateRequestTags(params.ExistingNode, requestTags)
+	//
+	// A tag-owned node carries no user and its IP is not in any tag owner's set,
+	// so checking the node alone rejects every tag on re-auth (#3374). Authorise
+	// against the authenticating user too: they are the one presenting the
+	// credential and may own the requested tags.
+	var authUser types.UserView
+	if params.User != nil {
+		authUser = params.User.View()
+	}
+
+	rejectedTags := s.validateRequestTagsForReauth(params.ExistingNode, authUser, requestTags)
 	if len(rejectedTags) > 0 {
 		return types.NodeView{}, fmt.Errorf(
 			"%w %v are invalid or not permitted",
@@ -1829,8 +1839,21 @@ func (s *State) applyAuthNodeUpdate(params authNodeUpdateParams) (types.NodeView
 	// Persist to database.
 	// Explicitly select all node columns so GORM includes nil/zero-value fields
 	// (see nodeUpdateColumns comment).
+	//
+	// AuthKeyID is excluded from nodeUpdateColumns (#2862: never persist a
+	// possibly-deleted key's stale reference on the shared update path). But
+	// when a re-auth untags a node it clears AuthKeyID to nil (above), and that
+	// must persist or the node reloads as tagged/ephemeral after a restart and
+	// is garbage-collected. Writing NULL can never cause an FK error, so include
+	// the column only in that clearing case; the other transitions keep the
+	// #2862-safe column set untouched.
+	updateColumns := nodeUpdateColumns
+	if !updatedNodeView.AuthKeyID().Valid() {
+		updateColumns = append(slices.Clone(nodeUpdateColumns), "AuthKeyID")
+	}
+
 	_, err := hsdb.Write(s.db.DB, func(tx *gorm.DB) (*types.Node, error) {
-		err := tx.Select(nodeUpdateColumns).Updates(updatedNodeView.AsStruct()).Error
+		err := tx.Select(updateColumns).Updates(updatedNodeView.AsStruct()).Error
 		if err != nil {
 			return nil, fmt.Errorf("saving node: %w", err)
 		}
@@ -2034,6 +2057,34 @@ func (s *State) validateRequestTags(node types.NodeView, requestTags []string) [
 	return rejectedTags
 }
 
+// validateRequestTagsForReauth authorises re-auth request tags against the
+// existing node OR the authenticating user. A tag-owned node (#3374) has no
+// user and its IP is in no owner set, so NodeCanHaveTag alone rejects every
+// tag; the authenticating user who owns the tags must also be consulted.
+// Tags neither the node nor the user owns are still rejected, so this
+// authorises the user, it does not skip authorisation.
+func (s *State) validateRequestTagsForReauth(node types.NodeView, authUser types.UserView, requestTags []string) []string {
+	if len(requestTags) == 0 {
+		return nil
+	}
+
+	var rejectedTags []string
+
+	for _, tag := range requestTags {
+		if s.polMan.NodeCanHaveTag(node, tag) {
+			continue
+		}
+
+		if authUser.Valid() && s.polMan.UserCanHaveTag(authUser, tag) {
+			continue
+		}
+
+		rejectedTags = append(rejectedTags, tag)
+	}
+
+	return rejectedTags
+}
+
 // processReauthTags handles tag changes during node re-authentication.
 // It processes RequestTags from the client and updates node tags accordingly.
 // Returns rejected tags (if any) for post-validation error handling.
@@ -2068,16 +2119,34 @@ func (s *State) processReauthTags(
 			node.Tags = []string{}
 			node.UserID = &user.ID
 			node.User = user
+
+			// The node is no longer tagged, so it must not keep a reference to
+			// the tagged auth key. Leaving AuthKey set means a node created by a
+			// tagged+ephemeral key stays IsEphemeral() after converting to
+			// user-owned and is garbage-collected on its next disconnect,
+			// silently deleting the user's just-claimed device. Clearing the
+			// reference is persisted via the AuthKeyID column added to this
+			// path's write below.
+			node.AuthKey = nil
+			node.AuthKeyID = nil
 		}
 
 		return nil
 	}
 
-	// Non-empty RequestTags: validate and apply
+	// Non-empty RequestTags: validate and apply. Authorise each tag against the
+	// node OR the authenticating user, matching the pre-check in
+	// validateRequestTagsForReauth. Without the user half, a tag-owned node
+	// (#3374) has every tag rejected here even after the pre-check passed, so
+	// this returns the tags as rejected and the re-advertised tag is silently
+	// dropped despite a success response.
+	authUser := user.View()
+
 	var approvedTags, rejectedTags []string
 
 	for _, tag := range requestTags {
-		if s.polMan.NodeCanHaveTag(node.View(), tag) {
+		if s.polMan.NodeCanHaveTag(node.View(), tag) ||
+			(authUser.Valid() && s.polMan.UserCanHaveTag(authUser, tag)) {
 			approvedTags = append(approvedTags, tag)
 		} else {
 			rejectedTags = append(rejectedTags, tag)

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -1801,8 +1801,14 @@ func (s *State) applyAuthNodeUpdate(params authNodeUpdateParams) (types.NodeView
 			} else {
 				node.Expiry = regData.Expiry
 			}
+		case isTagged && node.IsExpired():
+			// Tagged → Tagged, but carrying a stale PAST expiry from an older
+			// headscale's logout stamp (#3371). Tagged nodes never expire, so
+			// clear it; a deliberate future expiry has IsExpired() == false and
+			// falls through to the no-op below.
+			node.Expiry = nil
 		}
-		// Tagged → Tagged: keep existing expiry (nil) - no action needed
+		// Tagged → Tagged with no stale expiry: keep existing expiry - no action.
 
 		// Apply default node expiry for non-tagged nodes when the
 		// resolved expiry is still nil or zero (e.g., CLI registration
@@ -2421,7 +2427,14 @@ func (s *State) HandleNodeFromPreAuthKey(
 	// must present a valid key. Without this a node that re-uses its NodeKey
 	// after expiry would skip validation and be re-authorised with a spent or
 	// expired key; the boundary must not depend on the client rotating its key.
+	//
+	// Tagged nodes are excluded: they never expire (KB 1068), so an
+	// IsExpired() tagged node only reflects a stale logout stamp left by an
+	// older headscale (#3371). Forcing it down the re-validation path burns its
+	// fresh key and blocks re-auth forever; treat it as a plain re-registration
+	// and clear the stale expiry in the update below.
 	isExpired := existsSameUser && existingNodeSameUser.Valid() &&
+		!existingNodeSameUser.IsTagged() &&
 		existingNodeSameUser.IsExpired()
 
 	// A tagged key presented for a currently user-owned node converts that node
@@ -2557,6 +2570,13 @@ func (s *State) HandleNodeFromPreAuthKey(
 				} else {
 					node.Expiry = nil
 				}
+			} else if node.IsExpired() {
+				// #3371: a tagged node must never carry key expiry. Clear a
+				// stale PAST expiry left by a logout (older headscale) so
+				// re-auth is not permanently blocked. A deliberate future
+				// expiry (headscale nodes expire) has IsExpired() == false and
+				// is left untouched.
+				node.Expiry = nil
 			}
 		})
 

--- a/integration/tags_test.go
+++ b/integration/tags_test.go
@@ -3203,3 +3203,202 @@ func TestTagsAuthKeyConvertToUserViaCLIRegister(t *testing.T) {
 		}
 	}, integrationutil.HAConvergeTimeout, 1*time.Second, "node should be user-owned after conversion via CLI register")
 }
+
+// TestTaggedNodeLogoutReloginSingleUseKeyOnline reproduces issue #3371
+// end-to-end with a real tailscale client: a tagged node registered with a
+// single-use key logs out (`tailscale logout`) and re-authenticates with a
+// FRESH single-use tagged key. Tagged nodes never expire (KB 1068), so logout
+// must not stamp an expiry; before the fix the node was left permanently
+// expired and the fresh key was consumed on a re-registration that still
+// reported NodeKeyExpired, locking the node out forever.
+//
+// The observable proof at the integration level is that after relogin the node
+// is back online with a NULL expiry and the same node ID — not stuck expired.
+//
+// https://github.com/juanfont/headscale/issues/3371
+func TestTaggedNodeLogoutReloginSingleUseKeyOnline(t *testing.T) {
+	IntegrationSkip(t)
+
+	spec := ScenarioSpec{
+		NodesPerUser: 0,
+		Users:        []string{tagTestUser},
+	}
+
+	scenario, err := NewScenario(spec)
+
+	require.NoError(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv(
+		[]tsic.Option{},
+		hsic.WithACLPolicy(tagsTestPolicy()),
+		hsic.WithTestName("tags-logout-single"),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	headscale, err := scenario.Headscale()
+	requireNoErrGetHeadscale(t, err)
+
+	userMap, err := headscale.MapUsers()
+	require.NoError(t, err)
+
+	userID := mustParseID(userMap[tagTestUser].Id)
+
+	// KEY1: single-use tag:valid-owned. Initial join.
+	key1, err := scenario.CreatePreAuthKeyWithTags(userID, false, false, []string{"tag:valid-owned"})
+	require.NoError(t, err)
+
+	client, err := scenario.CreateTailscaleNode(
+		"head",
+		tsic.WithNetwork(scenario.networks[scenario.testDefaultNetwork]),
+	)
+	require.NoError(t, err)
+
+	err = client.Login(headscale.GetEndpoint(), key1.Key)
+	require.NoError(t, err)
+
+	var initialNodeID uint64
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err := headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 1)
+
+		if len(nodes) == 1 {
+			initialNodeID = mustParseID(nodes[0].Id)
+			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
+			assert.Nil(c, nodes[0].Expiry, "tagged node must have no expiry")
+		}
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
+
+	// `tailscale logout`. A tagged node must not be expired by this.
+	err = client.Logout()
+	require.NoError(t, err)
+
+	err = client.WaitForNeedsLogin(integrationutil.ScaledTimeout(60 * time.Second))
+	require.NoError(t, err)
+
+	// The node must remain in the DB, tagged, and crucially NOT carry a
+	// stale expiry. This is the #3371 root cause (a) surface.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err := headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 1, "node must persist through logout")
+
+		if len(nodes) == 1 {
+			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
+			assert.Nil(c, nodes[0].Expiry, "#3371: logout must not stamp expiry on a tagged node")
+		}
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "tagged node must survive logout without expiry")
+
+	// KEY2: a FRESH single-use tagged key. Relogin.
+	key2, err := scenario.CreatePreAuthKeyWithTags(userID, false, false, []string{"tag:valid-owned"})
+	require.NoError(t, err)
+
+	err = client.Login(headscale.GetEndpoint(), key2.Key)
+	require.NoError(t, err,
+		"#3371: a fresh key must re-authenticate the tagged node after logout")
+
+	// Back online, same node, still tagged, still no expiry.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err := headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 1, "must not duplicate the node")
+
+		if len(nodes) == 1 {
+			assert.Equal(c, initialNodeID, mustParseID(nodes[0].Id), "node ID must be unchanged")
+			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
+			assert.Nil(c, nodes[0].Expiry, "#3371: tagged node must have no expiry after relogin")
+			assert.True(c, nodes[0].Online, "#3371: tagged node must be online after relogin, not stuck expired")
+		}
+	}, integrationutil.ScaledTimeout(60*time.Second), integrationutil.SlowPoll, "tagged node must come back online after relogin")
+
+	t.Logf("Test #3371 PASS: tagged node logged out and re-authenticated online with a fresh single-use key")
+}
+
+// TestTaggedNodeLogoutReloginReusableKeyOnline is the reusable-key variant of
+// issue #3371 (the "tailscale up hangs indefinitely" report). With a reusable
+// key the relogin does not hit "authkey already used", but before the fix the
+// node still stayed expired, so the client never observed a non-expired node.
+// The observable proof is the same: online with NULL expiry after relogin.
+//
+// https://github.com/juanfont/headscale/issues/3371
+func TestTaggedNodeLogoutReloginReusableKeyOnline(t *testing.T) {
+	IntegrationSkip(t)
+
+	spec := ScenarioSpec{
+		NodesPerUser: 0,
+		Users:        []string{tagTestUser},
+	}
+
+	scenario, err := NewScenario(spec)
+
+	require.NoError(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv(
+		[]tsic.Option{},
+		hsic.WithACLPolicy(tagsTestPolicy()),
+		hsic.WithTestName("tags-logout-reuse"),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	headscale, err := scenario.Headscale()
+	requireNoErrGetHeadscale(t, err)
+
+	userMap, err := headscale.MapUsers()
+	require.NoError(t, err)
+
+	userID := mustParseID(userMap[tagTestUser].Id)
+
+	// A single REUSABLE tag:valid-owned key used for both login and relogin.
+	key, err := scenario.CreatePreAuthKeyWithTags(userID, true, false, []string{"tag:valid-owned"})
+	require.NoError(t, err)
+
+	client, err := scenario.CreateTailscaleNode(
+		"head",
+		tsic.WithNetwork(scenario.networks[scenario.testDefaultNetwork]),
+	)
+	require.NoError(t, err)
+
+	err = client.Login(headscale.GetEndpoint(), key.Key)
+	require.NoError(t, err)
+
+	var initialNodeID uint64
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err := headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 1)
+
+		if len(nodes) == 1 {
+			initialNodeID = mustParseID(nodes[0].Id)
+			assert.Nil(c, nodes[0].Expiry, "tagged node must have no expiry")
+		}
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
+
+	err = client.Logout()
+	require.NoError(t, err)
+
+	err = client.WaitForNeedsLogin(integrationutil.ScaledTimeout(60 * time.Second))
+	require.NoError(t, err)
+
+	// Relogin with the SAME reusable key.
+	err = client.Login(headscale.GetEndpoint(), key.Key)
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err := headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 1, "must not duplicate the node")
+
+		if len(nodes) == 1 {
+			assert.Equal(c, initialNodeID, mustParseID(nodes[0].Id), "node ID must be unchanged")
+			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
+			assert.Nil(c, nodes[0].Expiry, "#3371: tagged node must have no expiry after reusable-key relogin")
+			assert.True(c, nodes[0].Online, "#3371: tagged node must be online after reusable-key relogin")
+		}
+	}, integrationutil.ScaledTimeout(60*time.Second), integrationutil.SlowPoll, "tagged node must come back online after reusable-key relogin")
+
+	t.Logf("Test #3371 PASS: tagged node logged out and re-authenticated online with a reusable key")
+}

--- a/integration/tags_test.go
+++ b/integration/tags_test.go
@@ -579,6 +579,213 @@ func TestTagsAuthKeyWithTagAdminOverrideReauthPreserves(t *testing.T) {
 	t.Logf("Test 2.5 PASS: Admin tags preserved through reauth (admin decisions are authoritative)")
 }
 
+// TestTagsReauthDifferentKeyRetagsNode reproduces issue #3370 end-to-end with a
+// real tailscale client: a node registered with a single-use tag:valid-owned
+// key is re-authenticated via `tailscale up --force-reauth` with a *fresh*
+// single-use tag:second key. Tailscale's documented behaviour (KB 1068) is that
+// re-keying replaces the device's tags, verified by the reporter against SaaS on
+// the same node/IP. Before the fix headscale consumes the new key but keeps the
+// old tag; after the fix the node retags in place.
+//
+// Unlike Test 2.5 (same reusable key + admin override -> tags preserved), this
+// presents a *different* key, so it exercises the opposite arm of the retag
+// discriminator. It also asserts what a state-unit test cannot: the new tag
+// propagates to the node's own Self view and netmap, and the node ID and IPs are
+// unchanged.
+//
+// https://github.com/juanfont/headscale/issues/3370
+func TestTagsReauthDifferentKeyRetagsNode(t *testing.T) {
+	IntegrationSkip(t)
+
+	spec := ScenarioSpec{
+		NodesPerUser: 0,
+		Users:        []string{tagTestUser},
+	}
+
+	scenario, err := NewScenario(spec)
+
+	require.NoError(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv(
+		[]tsic.Option{},
+		hsic.WithACLPolicy(tagsTestPolicy()),
+		hsic.WithTestName("tags-rekey-retag"),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	headscale, err := scenario.Headscale()
+	requireNoErrGetHeadscale(t, err)
+
+	userMap, err := headscale.MapUsers()
+	require.NoError(t, err)
+
+	userID := mustParseID(userMap[tagTestUser].Id)
+
+	// KEY1: single-use tag:valid-owned.
+	key1, err := scenario.CreatePreAuthKeyWithTags(userID, false, false, []string{"tag:valid-owned"})
+	require.NoError(t, err)
+
+	client, err := scenario.CreateTailscaleNode(
+		"head",
+		tsic.WithNetwork(scenario.networks[scenario.testDefaultNetwork]),
+	)
+	require.NoError(t, err)
+
+	err = client.Login(headscale.GetEndpoint(), key1.Key)
+	require.NoError(t, err)
+
+	var (
+		initialNodeID uint64
+		initialIPs    []string
+	)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err := headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 1)
+
+		if len(nodes) == 1 {
+			initialNodeID = mustParseID(nodes[0].Id)
+			initialIPs = nodes[0].IpAddresses
+			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
+		}
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
+
+	t.Logf("Step 1: node %d registered with tag:valid-owned, IPs %v", initialNodeID, initialIPs)
+
+	// KEY2: fresh single-use tag:second. Re-key via --force-reauth.
+	key2, err := scenario.CreatePreAuthKeyWithTags(userID, false, false, []string{"tag:second"})
+	require.NoError(t, err)
+
+	//nolint:errcheck // result is verified via EventuallyWithT below
+	client.Execute([]string{
+		"tailscale", "up",
+		"--login-server=" + headscale.GetEndpoint(),
+		"--hostname=" + client.Hostname(),
+		"--authkey=" + key2.Key,
+		"--force-reauth",
+	})
+
+	// Server-side: node retagged in place, same node ID and IPs, no duplicate.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err := headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 1, "must not duplicate the node")
+
+		if len(nodes) == 1 {
+			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:second"})
+			assert.Equal(c, initialNodeID, mustParseID(nodes[0].Id), "node ID must be unchanged")
+			assert.ElementsMatch(c, initialIPs, nodes[0].IpAddresses, "IPs must be preserved")
+		}
+	}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.SlowPoll, "server must reflect the retag")
+
+	// Node self view: the new tag propagates to the client (issue #2978 surface).
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:second"})
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "node self view must reflect the retag")
+
+	// Netmap: independent serialization surface.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assertNetmapSelfHasTagsWithCollect(c, client, []string{"tag:second"})
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "netmap self must reflect the retag")
+
+	t.Logf("Test #3370 PASS: re-keying with a different tagged key retagged the node in place")
+}
+
+// TestTagsReauthDifferentKeyRemovesTag is the sharpest proof of the KB 1068
+// "replaces, not merges" rule at the integration level: a node registered with
+// a two-tag key is re-keyed with a single-tag key, and the second tag must be
+// *removed*, not retained. Tag removal is the highest-risk propagation path
+// (peers must stop seeing the removed tag), so it is worth a real-client test.
+//
+// https://github.com/juanfont/headscale/issues/3370
+func TestTagsReauthDifferentKeyRemovesTag(t *testing.T) {
+	IntegrationSkip(t)
+
+	spec := ScenarioSpec{
+		NodesPerUser: 0,
+		Users:        []string{tagTestUser},
+	}
+
+	scenario, err := NewScenario(spec)
+
+	require.NoError(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv(
+		[]tsic.Option{},
+		hsic.WithACLPolicy(tagsTestPolicy()),
+		hsic.WithTestName("tags-rekey-remove"),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	headscale, err := scenario.Headscale()
+	requireNoErrGetHeadscale(t, err)
+
+	userMap, err := headscale.MapUsers()
+	require.NoError(t, err)
+
+	userID := mustParseID(userMap[tagTestUser].Id)
+
+	// KEY1: single-use with BOTH tags.
+	key1, err := scenario.CreatePreAuthKeyWithTags(userID, false, false, []string{"tag:valid-owned", "tag:second"})
+	require.NoError(t, err)
+
+	client, err := scenario.CreateTailscaleNode(
+		"head",
+		tsic.WithNetwork(scenario.networks[scenario.testDefaultNetwork]),
+	)
+	require.NoError(t, err)
+
+	err = client.Login(headscale.GetEndpoint(), key1.Key)
+	require.NoError(t, err)
+
+	var initialNodeID uint64
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err := headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 1)
+
+		if len(nodes) == 1 {
+			initialNodeID = mustParseID(nodes[0].Id)
+			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:second", "tag:valid-owned"})
+		}
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial registration")
+
+	// KEY2: fresh single-use with ONLY tag:valid-owned. Re-key.
+	key2, err := scenario.CreatePreAuthKeyWithTags(userID, false, false, []string{"tag:valid-owned"})
+	require.NoError(t, err)
+
+	//nolint:errcheck // result is verified via EventuallyWithT below
+	client.Execute([]string{
+		"tailscale", "up",
+		"--login-server=" + headscale.GetEndpoint(),
+		"--hostname=" + client.Hostname(),
+		"--authkey=" + key2.Key,
+		"--force-reauth",
+	})
+
+	// tag:second must be gone on every surface.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err := headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 1)
+
+		if len(nodes) == 1 {
+			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
+			assert.Equal(c, initialNodeID, mustParseID(nodes[0].Id))
+		}
+	}, integrationutil.ScaledTimeout(20*time.Second), integrationutil.SlowPoll, "re-keying must replace (remove tag:second), not merge")
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assertNodeSelfHasTagsWithCollect(c, client, []string{"tag:valid-owned"})
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "removed tag must clear from node self view")
+
+	t.Logf("Test #3370 PASS: re-keying replaced the tag set (tag:second removed)")
+}
+
 // TestTagsAuthKeyWithTagCLICannotModifyAdminTags tests that the client CLI
 // cannot modify admin-assigned tags.
 //

--- a/integration/tags_test.go
+++ b/integration/tags_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juanfont/headscale/integration/hsic"
 	"github.com/juanfont/headscale/integration/integrationutil"
 	"github.com/juanfont/headscale/integration/tsic"
+	"github.com/oauth2-proxy/mockoidc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"tailscale.com/tailcfg"
@@ -3608,4 +3609,251 @@ func TestTaggedNodeLogoutReloginReusableKeyOnline(t *testing.T) {
 	}, integrationutil.ScaledTimeout(60*time.Second), integrationutil.SlowPoll, "tagged node must come back online after reusable-key relogin")
 
 	t.Logf("Test #3371 PASS: tagged node logged out and re-authenticated online with a reusable key")
+}
+
+// TestTagsOIDCReauthAddOwnedTag reproduces issue #3374 through the interactive
+// OIDC path with a real client. A node is registered tag-owned (no user) via
+// --advertise-tags, then re-authenticates via OIDC advertising an ADDITIONAL
+// owned tag. Because a tag-owned node has no user and its IP is in no owner
+// set, the pre-fix authorization (which asked only "can this NODE have the
+// tag") rejected the whole set, leaving the node logged out. The fix also
+// authorises against the authenticating user, so the added owned tag is
+// accepted.
+//
+// This is the OIDC/interactive twin of the #3370 PAK-path retag tests, and it
+// hard-asserts the resulting tag SET (the pre-existing web-auth add-tag test
+// only logs), so it catches the silent-drop where the pre-check passes but the
+// apply-time re-check in processReauthTags still rejects.
+//
+// https://github.com/juanfont/headscale/issues/3374
+func TestTagsOIDCReauthAddOwnedTag(t *testing.T) {
+	IntegrationSkip(t)
+
+	oidcUser := "oidcuser"
+
+	// Each OIDC login consumes one mock user, so the same identity must be
+	// listed twice: once for the initial login and once for the reauth.
+	spec := ScenarioSpec{
+		NodesPerUser: 0,
+		OIDCUsers: []mockoidc.MockUser{
+			oidcMockUser(oidcUser, true),
+			oidcMockUser(oidcUser, true),
+		},
+	}
+
+	scenario, err := NewScenario(spec)
+
+	require.NoError(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	oidcMap := map[string]string{
+		"HEADSCALE_OIDC_ISSUER":             scenario.mockOIDC.Issuer(),
+		"HEADSCALE_OIDC_CLIENT_ID":          scenario.mockOIDC.ClientID(),
+		"CREDENTIALS_DIRECTORY_TEST":        "/tmp",
+		"HEADSCALE_OIDC_CLIENT_SECRET_PATH": "${CREDENTIALS_DIRECTORY_TEST}/hs_client_oidc_secret",
+	}
+
+	// The OIDC user owns both tags. Ownership is what authorises the reauth tag
+	// change once the node is tag-owned. Reference the user by email; it already
+	// contains an "@", so no trailing "@" is added (that suffix is only for
+	// non-email usernames).
+	owner := new(policyv2.Username(oidcUser + "@headscale.net"))
+	policy := &policyv2.Policy{
+		TagOwners: policyv2.TagOwners{
+			"tag:valid-owned": policyv2.Owners{owner},
+			"tag:second":      policyv2.Owners{owner},
+		},
+		ACLs: []policyv2.ACL{
+			{
+				Action:       "accept",
+				Sources:      []policyv2.Alias{policyv2.Wildcard},
+				Destinations: []policyv2.AliasWithPorts{{Alias: policyv2.Wildcard, Ports: []tailcfg.PortRange{tailcfg.PortRangeAny}}},
+			},
+		},
+	}
+
+	err = scenario.CreateHeadscaleEnvWithLoginURL(
+		[]tsic.Option{
+			tsic.WithExtraLoginArgs([]string{"--advertise-tags=tag:valid-owned"}),
+		},
+		hsic.WithTestName("tags-oidc-addtag"),
+		hsic.WithConfigEnv(oidcMap),
+		hsic.WithFileInContainer("/tmp/hs_client_oidc_secret", []byte(scenario.mockOIDC.ClientSecret())),
+		hsic.WithACLPolicy(policy),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	headscale, err := scenario.Headscale()
+	requireNoErrGetHeadscale(t, err)
+
+	client, err := scenario.CreateTailscaleNode(
+		"unstable",
+		tsic.WithNetwork(scenario.networks[scenario.testDefaultNetwork]),
+		tsic.WithExtraLoginArgs([]string{"--advertise-tags=tag:valid-owned"}),
+	)
+	require.NoError(t, err)
+
+	// Initial OIDC login advertising tag:valid-owned.
+	u, err := client.LoginWithURL(headscale.GetEndpoint())
+	require.NoError(t, err)
+
+	_, err = doLoginURL(client.Hostname(), u)
+	require.NoError(t, err)
+
+	var initialNodeID uint64
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err := headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 1)
+
+		if len(nodes) == 1 {
+			initialNodeID = mustParseID(nodes[0].Id)
+			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
+		}
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial tag-owned registration")
+
+	// Re-authenticate advertising an ADDITIONAL owned tag via --force-reauth,
+	// which drives the register/auth path (HandleNodeFromAuthPath), not a poll.
+	// Parse the login URL from this command's own output; issuing a separate
+	// `tailscale up` while a reauth is pending errors server-side.
+	command := []string{
+		"tailscale", "up",
+		"--login-server=" + headscale.GetEndpoint(),
+		"--hostname=" + client.Hostname(),
+		"--advertise-tags=tag:valid-owned,tag:second",
+		"--force-reauth",
+	}
+
+	stdout, stderr, _ := client.Execute(command)
+	t.Logf("reauth command output: stdout=%s stderr=%s", stdout, stderr)
+
+	loginURL, err := util.ParseLoginURLFromCLILogin(stdout + stderr)
+	require.NoError(t, err, "failed to parse login URL from reauth command")
+
+	_, err = doLoginURL(client.Hostname(), loginURL)
+	require.NoError(t, err)
+
+	// Both tags must be present — not rejected, not silently dropped.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err := headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 1, "must not duplicate the node")
+
+		if len(nodes) == 1 {
+			assert.Equal(c, initialNodeID, mustParseID(nodes[0].Id), "node ID must be unchanged")
+			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned", "tag:second"})
+		}
+	}, integrationutil.ScaledTimeout(30*time.Second), integrationutil.SlowPoll, "#3374: added owned tag must be accepted on OIDC reauth")
+
+	t.Logf("Test #3374 PASS: OIDC reauth added an owned tag to a tag-owned node")
+}
+
+// TestTagsReauthEmptyTagsReturnsToUserSurvives covers the #3374 untag path with
+// a real client: a tag-owned node created by a tagged+ephemeral key
+// re-authenticates via user login with an EMPTY tag set. It must return to the
+// user, and — crucially — survive: clearing the tags must also clear the
+// node's reference to the ephemeral auth key, or the node stays IsEphemeral()
+// and is garbage-collected on its next disconnect, silently deleting the
+// user's just-claimed device.
+//
+// https://github.com/juanfont/headscale/issues/3374
+func TestTagsReauthEmptyTagsReturnsToUserSurvives(t *testing.T) {
+	IntegrationSkip(t)
+
+	spec := ScenarioSpec{
+		NodesPerUser: 0,
+		Users:        []string{tagTestUser},
+	}
+
+	scenario, err := NewScenario(spec)
+
+	require.NoError(t, err)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnvWithLoginURL(
+		[]tsic.Option{},
+		hsic.WithACLPolicy(tagsTestPolicy()),
+		hsic.WithTestName("tags-untag-survive"),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	headscale, err := scenario.Headscale()
+	requireNoErrGetHeadscale(t, err)
+
+	userMap, err := headscale.MapUsers()
+	require.NoError(t, err)
+
+	userID := mustParseID(userMap[tagTestUser].Id)
+
+	// A tagged + EPHEMERAL key: the node is tag-owned and ephemeral.
+	key, err := scenario.CreatePreAuthKeyWithTags(userID, false, true, []string{"tag:valid-owned"})
+	require.NoError(t, err)
+
+	client, err := scenario.CreateTailscaleNode(
+		"head",
+		tsic.WithNetwork(scenario.networks[scenario.testDefaultNetwork]),
+	)
+	require.NoError(t, err)
+
+	err = client.Login(headscale.GetEndpoint(), key.Key)
+	require.NoError(t, err)
+
+	err = client.WaitForRunning(integrationutil.PeerSyncTimeout())
+	require.NoError(t, err)
+
+	var initialNodeID uint64
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err := headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 1)
+
+		if len(nodes) == 1 {
+			initialNodeID = mustParseID(nodes[0].Id)
+			assertNodeHasTagsWithCollect(c, nodes[0], []string{"tag:valid-owned"})
+		}
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll, "waiting for initial tag-owned ephemeral registration")
+
+	// Re-authenticate with an EMPTY tag set via --force-reauth. An
+	// already-authenticated node only emits a fresh login URL when forced, so
+	// parse the URL from this command's own output rather than issuing a
+	// second `tailscale up` (which would error with "no URL found").
+	command := []string{
+		"tailscale", "up",
+		"--login-server=" + headscale.GetEndpoint(),
+		"--hostname=" + client.Hostname(),
+		"--advertise-tags=",
+		"--force-reauth",
+	}
+
+	stdout, stderr, _ := client.Execute(command)
+	t.Logf("reauth command output: stdout=%s stderr=%s", stdout, stderr)
+
+	loginURL, err := util.ParseLoginURLFromCLILogin(stdout + stderr)
+	require.NoError(t, err, "failed to parse login URL from reauth command")
+
+	body, err := doLoginURL(client.Hostname(), loginURL)
+	require.NoError(t, err)
+
+	// CLI user-login registration untags the node and returns it to the user.
+	err = scenario.runHeadscaleRegister(tagTestUser, body)
+	require.NoError(t, err)
+
+	// Node returns to the user, keeps its ID, and does NOT vanish.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		nodes, err := headscale.ListNodes()
+		assert.NoError(c, err)
+		assert.Len(c, nodes, 1, "#3374: untagged node must survive, not be GC'd as ephemeral")
+
+		if len(nodes) == 1 {
+			assert.Equal(c, initialNodeID, mustParseID(nodes[0].Id), "node ID must be unchanged")
+			assert.Empty(c, nodes[0].Tags, "#3374: node must have no tags after untag")
+			// A user-owned node reports its real user; a tagged node would
+			// report the special "tagged-devices" user instead.
+			assert.Equal(c, tagTestUser, nodes[0].User.Name, "#3374: untagged node must return to the authenticating user")
+		}
+	}, integrationutil.ScaledTimeout(30*time.Second), integrationutil.SlowPoll, "#3374: empty-tags reauth returns node to user and it survives")
+
+	t.Logf("Test #3374 PASS: empty-tags reauth returned the ephemeral tag-owned node to its user and it survived")
 }


### PR DESCRIPTION
This PR takes a stab at fixing several issues discovered by @fredrikekre when it comes to auth key authentication in 0.29. 

Updates https://github.com/juanfont/headscale/issues/3374
Updates https://github.com/juanfont/headscale/issues/3370
Updates https://github.com/juanfont/headscale/issues/3371
Closes https://github.com/juanfont/headscale/pull/3381
Closes https://github.com/juanfont/headscale/pull/3372