### PR TITLE
feat(policy): support SSH session recording

### DIFF
--- a/hscontrol/policy/v2/filter.go
+++ b/hscontrol/policy/v2/filter.go
@@ -250,6 +250,65 @@ func sshCheck(baseURL string) tailcfg.SSHAction {
 	}
 }
 
+// sshRecorderPort is the port a session recorder listens on. Tailscale's ACL
+// syntax has no port field for recorders and the SaaS control plane hardcodes
+// 80; matching that keeps policies portable in both directions.
+const sshRecorderPort = 80
+
+// maxSSHRecorders caps how many recorder ADDRESSES one rule may resolve to.
+//
+// Addresses, not nodes: a dual-stack recorder contributes both its v4 and v6
+// address, so this is four dual-stack nodes rather than eight.
+//
+// ConnectToRecorder walks the list in order with a per-target dial timeout
+// inside an overall budget of about 30 seconds. A recorder alias that resolved
+// to a wide prefix would turn into hundreds of dial targets and burn that
+// budget before reaching a live one — a policy-authored delay on every session
+// establishment, and under enforceRecorder a policy-authored SSH outage. The
+// single-IP requirement below is the real defence; this is the backstop.
+const maxSSHRecorders = 8
+
+// resolveRecorders turns recorder aliases into concrete addresses.
+//
+// Each alias must resolve to individual node addresses. A prefix wider than a
+// single IP is rejected rather than expanded: "tag:recorder" naming two nodes
+// is two addresses, but a /24 is not a recorder, it is a mistake.
+func resolveRecorders(
+	aliases SSHSrcAliases,
+	pol *Policy,
+	users types.Users,
+	nodes views.Slice[types.NodeView],
+) ([]netip.AddrPort, error) {
+	resolved, err := aliases.Resolve(pol, users, nodes)
+	if err != nil {
+		return nil, fmt.Errorf("resolving recorder aliases: %w", err)
+	}
+
+	if resolved == nil {
+		return nil, nil
+	}
+
+	var addrs []netip.AddrPort
+
+	for _, prefix := range resolved.Prefixes() {
+		if !prefix.IsSingleIP() {
+			return nil, fmt.Errorf(
+				"recorder must resolve to individual nodes, got prefix %s", prefix,
+			)
+		}
+
+		if len(addrs) >= maxSSHRecorders {
+			return nil, fmt.Errorf(
+				"recorder resolves to more than %d addresses", maxSSHRecorders,
+			)
+		}
+
+		addrs = append(addrs, netip.AddrPortFrom(prefix.Addr(), sshRecorderPort))
+	}
+
+	return addrs, nil
+}
+
 //nolint:gocyclo // SSH compilation walks per-rule branches with intertwined autogroup:self handling
 func (pol *Policy) compileSSHPolicy(
 	baseURL string,
@@ -299,6 +358,53 @@ func (pol *Policy) compileSSHPolicy(
 				"parsing SSH policy, unknown action %q, index: %d: %w",
 				rule.Action, index, err,
 			)
+		}
+
+		// Session recording. tailscaled has understood SSHAction.Recorders
+		// since capability version 61; populating it is all that was missing.
+		//
+		// Note this is set on the action for BOTH accept and check. For check,
+		// the client fetches a fresh action from HoldAndDelegate, but
+		// tailssh.recorders() falls back to the action derived here when the
+		// delegated one carries no recorders — so check-mode inherits
+		// recording without needing the delegate endpoint to know about it.
+		if len(rule.Recorder) > 0 {
+			recorders, err := resolveRecorders(rule.Recorder, pol, users, nodes)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"parsing SSH policy, resolving recorders, index: %d: %w",
+					index, err,
+				)
+			}
+
+			if len(recorders) > 0 {
+				action.Recorders = recorders
+
+				// Tell the user their session is being recorded, before it
+				// starts. Notice of monitoring is a legal requirement in many
+				// jurisdictions, and for a feature that exists to make sessions
+				// auditable, recording someone silently is the wrong default.
+				// Carried over from the earlier attempt at this in #1820.
+				action.Message = "# This session is being recorded.\n"
+
+				if rule.EnforceRecorder {
+					action.OnRecordingFailure = &tailcfg.SSHRecorderFailureAction{
+						RejectSessionWithMessage:    "session not started: recording is required and no recorder could be reached",
+						TerminateSessionWithMessage: "session terminated: recording failed and recording is required",
+						// NotifyURL is deliberately left empty: it posts an
+						// SSHEventNotifyRequest back to control over Noise, and
+						// headscale implements no such endpoint.
+					}
+				}
+			} else if rule.EnforceRecorder {
+				// Enforcement with nothing to enforce against would silently
+				// degrade to unrecorded sessions, which is the one outcome an
+				// operator who set this flag does not want.
+				return nil, fmt.Errorf(
+					"parsing SSH policy, enforceRecorder is set but no recorder resolved to a node, index: %d",
+					index,
+				)
+			}
 		}
 
 		acceptEnv := rule.AcceptEnv

