### PR TITLE
docs: add Head-Control to the web UI list

### DIFF
--- a/docs/ref/integration/web-ui.md
+++ b/docs/ref/integration/web-ui.md
@@ -25,5 +25,7 @@ Headscale doesn't provide a built-in web interface but users may pick one from t
 - [Headscale UI](https://github.com/MunMunMiao/headscale-ui) - Headscale UI online and Self-hosting
 - [Headscale Panel](https://github.com/headscale-panel/panel) - A modern Headscale management panel with a clean,
   network-operations-focused UI
+- [Head-Control](https://github.com/Panagiotis1226/Head-Control) - Self-hosted admin console for headscale with ACL
+  editing, policy history and DNS management
 
 You can ask for support on our [Discord server](https://discord.gg/c84AZQhmpx) in the "web-interfaces" channel.


### PR DESCRIPTION
Adds [Head-Control](https://github.com/Panagiotis1226/Head-Control) to the community web interface list in `docs/ref/integration/web-ui.md`. Documentation only, no code changes.

Head-Control is a self-hosted admin console for headscale: Go backend, single Docker Compose deployment, SQLite. It covers the headscale v0.29.x API and supports ACL editing in both policy modes, policy version history with rollback, DNS record management, and user/machine management.

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] updated documentation if needed
