### PR TITLE
cli: remove leftover trace log from #3324 that always renders a JSON marshaling error

### DIFF
--- a/cmd/headscale/cli/users.go
+++ b/cmd/headscale/cli/users.go
@@ -118,8 +118,6 @@ var createUserCmd = &cobra.Command{
 	RunE: clientRunE(func(ctx context.Context, client *clientv1.ClientWithResponses, cmd *cobra.Command, args []string) error {
 		userName := args[0]
 
-		log.Trace().Interface(zf.Client, client).Msg("obtained API client")
-
 		request := clientv1.CreateUserJSONRequestBody{Name: &userName}
 
 		if displayName, _ := cmd.Flags().GetString("display-name"); displayName != "" {


### PR DESCRIPTION
Noticed this while testing out #3394.
