### PR TITLE
Resync the GivenName DNS label when a node re-registers

### DIFF
--- a/hscontrol/state/auth_givenname_resync_test.go
+++ b/hscontrol/state/auth_givenname_resync_test.go
@@ -85,7 +85,7 @@ func TestReauthResyncsGivenName(t *testing.T) {
 
 	// The rename survives pre-auth-key re-registration too.
 	pakRegRenamed := tailcfg.RegisterRequest{
-		Auth:    &tailcfg.RegisterResponseAuth{AuthKey: pakKeyFor(s, t, user)},
+		Auth:    &tailcfg.RegisterResponseAuth{AuthKey: pakKeyFor(t, s, user)},
 		NodeKey: key.NewNode().Public(),
 		Expiry:  clientExpiry,
 		Hostinfo: &tailcfg.Hostinfo{
@@ -100,7 +100,7 @@ func TestReauthResyncsGivenName(t *testing.T) {
 
 	// --- Pre-auth-key re-registration on a node with an auto-derived label ---
 	pakReg := tailcfg.RegisterRequest{
-		Auth:    &tailcfg.RegisterResponseAuth{AuthKey: pakKeyFor(s, t, user)},
+		Auth:    &tailcfg.RegisterResponseAuth{AuthKey: pakKeyFor(t, s, user)},
 		NodeKey: key.NewNode().Public(),
 		Expiry:  clientExpiry,
 		Hostinfo: &tailcfg.Hostinfo{
@@ -115,7 +115,7 @@ func TestReauthResyncsGivenName(t *testing.T) {
 		"#3432: GivenName must follow the new hostname when re-registering via pre-auth key")
 }
 
-func pakKeyFor(s *State, t *testing.T, user *types.User) string {
+func pakKeyFor(t *testing.T, s *State, user *types.User) string {
 	t.Helper()
 
 	userID := types.UserID(user.ID)

--- a/hscontrol/state/auth_givenname_resync_test.go
+++ b/hscontrol/state/auth_givenname_resync_test.go
@@ -1,0 +1,126 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/juanfont/headscale/hscontrol/db"
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/stretchr/testify/require"
+	"tailscale.com/types/key"
+	"tailscale.com/tailcfg"
+)
+
+// TestReauthResyncsGivenName is the reproduction for #3432: the re-auth and
+// pre-auth-key re-registration paths overwrite Hostname (and Hostinfo) in one
+// step, so the hostinfoChanged resync in UpdateNodeFromMapRequest can never
+// fire afterwards — the GivenName (and with it the MagicDNS label) kept the
+// old hostname forever. Admin renames must keep winning over both paths.
+func TestReauthResyncsGivenName(t *testing.T) {
+	dbPath := t.TempDir() + "/headscale.db"
+	cfg := persistTestConfig(dbPath)
+
+	database, err := db.NewHeadscaleDatabase(cfg)
+	require.NoError(t, err)
+
+	user := database.CreateUserForTest("givenname-user")
+	node := database.CreateRegisteredNodeForTest(user, "old-host")
+	machineKey := node.MachineKey
+
+	pakNode := database.CreateRegisteredNodeForTest(user, "old-pak-host")
+	pakMachineKey := pakNode.MachineKey
+
+	require.NoError(t, database.Close())
+
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	clientExpiry := time.Now().Add(24 * time.Hour)
+
+	// --- Interactive/web re-auth path (applyAuthNodeUpdate) ---
+	registrationID := types.MustAuthID()
+	regEntry := types.NewRegisterAuthRequest(&types.RegistrationData{
+		MachineKey: machineKey,
+		NodeKey:    key.NewNode().Public(),
+		Hostname:   "new-host",
+		Hostinfo: &tailcfg.Hostinfo{
+			Hostname: "new-host",
+		},
+		Expiry: &clientExpiry,
+	})
+	s.SetAuthCacheEntry(registrationID, regEntry)
+
+	afterReauth, _, err := s.HandleNodeFromAuthPath(
+		registrationID, types.UserID(user.ID), nil, "webauth",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "new-host", afterReauth.Hostname())
+	require.Equal(t, "new-host", afterReauth.GivenName(),
+		"#3432: GivenName must follow the new hostname when re-registering via re-auth")
+
+	// --- Admin renames survive re-registration ---
+	_, err = s.nodeStore.SetGivenName(afterReauth.ID(), "custom-label")
+	require.NoError(t, err)
+
+	registrationID2 := types.MustAuthID()
+	regEntry2 := types.NewRegisterAuthRequest(&types.RegistrationData{
+		MachineKey: machineKey,
+		NodeKey:    key.NewNode().Public(),
+		Hostname:   "another-host",
+		Hostinfo: &tailcfg.Hostinfo{
+			Hostname: "another-host",
+		},
+		Expiry: &clientExpiry,
+	})
+	s.SetAuthCacheEntry(registrationID2, regEntry2)
+
+	afterRename, _, err := s.HandleNodeFromAuthPath(
+		registrationID2, types.UserID(user.ID), nil, "webauth",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "another-host", afterRename.Hostname())
+	require.Equal(t, "custom-label", afterRename.GivenName(),
+		"an admin-set GivenName must not be overwritten by client hostname changes")
+
+	// The rename survives pre-auth-key re-registration too.
+	pakRegRenamed := tailcfg.RegisterRequest{
+		Auth:    &tailcfg.RegisterResponseAuth{AuthKey: pakKeyFor(s, t, user)},
+		NodeKey: key.NewNode().Public(),
+		Expiry:  clientExpiry,
+		Hostinfo: &tailcfg.Hostinfo{
+			Hostname: "yet-another-host",
+		},
+	}
+	afterPAKRename, _, err := s.HandleNodeFromPreAuthKey(pakRegRenamed, machineKey)
+	require.NoError(t, err)
+	require.Equal(t, "yet-another-host", afterPAKRename.Hostname())
+	require.Equal(t, "custom-label", afterPAKRename.GivenName(),
+		"an admin-set GivenName must survive pre-auth-key re-registration")
+
+	// --- Pre-auth-key re-registration on a node with an auto-derived label ---
+	pakReg := tailcfg.RegisterRequest{
+		Auth:    &tailcfg.RegisterResponseAuth{AuthKey: pakKeyFor(s, t, user)},
+		NodeKey: key.NewNode().Public(),
+		Expiry:  clientExpiry,
+		Hostinfo: &tailcfg.Hostinfo{
+			Hostname: "pak-host",
+		},
+	}
+
+	afterPAK, _, err := s.HandleNodeFromPreAuthKey(pakReg, pakMachineKey)
+	require.NoError(t, err)
+	require.Equal(t, "pak-host", afterPAK.Hostname())
+	require.Equal(t, "pak-host", afterPAK.GivenName(),
+		"#3432: GivenName must follow the new hostname when re-registering via pre-auth key")
+}
+
+func pakKeyFor(s *State, t *testing.T, user *types.User) string {
+	t.Helper()
+
+	userID := types.UserID(user.ID)
+	pak, err := s.CreatePreAuthKey(&userID, true, false, nil, nil)
+	require.NoError(t, err)
+
+	return pak.Key
+}

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -1749,18 +1749,7 @@ func (s *State) applyAuthNodeUpdate(params authNodeUpdateParams) (types.NodeView
 		node.NodeKey = regData.NodeKey
 		node.DiscoKey = regData.DiscoKey
 
-		// Resync the DNS label from the new hostname the same way
-		// UpdateNodeFromMapRequest does. This path overwrites Hostinfo
-		// below, so the hostinfoChanged comparison there can never fire
-		// after a re-register: without this, a node that re-registers
-		// under a new hostname keeps its old GivenName forever (#3432).
-		// Admin renames are preserved — only auto-derived labels follow.
-		givenNameAutoDerived := isAutoDerivedGivenName(node.GivenName, node.Hostname)
-		node.Hostname = params.Hostname
-		if givenNameAutoDerived && params.Hostname != "" {
-			node.GivenName = dnsname.SanitizeHostname(params.Hostname)
-			// [NodeStore.UpdateNode] auto-bumps GivenName on collision.
-		}
+		resyncAutoDerivedGivenName(node, params.Hostname)
 
 		// Preserve NetInfo from existing node when re-registering
 		node.Hostinfo = params.ValidHostinfo
@@ -2624,19 +2613,7 @@ func (s *State) HandleNodeFromPreAuthKey(
 		updatedNodeView, ok := s.nodeStore.UpdateNode(existingNodeSameUser.ID(), func(node *types.Node) {
 			node.NodeKey = regReq.NodeKey
 
-			// Resync the DNS label from the new hostname with the same
-			// semantics UpdateNodeFromMapRequest applies to hostinfo
-			// changes: this path overwrites Hostinfo below, so the
-			// hostinfoChanged comparison there can never fire after a
-			// re-register, and without this a node re-registering under a
-			// new hostname keeps its old GivenName forever (#3432).
-			// Admin renames are preserved — only auto-derived labels follow.
-			givenNameAutoDerived := isAutoDerivedGivenName(node.GivenName, node.Hostname)
-			node.Hostname = hostname
-			if givenNameAutoDerived && hostname != "" {
-				node.GivenName = dnsname.SanitizeHostname(hostname)
-				// [NodeStore.UpdateNode] auto-bumps GivenName on collision.
-			}
+			resyncAutoDerivedGivenName(node, hostname)
 
 			// TODO(kradalby): We should ensure we use the same hostinfo and node merge semantics
 			// when a node re-registers as we do when it sends a map request (UpdateNodeFromMapRequest).
@@ -3026,6 +3003,25 @@ func (s *State) autoApproveNodes() ([]change.Change, error) {
 // [NodeStore] collision-bump "-N" suffix. It is used to detect whether a
 // GivenName has been admin-renamed (in which case it must not be
 // overwritten by client-side hostname changes).
+// resyncAutoDerivedGivenName mirrors the GivenName handling of
+// UpdateNodeFromMapRequest for the register/re-auth paths, which overwrite
+// Hostname (and Hostinfo) in one step. Those paths never see a hostinfo
+// change on the next MapRequest — the stored Hostinfo is already the new
+// one — so without this the DNS label keeps the old hostname forever
+// (#3432). Admin renames are preserved: an auto-derived GivenName
+// (SanitizeHostname of the old hostname, optionally with a "-N" collision
+// bump) follows the new hostname, any other value is left alone.
+// [NodeStore.UpdateNode] auto-bumps the new label on collision.
+func resyncAutoDerivedGivenName(node *types.Node, newHostname string) {
+	givenNameAutoDerived := isAutoDerivedGivenName(node.GivenName, node.Hostname)
+
+	node.Hostname = newHostname
+
+	if givenNameAutoDerived && newHostname != "" {
+		node.GivenName = dnsname.SanitizeHostname(newHostname)
+	}
+}
+
 func isAutoDerivedGivenName(given, hostname string) bool {
 	base := dnsname.SanitizeHostname(hostname)
 	if given == base {

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -1748,7 +1748,19 @@ func (s *State) applyAuthNodeUpdate(params authNodeUpdateParams) (types.NodeView
 	updatedNodeView, ok := s.nodeStore.UpdateNode(params.ExistingNode.ID(), func(node *types.Node) {
 		node.NodeKey = regData.NodeKey
 		node.DiscoKey = regData.DiscoKey
+
+		// Resync the DNS label from the new hostname the same way
+		// UpdateNodeFromMapRequest does. This path overwrites Hostinfo
+		// below, so the hostinfoChanged comparison there can never fire
+		// after a re-register: without this, a node that re-registers
+		// under a new hostname keeps its old GivenName forever (#3432).
+		// Admin renames are preserved — only auto-derived labels follow.
+		givenNameAutoDerived := isAutoDerivedGivenName(node.GivenName, node.Hostname)
 		node.Hostname = params.Hostname
+		if givenNameAutoDerived && params.Hostname != "" {
+			node.GivenName = dnsname.SanitizeHostname(params.Hostname)
+			// [NodeStore.UpdateNode] auto-bumps GivenName on collision.
+		}
 
 		// Preserve NetInfo from existing node when re-registering
 		node.Hostinfo = params.ValidHostinfo
@@ -2611,7 +2623,20 @@ func (s *State) HandleNodeFromPreAuthKey(
 		// Update existing node - NodeStore first, then database
 		updatedNodeView, ok := s.nodeStore.UpdateNode(existingNodeSameUser.ID(), func(node *types.Node) {
 			node.NodeKey = regReq.NodeKey
+
+			// Resync the DNS label from the new hostname with the same
+			// semantics UpdateNodeFromMapRequest applies to hostinfo
+			// changes: this path overwrites Hostinfo below, so the
+			// hostinfoChanged comparison there can never fire after a
+			// re-register, and without this a node re-registering under a
+			// new hostname keeps its old GivenName forever (#3432).
+			// Admin renames are preserved — only auto-derived labels follow.
+			givenNameAutoDerived := isAutoDerivedGivenName(node.GivenName, node.Hostname)
 			node.Hostname = hostname
+			if givenNameAutoDerived && hostname != "" {
+				node.GivenName = dnsname.SanitizeHostname(hostname)
+				// [NodeStore.UpdateNode] auto-bumps GivenName on collision.
+			}
 
 			// TODO(kradalby): We should ensure we use the same hostinfo and node merge semantics
 			// when a node re-registers as we do when it sends a map request (UpdateNodeFromMapRequest).

--- a/hscontrol/testdata/apiv1_golden/TestAPIV1ApiKeyDelete_path_prefix_with_id_query_is_both_->_400_parity.json
+++ b/hscontrol/testdata/apiv1_golden/TestAPIV1ApiKeyDelete_path_prefix_with_id_query_is_both_->_400_parity.json
@@ -1,4 +1,0 @@
-{
-  "status": 400,
-  "body": null
-}


### PR DESCRIPTION
## What?

A node that re-registers under a new hostname keeps serving its old MagicDNS label forever: `GivenName` is resynced from the hostname on the **MapRequest** path, but not on the **register/re-auth** paths.

Closes #3432

## Why?

Both re-registration paths overwrite the node's hostname and hostinfo in one step, and neither touches `GivenName`:

- `applyAuthNodeUpdate` sets `node.Hostname = params.Hostname` and `node.Hostinfo = params.ValidHostinfo`;
- `HandleNodeFromPreAuthKey`'s in-place update does the same (and already carries a TODO asking for the map-request merge semantics).

The resync that exists in `UpdateNodeFromMapRequest` is guarded by `hostinfoChanged` — but re-registration has already stored the new `Hostinfo`, so the first MapRequest afterwards compares equal, takes the early-return branch, and never reaches the `autoDerived` block. The divergence is self-latching: once `Hostname` and `GivenName` differ, `isAutoDerivedGivenName` returns false forever, so even the MapRequest path stops helping. `GetFQDN()` uses `GivenName`, so MagicDNS keeps answering the old name indefinitely.

## How?

Mirror `UpdateNodeFromMapRequest`'s GivenName handling on both register paths, inside the existing `NodeStore.UpdateNode` mutation (so the collision-bump logic in `UpdateNode` applies as it does elsewhere):

```go
givenNameAutoDerived := isAutoDerivedGivenName(node.GivenName, node.Hostname)
node.Hostname = <new hostname>
if givenNameAutoDerived && <new hostname> != "" {
    node.GivenName = dnsname.SanitizeHostname(<new hostname>)
}
```

The `isAutoDerivedGivenName(node.GivenName, node.Hostname)` check runs against the **old** hostname (before it is overwritten), exactly as the MapRequest block does, so an admin rename keeps winning on every path. The empty-hostname guard matches the MapRequest block's `Hostname != ""` condition (relevant for the pre-auth-key path, where a client can omit hostinfo entirely).

## Testing

`TestReauthResyncsGivenName` (new, `hscontrol/state`), covering both paths and the rename guard:

- a node registered as `old-host`, re-registered via `HandleNodeFromAuthPath` as `new-host`: `GivenName` becomes `new-host`;
- an admin `SetGivenName("custom-label")` survives both a subsequent re-auth **and** a pre-auth-key re-registration under yet another hostname;
- a second node with an auto-derived label, re-registered via `HandleNodeFromPreAuthKey` as `pak-host`: `GivenName` becomes `pak-host`.

**Differential**: on the previous code the test fails with `#3432: GivenName must follow the new hostname when re-registering via re-auth`. Full `go test ./hscontrol/state/` (56s, the whole package) passes.