### PR TITLE
Fix inverted HTTP metrics skip condition

### DIFF
--- a/hscontrol/app.go
+++ b/hscontrol/app.go
@@ -447,7 +447,7 @@ func (h *Headscale) createRouter(apiV1Mux, apiV2Mux http.Handler) *chi.Mux {
 		Host:  false,
 		Proto: true,
 		Skip: func(r *http.Request) bool {
-			return r.Method != http.MethodOptions
+			return r.Method == http.MethodOptions
 		},
 	}))
 	r.Use(middleware.RequestID)

--- a/hscontrol/noise.go
+++ b/hscontrol/noise.go
@@ -150,7 +150,7 @@ func (h *Headscale) NoiseUpgradeHandler(
 		Host:  false,
 		Proto: true,
 		Skip: func(r *http.Request) bool {
-			return r.Method != http.MethodOptions
+			return r.Method == http.MethodOptions
 		},
 	}))
 	r.Use(middleware.RequestID)


### PR DESCRIPTION
### Problem

The `Skip` function passed to `metrics.Collector` in both routers had the condition backwards:

```go
Skip: func(r *http.Request) bool {
    return r.Method != http.MethodOptions  // skips everything except OPTIONS
},
```

A `Skip` function that returns `true` tells the middleware to **not** record metrics for that request. With `!=`, the function returns `true` for every method that is not OPTIONS — meaning GET, POST, PUT, DELETE and all other real traffic is silently excluded from `http_requests_total` and `http_request_duration_seconds`. Only `OPTIONS` preflight requests were ever counted.

### Fix

Change `!=` to `==` so OPTIONS (a CORS preflight with no application value in metrics) is the one method skipped, and all other traffic is recorded as intended.

The same inverted condition existed in both the main router (`createRouter` in `app.go`) and the Noise upgrade router (`NoiseUpgradeHandler` in `noise.go`). Both are fixed in this commit.

### Verification

```bash
# send regular requests to any endpoint
for i in $(seq 1 5); do curl -s http://127.0.0.1:8080/health >/dev/null; done

# metrics now show http_requests_total with method="GET"
curl -s http://127.0.0.1:9090/metrics | grep http_requests_total
```

Fixes #3412