### PR TITLE
ci: add source metadata to container images

### DIFF
--- a/.github/workflows/container-main.yml
+++ b/.github/workflows/container-main.yml
@@ -58,6 +58,8 @@ jobs:
         run: |
           ko build \
             --bare \
+            --image-annotation=org.opencontainers.image.source=https://github.com/juanfont/headscale \
+            --image-label=org.opencontainers.image.source=https://github.com/juanfont/headscale \
             --platform=linux/amd64,linux/arm64 \
             --tags=main-${GITHUB_SHA::7},development \
             ./cmd/headscale
@@ -70,6 +72,8 @@ jobs:
         run: |
           ko build \
             --bare \
+            --image-annotation=org.opencontainers.image.source=https://github.com/juanfont/headscale \
+            --image-label=org.opencontainers.image.source=https://github.com/juanfont/headscale \
             --platform=linux/amd64,linux/arm64 \
             --tags=main-${GITHUB_SHA::7},development \
             ./cmd/headscale

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -102,6 +102,10 @@ kos:
     # for tagging and naming the container.
     bare: true
     base_image: gcr.io/distroless/base-debian13
+    labels:
+      org.opencontainers.image.source: https://github.com/juanfont/headscale
+    annotations:
+      org.opencontainers.image.source: https://github.com/juanfont/headscale
     build: headscale
     main: ./cmd/headscale
     env:
@@ -131,6 +135,10 @@ kos:
 
     bare: true
     base_image: gcr.io/distroless/base-debian13:debug
+    labels:
+      org.opencontainers.image.source: https://github.com/juanfont/headscale
+    annotations:
+      org.opencontainers.image.source: https://github.com/juanfont/headscale
     build: headscale
     main: ./cmd/headscale
     env:


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->

Well, the nature of the problem is very simple: Renovate associates changes to the `headscale/headscale` container as linked to [GoogleContainerTools/distroless](https://github.com/GoogleContainerTools/distroless), because of inheritance.

The solution is to explicitly use [org.opencontainers](https://github.com/opencontainers/image-spec/blob/main/annotations.md) annotations to overwrite this.

Relevant Renovate docs: https://docs.renovatebot.com/modules/datasource/docker/

<img width="1942" height="1004" alt="image" src="https://github.com/user-attachments/assets/fd0447e8-644e-4bf3-8a53-6b9c2b8d55d6" />
