### PR TITLE
docs: restore Sealos community installation guide

### DIFF
--- a/docs/setup/install/sealos.md
+++ b/docs/setup/install/sealos.md
@@ -1,0 +1,70 @@
+# Sealos
+
+!!! warning "Community documentation"
+
+    This page is maintained by the Sealos templates community and is not
+    verified by headscale developers. Report deployment-specific issues in the
+    [Sealos templates repository](https://github.com/labring-actions/templates/issues).
+    Confirm that the template uses a supported headscale release before
+    production use.
+
+The community-maintained Sealos template deploys headscale and
+[Headplane](https://github.com/tale/headplane) on Kubernetes. It configures
+persistent storage, TLS-enabled endpoints, and SQLite by default. PostgreSQL is
+available as a deployment option.
+
+[![Deploy on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/headscale)
+
+## Deploy
+
+1. Open the Sealos template and select **Deploy Now**.
+1. Keep SQLite for the default deployment, or enable PostgreSQL to provision a
+   dedicated database.
+1. Wait for the headscale and Headplane containers to become ready.
+1. Open the application URL. The root path redirects to Headplane at `/admin/`.
+
+The template also creates a separate TLS endpoint for the headscale gRPC API.
+
+## Sign in and register a node
+
+Create a headscale API key from the headscale container:
+
+```shell
+headscale apikeys create
+```
+
+Paste the key into the Headplane sign-in page. In Headplane, create a user and
+then create a pre-authentication key for that user.
+
+Connect a node with the public application URL and the pre-authentication key:
+
+```shell
+tailscale up \
+  --login-server=https://<HEADSCALE_DOMAIN> \
+  --authkey=<PRE_AUTH_KEY>
+```
+
+Continue with the [getting started guide](../../usage/getting-started.md) for
+the standard headscale registration workflow.
+
+## Persistence and database
+
+The template persists these paths:
+
+| Path                 | Contents                                 |
+| -------------------- | ---------------------------------------- |
+| `/var/lib/headscale` | SQLite database, keys, and runtime state |
+| `/etc/headscale`     | Headscale configuration                  |
+| `/var/lib/headplane` | Headplane state                          |
+
+When PostgreSQL is enabled, Sealos provisions a dedicated database and injects
+its credentials from a Kubernetes Secret. The headscale configuration and keys
+remain on persistent volumes.
+
+## Updating
+
+Review the template's
+[deployment notes](https://github.com/labring-actions/templates/tree/kb-0.9/template/headscale)
+for its currently tested headscale and Headplane versions. Before changing the
+headscale image version, back up the database and persistent volumes and follow
+the [upgrade guide](../upgrade.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -172,6 +172,7 @@ nav:
           - Official releases: setup/install/official.md
           - Community packages: setup/install/community.md
           - Container: setup/install/container.md
+          - Sealos (community): setup/install/sealos.md
           - Build from source: setup/install/source.md
           - Development builds: setup/install/main.md
       - Upgrade: setup/upgrade.md


### PR DESCRIPTION
> **Dependency:** The live-validated template update is tracked in https://github.com/labring-actions/templates/pull/731. This pull request remains a draft until that change is merged and the published template is verified.

## Context

The original Sealos guide was merged in #1666 and removed in #2292 because the
available template was still pinned to an old 0.23 beta release.

The community template has now been rebuilt and live-validated with Headscale
0.29.2 and Headplane 0.7.0. This PR restores a version-neutral community guide
with an explicit maintenance and support boundary.

## Changes

- add `docs/setup/install/sealos.md`
- add one installation navigation entry in `mkdocs.yml`
- document API-key login, node registration, persistence, SQLite, optional
  PostgreSQL, and upgrade handling
- direct deployment-specific issues to the Sealos templates repository

## Validation

- Sealos template: https://sealos.io/products/app-store/headscale
- Template source: https://github.com/labring-actions/templates/tree/kb-0.9/template/headscale
- Tested deployment: 2026-07-24
- Headscale: 0.29.2
- Headplane: 0.7.0
- Verified: Headplane API-key login, user and pre-auth key creation, node
  registration flow, SQLite persistence, PostgreSQL persistence, and config
  recovery
- Persistence: `/var/lib/headscale`, `/etc/headscale`, and `/var/lib/headplane`
- Documentation build: `mkdocs build --strict`

## Maintenance

I can help maintain this community deployment path and follow up when supported
Headscale versions, Headplane integration, or Sealos template behavior change.

- [x] have read the `CONTRIBUTING.md` file
- [ ] raised a GitHub issue or discussed it beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation
- [ ] updated `CHANGELOG.md`