--- a/hscontrol/policy/v2/filter.go
+++ b/hscontrol/policy/v2/filter.go
@@ -19,6 +19,11 @@ import (
 var (
 	ErrInvalidAction = errors.New("invalid action")
 	errSelfInSources = errors.New("autogroup:self cannot be used in sources")
+
+	errRecorderNotSingleIP   = errors.New("recorder must resolve to individual nodes")
+	errTooManyRecorders      = errors.New("too many recorder addresses")
+	errEnforceWithNoRecorder = errors.New(
+		"enforceRecorder is set but no recorder resolved to a node")
 )
 
 // companionCap pairs a well-known Tailscale capability with its
@@ -292,15 +297,11 @@ func resolveRecorders(
 
 	for _, prefix := range resolved.Prefixes() {
 		if !prefix.IsSingleIP() {
-			return nil, fmt.Errorf(
-				"recorder must resolve to individual nodes, got prefix %s", prefix,
-			)
+			return nil, fmt.Errorf("%w: got prefix %s", errRecorderNotSingleIP, prefix)
 		}
 
 		if len(addrs) >= maxSSHRecorders {
-			return nil, fmt.Errorf(
-				"recorder resolves to more than %d addresses", maxSSHRecorders,
-			)
+			return nil, fmt.Errorf("%w: more than %d", errTooManyRecorders, maxSSHRecorders)
 		}
 
 		addrs = append(addrs, netip.AddrPortFrom(prefix.Addr(), sshRecorderPort))
@@ -400,10 +401,7 @@ func (pol *Policy) compileSSHPolicy(
 				// Enforcement with nothing to enforce against would silently
 				// degrade to unrecorded sessions, which is the one outcome an
 				// operator who set this flag does not want.
-				return nil, fmt.Errorf(
-					"parsing SSH policy, enforceRecorder is set but no recorder resolved to a node, index: %d",
-					index,
-				)
+				return nil, fmt.Errorf("parsing SSH policy, index %d: %w", index, errEnforceWithNoRecorder)
 			}
 		}
 

--- a/hscontrol/policy/v2/filter_test.go
+++ b/hscontrol/policy/v2/filter_test.go
@@ -4151,3 +4151,170 @@ func TestDestinationsToNetPortRange_AutogroupInternet(t *testing.T) {
 		})
 	}
 }
