### PR TITLE
Update AppleTV configuration steps

### DIFF
--- a/docs/usage/connect/apple.md
+++ b/docs/usage/connect/apple.md
@@ -57,10 +57,10 @@ Install the official Tailscale tvOS client from the [App Store](https://apps.app
 
 ### Configuring the headscale URL
 
+- Open Tailscale
+- Click the button `Install VPN configuration` and confirm the appearing popup by clicking the `Allow` button (but don't signin yet)
 - Open Settings (the Apple tvOS settings) > Apps > Tailscale
 - Under `ALTERNATE COORDINATION SERVER URL`, select `URL`
 - Enter the URL of your headscale instance (e.g `https://headscale.example.com`) and press `OK`
-- Return to the tvOS Home screen
-- Open Tailscale
-- Click the button `Install VPN configuration` and confirm the appearing popup by clicking the `Allow` button
+- Return to the tvOS Home screen and open Tailscale
 - Scan the QR code and follow the login procedure

--- a/docs/usage/connect/apple.md
+++ b/docs/usage/connect/apple.md
@@ -53,12 +53,12 @@ Install the official Tailscale tvOS client from the [App Store](https://apps.app
 
 !!! danger
 
-    **Don't** open the Tailscale App after installation!
+    **Don't** sign in to the Tailscale App before the headscale URL is configured!
 
 ### Configuring the headscale URL
 
 - Open Tailscale
-- Click the button `Install VPN configuration` and confirm the appearing popup by clicking the `Allow` button (but don't signin yet)
+- Click the button `Install VPN configuration` and confirm the appearing popup by clicking the `Allow` button, but don't sign in yet
 - Open Settings (the Apple tvOS settings) > Apps > Tailscale
 - Under `ALTERNATE COORDINATION SERVER URL`, select `URL`
 - Enter the URL of your headscale instance (e.g `https://headscale.example.com`) and press `OK`

--- a/hscontrol/templates/apple.go
+++ b/hscontrol/templates/apple.go
@@ -149,6 +149,22 @@ func Apple(url string) *elem.Element {
 			elem.Li(
 				nil,
 				elem.Text("Open "),
+				elem.Strong(nil, elem.Text("Tailscale")),
+			),
+			elem.Li(
+				nil,
+				elem.Text("Select "),
+				elem.Strong(nil, elem.Text("Install VPN configuration")),
+			),
+			elem.Li(
+				nil,
+				elem.Text("Select "),
+				elem.Strong(nil, elem.Text("Allow")),
+				elem.Text(", but don't sign in yet"),
+			),
+			elem.Li(
+				nil,
+				elem.Text("Open "),
 				elem.Strong(nil, elem.Text("Settings")),
 				elem.Text(" (the Apple tvOS settings) > "),
 				elem.Strong(nil, elem.Text("Apps")),
@@ -166,22 +182,8 @@ func Apple(url string) *elem.Element {
 				nil,
 				elem.Text("Return to the tvOS "),
 				elem.Strong(nil, elem.Text("Home")),
-				elem.Text(" screen"),
-			),
-			elem.Li(
-				nil,
-				elem.Text("Open "),
+				elem.Text(" screen and open "),
 				elem.Strong(nil, elem.Text("Tailscale")),
-			),
-			elem.Li(
-				nil,
-				elem.Text("Select "),
-				elem.Strong(nil, elem.Text("Install VPN configuration")),
-			),
-			elem.Li(
-				nil,
-				elem.Text("Select "),
-				elem.Strong(nil, elem.Text("Allow")),
 			),
 			elem.Li(
 				nil,


### PR DESCRIPTION
The instructions didn't work for tvOS 26.6 / Tailscale 1.102.2. When the `ALTERNATE COORDINATION SERVER URL` is set, the `Install VPN Configuration` button breaks.  Clicking does nothing and the tvOS app logs showed `addUser: backendManager does not exist`.

Instead I first started tailscale and installed the vpn profile and then add the headscale url and then signed. Which seemed to have worked

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [ ] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [ ] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
