### PR TITLE
Makefile: enable CGO for `make test` in dev shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build: check-deps $(GO_SOURCES) go.mod go.sum
 .PHONY: test
 test: check-deps $(GO_SOURCES) go.mod go.sum
 	@echo "Running Go tests..."
-	go test -race ./...
+	CGO_ENABLED=1 go test -race ./...
 
 
 # Formatting targets


### PR DESCRIPTION
Fixes #3401

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [X] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [X] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

### Testing

```console
sfllaw@h2co3:~/Projects/headscale/make-test-with-cgo-enabled$ nix develop
sfllaw@h2co3:~/Projects/headscale/make-test-with-cgo-enabled$ echo $CGO_ENABLED
0
sfllaw@h2co3:~/Projects/headscale/make-test-with-cgo-enabled$ make test
Running Go tests...
CGO_ENABLED=1 go test -race ./...
?   	github.com/juanfont/headscale/cmd/dev	[no test files]
?   	github.com/juanfont/headscale/cmd/gen-openapi	[no test files]
ok  	github.com/juanfont/headscale/cmd/headscale	1.053s
```