+
+// TestCompileSSHPolicy_Recorders covers session recording end to end at the
+// policy layer: that a recorder alias resolves to an address on the recorder
+// port, that enforcement produces an OnRecordingFailure action, and — the case
+// that matters most — that recorders land on the CHECK action too.
+//
+// Why check specifically: tailssh.recorders() reads finalAction.Recorders but
+// falls back to action0.Recorders, where action0 is the action compiled here.
+// That fallback is what lets check mode record without the HoldAndDelegate
+// endpoint knowing anything about recording. It is also load-bearing for the
+// whole compliance story, because check is the only action that disables port
+// forwarding — under accept a user can tunnel arbitrary traffic while the
+// recording shows an idle shell. If an upstream refactor ever drops that
+// fallback, this test is what catches it.
+func TestCompileSSHPolicy_Recorders(t *testing.T) {
+	users := types.Users{
+		{Name: "user1", Model: gorm.Model{ID: 1}},
+	}
+
+	uid := uint(1)
+	src := &types.Node{
+		Hostname: "workstation",
+		IPv4:     createAddr("100.64.0.1"),
+		UserID:   &uid,
+		User:     &users[0],
+	}
+	recorder := &types.Node{
+		Hostname: "castsink",
+		IPv4:     createAddr("100.64.0.9"),
+		UserID:   &uid,
+		User:     &users[0],
+		Tags:     []string{"tag:recorder"},
+	}
+
+	nodes := types.Nodes{src, recorder}
+
+	policyFor := func(action SSHAction, enforce bool) *Policy {
+		return &Policy{
+			TagOwners: TagOwners{
+				Tag("tag:recorder"): Owners{up("user1@")},
+			},
+			SSHs: []SSH{
+				{
+					Action:          action,
+					Sources:         SSHSrcAliases{up("user1@")},
+					Destinations:    SSHDstAliases{up("user1@")},
+					Users:           []SSHUser{"root"},
+					Recorder:        SSHSrcAliases{tp("tag:recorder")},
+					EnforceRecorder: enforce,
+				},
+			},
+		}
+	}
+
+	wantAddr := netip.AddrPortFrom(netip.MustParseAddr("100.64.0.9"), 80)
+
+	t.Run("accept carries recorders", func(t *testing.T) {
+		pol := policyFor("accept", false)
+		require.NoError(t, pol.validate())
+
+		got, err := pol.compileSSHPolicy("unused-server-url", users, src.View(), nodes.ViewSlice())
+		require.NoError(t, err)
+		require.Len(t, got.Rules, 1)
+
+		require.Equal(t, []netip.AddrPort{wantAddr}, got.Rules[0].Action.Recorders)
+		// Not enforcing, so a recorder outage must not reject the session.
+		require.Nil(t, got.Rules[0].Action.OnRecordingFailure)
+		// The user must be told before the session starts. Notice of
+		// monitoring is a legal requirement in many jurisdictions.
+		require.Contains(t, got.Rules[0].Action.Message, "recorded")
+	})
+
+	t.Run("check carries recorders — the action0 fallback", func(t *testing.T) {
+		pol := policyFor("check", false)
+		require.NoError(t, pol.validate())
+
+		got, err := pol.compileSSHPolicy("unused-server-url", users, src.View(), nodes.ViewSlice())
+		require.NoError(t, err)
+		require.Len(t, got.Rules, 1)
+
+		action := got.Rules[0].Action
+		require.Equal(t, []netip.AddrPort{wantAddr}, action.Recorders,
+			"check-mode inherits recorders via tailssh.recorders() falling back to action0")
+
+		// Check mode must still be check mode: this is the only action that
+		// disables forwarding, which is what makes the recording meaningful.
+		require.False(t, action.Accept)
+		require.NotEmpty(t, action.HoldAndDelegate)
+		require.False(t, action.AllowLocalPortForwarding)
+		require.False(t, action.AllowRemotePortForwarding)
+		require.False(t, action.AllowAgentForwarding)
+	})
+
+	t.Run("enforcement rejects and terminates", func(t *testing.T) {
+		pol := policyFor("accept", true)
+		require.NoError(t, pol.validate())
+
+		got, err := pol.compileSSHPolicy("unused-server-url", users, src.View(), nodes.ViewSlice())
+		require.NoError(t, err)
+		require.Len(t, got.Rules, 1)
+
+		onFail := got.Rules[0].Action.OnRecordingFailure
+		require.NotNil(t, onFail)
+		require.NotEmpty(t, onFail.RejectSessionWithMessage)
+		require.NotEmpty(t, onFail.TerminateSessionWithMessage)
+		// Deliberately empty: it posts back to control over Noise and
+		// headscale implements no such endpoint.
+		require.Empty(t, onFail.NotifyURL)
+	})
+
+	t.Run("no recorder means no recording", func(t *testing.T) {
+		pol := &Policy{
+			SSHs: []SSH{{
+				Action:       "accept",
+				Sources:      SSHSrcAliases{up("user1@")},
+				Destinations: SSHDstAliases{up("user1@")},
+				Users:        []SSHUser{"root"},
+			}},
+		}
+		require.NoError(t, pol.validate())
+
+		got, err := pol.compileSSHPolicy("unused-server-url", users, src.View(), nodes.ViewSlice())
+		require.NoError(t, err)
+		require.Len(t, got.Rules, 1)
+		require.Empty(t, got.Rules[0].Action.Recorders)
+		// And no recording notice when nothing is being recorded.
+		require.Empty(t, got.Rules[0].Action.Message)
+	})
+
+	t.Run("enforcing with an unresolvable recorder is an error, not a silent downgrade", func(t *testing.T) {
+		pol := &Policy{
+			TagOwners: TagOwners{Tag("tag:nowhere"): Owners{up("user1@")}},
+			SSHs: []SSH{{
+				Action:          "accept",
+				Sources:         SSHSrcAliases{up("user1@")},
+				Destinations:    SSHDstAliases{up("user1@")},
+				Users:           []SSHUser{"root"},
+				Recorder:        SSHSrcAliases{tp("tag:nowhere")},
+				EnforceRecorder: true,
+			}},
+		}
+		require.NoError(t, pol.validate())
+
+		_, err := pol.compileSSHPolicy("unused-server-url", users, src.View(), nodes.ViewSlice())
+		require.Error(t, err, "enforceRecorder with nothing to enforce against must fail loudly")
+	})
+
+	t.Run("a wide prefix is rejected, not expanded", func(t *testing.T) {
+		// The DoS path: ConnectToRecorder walks the recorder list in order
+		// inside a ~30s budget, so a /24 silently expanded to 256 targets is a
+		// policy-authored delay on every session — and under enforcement, a
+		// policy-authored SSH outage.
+		pol := &Policy{
+			Hosts: Hosts{"recorders": Prefix(netip.MustParsePrefix("100.64.0.0/24"))},
+			SSHs: []SSH{{
+				Action:       "accept",
+				Sources:      SSHSrcAliases{up("user1@")},
+				Destinations: SSHDstAliases{up("user1@")},
+				Users:        []SSHUser{"root"},
+				Recorder:     SSHSrcAliases{hp("recorders")},
+			}},
+		}
+
+		_, err := pol.compileSSHPolicy("unused-server-url", users, src.View(), nodes.ViewSlice())
+		require.ErrorContains(t, err, "individual nodes")
+	})
+}

