### PR TITLE
Reject unknown OAuth client scopes at creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,6 @@ keys remain all-access.
 
 - Expiring or deleting a non-existent pre-auth key now returns an error instead of silently succeeding [#3324](https://github.com/juanfont/headscale/pull/3324)
 - Improve systemd service file hardening [#3341](https://github.com/juanfont/headscale/pull/3341)
-- Creating an OAuth client now rejects scopes outside the known vocabulary instead of storing them verbatim [#3406](https://github.com/juanfont/headscale/issues/3406)
 
 ## 0.29.3 (2026-07-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ keys remain all-access.
 
 - Expiring or deleting a non-existent pre-auth key now returns an error instead of silently succeeding [#3324](https://github.com/juanfont/headscale/pull/3324)
 - Improve systemd service file hardening [#3341](https://github.com/juanfont/headscale/pull/3341)
+- Creating an OAuth client now rejects scopes outside the known vocabulary instead of storing them verbatim [#3406](https://github.com/juanfont/headscale/issues/3406)
 
 ## 0.29.3 (2026-07-29)
 

--- a/cmd/headscale/cli/oauth_client.go
+++ b/cmd/headscale/cli/oauth_client.go
@@ -23,7 +23,7 @@ func init() {
 	oauthClientsCmd.AddCommand(listOAuthClientsCmd)
 
 	createOAuthClientCmd.Flags().
-		StringArrayP("scope", "s", nil, "Scope the client's tokens are granted (repeatable): auth_keys, oauth_keys, devices:core, devices:routes, policy_file, feature_settings (each with a :read variant), or all/all:read")
+		StringArrayP("scope", "s", nil, "Scope the client's tokens are granted (repeatable): auth_keys, oauth_keys, devices:core, devices:routes, policy_file, feature_settings, users (each with a :read variant), or all/all:read")
 	createOAuthClientCmd.Flags().
 		StringArrayP("tag", "t", nil, "Tag the client's tokens may assign to devices (repeatable), e.g. tag:k8s-operator")
 	createOAuthClientCmd.Flags().StringP("description", "d", "", "Human-readable description")

--- a/hscontrol/api/v2/errors.go
+++ b/hscontrol/api/v2/errors.go
@@ -72,6 +72,7 @@ func mapError(msg string, err error) error {
 
 	case errors.Is(err, db.ErrPreAuthKeyNotTaggedOrOwned),
 		errors.Is(err, db.ErrPreAuthKeyACLTagInvalid),
+		errors.Is(err, db.ErrOAuthClientScopeInvalid),
 		errors.Is(err, state.ErrGivenNameInvalid),
 		errors.Is(err, state.ErrGivenNameTaken),
 		errors.Is(err, state.ErrNodeNameNotUnique),

--- a/hscontrol/db/oauth.go
+++ b/hscontrol/db/oauth.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juanfont/headscale/hscontrol/scope"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"golang.org/x/crypto/argon2"
 	"gorm.io/gorm"
@@ -37,6 +38,7 @@ var (
 	ErrOAuthClientNotFound      = fmt.Errorf("oauth client not found: %w", gorm.ErrRecordNotFound)
 	ErrOAuthClientFailedToParse = errors.New("failed to parse oauth client secret")
 	ErrOAuthClientRevoked       = errors.New("oauth client revoked")
+	ErrOAuthClientScopeInvalid  = errors.New("oauth client scope invalid")
 
 	ErrAccessTokenNotFound      = fmt.Errorf("oauth access token not found: %w", gorm.ErrRecordNotFound)
 	ErrAccessTokenFailedToParse = errors.New("failed to parse oauth access token")
@@ -132,6 +134,39 @@ func verifySecret(encoded []byte, secret string) error {
 	return nil
 }
 
+// validateScopes deduplicates and sorts scopes, rejecting any value outside the
+// vocabulary in [scope.Known]. An unknown scope satisfies no requirement, so
+// storing one would silently mint a client with fewer permissions than asked
+// for.
+func validateScopes(scopes []string) ([]string, error) {
+	scopes = set.SetOf(scopes).Slice()
+	slices.Sort(scopes)
+
+	for _, s := range scopes {
+		if !scope.Scope(s).Valid() {
+			return nil, fmt.Errorf(
+				"%w: '%s' is not one of %s",
+				ErrOAuthClientScopeInvalid,
+				s,
+				strings.Join(scopeNames(), ", "),
+			)
+		}
+	}
+
+	return scopes, nil
+}
+
+func scopeNames() []string {
+	known := scope.Known()
+	names := make([]string, len(known))
+
+	for i, s := range known {
+		names[i] = string(s)
+	}
+
+	return names
+}
+
 // CreateOAuthClient creates a new [types.OAuthClient] and returns the plaintext
 // secret (shown ONCE) alongside the stored client. creatorUserID is the user who
 // created it (informational), or nil.
@@ -145,8 +180,10 @@ func (hsdb *HSDatabase) CreateOAuthClient(
 		return "", nil, err
 	}
 
-	scopes = set.SetOf(scopes).Slice()
-	slices.Sort(scopes)
+	scopes, err = validateScopes(scopes)
+	if err != nil {
+		return "", nil, err
+	}
 
 	clientID := rands.HexString(oauthClientIDLength)
 	secret := rands.HexString(oauthClientSecretLength)

--- a/hscontrol/db/oauth.go
+++ b/hscontrol/db/oauth.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juanfont/headscale/hscontrol/types"
 	"golang.org/x/crypto/argon2"
 	"gorm.io/gorm"
+	"tailscale.com/util/multierr"
 	"tailscale.com/util/rands"
 	"tailscale.com/util/set"
 )
@@ -134,37 +135,20 @@ func verifySecret(encoded []byte, secret string) error {
 	return nil
 }
 
-// validateScopes deduplicates and sorts scopes, rejecting any value outside the
-// vocabulary in [scope.Known]. An unknown scope satisfies no requirement, so
-// storing one would silently mint a client with fewer permissions than asked
-// for.
-func validateScopes(scopes []string) ([]string, error) {
-	scopes = set.SetOf(scopes).Slice()
-	slices.Sort(scopes)
+// validateScopes rejects any value outside the vocabulary in [scope.Known]. An
+// unknown scope satisfies no requirement, so storing one would silently mint a
+// client with fewer permissions than asked for. Every offending scope is
+// reported so the caller can correct them all in one pass.
+func validateScopes(scopes []string) error {
+	var errs []error
 
 	for _, s := range scopes {
 		if !scope.Scope(s).Valid() {
-			return nil, fmt.Errorf(
-				"%w: '%s' is not one of %s",
-				ErrOAuthClientScopeInvalid,
-				s,
-				strings.Join(scopeNames(), ", "),
-			)
+			errs = append(errs, fmt.Errorf("%w: %q", ErrOAuthClientScopeInvalid, s))
 		}
 	}
 
-	return scopes, nil
-}
-
-func scopeNames() []string {
-	known := scope.Known()
-	names := make([]string, len(known))
-
-	for i, s := range known {
-		names[i] = string(s)
-	}
-
-	return names
+	return multierr.New(errs...)
 }
 
 // CreateOAuthClient creates a new [types.OAuthClient] and returns the plaintext
@@ -180,10 +164,13 @@ func (hsdb *HSDatabase) CreateOAuthClient(
 		return "", nil, err
 	}
 
-	scopes, err = validateScopes(scopes)
+	err = validateScopes(scopes)
 	if err != nil {
 		return "", nil, err
 	}
+
+	scopes = set.SetOf(scopes).Slice()
+	slices.Sort(scopes)
 
 	clientID := rands.HexString(oauthClientIDLength)
 	secret := rands.HexString(oauthClientSecretLength)

--- a/hscontrol/db/oauth_test.go
+++ b/hscontrol/db/oauth_test.go
@@ -243,3 +243,20 @@ func TestOAuthClientCreateRejectsUnknownScopes(t *testing.T) {
 		})
 	}
 }
+
+// TestOAuthClientCreateReportsEveryUnknownScope asserts validation does not stop
+// at the first bad scope, so a caller can fix them all in one pass.
+func TestOAuthClientCreateReportsEveryUnknownScope(t *testing.T) {
+	db, err := newSQLiteTestDB()
+	require.NoError(t, err)
+
+	_, _, err = db.CreateOAuthClient(
+		[]string{"auth_keys", "devices:everything", "EVIL:superuser"},
+		[]string{"tag:ci"},
+		"",
+		nil,
+	)
+	require.ErrorIs(t, err, ErrOAuthClientScopeInvalid)
+	assert.Contains(t, err.Error(), "devices:everything")
+	assert.Contains(t, err.Error(), "EVIL:superuser")
+}

--- a/hscontrol/db/oauth_test.go
+++ b/hscontrol/db/oauth_test.go
@@ -202,3 +202,44 @@ func TestAccessTokenRejectedWhenClientGone(t *testing.T) {
 	_, err = db.AuthenticateAccessToken(tokenStr2)
 	require.ErrorIs(t, err, ErrAccessTokenClientRevoked)
 }
+
+// TestOAuthClientCreateRejectsUnknownScopes asserts scopes are validated against
+// the known vocabulary the same way tags are, instead of being stored verbatim.
+func TestOAuthClientCreateRejectsUnknownScopes(t *testing.T) {
+	tests := []struct {
+		name   string
+		scopes []string
+		valid  bool
+	}{
+		{name: "known write and read scopes", scopes: []string{"auth_keys", "devices:core:read"}, valid: true},
+		{name: "super scopes", scopes: []string{"all", "all:read"}, valid: true},
+		{name: "arbitrary scope", scopes: []string{"EVIL:superuser"}},
+		{name: "path traversal", scopes: []string{"../../etc/passwd"}},
+		{name: "wildcard", scopes: []string{"*::*"}},
+		{name: "empty scope", scopes: []string{""}},
+		{name: "wrong case", scopes: []string{"AUTH_KEYS"}},
+		{name: "one unknown among known", scopes: []string{"auth_keys", "devices:everything"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, err := newSQLiteTestDB()
+			require.NoError(t, err)
+
+			_, client, err := db.CreateOAuthClient(tt.scopes, []string{"tag:ci"}, "", nil)
+			if tt.valid {
+				require.NoError(t, err)
+				assert.ElementsMatch(t, tt.scopes, client.Scopes)
+
+				return
+			}
+
+			require.ErrorIs(t, err, ErrOAuthClientScopeInvalid)
+			assert.Nil(t, client)
+
+			clients, err := db.ListOAuthClients()
+			require.NoError(t, err)
+			assert.Empty(t, clients, "rejected client must not be stored")
+		})
+	}
+}

--- a/hscontrol/scope/scope.go
+++ b/hscontrol/scope/scope.go
@@ -8,7 +8,10 @@
 // hscontrol/api/v2, so it can be tested exhaustively on its own.
 package scope
 
-import "strings"
+import (
+	"slices"
+	"strings"
+)
 
 // Scope is an OAuth capability an operation requires and a token grants. The names
 // mirror Tailscale's API scopes; a "...:read" scope is the read-only subset of its
@@ -60,6 +63,13 @@ func Known() []Scope {
 		FeatureSettings, FeatureSettingsRead,
 		Users, UsersRead,
 	}
+}
+
+// Valid reports whether s is part of the known scope vocabulary. Scopes outside
+// it never satisfy any requirement, so they are rejected at creation time
+// rather than stored as permanently inert grants.
+func (s Scope) Valid() bool {
+	return slices.Contains(Known(), s)
 }
 
 // IsRead reports whether s is a read-only scope (its name ends with ":read").

--- a/hscontrol/scope/scope_test.go
+++ b/hscontrol/scope/scope_test.go
@@ -232,3 +232,17 @@ func TestKnownIsComplete(t *testing.T) {
 		t.Errorf("Known() has %d scopes, want 16", len(known))
 	}
 }
+
+func TestValid(t *testing.T) {
+	for _, s := range Known() {
+		if !s.Valid() {
+			t.Errorf("Known scope %q reported invalid", s)
+		}
+	}
+
+	for _, s := range []Scope{"", "EVIL:superuser", "*::*", "../../etc/passwd", "AUTH_KEYS", "devices", "all:write"} {
+		if s.Valid() {
+			t.Errorf("unknown scope %q reported valid", s)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3406

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand (#3406)
- [x] added unit tests
- [ ] added integration tests — the behaviour is fully covered at the `db.CreateOAuthClient` chokepoint every caller (CLI and v2 API) goes through; happy to add an `integration/cli_oauth_clients_test.go` case if you'd prefer one.
- [ ] updated documentation if needed — the CLI `--scope` help text now also lists `users`, which was already part of the vocabulary
- [x] updated CHANGELOG.md

## Problem

`CreateOAuthClient` validated tags via `validateACLTags` but not scopes: any string was deduplicated, sorted and stored verbatim, so `headscale oauth-client create -s 'EVIL:superuser' -s '../../etc/passwd'` succeeded. Since an unknown scope satisfies nothing in `scope.Grants`, this silently mints a client with fewer permissions than the operator asked for, and a typo like `auth_key` fails at request time rather than creation time.

## Change

- `scope.Scope.Valid()` reports membership in the existing `scope.Known()` vocabulary — the canonical list already used by the grant predicate, so validation cannot drift from enforcement.
- `db.validateScopes` replaces the inline dedup/sort in `CreateOAuthClient`, rejecting unknown values with `ErrOAuthClientScopeInvalid` and an error naming the accepted set.
- `mapError` maps that error to 400, so an invalid scope surfaces exactly like an invalid tag does today.
- Validation lives in the db layer rather than the CLI so the v2 API path (`POST` keys) is covered too.

## Verification

```
go build ./...                       # clean
go vet ./...                         # clean
gofmt -l .                           # no output
go test ./hscontrol/... ./cmd/...
```

Test suite is clean apart from two failures that also reproduce on an unmodified checkout in this environment: `TestAPIv2OAuthScopes` (needs `tofu`, provided by the nix dev shell) and `TestDialHeadscaleSocketRetriesUntilPresent` (macOS unix socket path length).

---
Disclosure: this patch was prepared with the assistance of Claude Code. I have reviewed the change and the test results above myself.