### PR TITLE
state,change,mapper: report LastSeen for online peers per tailcfg protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ keys remain all-access.
 - Fix `headscale users rename` sending the raw `--identifier` flag value instead of the matched user's identifier, so renaming by name works again [#3442](https://github.com/juanfont/headscale/pull/3442)
 - Fix tailsql not shutting down with headscale, leaving the process hanging on graceful shutdown [#3400](https://github.com/juanfont/headscale/pull/3400)
 - Fix tvOS setup instructions: install the VPN configuration before setting the coordination server URL [#3431](https://github.com/juanfont/headscale/pull/3431)
+- The peer patches sent when a node connects or disconnects now carry `LastSeen`, so clients learn when a peer was last seen without waiting for a full map [#3420](https://github.com/juanfont/headscale/pull/3420)
 
 ## 0.29.3 (2026-07-29)
 

--- a/hscontrol/mapper/batcher_test.go
+++ b/hscontrol/mapper/batcher_test.go
@@ -66,7 +66,7 @@ func (t *testBatcherWrapper) AddNode(id types.NodeID, c chan<- *tailcfg.MapRespo
 		return fmt.Errorf("%w: %d", errNodeNotFoundAfterAdd, id)
 	}
 
-	t.AddWork(change.NodeOnline(node.ID()))
+	t.AddWork(change.NodeOnline(node.ID(), time.Now()))
 
 	return nil
 }
@@ -90,7 +90,7 @@ func (t *testBatcherWrapper) RemoveNode(id types.NodeID, c chan<- *tailcfg.MapRe
 	// Do this BEFORE removing from batcher so the change can be processed
 	node, ok := t.state.GetNodeByID(id)
 	if ok {
-		t.AddWork(change.NodeOffline(node.ID()))
+		t.AddWork(change.NodeOffline(node.ID(), time.Now()))
 	}
 
 	// Finally remove from the real batcher

--- a/hscontrol/mapper/mapper_test.go
+++ b/hscontrol/mapper/mapper_test.go
@@ -5,6 +5,7 @@ import (
 	"net/netip"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -257,7 +258,7 @@ func TestBuildFromChangeFiltersPeerPatchesByVisibility(t *testing.T) {
 	m := &mapper{state: s, cfg: cfg}
 
 	// n2 (user2) comes online; n1 (user1) must NOT receive its patch.
-	leakChange := change.NodeOnline(n2.ID)
+	leakChange := change.NodeOnline(n2.ID, time.Now())
 	resp, err := m.buildFromChange(n1.ID, tailcfg.CurrentCapabilityVersion, &leakChange)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -268,7 +269,7 @@ func TestBuildFromChangeFiltersPeerPatchesByVisibility(t *testing.T) {
 	}
 
 	// Control: n1b (same user) coming online IS visible to n1.
-	okChange := change.NodeOnline(n1b.ID)
+	okChange := change.NodeOnline(n1b.ID, time.Now())
 	resp2, err := m.buildFromChange(n1.ID, tailcfg.CurrentCapabilityVersion, &okChange)
 	require.NoError(t, err)
 	require.NotNil(t, resp2)
@@ -278,6 +279,9 @@ func TestBuildFromChangeFiltersPeerPatchesByVisibility(t *testing.T) {
 	for _, p := range resp2.PeersChangedPatch {
 		if p.NodeID == n1b.ID.NodeID() {
 			gotVisible = true
+
+			assert.NotNil(t, p.LastSeen,
+				"an online patch must carry LastSeen as delivered by the mapper")
 		}
 	}
 
@@ -425,7 +429,7 @@ func TestBuildFromChangeVisibilityMatchesFullMap(t *testing.T) {
 	patchReaches := func(t *testing.T, id types.NodeID) bool {
 		t.Helper()
 
-		c := change.NodeOnline(id)
+		c := change.NodeOnline(id, time.Now())
 		resp, err := m.buildFromChange(n1.ID, capVer, &c)
 		require.NoError(t, err)
 

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -645,7 +645,7 @@ func (s *State) Connect(id types.NodeID) ([]change.Change, uint64) {
 	// A node coming online sends a lightweight online peer patch. Subnet
 	// routers, relay targets, and via targets get their full peer recompute
 	// from the gated PolicyChange below, so no full update is needed here.
-	c := []change.Change{change.NodeOnline(node.ID())}
+	c := []change.Change{change.NodeOnline(node.ID(), time.Now())}
 
 	log.Info().EmbedObject(node).Msg("node connected")
 
@@ -680,6 +680,8 @@ func (s *State) Connect(id types.NodeID) ([]change.Change, uint64) {
 func (s *State) Disconnect(id types.NodeID, epoch uint64) ([]change.Change, error) {
 	var wentOffline bool
 
+	var lastSeen time.Time
+
 	node, ok := s.nodeStore.UpdateNode(id, func(n *types.Node) {
 		if n.ActiveSessions > 0 {
 			n.ActiveSessions--
@@ -691,8 +693,8 @@ func (s *State) Disconnect(id types.NodeID, epoch uint64) ([]change.Change, erro
 
 		wentOffline = true
 
-		now := time.Now()
-		n.LastSeen = &now
+		lastSeen = time.Now()
+		n.LastSeen = new(lastSeen)
 		n.IsOnline = new(false)
 		// Offline nodes are not HA candidates; drop any stale
 		// Unhealthy bit so it does not surface in DebugRoutes.
@@ -731,7 +733,7 @@ func (s *State) Disconnect(id types.NodeID, epoch uint64) ([]change.Change, erro
 	// A node going offline sends a lightweight offline peer patch. Subnet
 	// routers and other recompute-forcing nodes rely on the gated
 	// PolicyChange below for the peer recompute, so no full update here.
-	cs := []change.Change{change.NodeOffline(node.ID()), c}
+	cs := []change.Change{change.NodeOffline(node.ID(), lastSeen), c}
 	if s.polMan.NodeNeedsPeerRecompute(node) {
 		cs = append(cs, change.PolicyChange())
 	}

--- a/hscontrol/types/change/change.go
+++ b/hscontrol/types/change/change.go
@@ -395,27 +395,34 @@ func DNSConfig() Change {
 	}
 }
 
-// NodeOnline creates a patch response for a node coming online.
-func NodeOnline(nodeID types.NodeID) Change {
+// NodeOnline creates a patch response for a node coming online. lastSeen is
+// the time the node connected; per the tailcfg protocol, a [tailcfg.PeerChange]
+// with LastSeen non-nil signals that the node's online status changed.
+func NodeOnline(nodeID types.NodeID, lastSeen time.Time) Change {
 	return Change{
 		Reason: "node online",
 		PeerPatches: []*tailcfg.PeerChange{
 			{
-				NodeID: nodeID.NodeID(),
-				Online: new(true),
+				NodeID:   nodeID.NodeID(),
+				Online:   new(true),
+				LastSeen: &lastSeen,
 			},
 		},
 	}
 }
 
-// NodeOffline creates a patch response for a node going offline.
-func NodeOffline(nodeID types.NodeID) Change {
+// NodeOffline creates a patch response for a node going offline. lastSeen is
+// the time the node disconnected; per the tailcfg protocol, a
+// [tailcfg.PeerChange] with LastSeen non-nil signals that the node's online
+// status changed.
+func NodeOffline(nodeID types.NodeID, lastSeen time.Time) Change {
 	return Change{
 		Reason: "node offline",
 		PeerPatches: []*tailcfg.PeerChange{
 			{
-				NodeID: nodeID.NodeID(),
-				Online: new(false),
+				NodeID:   nodeID.NodeID(),
+				Online:   new(false),
+				LastSeen: &lastSeen,
 			},
 		},
 	}

--- a/hscontrol/types/change/change_test.go
+++ b/hscontrol/types/change/change_test.go
@@ -13,6 +13,10 @@ import (
 	"tailscale.com/types/key"
 )
 
+// testLastSeen is a fixed timestamp for online/offline patch constructors so
+// Change values built in table entries compare equal.
+var testLastSeen = time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+
 func TestChange_FieldSync(t *testing.T) {
 	r := Change{}
 	fieldNames := r.boolFieldNames()
@@ -315,7 +319,7 @@ func TestChange_IsBroadcastPolicyChange(t *testing.T) {
 		{name: "policy change", c: PolicyChange(), want: true},
 		{name: "self-update recompute", c: originUpdate, want: false},
 		{name: "targeted recompute", c: targeted, want: false},
-		{name: "online patch", c: NodeOnline(1), want: false},
+		{name: "online patch", c: NodeOnline(1, testLastSeen), want: false},
 		{name: "full update", c: FullUpdate(), want: false},
 		{name: "derp map", c: DERPMap(), want: false},
 	}
@@ -357,10 +361,13 @@ func TestDedupePolicyChanges(t *testing.T) {
 		{
 			name: "peer patches survive between collapsed policy changes",
 			changes: []Change{
-				NodeOnline(1), PolicyChange(), NodeOnline(2), PolicyChange(), NodeOffline(3),
+				NodeOnline(1, testLastSeen), PolicyChange(),
+				NodeOnline(2, testLastSeen), PolicyChange(),
+				NodeOffline(3, testLastSeen),
 			},
 			want: []Change{
-				NodeOnline(1), PolicyChange(), NodeOnline(2), NodeOffline(3),
+				NodeOnline(1, testLastSeen), PolicyChange(),
+				NodeOnline(2, testLastSeen), NodeOffline(3, testLastSeen),
 			},
 		},
 		{
@@ -380,8 +387,8 @@ func TestDedupePolicyChanges(t *testing.T) {
 		},
 		{
 			name:    "changes without any recompute are unchanged",
-			changes: []Change{NodeOnline(1), DERPMap()},
-			want:    []Change{NodeOnline(1), DERPMap()},
+			changes: []Change{NodeOnline(1, testLastSeen), DERPMap()},
+			want:    []Change{NodeOnline(1, testLastSeen), DERPMap()},
 		},
 	}
 
@@ -632,8 +639,8 @@ func TestNodeOnlineOfflineForSubnetRouter(t *testing.T) {
 		got        Change
 		wantOnline bool
 	}{
-		{name: "online", got: NodeOnline(view.ID()), wantOnline: true},
-		{name: "offline", got: NodeOffline(view.ID()), wantOnline: false},
+		{name: "online", got: NodeOnline(view.ID(), testLastSeen), wantOnline: true},
+		{name: "offline", got: NodeOffline(view.ID(), testLastSeen), wantOnline: false},
 	}
 
 	for _, tt := range tests {
@@ -652,6 +659,12 @@ func TestNodeOnlineOfflineForSubnetRouter(t *testing.T) {
 
 			require.NotNil(t, patch.Online)
 			assert.Equal(t, tt.wantOnline, *patch.Online)
+
+			// Per the tailcfg protocol, an online-status transition patch
+			// must carry LastSeen (connect or disconnect time).
+			require.NotNil(t, patch.LastSeen,
+				"online/offline patch must report LastSeen")
+			assert.Equal(t, testLastSeen, *patch.LastSeen)
 		})
 	}
 }


### PR DESCRIPTION
tailcfg documents `Node.LastSeen` as "when the node was last online … nil if never been online", and `PeerChange.LastSeen` as accompanying online-status changes. headscale only sent `LastSeen` for offline peers and never included it in online/offline patches, so clients on the new InitialStatus + peer-delta code path (Tailscale 1.102 on Apple platforms, tailscale/tailscale@`6bf05cb63`) saw online peers as never-online — rendering exit nodes as offline in the GUI.

- emit `LastSeen` for online peers in `TailNode`, per tailcfg semantics
- set `LastSeen` on connect/disconnect in `State` and carry it in the `NodeOnline`/`NodeOffline` change patches

Covered by a new servertest regression test and updated change/mapper tests. Note: this alone does not fix the empty exit-node list from #3415 — that turned out to be the GUI requiring a suggested exit node; see the issue for analysis and a policy (`nodeAttrs`) workaround.

Updates #3415