--- a/hscontrol/policy/v2/types.go
+++ b/hscontrol/policy/v2/types.go
@@ -2874,6 +2874,24 @@ type SSH struct {
 	Users        SSHUsers        `json:"users"`
 	CheckPeriod  *SSHCheckPeriod `json:"checkPeriod,omitempty"`
 	AcceptEnv    []string        `json:"acceptEnv,omitempty"`
+
+	// Recorder lists the nodes that SSH sessions matching this rule are
+	// streamed to for recording. Each alias must resolve to a single node —
+	// see [SSH.resolveRecorders].
+	//
+	// The client side of this has existed since capability version 61: given
+	// [tailcfg.SSHAction.Recorders], tailscaled connects to each recorder in
+	// order and streams the session as an asciinema cast. Headscale simply
+	// never populated the field, so the capability was unreachable.
+	// +optional
+	Recorder SSHSrcAliases `json:"recorder,omitempty"`
+
+	// EnforceRecorder rejects a session when no recording can be started,
+	// rather than allowing it to proceed unrecorded. Off by default: for a
+	// deployment where SSH is the only way in, a recorder outage becoming a
+	// total SSH outage is a self-inflicted lockout.
+	// +optional
+	EnforceRecorder bool `json:"enforceRecorder,omitempty"`
 }
 
 // SSHSrcAliases is a list of aliases that can be used as sources in an [SSH] rule.


