### PR TITLE
hscontrol: allow changing a user's display name, email and profile picture

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -290,6 +290,7 @@ jobs:
           - TestUserCommand
           - TestUserCreateCommand
           - TestUserCommandValidation
+          - TestUserSetCommand
           - TestDERPVerifyEndpoint
           - TestResolveMagicDNS
           - TestResolveMagicDNSExtraRecordsPath

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ keys remain all-access.
 
 ### Changes
 
+- Add `headscale users set` and `PUT /api/v1/user/{id}` to change the display name, email and profile picture URL of an existing user [#2166](https://github.com/juanfont/headscale/issues/2166)
+- Fix user profile changes (rename, OIDC re-login) not reaching connected nodes until the server restarted [#2166](https://github.com/juanfont/headscale/issues/2166)
 - Expiring or deleting a non-existent pre-auth key now returns an error instead of silently succeeding [#3324](https://github.com/juanfont/headscale/pull/3324)
 - Improve systemd service file hardening [#3341](https://github.com/juanfont/headscale/pull/3341)
 

--- a/cmd/headscale/cli/users.go
+++ b/cmd/headscale/cli/users.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strconv"
 
 	clientv1 "github.com/juanfont/headscale/gen/client/v1"
+	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/util"
 	"github.com/juanfont/headscale/hscontrol/util/zlog/zf"
 	"github.com/rs/zerolog/log"
@@ -19,6 +19,9 @@ import (
 var (
 	errFlagRequired       = errors.New("--name or --identifier flag is required")
 	errMultipleUsersMatch = errors.New("multiple users match query, specify an ID")
+	errNoUserFieldsToSet  = errors.New(
+		"at least one of --display-name, --email or --picture-url is required",
+	)
 )
 
 func usernameAndIDFlag(cmd *cobra.Command) {
@@ -96,6 +99,11 @@ func init() {
 	usernameAndIDFlag(renameUserCmd)
 	renameUserCmd.Flags().StringP("new-name", "r", "", "New username")
 	mustMarkRequired(renameUserCmd, "new-name")
+	userCmd.AddCommand(setUserCmd)
+	usernameAndIDFlag(setUserCmd)
+	setUserCmd.Flags().StringP("display-name", "d", "", "Display name, empty to clear")
+	setUserCmd.Flags().StringP("email", "e", "", "Email, empty to clear")
+	setUserCmd.Flags().StringP("picture-url", "p", "", "Profile picture URL, empty to clear")
 }
 
 var userCmd = &cobra.Command{
@@ -129,8 +137,8 @@ var createUserCmd = &cobra.Command{
 		}
 
 		if pictureURL, _ := cmd.Flags().GetString("picture-url"); pictureURL != "" {
-			if _, err := url.Parse(pictureURL); err != nil { //nolint:noinlineerr
-				return fmt.Errorf("invalid picture URL: %w", err)
+			if err := types.ValidateProfilePicURL(pictureURL); err != nil { //nolint:noinlineerr
+				return err
 			}
 
 			request.PictureUrl = &pictureURL
@@ -232,6 +240,80 @@ var listUsersCmd = &cobra.Command{
 			return renderTable([]string{"ID", "Name", "Username", "Email", colCreated}, rows)
 		})
 	}),
+}
+
+var setUserCmd = &cobra.Command{
+	Use:   "set --identifier ID or --name NAME",
+	Short: "Sets the profile fields of a user",
+	Long: `Sets the display name, email and profile picture URL of an existing user.
+
+Only the flags that are given are changed; passing a flag with an empty value
+clears that field. The display name and the profile picture are what Tailscale
+clients show for the user, for example in "tailscale whois".
+
+Users provisioned by OIDC cannot be edited here: the identity provider
+re-applies its claims on every login and would overwrite the change.`,
+	Example: `  headscale users set -i 1 --display-name "Vika" --picture-url "https://example.com/vika.png"
+  headscale users set -n vika --picture-url ""`,
+	RunE: clientRunE(func(ctx context.Context, client *clientv1.ClientWithResponses, cmd *cobra.Command, args []string) error {
+		_, user, err := resolveSingleUser(ctx, client, cmd)
+		if err != nil {
+			return err
+		}
+
+		request, err := setUserRequestFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		log.Trace().Interface(zf.Request, request).Msg("sending SetUser request")
+
+		resp, err := client.SetUserWithResponse(ctx, user.Id, request)
+		if err != nil {
+			return fmt.Errorf("setting user: %w", err)
+		}
+
+		if resp.StatusCode() != http.StatusOK {
+			return apiError(resp.StatusCode(), resp.ApplicationproblemJSONDefault)
+		}
+
+		return printOutput(cmd, resp.JSON200.User, "User updated")
+	}),
+}
+
+// setUserRequestFromFlags builds the update body from the flags the user
+// actually passed. Flags.Changed is what separates "leave this field alone"
+// from "clear this field", which a plain empty-string check cannot express.
+func setUserRequestFromFlags(cmd *cobra.Command) (clientv1.SetUserJSONRequestBody, error) {
+	var request clientv1.SetUserJSONRequestBody
+
+	if cmd.Flags().Changed("display-name") {
+		displayName, _ := cmd.Flags().GetString("display-name")
+		request.DisplayName = &displayName
+	}
+
+	if cmd.Flags().Changed("email") {
+		email, _ := cmd.Flags().GetString("email")
+		request.Email = &email
+	}
+
+	if cmd.Flags().Changed("picture-url") {
+		pictureURL, _ := cmd.Flags().GetString("picture-url")
+		// Validated client-side too, so a typo fails before the round trip.
+		if pictureURL != "" {
+			if err := types.ValidateProfilePicURL(pictureURL); err != nil { //nolint:noinlineerr
+				return request, err
+			}
+		}
+
+		request.PictureUrl = &pictureURL
+	}
+
+	if request.DisplayName == nil && request.Email == nil && request.PictureUrl == nil {
+		return request, errNoUserFieldsToSet
+	}
+
+	return request, nil
 }
 
 var renameUserCmd = &cobra.Command{

--- a/cmd/headscale/cli/users_test.go
+++ b/cmd/headscale/cli/users_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetUserRequestFromFlags pins the distinction the whole command rests on:
+// a flag that was never passed leaves the field alone (nil), while a flag passed
+// with an empty value clears it (pointer to ""). An empty-string check alone
+// cannot express that.
+func TestSetUserRequestFromFlags(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		wantErr         error
+		wantDisplayName *string
+		wantEmail       *string
+		wantPictureURL  *string
+	}{
+		{
+			name:    "no flags is an error",
+			args:    nil,
+			wantErr: errNoUserFieldsToSet,
+		},
+		{
+			name:            "display name only",
+			args:            []string{"--display-name", "Vika"},
+			wantDisplayName: new("Vika"),
+		},
+		{
+			name:            "empty flag clears the field",
+			args:            []string{"--picture-url", ""},
+			wantPictureURL:  new(""),
+			wantDisplayName: nil,
+		},
+		{
+			name:            "all three",
+			args:            []string{"--display-name", "Vika", "--email", "v@example.com", "--picture-url", "https://example.com/v.png"},
+			wantDisplayName: new("Vika"),
+			wantEmail:       new("v@example.com"),
+			wantPictureURL:  new("https://example.com/v.png"),
+		},
+		{
+			// Caught before the round trip so the operator gets an immediate
+			// error rather than a 400.
+			name:    "invalid picture url",
+			args:    []string{"--picture-url", "not-a-url"},
+			wantErr: types.ErrInvalidProfilePicURL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "set"}
+			cmd.Flags().StringP("display-name", "d", "", "")
+			cmd.Flags().StringP("email", "e", "", "")
+			cmd.Flags().StringP("picture-url", "p", "", "")
+			require.NoError(t, cmd.Flags().Parse(tt.args))
+
+			got, err := setUserRequestFromFlags(cmd)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDisplayName, got.DisplayName)
+			assert.Equal(t, tt.wantEmail, got.Email)
+			assert.Equal(t, tt.wantPictureURL, got.PictureUrl)
+		})
+	}
+}

--- a/docs/ref/api.md
+++ b/docs/ref/api.md
@@ -50,6 +50,16 @@ Headscale server at `/api/v1/docs` for details.
         https://headscale.example.com/api/v1/user?name=bob
     ```
 
+=== "Set the profile of user 1"
+
+    ```console
+    curl -X PUT -H "Authorization: Bearer <API_KEY>" \
+        --json '{"displayName": "Vika", "pictureUrl": "https://example.com/vika.png"}' \
+        https://headscale.example.com/api/v1/user/1
+    ```
+
+    Only the fields present in the request body are changed; a field set to an empty string is cleared.
+
 === "Register a node"
 
     ```console

--- a/docs/ref/oidc.md
+++ b/docs/ref/oidc.md
@@ -242,6 +242,10 @@ endpoint.
 | provider identifier | `iss`, `sub`         | A stable and unique identifier for a user, typically a combination of `iss` and `sub` OIDC claims |
 |                     | `groups`             | [Only used to filter for allowed groups](#authorize-users-with-filters)                           |
 
+The identity provider is the source of truth for these fields: Headscale re-applies the claims on every login. Users
+provisioned via OIDC therefore can not be edited with `headscale users rename` or `headscale users set`, which return an
+error instead of accepting a change that the next login would silently overwrite.
+
 ## Limitations
 
 - Support for OpenID Connect aims to be generic and vendor independent. It offers only limited support for quirks of

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -94,6 +94,39 @@ managed with the `headscale users` command. Invoke the built-in help for more in
       headscale users list
     ```
 
+### Set the profile of a headscale user
+
+A headscale user has a display name and a profile picture in addition to its username. Tailscale clients show both, for
+example in the output of `tailscale whois` and in the device lists of the graphical clients. Both may be set when the
+user is created and changed later with `headscale users set`:
+
+=== "Native"
+
+    ```shell
+    headscale users set --name <USER> \
+      --display-name "Vika" \
+      --picture-url "https://example.com/vika.png"
+    ```
+
+=== "Container"
+
+    ```shell
+    docker exec -it headscale \
+      headscale users set --name <USER> \
+      --display-name "Vika" \
+      --picture-url "https://example.com/vika.png"
+    ```
+
+Only the fields that are given are changed. Pass a flag with an empty value to remove a field, for example
+`--picture-url ""`. The profile picture must be an absolute `http` or `https` URL; headscale stores the URL and hands it
+to the clients, it does not host the image.
+
+!!! note "Users provisioned via OIDC"
+
+    Users that were created by [OIDC](../ref/oidc.md) can not be edited with this command. Their display name, email and
+    profile picture come from the identity provider, which re-applies its claims on every login and would overwrite any
+    local change.
+
 ## Register a node
 
 One has to [register a node](../ref/registration.md) first to use headscale as coordination server with Tailscale. The

--- a/gen/client/v1/client.gen.go
+++ b/gen/client/v1/client.gen.go
@@ -299,6 +299,18 @@ type SetTagsRequestBody struct {
 	Tags *[]string `json:"tags,omitempty"`
 }
 
+// SetUserRequestBody defines model for SetUserRequestBody.
+type SetUserRequestBody struct {
+	// DisplayName Display name; empty string clears it.
+	DisplayName *string `json:"displayName,omitempty"`
+
+	// Email Email; empty string clears it.
+	Email *string `json:"email,omitempty"`
+
+	// PictureUrl Profile picture URL; empty string clears it.
+	PictureUrl *string `json:"pictureUrl,omitempty"`
+}
+
 // User defines model for User.
 type User struct {
 	CreatedAt     time.Time `json:"createdAt"`
@@ -393,6 +405,9 @@ type ExpirePreAuthKeyJSONRequestBody = ExpirePreAuthKeyRequestBody
 
 // CreateUserJSONRequestBody defines body for CreateUser for application/json ContentType.
 type CreateUserJSONRequestBody = CreateUserRequestBody
+
+// SetUserJSONRequestBody defines body for SetUser for application/json ContentType.
+type SetUserJSONRequestBody = SetUserRequestBody
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
@@ -578,6 +593,11 @@ type ClientInterface interface {
 
 	// DeleteUser request
 	DeleteUser(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SetUserWithBody request with any body
+	SetUserWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SetUser(ctx context.Context, id string, body SetUserJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RenameUser request
 	RenameUser(ctx context.Context, oldId string, newName string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1077,6 +1097,30 @@ func (c *Client) CreateUser(ctx context.Context, body CreateUserJSONRequestBody,
 
 func (c *Client) DeleteUser(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDeleteUserRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SetUserWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetUserRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SetUser(ctx context.Context, id string, body SetUserJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetUserRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2298,6 +2342,53 @@ func NewDeleteUserRequest(server string, id string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewSetUserRequest calls the generic SetUser builder with application/json body
+func NewSetUserRequest(server string, id string, body SetUserJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSetUserRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewSetUserRequestWithBody generates requests for SetUser with any type of body
+func NewSetUserRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uint64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/user/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewRenameUserRequest generates requests for RenameUser
 func NewRenameUserRequest(server string, oldId string, newName string) (*http.Request, error) {
 	var err error
@@ -2493,6 +2584,11 @@ type ClientWithResponsesInterface interface {
 
 	// DeleteUserWithResponse request
 	DeleteUserWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteUserResponse, error)
+
+	// SetUserWithBodyWithResponse request with any body
+	SetUserWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetUserResponse, error)
+
+	SetUserWithResponse(ctx context.Context, id string, body SetUserJSONRequestBody, reqEditors ...RequestEditorFn) (*SetUserResponse, error)
 
 	// RenameUserWithResponse request
 	RenameUserWithResponse(ctx context.Context, oldId string, newName string, reqEditors ...RequestEditorFn) (*RenameUserResponse, error)
@@ -3366,6 +3462,37 @@ func (r DeleteUserResponse) ContentType() string {
 	return ""
 }
 
+type SetUserResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *UserOutputBody
+	ApplicationproblemJSONDefault *ErrorModel
+}
+
+// Status returns HTTPResponse.Status
+func (r SetUserResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SetUserResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r SetUserResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type RenameUserResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -3759,6 +3886,23 @@ func (c *ClientWithResponses) DeleteUserWithResponse(ctx context.Context, id str
 		return nil, err
 	}
 	return ParseDeleteUserResponse(rsp)
+}
+
+// SetUserWithBodyWithResponse request with arbitrary body returning *SetUserResponse
+func (c *ClientWithResponses) SetUserWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetUserResponse, error) {
+	rsp, err := c.SetUserWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSetUserResponse(rsp)
+}
+
+func (c *ClientWithResponses) SetUserWithResponse(ctx context.Context, id string, body SetUserJSONRequestBody, reqEditors ...RequestEditorFn) (*SetUserResponse, error) {
+	rsp, err := c.SetUser(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSetUserResponse(rsp)
 }
 
 // RenameUserWithResponse request returning *RenameUserResponse
@@ -4677,6 +4821,39 @@ func ParseDeleteUserResponse(rsp *http.Response) (*DeleteUserResponse, error) {
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest DeleteUserOutputBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSetUserResponse parses an HTTP response from a SetUserWithResponse call
+func ParseSetUserResponse(rsp *http.Response) (*SetUserResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SetUserResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest UserOutputBody
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/hscontrol/api/v1/errors.go
+++ b/hscontrol/api/v1/errors.go
@@ -6,6 +6,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/juanfont/headscale/hscontrol/db"
 	"github.com/juanfont/headscale/hscontrol/state"
+	"github.com/juanfont/headscale/hscontrol/types"
 	"gorm.io/gorm"
 )
 
@@ -35,6 +36,8 @@ func mapError(msg string, err error) error {
 		errors.Is(err, state.ErrRequestedTagsInvalidOrNotPermitted),
 		errors.Is(err, db.ErrUserStillHasNodes),
 		errors.Is(err, db.ErrCannotChangeOIDCUser),
+		errors.Is(err, types.ErrEmptyUserProfileUpdate),
+		errors.Is(err, types.ErrInvalidProfilePicURL),
 		errors.Is(err, db.ErrPreAuthKeyNotTaggedOrOwned),
 		errors.Is(err, db.ErrSingleUseAuthKeyHasBeenUsed):
 		return huma.Error400BadRequest(msg, err)

--- a/hscontrol/api/v1/users.go
+++ b/hscontrol/api/v1/users.go
@@ -35,7 +35,23 @@ type (
 	}
 )
 
+// SetUserRequestBody is a partial update of a user's presentational fields.
+//
+// A field that is absent from the request body is left unchanged; a field that
+// is present is written as given, and an explicit empty string clears it. That
+// distinction is why the fields are pointers.
+type SetUserRequestBody struct {
+	DisplayName *string `doc:"Display name; empty string clears it."        json:"displayName,omitempty"`
+	Email       *string `doc:"Email; empty string clears it."               json:"email,omitempty"`
+	PictureURL  *string `doc:"Profile picture URL; empty string clears it." json:"pictureUrl,omitempty"`
+}
+
 type (
+	setUserInput struct {
+		ID   string `format:"uint64" path:"id"`
+		Body SetUserRequestBody
+	}
+
 	renameUserInput struct {
 		OldID   string `format:"uint64" path:"oldId"`
 		NewName string `path:"newName"`
@@ -91,6 +107,41 @@ func registerUsers(api huma.API, b Backend) {
 		}
 
 		b.Change(policyChanged)
+
+		out := &userOutput{}
+		out.Body.User = userFromView(user.View())
+
+		return out, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "setUser",
+		Method:      http.MethodPut,
+		Path:        "/api/v1/user/{id}",
+		Summary:     "Set user profile fields",
+		Description: "Updates the presentational fields of a user: display name, " +
+			"email and profile picture URL. Fields left out of the request body are " +
+			"unchanged; a field set to an empty string is cleared. Users provisioned " +
+			"by OIDC cannot be edited, as the provider re-applies its claims on every " +
+			"login.",
+		Tags:     []string{"Users"},
+		Security: bearerAuth,
+	}, func(ctx context.Context, in *setUserInput) (*userOutput, error) {
+		id, err := parseUserID(in.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		user, c, err := b.State.SetUserProfile(id, types.UserProfileUpdate{
+			DisplayName:   in.Body.DisplayName,
+			Email:         in.Body.Email,
+			ProfilePicURL: in.Body.PictureURL,
+		})
+		if err != nil {
+			return nil, mapError("setting user profile", err)
+		}
+
+		b.Change(c)
 
 		out := &userOutput{}
 		out.Body.User = userFromView(user.View())

--- a/hscontrol/apiv1_users_test.go
+++ b/hscontrol/apiv1_users_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/juanfont/headscale/hscontrol/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,6 +51,123 @@ func TestAPIV1CreateUser(t *testing.T) {
 			[]byte(`{"name":"dup"}`))
 		assertStatus(t, res, http.StatusConflict)
 	})
+}
+
+// seedUserWithProfile creates a user whose presentational fields are already
+// populated, so a subsequent setUser can be seen to change and to clear them.
+func seedUserWithProfile(name string) func(t *testing.T, app *Headscale) {
+	return func(t *testing.T, app *Headscale) {
+		t.Helper()
+
+		user := app.state.CreateUserForTest(name)
+
+		_, _, err := app.state.SetUserProfile(types.UserID(user.ID), types.UserProfileUpdate{
+			DisplayName:   new("Original"),
+			Email:         new("original@example.com"),
+			ProfilePicURL: new("https://example.com/original.png"),
+		})
+		require.NoError(t, err)
+	}
+}
+
+func TestAPIV1SetUser(t *testing.T) {
+	t.Run("parity", func(t *testing.T) {
+		assertParityIsolated(t, seedUsers("vika"), http.MethodPut, "/api/v1/user/1",
+			[]byte(`{"displayName":"Vika","pictureUrl":"https://example.com/vika.png"}`))
+	})
+
+	t.Run("absent fields are untouched", func(t *testing.T) {
+		h := newAPIV1Harness(t)
+		seedUserWithProfile("vika")(t, h.app)
+
+		res := h.callHuma(http.MethodPut, "/api/v1/user/1",
+			[]byte(`{"displayName":"Vika"}`))
+		require.Equal(t, http.StatusOK, res.status)
+
+		user := decodeUser(t, res.body)
+		assert.Equal(t, "Vika", user["displayName"])
+		assert.Equal(t, "original@example.com", user["email"])
+		assert.Equal(t, "https://example.com/original.png", user["profilePicUrl"])
+	})
+
+	// The distinction the pointer fields exist for: an explicit empty string
+	// removes the avatar, while omitting the field keeps it.
+	t.Run("empty string clears field", func(t *testing.T) {
+		h := newAPIV1Harness(t)
+		seedUserWithProfile("vika")(t, h.app)
+
+		res := h.callHuma(http.MethodPut, "/api/v1/user/1", []byte(`{"pictureUrl":""}`))
+		require.Equal(t, http.StatusOK, res.status)
+
+		user := decodeUser(t, res.body)
+		assert.Empty(t, user["profilePicUrl"])
+		assert.Equal(t, "Original", user["displayName"])
+	})
+
+	t.Run("empty body rejected", func(t *testing.T) {
+		h := newAPIV1Harness(t)
+		seedUsers("vika")(t, h.app)
+
+		res := h.callHuma(http.MethodPut, "/api/v1/user/1", []byte(`{}`))
+		assertStatus(t, res, http.StatusBadRequest)
+	})
+
+	// Headscale hands this URL to every client's user interface, so a scheme
+	// that is not http(s) must not be storable.
+	t.Run("invalid picture url rejected", func(t *testing.T) {
+		for _, bad := range []string{"/avatar.png", "javascript:alert(1)", "example.com/a.png"} {
+			h := newAPIV1Harness(t)
+			seedUsers("vika")(t, h.app)
+
+			res := h.callHuma(http.MethodPut, "/api/v1/user/1",
+				[]byte(`{"pictureUrl":"`+bad+`"}`))
+			assertStatus(t, res, http.StatusBadRequest)
+		}
+	})
+
+	// OIDC re-applies its claims on every login, so a manual edit would be
+	// silently reverted; refusing is the honest answer.
+	t.Run("oidc user rejected", func(t *testing.T) {
+		h := newAPIV1Harness(t)
+
+		user := h.app.state.CreateUserForTest("oidc")
+		_, _, err := h.app.state.UpdateUser(types.UserID(user.ID), func(u *types.User) error {
+			u.Provider = util.RegisterMethodOIDC
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		res := h.callHuma(http.MethodPut, "/api/v1/user/1", []byte(`{"displayName":"Manual"}`))
+		assertStatus(t, res, http.StatusBadRequest)
+	})
+
+	t.Run("nonexistent user", func(t *testing.T) {
+		h := newAPIV1Harness(t)
+
+		res := h.callHuma(http.MethodPut, "/api/v1/user/999", []byte(`{"displayName":"x"}`))
+		assertStatus(t, res, http.StatusNotFound)
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		h := newAPIV1Harness(t)
+
+		res := h.callHuma(http.MethodPut, "/api/v1/user/abc", []byte(`{"displayName":"x"}`))
+		assertStatus(t, res, http.StatusBadRequest)
+	})
+}
+
+// decodeUser unwraps the {"user": {...}} envelope the user endpoints return.
+func decodeUser(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+
+	var got struct {
+		User map[string]any `json:"user"`
+	}
+
+	require.NoError(t, json.Unmarshal(body, &got))
+
+	return got.User
 }
 
 func TestAPIV1RenameUser(t *testing.T) {

--- a/hscontrol/db/users.go
+++ b/hscontrol/db/users.go
@@ -117,6 +117,59 @@ func RenameUser(tx *gorm.DB, uid types.UserID, newName string) error {
 	return nil
 }
 
+// SetUserProfile applies a partial update to the presentational fields of a
+// [types.User] and returns the stored user.
+//
+// Only the fields set in update are written. The update is applied with a
+// column map rather than a struct because GORM's struct-based Updates skips
+// zero values, which would make it impossible to clear a display name or a
+// profile picture.
+//
+// OIDC-provisioned users are rejected: [types.User.FromClaim] overwrites all
+// three fields on every login, so a manual edit would be silently reverted.
+func SetUserProfile(
+	tx *gorm.DB,
+	uid types.UserID,
+	update types.UserProfileUpdate,
+) (*types.User, error) {
+	if err := update.Validate(); err != nil { //nolint:noinlineerr
+		return nil, err
+	}
+
+	user, err := GetUserByID(tx, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	if user.Provider == util.RegisterMethodOIDC {
+		return nil, ErrCannotChangeOIDCUser
+	}
+
+	columns := make(map[string]any, 3)
+
+	if update.DisplayName != nil {
+		columns["display_name"] = *update.DisplayName
+		user.DisplayName = *update.DisplayName
+	}
+
+	if update.Email != nil {
+		columns["email"] = *update.Email
+		user.Email = *update.Email
+	}
+
+	if update.ProfilePicURL != nil {
+		columns["profile_pic_url"] = *update.ProfilePicURL
+		user.ProfilePicURL = *update.ProfilePicURL
+	}
+
+	err = tx.Model(&types.User{}).Where("id = ?", uid).Updates(columns).Error
+	if err != nil {
+		return nil, fmt.Errorf("updating user profile: %w", err)
+	}
+
+	return user, nil
+}
+
 func (hsdb *HSDatabase) GetUserByID(uid types.UserID) (*types.User, error) {
 	return GetUserByID(hsdb.DB, uid)
 }

--- a/hscontrol/db/users_test.go
+++ b/hscontrol/db/users_test.go
@@ -279,3 +279,145 @@ func TestRenameUser(t *testing.T) {
 		})
 	}
 }
+
+func TestSetUserProfile(t *testing.T) {
+	// seeded is the starting point for every case: all three presentational
+	// fields populated, so both "change" and "clear" are observable.
+	seeded := func(t *testing.T, db *HSDatabase) *types.User {
+		t.Helper()
+
+		user := db.CreateUserForTest("test")
+
+		updated, err := Write(db.DB, func(tx *gorm.DB) (*types.User, error) {
+			return SetUserProfile(tx, types.UserID(user.ID), types.UserProfileUpdate{
+				DisplayName:   new("Original"),
+				Email:         new("original@example.com"),
+				ProfilePicURL: new("https://example.com/original.png"),
+			})
+		})
+		require.NoError(t, err)
+
+		return updated
+	}
+
+	tests := []struct {
+		name    string
+		update  types.UserProfileUpdate
+		wantErr error
+		want    types.UserProfileUpdate // expected end state, all fields set
+	}{
+		{
+			name: "set_all_fields",
+			update: types.UserProfileUpdate{
+				DisplayName:   new("Vika"),
+				Email:         new("vika@example.com"),
+				ProfilePicURL: new("https://example.com/vika.png"),
+			},
+			want: types.UserProfileUpdate{
+				DisplayName:   new("Vika"),
+				Email:         new("vika@example.com"),
+				ProfilePicURL: new("https://example.com/vika.png"),
+			},
+		},
+		{
+			// The interesting case: GORM's struct-based Updates would drop
+			// these because they are zero values.
+			name: "empty_string_clears_field",
+			update: types.UserProfileUpdate{
+				DisplayName:   new(""),
+				ProfilePicURL: new(""),
+			},
+			want: types.UserProfileUpdate{
+				DisplayName:   new(""),
+				Email:         new("original@example.com"),
+				ProfilePicURL: new(""),
+			},
+		},
+		{
+			name:   "absent_field_is_untouched",
+			update: types.UserProfileUpdate{ProfilePicURL: new("https://example.com/new.png")},
+			want: types.UserProfileUpdate{
+				DisplayName:   new("Original"),
+				Email:         new("original@example.com"),
+				ProfilePicURL: new("https://example.com/new.png"),
+			},
+		},
+		{
+			name:    "empty_update_rejected",
+			update:  types.UserProfileUpdate{},
+			wantErr: types.ErrEmptyUserProfileUpdate,
+		},
+		{
+			name:    "relative_picture_url_rejected",
+			update:  types.UserProfileUpdate{ProfilePicURL: new("/avatar.png")},
+			wantErr: types.ErrInvalidProfilePicURL,
+		},
+		{
+			name:    "javascript_picture_url_rejected",
+			update:  types.UserProfileUpdate{ProfilePicURL: new("javascript:alert(1)")},
+			wantErr: types.ErrInvalidProfilePicURL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, err := newSQLiteTestDB()
+			require.NoError(t, err)
+
+			user := seeded(t, db)
+
+			got, err := Write(db.DB, func(tx *gorm.DB) (*types.User, error) {
+				return SetUserProfile(tx, types.UserID(user.ID), tt.update)
+			})
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			// The returned user and the persisted row must agree; a returned
+			// value that is not what was written would be the worst failure.
+			stored, err := db.GetUserByID(types.UserID(user.ID))
+			require.NoError(t, err)
+
+			for _, u := range []*types.User{got, stored} {
+				assert.Equal(t, *tt.want.DisplayName, u.DisplayName)
+				assert.Equal(t, *tt.want.Email, u.Email)
+				assert.Equal(t, *tt.want.ProfilePicURL, u.ProfilePicURL)
+			}
+		})
+	}
+
+	t.Run("error_user_not_found", func(t *testing.T) {
+		db, err := newSQLiteTestDB()
+		require.NoError(t, err)
+
+		_, err = Write(db.DB, func(tx *gorm.DB) (*types.User, error) {
+			return SetUserProfile(tx, 99988, types.UserProfileUpdate{
+				DisplayName: new("nobody"),
+			})
+		})
+		assert.ErrorIs(t, err, ErrUserNotFound)
+	})
+
+	// OIDC re-applies its claims on every login, so an edit here would be
+	// silently reverted. Refuse it, exactly as RenameUser does.
+	t.Run("error_oidc_user", func(t *testing.T) {
+		db, err := newSQLiteTestDB()
+		require.NoError(t, err)
+
+		user := db.CreateUserForTest("oidc")
+		user.Provider = util.RegisterMethodOIDC
+		require.NoError(t, db.DB.Save(user).Error)
+
+		_, err = Write(db.DB, func(tx *gorm.DB) (*types.User, error) {
+			return SetUserProfile(tx, types.UserID(user.ID), types.UserProfileUpdate{
+				DisplayName: new("Manual"),
+			})
+		})
+		assert.ErrorIs(t, err, ErrCannotChangeOIDCUser)
+	})
+}

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -416,11 +416,15 @@ func (s *State) CreateUser(user types.User) (*types.User, change.Change, error) 
 // UpdateUser modifies an existing user using the provided update function within a transaction.
 // Returns the updated user, change set, and any error.
 func (s *State) UpdateUser(userID types.UserID, updateFn func(*types.User) error) (*types.User, change.Change, error) {
+	var before types.User
+
 	user, err := hsdb.Write(s.db.DB, func(tx *gorm.DB) (*types.User, error) {
 		user, err := hsdb.GetUserByID(tx, userID)
 		if err != nil {
 			return nil, err
 		}
+
+		before = *user
 
 		if err := updateFn(user); err != nil { //nolint:noinlineerr
 			return nil, err
@@ -438,15 +442,103 @@ func (s *State) UpdateUser(userID types.UserID, updateFn func(*types.User) error
 		return nil, change.Change{}, err
 	}
 
+	return s.publishUserUpdate(before, user)
+}
+
+// SetUserProfile applies a partial update to a user's presentational fields
+// (display name, email, profile picture URL) and propagates the result to
+// connected clients.
+//
+// Unlike [State.UpdateUser], a field explicitly set to the empty string is
+// cleared rather than ignored, so an operator can remove a display name or an
+// avatar once it has been set.
+func (s *State) SetUserProfile(
+	userID types.UserID,
+	update types.UserProfileUpdate,
+) (*types.User, change.Change, error) {
+	var before types.User
+
+	user, err := hsdb.Write(s.db.DB, func(tx *gorm.DB) (*types.User, error) {
+		current, err := hsdb.GetUserByID(tx, userID)
+		if err != nil {
+			return nil, err
+		}
+
+		before = *current
+
+		return hsdb.SetUserProfile(tx, userID, update)
+	})
+	if err != nil {
+		return nil, change.Change{}, err
+	}
+
+	return s.publishUserUpdate(before, user)
+}
+
+// publishUserUpdate makes a written user record visible to the rest of the
+// system: it refreshes the copies cached in [NodeStore] and reports the
+// [change.Change] connected clients need.
+func (s *State) publishUserUpdate(
+	before types.User,
+	user *types.User,
+) (*types.User, change.Change, error) {
+	s.refreshNodeStoreUser(user)
+
 	// Check if policy manager needs updating
 	c, err := s.updatePolicyManagerUsers()
 	if err != nil {
 		return user, change.Change{}, fmt.Errorf("updating policy manager after user update: %w", err)
 	}
 
-	// TODO(kradalby): We might want to update nodestore with the user data
+	// [tailcfg.UserProfile] is only re-sent as part of a full update, so a
+	// change to a field the clients display has to force one. The comparison
+	// matters: OIDC re-applies the claims on every single login, and
+	// broadcasting a full update to every node each time would be a
+	// significant regression.
+	if userProfileChanged(before, *user) {
+		c = c.Merge(change.UserAdded())
+	}
 
 	return user, c, nil
+}
+
+// userProfileChanged reports whether a user update altered a field that
+// connected clients can observe, i.e. anything that feeds
+// [types.User.TailscaleUserProfile].
+func userProfileChanged(before, after types.User) bool {
+	return before.Name != after.Name ||
+		before.DisplayName != after.DisplayName ||
+		before.Email != after.Email ||
+		before.ProfilePicURL != after.ProfilePicURL
+}
+
+// refreshNodeStoreUser re-points every node owned by user at the updated
+// record. [types.Node] embeds its owning [types.User], and the mapper reads the
+// owner from the [NodeStore] snapshot rather than the database, so without this
+// a profile change would stay invisible to already-connected nodes until the
+// server restarted.
+func (s *State) refreshNodeStoreUser(user *types.User) {
+	if user == nil {
+		return
+	}
+
+	nodes := s.nodeStore.ListNodesByUser(types.UserID(user.ID))
+	if nodes.Len() == 0 {
+		return
+	}
+
+	updates := make(map[types.NodeID]UpdateNodeFunc, nodes.Len())
+
+	for _, node := range nodes.All() {
+		// One copy per node: the nodes must not end up sharing a mutable
+		// [types.User] through the snapshot.
+		updated := *user
+		updates[node.ID()] = func(n *types.Node) {
+			n.User = &updated
+		}
+	}
+
+	s.nodeStore.UpdateNodes(updates)
 }
 
 // DeleteUser permanently removes a user and all associated data (nodes, API keys, etc).

--- a/hscontrol/state/user_profile_test.go
+++ b/hscontrol/state/user_profile_test.go
@@ -1,0 +1,177 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/db"
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/juanfont/headscale/hscontrol/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newStateWithUserAndNode returns a started State holding one user who owns one
+// registered node, which is what makes the NodeStore staleness observable.
+func newStateWithUserAndNode(t *testing.T) (*State, types.UserID, types.NodeID) {
+	t.Helper()
+
+	const userName = "vika"
+
+	cfg := persistTestConfig(t.TempDir() + "/headscale.db")
+
+	database, err := db.NewHeadscaleDatabase(cfg)
+	require.NoError(t, err)
+
+	user := database.CreateUserForTest(userName)
+	node := database.CreateRegisteredNodeForTest(user, userName+"-node")
+	require.NoError(t, database.Close())
+
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	return s, types.UserID(user.ID), node.ID
+}
+
+// TestSetUserProfilePropagatesToNodeStore is the load-bearing test for the
+// feature: types.Node embeds its owning types.User, and the mapper reads the
+// owner from the NodeStore snapshot rather than the database. If the write path
+// only updated the database row, a new avatar would never reach an
+// already-connected client, which is the entire point of the feature.
+func TestSetUserProfilePropagatesToNodeStore(t *testing.T) {
+	s, userID, nodeID := newStateWithUserAndNode(t)
+
+	_, c, err := s.SetUserProfile(userID, types.UserProfileUpdate{
+		DisplayName:   new("Vika"),
+		ProfilePicURL: new("https://example.com/vika.png"),
+	})
+	require.NoError(t, err)
+
+	// A full update is what carries MapResponse.UserProfiles, so anything less
+	// leaves connected clients showing the old profile.
+	assert.True(t, c.IsFull(),
+		"a visible profile change must produce a full update, got %+v", c)
+
+	node, ok := s.GetNodeByID(nodeID)
+	require.True(t, ok)
+
+	owner := node.Owner()
+	require.True(t, owner.Valid())
+	assert.Equal(t, "Vika", owner.DisplayName())
+	assert.Equal(t, "https://example.com/vika.png", owner.ProfilePicURL())
+
+	// The value the client actually receives.
+	profile := owner.TailscaleUserProfile()
+	assert.Equal(t, "Vika", profile.DisplayName)
+	assert.Equal(t, "https://example.com/vika.png", profile.ProfilePicURL)
+}
+
+// TestSetUserProfileClearsFields proves an explicit empty string removes a
+// value. GORM's struct-based Updates skips zero values, so without the
+// column-map write path an avatar could be set but never removed.
+func TestSetUserProfileClearsFields(t *testing.T) {
+	s, userID, nodeID := newStateWithUserAndNode(t)
+
+	_, _, err := s.SetUserProfile(userID, types.UserProfileUpdate{
+		DisplayName:   new("Vika"),
+		ProfilePicURL: new("https://example.com/vika.png"),
+	})
+	require.NoError(t, err)
+
+	// Clear the picture, leave the display name alone.
+	user, _, err := s.SetUserProfile(userID, types.UserProfileUpdate{
+		ProfilePicURL: new(""),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, user.ProfilePicURL)
+	assert.Equal(t, "Vika", user.DisplayName, "an absent field must be untouched")
+
+	stored, err := s.GetUserByID(userID)
+	require.NoError(t, err)
+	assert.Empty(t, stored.ProfilePicURL)
+	assert.Equal(t, "Vika", stored.DisplayName)
+
+	node, ok := s.GetNodeByID(nodeID)
+	require.True(t, ok)
+	assert.Empty(t, node.Owner().ProfilePicURL())
+}
+
+// TestSetUserProfileNoVisibleChangeDoesNotBroadcast guards a performance
+// regression rather than a correctness one: OIDC re-applies its claims on every
+// single login through the same publish path, and sending a full update to every
+// node on every login would be expensive.
+func TestSetUserProfileNoVisibleChangeDoesNotBroadcast(t *testing.T) {
+	s, userID, _ := newStateWithUserAndNode(t)
+
+	_, _, err := s.SetUserProfile(userID, types.UserProfileUpdate{
+		DisplayName: new("Vika"),
+	})
+	require.NoError(t, err)
+
+	// Writing the same value again changes nothing a client can see.
+	_, c, err := s.SetUserProfile(userID, types.UserProfileUpdate{
+		DisplayName: new("Vika"),
+	})
+	require.NoError(t, err)
+	assert.False(t, c.IsFull(),
+		"a write that changes nothing visible must not force a full update, got %+v", c)
+}
+
+func TestSetUserProfileErrors(t *testing.T) {
+	t.Run("unknown user", func(t *testing.T) {
+		s, _, _ := newStateWithUserAndNode(t)
+
+		_, _, err := s.SetUserProfile(99988, types.UserProfileUpdate{
+			DisplayName: new("Nobody"),
+		})
+		assert.ErrorIs(t, err, db.ErrUserNotFound)
+	})
+
+	t.Run("empty update", func(t *testing.T) {
+		s, userID, _ := newStateWithUserAndNode(t)
+
+		_, _, err := s.SetUserProfile(userID, types.UserProfileUpdate{})
+		assert.ErrorIs(t, err, types.ErrEmptyUserProfileUpdate)
+	})
+
+	t.Run("invalid picture url", func(t *testing.T) {
+		s, userID, _ := newStateWithUserAndNode(t)
+
+		_, _, err := s.SetUserProfile(userID, types.UserProfileUpdate{
+			ProfilePicURL: new("not-a-url"),
+		})
+		assert.ErrorIs(t, err, types.ErrInvalidProfilePicURL)
+	})
+
+	t.Run("oidc user", func(t *testing.T) {
+		s, userID, _ := newStateWithUserAndNode(t)
+
+		_, _, err := s.UpdateUser(userID, func(u *types.User) error {
+			u.Provider = util.RegisterMethodOIDC
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		_, _, err = s.SetUserProfile(userID, types.UserProfileUpdate{
+			DisplayName: new("Manual"),
+		})
+		assert.ErrorIs(t, err, db.ErrCannotChangeOIDCUser)
+	})
+}
+
+// TestRenameUserPropagatesToNodeStore covers the same staleness fix on the
+// pre-existing rename path: the login name a peer sees comes from the node's
+// cached owner too.
+func TestRenameUserPropagatesToNodeStore(t *testing.T) {
+	s, userID, nodeID := newStateWithUserAndNode(t)
+
+	_, c, err := s.RenameUser(userID, "vika-renamed")
+	require.NoError(t, err)
+	assert.True(t, c.IsFull(), "a rename must refresh user profiles, got %+v", c)
+
+	node, ok := s.GetNodeByID(nodeID)
+	require.True(t, ok)
+	assert.Equal(t, "vika-renamed", node.Owner().Name())
+	assert.Equal(t, "vika-renamed", node.Owner().TailscaleUserProfile().LoginName)
+}

--- a/hscontrol/testdata/apiv1_golden/TestAPIV1SetUser_parity.json
+++ b/hscontrol/testdata/apiv1_golden/TestAPIV1SetUser_parity.json
@@ -1,0 +1,15 @@
+{
+  "status": 200,
+  "body": {
+    "user": {
+      "createdAt": "\u003ctimestamp\u003e",
+      "displayName": "Vika",
+      "email": "",
+      "id": "1",
+      "name": "vika",
+      "profilePicUrl": "https://example.com/vika.png",
+      "provider": "",
+      "providerId": ""
+    }
+  }
+}

--- a/hscontrol/types/users.go
+++ b/hscontrol/types/users.go
@@ -97,6 +97,73 @@ type User struct {
 	ProfilePicURL string
 }
 
+// ErrEmptyUserProfileUpdate is returned when a profile update requests no changes.
+var ErrEmptyUserProfileUpdate = errors.New("no profile fields to update")
+
+// ErrInvalidProfilePicURL is returned when a profile picture URL is not an
+// absolute http(s) URL.
+var ErrInvalidProfilePicURL = errors.New(
+	"profile picture URL must be an absolute http or https URL",
+)
+
+// UserProfileUpdate is a partial update of the presentational fields of a
+// [User]: the fields that end up in [tailcfg.UserProfile] and are shown by
+// clients.
+//
+// A nil field is left unchanged. A non-nil field is written as given,
+// including the empty string, which clears the value. This is why the fields
+// are pointers: "leave the avatar alone" and "remove the avatar" are different
+// requests.
+type UserProfileUpdate struct {
+	DisplayName   *string
+	Email         *string
+	ProfilePicURL *string
+}
+
+// IsEmpty reports whether the update requests no changes at all.
+func (u UserProfileUpdate) IsEmpty() bool {
+	return u.DisplayName == nil && u.Email == nil && u.ProfilePicURL == nil
+}
+
+// Validate checks that the update is well formed. An update that changes
+// nothing is an error: it is almost always a caller mistake rather than an
+// intentional no-op.
+func (u UserProfileUpdate) Validate() error {
+	if u.IsEmpty() {
+		return ErrEmptyUserProfileUpdate
+	}
+
+	if u.Email != nil && *u.Email != "" {
+		if _, err := mail.ParseAddress(*u.Email); err != nil { //nolint:noinlineerr
+			return fmt.Errorf("invalid email: %w", err)
+		}
+	}
+
+	if u.ProfilePicURL != nil && *u.ProfilePicURL != "" {
+		if err := ValidateProfilePicURL(*u.ProfilePicURL); err != nil { //nolint:noinlineerr
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ValidateProfilePicURL checks that s is an absolute http or https URL.
+// Headscale hands this value to every client's user interface, so a relative
+// path or a "javascript:" scheme must not get that far.
+func ValidateProfilePicURL(s string) error {
+	parsed, err := url.Parse(s)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidProfilePicURL, err)
+	}
+
+	if parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return fmt.Errorf("%w: %q", ErrInvalidProfilePicURL, s)
+	}
+
+	return nil
+}
+
 func (u *User) StringID() string {
 	if u == nil {
 		return ""

--- a/hscontrol/types/users_test.go
+++ b/hscontrol/types/users_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/juanfont/headscale/hscontrol/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestUnmarshallOIDCClaims(t *testing.T) {
@@ -551,4 +553,110 @@ func TestOIDCClaimsJSONToUser(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateProfilePicURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{name: "https", url: "https://example.com/vika.png"},
+		{name: "http", url: "http://example.com/vika.png"},
+		{name: "with query and port", url: "https://example.com:8443/a.png?size=64"},
+		{name: "uppercase scheme is normalised by url.Parse", url: "HTTPS://example.com/a.png"},
+		{name: "relative path", url: "/vika.png", wantErr: true},
+		{name: "bare host", url: "example.com/vika.png", wantErr: true},
+		// The reason this validation exists at all: the value is rendered by
+		// every client's user interface.
+		{name: "javascript scheme", url: "javascript:alert(1)", wantErr: true},
+		{name: "data scheme", url: "data:image/png;base64,AAAA", wantErr: true},
+		{name: "file scheme", url: "file:///etc/passwd", wantErr: true},
+		{name: "no host", url: "https://", wantErr: true},
+		{name: "control character", url: "https://example.com/\x7f", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateProfilePicURL(tt.url)
+			if tt.wantErr {
+				assert.ErrorIs(t, err, ErrInvalidProfilePicURL)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUserProfileUpdateValidate(t *testing.T) {
+	tests := []struct {
+		name string
+		// wantErr is the sentinel to match, or nil when any error will do
+		// (net/mail does not export one). wantAnyErr covers that case.
+		update     UserProfileUpdate
+		wantErr    error
+		wantAnyErr bool
+	}{
+		{
+			name:    "empty update",
+			update:  UserProfileUpdate{},
+			wantErr: ErrEmptyUserProfileUpdate,
+		},
+		{
+			// Clearing is a legitimate request, so an explicit empty string
+			// must not be mistaken for "nothing to do".
+			name:   "clearing everything is a valid update",
+			update: UserProfileUpdate{DisplayName: new(""), ProfilePicURL: new("")},
+		},
+		{
+			name:   "valid",
+			update: UserProfileUpdate{ProfilePicURL: new("https://example.com/a.png")},
+		},
+		{
+			name:    "bad picture url",
+			update:  UserProfileUpdate{ProfilePicURL: new("nope")},
+			wantErr: ErrInvalidProfilePicURL,
+		},
+		{
+			name:       "bad email",
+			update:     UserProfileUpdate{Email: new("not-an-email")},
+			wantAnyErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.update.Validate()
+
+			switch {
+			case tt.wantErr != nil:
+				require.ErrorIs(t, err, tt.wantErr)
+			case tt.wantAnyErr:
+				require.Error(t, err)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUserProfilePicReachesTailscaleTypes(t *testing.T) {
+	user := User{
+		Model:         gorm.Model{ID: 7},
+		Name:          "vika",
+		DisplayName:   "Vika",
+		ProfilePicURL: "https://example.com/vika.png",
+	}
+
+	// All three tailcfg shapes carry the avatar; UserProfile is the one the
+	// client renders for peers and that "tailscale whois" reports.
+	assert.Equal(t, "https://example.com/vika.png", user.TailscaleUserProfile().ProfilePicURL)
+	assert.Equal(t, "https://example.com/vika.png", user.TailscaleUser().ProfilePicURL)
+	assert.Equal(t, "https://example.com/vika.png", user.TailscaleLogin().ProfilePicURL)
+
+	assert.Equal(t, "Vika", user.TailscaleUserProfile().DisplayName)
+	assert.Equal(t, "vika", user.TailscaleUserProfile().LoginName)
+
+	// The view path serialisers use must agree with the struct path.
+	assert.Equal(t, user.TailscaleUserProfile(), user.View().TailscaleUserProfile())
 }

--- a/integration/cli_users_test.go
+++ b/integration/cli_users_test.go
@@ -336,3 +336,120 @@ func TestUserCommandValidation(t *testing.T) {
 		})
 	}
 }
+
+// TestUserSetCommand exercises `headscale users set`: changing the display name
+// and profile picture of an existing user, clearing the picture with an empty
+// value, and the validation error paths.
+//
+// The point of the feature is that Tailscale clients render these fields, so the
+// test does not stop at the API: it asserts the new profile actually arrives in
+// the connected node's netmap as tailcfg.UserProfile.
+func TestUserSetCommand(t *testing.T) {
+	IntegrationSkip(t)
+
+	scenario, headscale := setupCLIScenario(t, "cli-userset", []string{"userset"}, 1)
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	clients, err := scenario.ListTailscaleClients()
+	require.NoError(t, err)
+	require.Len(t, clients, 1)
+
+	client := clients[0]
+
+	updated := assertJSONRoundtrip[*clientv1.User](t, headscale, []string{
+		"headscale", "users", "set",
+		"--name", "userset",
+		"--display-name", "User Set",
+		"--picture-url", "https://example.com/userset.png",
+		"--output", "json",
+	})
+
+	assert.Equal(t, "userset", updated.Name)
+	assert.Equal(t, "User Set", updated.DisplayName)
+	assert.Equal(t, "https://example.com/userset.png", updated.ProfilePicUrl)
+
+	// Read-after-write: the values must survive a list query.
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		var users []*clientv1.User
+
+		err := executeAndUnmarshal(headscale,
+			[]string{"headscale", "users", "list", "--name", "userset", "--output", "json"},
+			&users,
+		)
+		assert.NoError(ct, err)
+
+		if !assert.Len(ct, users, 1) {
+			return
+		}
+
+		assert.Equal(ct, "User Set", users[0].DisplayName)
+		assert.Equal(ct, "https://example.com/userset.png", users[0].ProfilePicUrl)
+	}, integrationutil.ScaledTimeout(10*time.Second), integrationutil.FastPoll,
+		"Waiting for the updated profile in users list")
+
+	// End-to-end: the node must receive the new profile in its netmap without
+	// reconnecting. This is what breaks if the write path only touches the
+	// database and leaves the in-memory node copies stale.
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		status, err := client.Status()
+		assert.NoError(ct, err)
+
+		if status == nil {
+			return
+		}
+
+		profile := status.User[status.Self.UserID]
+		assert.Equal(ct, "User Set", profile.DisplayName)
+		assert.Equal(ct, "https://example.com/userset.png", profile.ProfilePicURL)
+	}, integrationutil.ScaledTimeout(60*time.Second), 1*time.Second,
+		"Waiting for the updated profile to reach the client netmap")
+
+	// An empty value clears the field; the display name, not passed, stays.
+	cleared := assertJSONRoundtrip[*clientv1.User](t, headscale, []string{
+		"headscale", "users", "set",
+		"--name", "userset",
+		"--picture-url", "",
+		"--output", "json",
+	})
+
+	assert.Empty(t, cleared.ProfilePicUrl)
+	assert.Equal(t, "User Set", cleared.DisplayName)
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "no fields",
+			args:    []string{"users", "set", "--name", "userset"},
+			wantErr: "at least one of",
+		},
+		{
+			name:    "missing selector",
+			args:    []string{"users", "set", "--display-name", "x"},
+			wantErr: "--name or --identifier",
+		},
+		{
+			name:    "invalid picture url",
+			args:    []string{"users", "set", "--name", "userset", "--picture-url", "not-a-url"},
+			wantErr: "profile picture URL",
+		},
+		{
+			name:    "unknown user",
+			args:    []string{"users", "set", "--identifier", "99999", "--display-name", "x"},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := headscale.Execute(append([]string{"headscale"}, tt.args...))
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2166. Design document posted on the issue as required by CONTRIBUTING.md:
https://github.com/juanfont/headscale/issues/2166#issuecomment-5320904646

## What is missing today

`DisplayName`, `Email` and `ProfilePicURL` already exist end to end — the DB
carries them, `User.TailscaleUserProfile()` fills them, the mapper emits them,
and `headscale users create` accepts all three. The only gap is that they cannot
be changed afterwards: an operator who created a user before deciding on an
avatar has to destroy and recreate it, which is impossible once that user owns
nodes.

## What this adds

**`PUT /api/v1/user/{id}`** with pointer semantics: an absent field is left
alone, a present field is set — including the empty string, which clears it.
Clearing an avatar is a real operation, and GORM's struct-based `Updates()`
silently skips zero values, so the DB layer builds an explicit column map
instead. An empty body is a `400`, not a silent no-op.

`pictureUrl` is validated to be an absolute `http`/`https` URL, server-side and
in the CLI. This value is handed to every client's UI, so `javascript:` and bare
strings are rejected. (This also replaces the existing `url.Parse` check in
`users create`, which accepted almost anything.)

**`headscale users set`**, following the flag style of `rename`/`destroy`:

```console
$ headscale users set -i 1 --display-name "Vika" --picture-url "https://example.com/vika.png"
$ headscale users set -n vika --picture-url ""   # clear
```

`Flags().Changed` is what distinguishes "not passed" from "passed empty".

**OIDC users are refused**, reusing `ErrCannotChangeOIDCUser` exactly as
`RenameUser` already does. `User.FromClaim` rewrites all three fields on every
login — including to `""` when a claim is absent — so a manual edit would be
silently reverted. The provider stays the source of truth.

## Two bugs this surfaced

Both predate this feature and affect `RenameUser` and OIDC re-login as well: any
user mutation was invisible to already-connected nodes until a restart.

1. **Stale `NodeStore`.** `types.Node` embeds the owner and the mapper reads it
   from the snapshot via `NodeView.Owner()`, not from the DB. `UpdateUser` wrote
   the row and left the cached copies alone — there is an explicit
   `TODO(kradalby): We might want to update nodestore with the user data` at the
   site. Now every node of that user is re-pointed at the updated record in a
   single `NodeStore.UpdateNodes` batch.
2. **No map update was emitted.** `UpdateUser` returned only the policy
   manager's change, which is empty when the policy does not reference the user.
   It now returns `change.UserAdded()` — but *only* when a client-visible field
   actually changed, because OIDC calls `UpdateUser` on every login and
   broadcasting a full update to every node on every login would be a serious
   regression.

## Relationship to #3107

#3107 asks for the same capability but is written against the gRPC/protobuf
stack that was removed in #3324; the API is now code-first with huma and the Go
client is generated from OpenAPI via `make client`. This is a fresh
implementation against the current architecture rather than a rebase, and it
also covers the NodeStore/broadcast defects above. Happy to defer if @Razano26
would rather bring theirs forward instead.

## Tests

- `hscontrol/db/users_test.go` — set each field, clear with `""`, leave absent
  fields untouched, reject OIDC users and unknown ids, reject invalid URLs
- `hscontrol/state/user_profile_test.go` — the cached `Owner()` in the NodeStore
  reflects the new values, no broadcast on a no-op, rename covered too
- `hscontrol/types/users_test.go` — `ProfilePicURL` in all three tailcfg shapes
- `hscontrol/apiv1_users_test.go` — golden parity plus 400/404/OIDC guards
- `cmd/headscale/cli/users_test.go` — flag semantics
- `integration/cli_users_test.go` — `TestUserSetCommand`, registered in
  `test-integration.yaml`

Verdicts on this machine:

```
go test -race ./hscontrol/types/... ./hscontrol/db/... ./hscontrol/state/... ./hscontrol/api/...   ok
go test -race ./hscontrol/ -run TestAPIV1                                                          ok
go test ./cmd/headscale/cli/ -run TestSetUserRequestFromFlags                                      ok
golangci-lint run (v2.12.2, the version pinned in flake.nix)                                       0 issues
```

Each of the four commits builds and passes `go vet` on its own. Disabling the
NodeStore refresh makes `TestSetUserProfilePropagatesToNodeStore` and
`TestRenameUserPropagatesToNodeStore` fail, so they are real regression guards.

**Caveat:** the integration suite does not run locally here —
`Dockerfile.tailscale-HEAD` fails to build tailscale from source. I confirmed
this is environmental by running the pre-existing, unmodified
`TestUserCreateCommand`, which fails identically. `TestUserSetCommand` is written
but needs CI to validate.

## Verified end to end

Built this branch, ran it against a real `tailscale` client, and read the profile
the client received from the control server:

```
 id 1 | alice@example.com | DisplayName: Alice Rossi | ProfilePicURL: https://avatars.githubusercontent.com/u/9784476?v=4
```

Changing another user's picture propagated to that already-connected client
without a restart (confirming fix 2), clearing it returned the field to empty,
and `javascript:alert(1)` was rejected:

```
Error: profile picture URL must be an absolute http or https URL: "javascript:alert(1)"
```

## Maintenance

Three string columns and one endpoint, no external dependency and no background
work. The risk area is the NodeStore refresh in `UpdateUser`, which the state
tests cover. I am happy to maintain this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