### PR DESCRIPTION
Closes #1793. Supersedes #1820, which was closed pending the policy rewrite — this is that same feature written against `policy/v2`.

## Why this is small

`tailscaled` has understood `tailcfg.SSHAction.Recorders` and `OnRecordingFailure` since **capability version 61 (2023-04-18)**: given a recorder address it connects and streams the session as an asciinema cast. Headscale simply never populated those fields, so the capability has been unreachable from a headscale-managed tailnet even though every client already ships it.

This adds the two fields Tailscale's ACL syntax already uses — `recorder` and `enforceRecorder` — resolves the aliases at SSH policy compile time, and sets them on the action.

```json
{
  "ssh": [{
    "action": "check",
    "src": ["group:admins"],
    "dst": ["tag:prod"],
    "users": ["root"],
    "recorder": ["tag:recorder"],
    "enforceRecorder": true
  }]
}
```

## Three points for reviewer attention

**Recorders are set for both `accept` and `check`.** For check the client fetches a fresh action from `HoldAndDelegate`, but `tailssh.recorders()` falls back to the policy-derived `action0` when the delegated action carries none. That fallback is why check mode records without the delegate endpoint needing to know anything about recording, and it keeps this change inside one package — `noise.go` and the delegate handler are untouched.

It also matters beyond patch size: `sshCheck` is the only action that disables port forwarding (`sshAccept` hardcodes all three to `true`), so check is the only mode where a recording is a faithful account of the session. There is a test pinning the fallback specifically, because an innocuous refactor could remove it silently.

**Recorders must resolve to individual nodes.** `ConnectToRecorder` walks the list in order inside an overall budget of ~30s, so a recorder alias expanded from a wide prefix becomes hundreds of dial targets that exhaust the budget before reaching a live one — a policy-authored delay on every session establishment and, under `enforceRecorder`, a policy-authored SSH outage. Prefixes wider than a single IP are rejected rather than expanded, with a cap as a backstop. (#1820 assumed `ExpandAlias` had already reduced these to single IPs; this checks rather than assumes.)

**`enforceRecorder` with no resolvable recorder is an error.** Compiling it to a rule with no recorders would silently produce unrecorded sessions — the one outcome an operator who set that flag does not want.

## Smaller decisions

- `SSHAction.Message` carries a recording notice, adopted from #1820 — **credit to @Qup42**. Notice of monitoring is a legal requirement in many jurisdictions and the right default for a feature that exists to make sessions auditable.
- `OnRecordingFailure.NotifyURL` is deliberately left empty. It posts an `SSHEventNotifyRequest` back to control over the Noise transport and headscale implements no such endpoint; wiring one is a larger change and is not needed for recording to work. Happy to follow up separately if wanted.
- The recorder port is hardcoded to 80, matching Tailscale SaaS — the ACL syntax has no port field for recorders.

## Testing

Six sub-tests in `TestCompileSSHPolicy_Recorders` cover accept, check (the `action0` fallback), enforcement, no-recorder, enforce-with-unresolvable-recorder, and wide-prefix rejection. Full `./hscontrol/policy/...` suite passes.

Verified end to end on a scratch tailnet — a patched headscale plus two `tailscaled` nodes — where the SSH destination's netmap contains:

```json
"action": {
  "holdAndDelegate": "http://headscale:8080/machine/ssh/action/...",
  "recorders": ["100.64.0.1:80", "[fd7a:115c:a1e0::1]:80"]
}
```

For a recorder, `qup42/loghead` works today, as does anything speaking the same protocol.