### PR TITLE
docs: add repository star count and activity badges to web UI list

### DIFF
--- a/docs/ref/integration/tools.md
+++ b/docs/ref/integration/tools.md
@@ -11,32 +11,26 @@ This page collects third-party tools, client libraries, and scripts related to h
     - ![GitHub stars](https://img.shields.io/github/stars/infradohq/headscale-operator?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/infradohq/headscale-operator)
     - Headscale Kubernetes Operator
-
 - [tailscale-manager](https://github.com/singlestore-labs/tailscale-manager)
     - ![GitHub stars](https://img.shields.io/github/stars/singlestore-labs/tailscale-manager?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/singlestore-labs/tailscale-manager)
     - Dynamically manage Tailscale route advertisements
-
 - [headscalebacktosqlite](https://github.com/bigbozza/headscalebacktosqlite)
     - ![GitHub stars](https://img.shields.io/github/stars/bigbozza/headscalebacktosqlite?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/bigbozza/headscalebacktosqlite)
     - Migrate headscale from PostgreSQL back to SQLite
-
 - [headscale-pf](https://github.com/YouSysAdmin/headscale-pf)
     - ![GitHub stars](https://img.shields.io/github/stars/YouSysAdmin/headscale-pf?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/YouSysAdmin/headscale-pf)
     - Populates user groups based on user groups in Jumpcloud or Authentik
-
 - [headscale-client-go](https://github.com/hibare/headscale-client-go)
     - ![GitHub stars](https://img.shields.io/github/stars/hibare/headscale-client-go?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/hibare/headscale-client-go)
     - A Go client implementation for the Headscale HTTP API.
-
 - [headscale-zabbix](https://github.com/dblanque/headscale-zabbix)
     - ![GitHub stars](https://img.shields.io/github/stars/dblanque/headscale-zabbix?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/dblanque/headscale-zabbix)
     - A Zabbix Monitoring Template for the Headscale Service.
-
 - [tailscale-exporter](https://github.com/adinhodovic/tailscale-exporter)
     - ![GitHub stars](https://img.shields.io/github/stars/adinhodovic/tailscale-exporter?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/adinhodovic/tailscale-exporter)

--- a/docs/ref/integration/tools.md
+++ b/docs/ref/integration/tools.md
@@ -8,31 +8,31 @@
 This page collects third-party tools, client libraries, and scripts related to headscale.
 
 - [headscale-operator](https://github.com/infradohq/headscale-operator)
-  ![GitHub stars](https://img.shields.io/github/stars/infradohq/headscale-operator?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/infradohq/headscale-operator)
+  - ![GitHub stars](https://img.shields.io/github/stars/infradohq/headscale-operator?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/infradohq/headscale-operator)
   - Headscale Kubernetes Operator
 - [tailscale-manager](https://github.com/singlestore-labs/tailscale-manager)
-  ![GitHub stars](https://img.shields.io/github/stars/singlestore-labs/tailscale-manager?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/singlestore-labs/tailscale-manager)
+  - ![GitHub stars](https://img.shields.io/github/stars/singlestore-labs/tailscale-manager?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/singlestore-labs/tailscale-manager)
   - Dynamically manage Tailscale route advertisements
 - [headscalebacktosqlite](https://github.com/bigbozza/headscalebacktosqlite)
-  ![GitHub stars](https://img.shields.io/github/stars/bigbozza/headscalebacktosqlite?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/bigbozza/headscalebacktosqlite)
+  - ![GitHub stars](https://img.shields.io/github/stars/bigbozza/headscalebacktosqlite?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/bigbozza/headscalebacktosqlite)
   - Migrate headscale from PostgreSQL back to SQLite
 - [headscale-pf](https://github.com/YouSysAdmin/headscale-pf)
-  ![GitHub stars](https://img.shields.io/github/stars/YouSysAdmin/headscale-pf?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/YouSysAdmin/headscale-pf)
+  - ![GitHub stars](https://img.shields.io/github/stars/YouSysAdmin/headscale-pf?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/YouSysAdmin/headscale-pf)
   - Populates user groups based on user groups in Jumpcloud or Authentik
 - [headscale-client-go](https://github.com/hibare/headscale-client-go)
-  ![GitHub stars](https://img.shields.io/github/stars/hibare/headscale-client-go?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/hibare/headscale-client-go)
+  - ![GitHub stars](https://img.shields.io/github/stars/hibare/headscale-client-go?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/hibare/headscale-client-go)
   - A Go client implementation for the Headscale HTTP API.
 - [headscale-zabbix](https://github.com/dblanque/headscale-zabbix)
-  ![GitHub stars](https://img.shields.io/github/stars/dblanque/headscale-zabbix?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/dblanque/headscale-zabbix)
+  - ![GitHub stars](https://img.shields.io/github/stars/dblanque/headscale-zabbix?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/dblanque/headscale-zabbix)
   - A Zabbix Monitoring Template for the Headscale Service.
 - [tailscale-exporter](https://github.com/adinhodovic/tailscale-exporter)
-  ![GitHub stars](https://img.shields.io/github/stars/adinhodovic/tailscale-exporter?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/adinhodovic/tailscale-exporter)
+  - ![GitHub stars](https://img.shields.io/github/stars/adinhodovic/tailscale-exporter?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/adinhodovic/tailscale-exporter)
   - A Prometheus exporter for Headscale that provides network-level metrics using
-  the Headscale API.
+    the Headscale API.

--- a/docs/ref/integration/tools.md
+++ b/docs/ref/integration/tools.md
@@ -7,16 +7,32 @@
 
 This page collects third-party tools, client libraries, and scripts related to headscale.
 
-- [headscale-operator](https://github.com/infradohq/headscale-operator) - Headscale Kubernetes Operator
-- [tailscale-manager](https://github.com/singlestore-labs/tailscale-manager) - Dynamically manage Tailscale route
-  advertisements
-- [headscalebacktosqlite](https://github.com/bigbozza/headscalebacktosqlite) - Migrate headscale from PostgreSQL back to
-  SQLite
-- [headscale-pf](https://github.com/YouSysAdmin/headscale-pf) - Populates user groups based on user groups in Jumpcloud
-  or Authentik
-- [headscale-client-go](https://github.com/hibare/headscale-client-go) - A Go client implementation for the Headscale
-  HTTP API.
-- [headscale-zabbix](https://github.com/dblanque/headscale-zabbix) - A Zabbix Monitoring Template for the Headscale
-  Service.
-- [tailscale-exporter](https://github.com/adinhodovic/tailscale-exporter) - A Prometheus exporter for Headscale that
-  provides network-level metrics using the Headscale API.
+- [headscale-operator](https://github.com/infradohq/headscale-operator)
+  ![GitHub stars](https://img.shields.io/github/stars/infradohq/headscale-operator?style=flat)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/infradohq/headscale-operator)
+  - Headscale Kubernetes Operator
+- [tailscale-manager](https://github.com/singlestore-labs/tailscale-manager)
+  ![GitHub stars](https://img.shields.io/github/stars/singlestore-labs/tailscale-manager?style=flat)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/singlestore-labs/tailscale-manager)
+  - Dynamically manage Tailscale route advertisements
+- [headscalebacktosqlite](https://github.com/bigbozza/headscalebacktosqlite)
+  ![GitHub stars](https://img.shields.io/github/stars/bigbozza/headscalebacktosqlite?style=flat)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/bigbozza/headscalebacktosqlite)
+  - Migrate headscale from PostgreSQL back to SQLite
+- [headscale-pf](https://github.com/YouSysAdmin/headscale-pf)
+  ![GitHub stars](https://img.shields.io/github/stars/YouSysAdmin/headscale-pf?style=flat)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/YouSysAdmin/headscale-pf)
+  - Populates user groups based on user groups in Jumpcloud or Authentik
+- [headscale-client-go](https://github.com/hibare/headscale-client-go)
+  ![GitHub stars](https://img.shields.io/github/stars/hibare/headscale-client-go?style=flat)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/hibare/headscale-client-go)
+  - A Go client implementation for the Headscale HTTP API.
+- [headscale-zabbix](https://github.com/dblanque/headscale-zabbix)
+  ![GitHub stars](https://img.shields.io/github/stars/dblanque/headscale-zabbix?style=flat)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/dblanque/headscale-zabbix)
+  - A Zabbix Monitoring Template for the Headscale Service.
+- [tailscale-exporter](https://github.com/adinhodovic/tailscale-exporter)
+  ![GitHub stars](https://img.shields.io/github/stars/adinhodovic/tailscale-exporter?style=flat)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/adinhodovic/tailscale-exporter)
+  - A Prometheus exporter for Headscale that provides network-level metrics using
+  the Headscale API.

--- a/docs/ref/integration/tools.md
+++ b/docs/ref/integration/tools.md
@@ -8,51 +8,37 @@
 This page collects third-party tools, client libraries, and scripts related to headscale.
 
 - [headscale-operator](https://github.com/infradohq/headscale-operator)
-
     - ![GitHub stars](https://img.shields.io/github/stars/infradohq/headscale-operator?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/infradohq/headscale-operator)
-
     - Headscale Kubernetes Operator
 
 - [tailscale-manager](https://github.com/singlestore-labs/tailscale-manager)
-
     - ![GitHub stars](https://img.shields.io/github/stars/singlestore-labs/tailscale-manager?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/singlestore-labs/tailscale-manager)
-
     - Dynamically manage Tailscale route advertisements
 
 - [headscalebacktosqlite](https://github.com/bigbozza/headscalebacktosqlite)
-
     - ![GitHub stars](https://img.shields.io/github/stars/bigbozza/headscalebacktosqlite?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/bigbozza/headscalebacktosqlite)
-
     - Migrate headscale from PostgreSQL back to SQLite
 
 - [headscale-pf](https://github.com/YouSysAdmin/headscale-pf)
-
     - ![GitHub stars](https://img.shields.io/github/stars/YouSysAdmin/headscale-pf?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/YouSysAdmin/headscale-pf)
-
     - Populates user groups based on user groups in Jumpcloud or Authentik
 
 - [headscale-client-go](https://github.com/hibare/headscale-client-go)
-
     - ![GitHub stars](https://img.shields.io/github/stars/hibare/headscale-client-go?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/hibare/headscale-client-go)
-
     - A Go client implementation for the Headscale HTTP API.
 
 - [headscale-zabbix](https://github.com/dblanque/headscale-zabbix)
-
     - ![GitHub stars](https://img.shields.io/github/stars/dblanque/headscale-zabbix?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/dblanque/headscale-zabbix)
-
     - A Zabbix Monitoring Template for the Headscale Service.
 
 - [tailscale-exporter](https://github.com/adinhodovic/tailscale-exporter)
-
     - ![GitHub stars](https://img.shields.io/github/stars/adinhodovic/tailscale-exporter?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/adinhodovic/tailscale-exporter)
-
     - A Prometheus exporter for Headscale that provides network-level metrics using
       the Headscale API.

--- a/docs/ref/integration/tools.md
+++ b/docs/ref/integration/tools.md
@@ -8,31 +8,51 @@
 This page collects third-party tools, client libraries, and scripts related to headscale.
 
 - [headscale-operator](https://github.com/infradohq/headscale-operator)
-  - ![GitHub stars](https://img.shields.io/github/stars/infradohq/headscale-operator?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/infradohq/headscale-operator)
-  - Headscale Kubernetes Operator
+
+    - ![GitHub stars](https://img.shields.io/github/stars/infradohq/headscale-operator?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/infradohq/headscale-operator)
+
+    - Headscale Kubernetes Operator
+
 - [tailscale-manager](https://github.com/singlestore-labs/tailscale-manager)
-  - ![GitHub stars](https://img.shields.io/github/stars/singlestore-labs/tailscale-manager?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/singlestore-labs/tailscale-manager)
-  - Dynamically manage Tailscale route advertisements
+
+    - ![GitHub stars](https://img.shields.io/github/stars/singlestore-labs/tailscale-manager?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/singlestore-labs/tailscale-manager)
+
+    - Dynamically manage Tailscale route advertisements
+
 - [headscalebacktosqlite](https://github.com/bigbozza/headscalebacktosqlite)
-  - ![GitHub stars](https://img.shields.io/github/stars/bigbozza/headscalebacktosqlite?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/bigbozza/headscalebacktosqlite)
-  - Migrate headscale from PostgreSQL back to SQLite
+
+    - ![GitHub stars](https://img.shields.io/github/stars/bigbozza/headscalebacktosqlite?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/bigbozza/headscalebacktosqlite)
+
+    - Migrate headscale from PostgreSQL back to SQLite
+
 - [headscale-pf](https://github.com/YouSysAdmin/headscale-pf)
-  - ![GitHub stars](https://img.shields.io/github/stars/YouSysAdmin/headscale-pf?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/YouSysAdmin/headscale-pf)
-  - Populates user groups based on user groups in Jumpcloud or Authentik
+
+    - ![GitHub stars](https://img.shields.io/github/stars/YouSysAdmin/headscale-pf?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/YouSysAdmin/headscale-pf)
+
+    - Populates user groups based on user groups in Jumpcloud or Authentik
+
 - [headscale-client-go](https://github.com/hibare/headscale-client-go)
-  - ![GitHub stars](https://img.shields.io/github/stars/hibare/headscale-client-go?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/hibare/headscale-client-go)
-  - A Go client implementation for the Headscale HTTP API.
+
+    - ![GitHub stars](https://img.shields.io/github/stars/hibare/headscale-client-go?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/hibare/headscale-client-go)
+
+    - A Go client implementation for the Headscale HTTP API.
+
 - [headscale-zabbix](https://github.com/dblanque/headscale-zabbix)
-  - ![GitHub stars](https://img.shields.io/github/stars/dblanque/headscale-zabbix?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/dblanque/headscale-zabbix)
-  - A Zabbix Monitoring Template for the Headscale Service.
+
+    - ![GitHub stars](https://img.shields.io/github/stars/dblanque/headscale-zabbix?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/dblanque/headscale-zabbix)
+
+    - A Zabbix Monitoring Template for the Headscale Service.
+
 - [tailscale-exporter](https://github.com/adinhodovic/tailscale-exporter)
-  - ![GitHub stars](https://img.shields.io/github/stars/adinhodovic/tailscale-exporter?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/adinhodovic/tailscale-exporter)
-  - A Prometheus exporter for Headscale that provides network-level metrics using
-    the Headscale API.
+
+    - ![GitHub stars](https://img.shields.io/github/stars/adinhodovic/tailscale-exporter?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/adinhodovic/tailscale-exporter)
+
+    - A Prometheus exporter for Headscale that provides network-level metrics using
+      the Headscale API.

--- a/docs/ref/integration/web-ui.md
+++ b/docs/ref/integration/web-ui.md
@@ -7,23 +7,45 @@
 
 Headscale doesn't provide a built-in web interface but users may pick one from the available options.
 
-- [headscale-ui](https://github.com/gurucomputing/headscale-ui) - A web frontend for the headscale Tailscale-compatible
-  coordination server
-- [HeadscaleUi](https://github.com/simcu/headscale-ui) - A static headscale admin ui, no backend environment required
-- [Headplane](https://github.com/tale/headplane) - An advanced Tailscale inspired frontend for headscale
-- [headscale-admin](https://github.com/GoodiesHQ/headscale-admin) - Headscale-Admin is meant to be a simple, modern web
-  interface for headscale
-- [ouroboros](https://github.com/yellowsink/ouroboros) - Ouroboros is designed for users to manage their own devices,
-  rather than for admins
-- [unraid-headscale-admin](https://github.com/ich777/unraid-headscale-admin) - A simple headscale admin UI for Unraid,
-  it offers Local (`docker exec`) and API Mode
-- [headscale-console](https://github.com/rickli-cloud/headscale-console) - WebAssembly-based client supporting SSH, VNC
-  and RDP with optional self-service capabilities
-- [headscale-piying](https://github.com/wszgrcy/headscale-piying) - headscale web ui, support visual ACL configuration
-- [HeadControl](https://github.com/ahmadzip/HeadControl) - Minimal Headscale admin dashboard, built with Go and HTMX
-- [Headscale Manager](https://github.com/hkdone/headscalemanager) - Headscale UI for Android
-- [Headscale UI](https://github.com/MunMunMiao/headscale-ui) - Headscale UI online and Self-hosting
-- [Headscale Panel](https://github.com/headscale-panel/panel) - A modern Headscale management panel with a clean,
-  network-operations-focused UI
+- [headscale-ui](https://github.com/gurucomputing/headscale-ui)
+  ![GitHub stars](https://img.shields.io/github/stars/gurucomputing/headscale-ui)
+  - A web frontend for the headscale Tailscale-compatible coordination server
+- [HeadscaleUi](https://github.com/simcu/headscale-ui)
+  ![GitHub stars](https://img.shields.io/github/stars/simcu/headscale-ui)
+  - A static headscale admin ui, no backend environment required
+- [Headplane](https://github.com/tale/headplane)
+  ![GitHub stars](https://img.shields.io/github/stars/tale/headplane)
+  - An advanced Tailscale inspired frontend for headscale
+- [headscale-admin](https://github.com/GoodiesHQ/headscale-admin)
+  ![GitHub stars](https://img.shields.io/github/stars/GoodiesHQ/headscale-admin)
+  - Headscale-Admin is meant to be a simple, modern web interface for headscale
+- [ouroboros](https://github.com/yellowsink/ouroboros)
+  ![GitHub stars](https://img.shields.io/github/stars/yellowsink/ouroboros)
+  - Ouroboros is designed for users to manage their own devices, rather than for
+  admins
+- [unraid-headscale-admin](https://github.com/ich777/unraid-headscale-admin)
+  ![GitHub stars](https://img.shields.io/github/stars/ich777/unraid-headscale-admin)
+  - A simple headscale admin UI for Unraid, it offers Local (`docker exec`) and
+  API Mode
+- [headscale-console](https://github.com/rickli-cloud/headscale-console)
+  ![GitHub stars](https://img.shields.io/github/stars/rickli-cloud/headscale-console)
+  - WebAssembly-based client supporting SSH, VNC and RDP with optional
+  self-service capabilities
+- [headscale-piying](https://github.com/wszgrcy/headscale-piying)
+  ![GitHub stars](https://img.shields.io/github/stars/wszgrcy/headscale-piying)
+  - headscale web ui, support visual ACL configuration
+- [HeadControl](https://github.com/ahmadzip/HeadControl)
+  ![GitHub stars](https://img.shields.io/github/stars/ahmadzip/HeadControl)
+  - Minimal Headscale admin dashboard, built with Go and HTMX
+- [Headscale Manager](https://github.com/hkdone/headscalemanager)
+  ![GitHub stars](https://img.shields.io/github/stars/hkdone/headscalemanager)
+  - Headscale UI for Android
+- [Headscale UI](https://github.com/MunMunMiao/headscale-ui)
+  ![GitHub stars](https://img.shields.io/github/stars/MunMunMiao/headscale-ui)
+  - Headscale UI online and Self-hosting
+- [Headscale Panel](https://github.com/headscale-panel/panel)
+  ![GitHub stars](https://img.shields.io/github/stars/headscale-panel/panel)
+  - A modern Headscale management panel with a clean, network-operations-focused
+  UI
 
 You can ask for support on our [Discord server](https://discord.gg/c84AZQhmpx) in the "web-interfaces" channel.

--- a/docs/ref/integration/web-ui.md
+++ b/docs/ref/integration/web-ui.md
@@ -11,60 +11,49 @@ Headscale doesn't provide a built-in web interface but users may pick one from t
     - ![GitHub stars](https://img.shields.io/github/stars/gurucomputing/headscale-ui?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/gurucomputing/headscale-ui)
     - A web frontend for the headscale Tailscale-compatible coordination server
-
 - [HeadscaleUi](https://github.com/simcu/headscale-ui)
     - ![GitHub stars](https://img.shields.io/github/stars/simcu/headscale-ui?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/simcu/headscale-ui)
     - A static headscale admin ui, no backend environment required
-
 - [Headplane](https://github.com/tale/headplane)
     - ![GitHub stars](https://img.shields.io/github/stars/tale/headplane?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/tale/headplane)
     - An advanced Tailscale inspired frontend for headscale
-
 - [headscale-admin](https://github.com/GoodiesHQ/headscale-admin)
     - ![GitHub stars](https://img.shields.io/github/stars/GoodiesHQ/headscale-admin?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/GoodiesHQ/headscale-admin)
     - Headscale-Admin is meant to be a simple, modern web interface for headscale
-
 - [ouroboros](https://github.com/yellowsink/ouroboros)
     - ![GitHub stars](https://img.shields.io/github/stars/yellowsink/ouroboros?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/yellowsink/ouroboros)
     - Ouroboros is designed for users to manage their own devices, rather than for
       admins
-
 - [unraid-headscale-admin](https://github.com/ich777/unraid-headscale-admin)
     - ![GitHub stars](https://img.shields.io/github/stars/ich777/unraid-headscale-admin?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/ich777/unraid-headscale-admin)
     - A simple headscale admin UI for Unraid, it offers Local (`docker exec`) and
       API Mode
-
 - [headscale-console](https://github.com/rickli-cloud/headscale-console)
     - ![GitHub stars](https://img.shields.io/github/stars/rickli-cloud/headscale-console?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/rickli-cloud/headscale-console)
     - WebAssembly-based client supporting SSH, VNC and RDP with optional
       self-service capabilities
-
 - [headscale-piying](https://github.com/wszgrcy/headscale-piying)
     - ![GitHub stars](https://img.shields.io/github/stars/wszgrcy/headscale-piying?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/wszgrcy/headscale-piying)
     - headscale web ui, support visual ACL configuration
-
 - [HeadControl](https://github.com/ahmadzip/HeadControl)
     - ![GitHub stars](https://img.shields.io/github/stars/ahmadzip/HeadControl?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/ahmadzip/HeadControl)
     - Minimal Headscale admin dashboard, built with Go and HTMX
-
 - [Headscale Manager](https://github.com/hkdone/headscalemanager)
     - ![GitHub stars](https://img.shields.io/github/stars/hkdone/headscalemanager?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/hkdone/headscalemanager)
     - Headscale UI for Android
-
 - [Headscale UI](https://github.com/MunMunMiao/headscale-ui)
     - ![GitHub stars](https://img.shields.io/github/stars/MunMunMiao/headscale-ui?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/MunMunMiao/headscale-ui)
     - Headscale UI online and Self-hosting
-
 - [Headscale Panel](https://github.com/headscale-panel/panel)
     - ![GitHub stars](https://img.shields.io/github/stars/headscale-panel/panel?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/headscale-panel/panel)

--- a/docs/ref/integration/web-ui.md
+++ b/docs/ref/integration/web-ui.md
@@ -9,42 +9,54 @@ Headscale doesn't provide a built-in web interface but users may pick one from t
 
 - [headscale-ui](https://github.com/gurucomputing/headscale-ui)
   ![GitHub stars](https://img.shields.io/github/stars/gurucomputing/headscale-ui)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/gurucomputing/headscale-ui)
   - A web frontend for the headscale Tailscale-compatible coordination server
 - [HeadscaleUi](https://github.com/simcu/headscale-ui)
   ![GitHub stars](https://img.shields.io/github/stars/simcu/headscale-ui)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/simcu/headscale-ui)
   - A static headscale admin ui, no backend environment required
 - [Headplane](https://github.com/tale/headplane)
   ![GitHub stars](https://img.shields.io/github/stars/tale/headplane)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/tale/headplane)
   - An advanced Tailscale inspired frontend for headscale
 - [headscale-admin](https://github.com/GoodiesHQ/headscale-admin)
   ![GitHub stars](https://img.shields.io/github/stars/GoodiesHQ/headscale-admin)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/GoodiesHQ/headscale-admin)
   - Headscale-Admin is meant to be a simple, modern web interface for headscale
 - [ouroboros](https://github.com/yellowsink/ouroboros)
   ![GitHub stars](https://img.shields.io/github/stars/yellowsink/ouroboros)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/yellowsink/ouroboros)
   - Ouroboros is designed for users to manage their own devices, rather than for
   admins
 - [unraid-headscale-admin](https://github.com/ich777/unraid-headscale-admin)
   ![GitHub stars](https://img.shields.io/github/stars/ich777/unraid-headscale-admin)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/ich777/unraid-headscale-admin)
   - A simple headscale admin UI for Unraid, it offers Local (`docker exec`) and
   API Mode
 - [headscale-console](https://github.com/rickli-cloud/headscale-console)
   ![GitHub stars](https://img.shields.io/github/stars/rickli-cloud/headscale-console)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/rickli-cloud/headscale-console)
   - WebAssembly-based client supporting SSH, VNC and RDP with optional
   self-service capabilities
 - [headscale-piying](https://github.com/wszgrcy/headscale-piying)
   ![GitHub stars](https://img.shields.io/github/stars/wszgrcy/headscale-piying)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/wszgrcy/headscale-piying)
   - headscale web ui, support visual ACL configuration
 - [HeadControl](https://github.com/ahmadzip/HeadControl)
   ![GitHub stars](https://img.shields.io/github/stars/ahmadzip/HeadControl)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/ahmadzip/HeadControl)
   - Minimal Headscale admin dashboard, built with Go and HTMX
 - [Headscale Manager](https://github.com/hkdone/headscalemanager)
   ![GitHub stars](https://img.shields.io/github/stars/hkdone/headscalemanager)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/hkdone/headscalemanager)
   - Headscale UI for Android
 - [Headscale UI](https://github.com/MunMunMiao/headscale-ui)
   ![GitHub stars](https://img.shields.io/github/stars/MunMunMiao/headscale-ui)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/MunMunMiao/headscale-ui)
   - Headscale UI online and Self-hosting
 - [Headscale Panel](https://github.com/headscale-panel/panel)
   ![GitHub stars](https://img.shields.io/github/stars/headscale-panel/panel)
+  ![GitHub last commit](https://img.shields.io/github/last-commit/headscale-panel/panel)
   - A modern Headscale management panel with a clean, network-operations-focused
   UI
 

--- a/docs/ref/integration/web-ui.md
+++ b/docs/ref/integration/web-ui.md
@@ -8,56 +8,56 @@
 Headscale doesn't provide a built-in web interface but users may pick one from the available options.
 
 - [headscale-ui](https://github.com/gurucomputing/headscale-ui)
-  ![GitHub stars](https://img.shields.io/github/stars/gurucomputing/headscale-ui?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/gurucomputing/headscale-ui)
+  - ![GitHub stars](https://img.shields.io/github/stars/gurucomputing/headscale-ui?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/gurucomputing/headscale-ui)
   - A web frontend for the headscale Tailscale-compatible coordination server
 - [HeadscaleUi](https://github.com/simcu/headscale-ui)
-  ![GitHub stars](https://img.shields.io/github/stars/simcu/headscale-ui?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/simcu/headscale-ui)
+  - ![GitHub stars](https://img.shields.io/github/stars/simcu/headscale-ui?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/simcu/headscale-ui)
   - A static headscale admin ui, no backend environment required
 - [Headplane](https://github.com/tale/headplane)
-  ![GitHub stars](https://img.shields.io/github/stars/tale/headplane?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/tale/headplane)
+  - ![GitHub stars](https://img.shields.io/github/stars/tale/headplane?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/tale/headplane)
   - An advanced Tailscale inspired frontend for headscale
 - [headscale-admin](https://github.com/GoodiesHQ/headscale-admin)
-  ![GitHub stars](https://img.shields.io/github/stars/GoodiesHQ/headscale-admin?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/GoodiesHQ/headscale-admin)
+  - ![GitHub stars](https://img.shields.io/github/stars/GoodiesHQ/headscale-admin?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/GoodiesHQ/headscale-admin)
   - Headscale-Admin is meant to be a simple, modern web interface for headscale
 - [ouroboros](https://github.com/yellowsink/ouroboros)
-  ![GitHub stars](https://img.shields.io/github/stars/yellowsink/ouroboros?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/yellowsink/ouroboros)
+  - ![GitHub stars](https://img.shields.io/github/stars/yellowsink/ouroboros?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/yellowsink/ouroboros)
   - Ouroboros is designed for users to manage their own devices, rather than for
-  admins
+    admins
 - [unraid-headscale-admin](https://github.com/ich777/unraid-headscale-admin)
-  ![GitHub stars](https://img.shields.io/github/stars/ich777/unraid-headscale-admin?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/ich777/unraid-headscale-admin)
+  - ![GitHub stars](https://img.shields.io/github/stars/ich777/unraid-headscale-admin?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/ich777/unraid-headscale-admin)
   - A simple headscale admin UI for Unraid, it offers Local (`docker exec`) and
-  API Mode
+    API Mode
 - [headscale-console](https://github.com/rickli-cloud/headscale-console)
-  ![GitHub stars](https://img.shields.io/github/stars/rickli-cloud/headscale-console?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/rickli-cloud/headscale-console)
+  - ![GitHub stars](https://img.shields.io/github/stars/rickli-cloud/headscale-console?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/rickli-cloud/headscale-console)
   - WebAssembly-based client supporting SSH, VNC and RDP with optional
-  self-service capabilities
+    self-service capabilities
 - [headscale-piying](https://github.com/wszgrcy/headscale-piying)
-  ![GitHub stars](https://img.shields.io/github/stars/wszgrcy/headscale-piying?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/wszgrcy/headscale-piying)
+  - ![GitHub stars](https://img.shields.io/github/stars/wszgrcy/headscale-piying?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/wszgrcy/headscale-piying)
   - headscale web ui, support visual ACL configuration
 - [HeadControl](https://github.com/ahmadzip/HeadControl)
-  ![GitHub stars](https://img.shields.io/github/stars/ahmadzip/HeadControl?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/ahmadzip/HeadControl)
+  - ![GitHub stars](https://img.shields.io/github/stars/ahmadzip/HeadControl?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/ahmadzip/HeadControl)
   - Minimal Headscale admin dashboard, built with Go and HTMX
 - [Headscale Manager](https://github.com/hkdone/headscalemanager)
-  ![GitHub stars](https://img.shields.io/github/stars/hkdone/headscalemanager?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/hkdone/headscalemanager)
+  - ![GitHub stars](https://img.shields.io/github/stars/hkdone/headscalemanager?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/hkdone/headscalemanager)
   - Headscale UI for Android
 - [Headscale UI](https://github.com/MunMunMiao/headscale-ui)
-  ![GitHub stars](https://img.shields.io/github/stars/MunMunMiao/headscale-ui?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/MunMunMiao/headscale-ui)
+  - ![GitHub stars](https://img.shields.io/github/stars/MunMunMiao/headscale-ui?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/MunMunMiao/headscale-ui)
   - Headscale UI online and Self-hosting
 - [Headscale Panel](https://github.com/headscale-panel/panel)
-  ![GitHub stars](https://img.shields.io/github/stars/headscale-panel/panel?style=flat)
-  ![GitHub last commit](https://img.shields.io/github/last-commit/headscale-panel/panel)
+  - ![GitHub stars](https://img.shields.io/github/stars/headscale-panel/panel?style=flat)
+    ![GitHub last commit](https://img.shields.io/github/last-commit/headscale-panel/panel)
   - A modern Headscale management panel with a clean, network-operations-focused
-  UI
+    UI
 
 You can ask for support on our [Discord server](https://discord.gg/c84AZQhmpx) in the "web-interfaces" channel.

--- a/docs/ref/integration/web-ui.md
+++ b/docs/ref/integration/web-ui.md
@@ -8,90 +8,66 @@
 Headscale doesn't provide a built-in web interface but users may pick one from the available options.
 
 - [headscale-ui](https://github.com/gurucomputing/headscale-ui)
-
     - ![GitHub stars](https://img.shields.io/github/stars/gurucomputing/headscale-ui?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/gurucomputing/headscale-ui)
-
     - A web frontend for the headscale Tailscale-compatible coordination server
 
 - [HeadscaleUi](https://github.com/simcu/headscale-ui)
-
     - ![GitHub stars](https://img.shields.io/github/stars/simcu/headscale-ui?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/simcu/headscale-ui)
-
     - A static headscale admin ui, no backend environment required
 
 - [Headplane](https://github.com/tale/headplane)
-
     - ![GitHub stars](https://img.shields.io/github/stars/tale/headplane?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/tale/headplane)
-
     - An advanced Tailscale inspired frontend for headscale
 
 - [headscale-admin](https://github.com/GoodiesHQ/headscale-admin)
-
     - ![GitHub stars](https://img.shields.io/github/stars/GoodiesHQ/headscale-admin?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/GoodiesHQ/headscale-admin)
-
     - Headscale-Admin is meant to be a simple, modern web interface for headscale
 
 - [ouroboros](https://github.com/yellowsink/ouroboros)
-
     - ![GitHub stars](https://img.shields.io/github/stars/yellowsink/ouroboros?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/yellowsink/ouroboros)
-
     - Ouroboros is designed for users to manage their own devices, rather than for
       admins
 
 - [unraid-headscale-admin](https://github.com/ich777/unraid-headscale-admin)
-
     - ![GitHub stars](https://img.shields.io/github/stars/ich777/unraid-headscale-admin?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/ich777/unraid-headscale-admin)
-
     - A simple headscale admin UI for Unraid, it offers Local (`docker exec`) and
       API Mode
 
 - [headscale-console](https://github.com/rickli-cloud/headscale-console)
-
     - ![GitHub stars](https://img.shields.io/github/stars/rickli-cloud/headscale-console?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/rickli-cloud/headscale-console)
-
     - WebAssembly-based client supporting SSH, VNC and RDP with optional
       self-service capabilities
 
 - [headscale-piying](https://github.com/wszgrcy/headscale-piying)
-
     - ![GitHub stars](https://img.shields.io/github/stars/wszgrcy/headscale-piying?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/wszgrcy/headscale-piying)
-
     - headscale web ui, support visual ACL configuration
 
 - [HeadControl](https://github.com/ahmadzip/HeadControl)
-
     - ![GitHub stars](https://img.shields.io/github/stars/ahmadzip/HeadControl?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/ahmadzip/HeadControl)
-
     - Minimal Headscale admin dashboard, built with Go and HTMX
 
 - [Headscale Manager](https://github.com/hkdone/headscalemanager)
-
     - ![GitHub stars](https://img.shields.io/github/stars/hkdone/headscalemanager?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/hkdone/headscalemanager)
-
     - Headscale UI for Android
 
 - [Headscale UI](https://github.com/MunMunMiao/headscale-ui)
-
     - ![GitHub stars](https://img.shields.io/github/stars/MunMunMiao/headscale-ui?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/MunMunMiao/headscale-ui)
-
     - Headscale UI online and Self-hosting
 
 - [Headscale Panel](https://github.com/headscale-panel/panel)
-
     - ![GitHub stars](https://img.shields.io/github/stars/headscale-panel/panel?style=flat)
       ![GitHub last commit](https://img.shields.io/github/last-commit/headscale-panel/panel)
-
     - A modern Headscale management panel with a clean, network-operations-focused
       UI
 

--- a/docs/ref/integration/web-ui.md
+++ b/docs/ref/integration/web-ui.md
@@ -8,56 +8,91 @@
 Headscale doesn't provide a built-in web interface but users may pick one from the available options.
 
 - [headscale-ui](https://github.com/gurucomputing/headscale-ui)
-  - ![GitHub stars](https://img.shields.io/github/stars/gurucomputing/headscale-ui?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/gurucomputing/headscale-ui)
-  - A web frontend for the headscale Tailscale-compatible coordination server
+
+    - ![GitHub stars](https://img.shields.io/github/stars/gurucomputing/headscale-ui?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/gurucomputing/headscale-ui)
+
+    - A web frontend for the headscale Tailscale-compatible coordination server
+
 - [HeadscaleUi](https://github.com/simcu/headscale-ui)
-  - ![GitHub stars](https://img.shields.io/github/stars/simcu/headscale-ui?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/simcu/headscale-ui)
-  - A static headscale admin ui, no backend environment required
+
+    - ![GitHub stars](https://img.shields.io/github/stars/simcu/headscale-ui?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/simcu/headscale-ui)
+
+    - A static headscale admin ui, no backend environment required
+
 - [Headplane](https://github.com/tale/headplane)
-  - ![GitHub stars](https://img.shields.io/github/stars/tale/headplane?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/tale/headplane)
-  - An advanced Tailscale inspired frontend for headscale
+
+    - ![GitHub stars](https://img.shields.io/github/stars/tale/headplane?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/tale/headplane)
+
+    - An advanced Tailscale inspired frontend for headscale
+
 - [headscale-admin](https://github.com/GoodiesHQ/headscale-admin)
-  - ![GitHub stars](https://img.shields.io/github/stars/GoodiesHQ/headscale-admin?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/GoodiesHQ/headscale-admin)
-  - Headscale-Admin is meant to be a simple, modern web interface for headscale
+
+    - ![GitHub stars](https://img.shields.io/github/stars/GoodiesHQ/headscale-admin?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/GoodiesHQ/headscale-admin)
+
+    - Headscale-Admin is meant to be a simple, modern web interface for headscale
+
 - [ouroboros](https://github.com/yellowsink/ouroboros)
-  - ![GitHub stars](https://img.shields.io/github/stars/yellowsink/ouroboros?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/yellowsink/ouroboros)
-  - Ouroboros is designed for users to manage their own devices, rather than for
-    admins
+
+    - ![GitHub stars](https://img.shields.io/github/stars/yellowsink/ouroboros?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/yellowsink/ouroboros)
+
+    - Ouroboros is designed for users to manage their own devices, rather than for
+      admins
+
 - [unraid-headscale-admin](https://github.com/ich777/unraid-headscale-admin)
-  - ![GitHub stars](https://img.shields.io/github/stars/ich777/unraid-headscale-admin?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/ich777/unraid-headscale-admin)
-  - A simple headscale admin UI for Unraid, it offers Local (`docker exec`) and
-    API Mode
+
+    - ![GitHub stars](https://img.shields.io/github/stars/ich777/unraid-headscale-admin?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/ich777/unraid-headscale-admin)
+
+    - A simple headscale admin UI for Unraid, it offers Local (`docker exec`) and
+      API Mode
+
 - [headscale-console](https://github.com/rickli-cloud/headscale-console)
-  - ![GitHub stars](https://img.shields.io/github/stars/rickli-cloud/headscale-console?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/rickli-cloud/headscale-console)
-  - WebAssembly-based client supporting SSH, VNC and RDP with optional
-    self-service capabilities
+
+    - ![GitHub stars](https://img.shields.io/github/stars/rickli-cloud/headscale-console?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/rickli-cloud/headscale-console)
+
+    - WebAssembly-based client supporting SSH, VNC and RDP with optional
+      self-service capabilities
+
 - [headscale-piying](https://github.com/wszgrcy/headscale-piying)
-  - ![GitHub stars](https://img.shields.io/github/stars/wszgrcy/headscale-piying?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/wszgrcy/headscale-piying)
-  - headscale web ui, support visual ACL configuration
+
+    - ![GitHub stars](https://img.shields.io/github/stars/wszgrcy/headscale-piying?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/wszgrcy/headscale-piying)
+
+    - headscale web ui, support visual ACL configuration
+
 - [HeadControl](https://github.com/ahmadzip/HeadControl)
-  - ![GitHub stars](https://img.shields.io/github/stars/ahmadzip/HeadControl?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/ahmadzip/HeadControl)
-  - Minimal Headscale admin dashboard, built with Go and HTMX
+
+    - ![GitHub stars](https://img.shields.io/github/stars/ahmadzip/HeadControl?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/ahmadzip/HeadControl)
+
+    - Minimal Headscale admin dashboard, built with Go and HTMX
+
 - [Headscale Manager](https://github.com/hkdone/headscalemanager)
-  - ![GitHub stars](https://img.shields.io/github/stars/hkdone/headscalemanager?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/hkdone/headscalemanager)
-  - Headscale UI for Android
+
+    - ![GitHub stars](https://img.shields.io/github/stars/hkdone/headscalemanager?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/hkdone/headscalemanager)
+
+    - Headscale UI for Android
+
 - [Headscale UI](https://github.com/MunMunMiao/headscale-ui)
-  - ![GitHub stars](https://img.shields.io/github/stars/MunMunMiao/headscale-ui?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/MunMunMiao/headscale-ui)
-  - Headscale UI online and Self-hosting
+
+    - ![GitHub stars](https://img.shields.io/github/stars/MunMunMiao/headscale-ui?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/MunMunMiao/headscale-ui)
+
+    - Headscale UI online and Self-hosting
+
 - [Headscale Panel](https://github.com/headscale-panel/panel)
-  - ![GitHub stars](https://img.shields.io/github/stars/headscale-panel/panel?style=flat)
-    ![GitHub last commit](https://img.shields.io/github/last-commit/headscale-panel/panel)
-  - A modern Headscale management panel with a clean, network-operations-focused
-    UI
+
+    - ![GitHub stars](https://img.shields.io/github/stars/headscale-panel/panel?style=flat)
+      ![GitHub last commit](https://img.shields.io/github/last-commit/headscale-panel/panel)
+
+    - A modern Headscale management panel with a clean, network-operations-focused
+      UI
 
 You can ask for support on our [Discord server](https://discord.gg/c84AZQhmpx) in the "web-interfaces" channel.

--- a/docs/ref/integration/web-ui.md
+++ b/docs/ref/integration/web-ui.md
@@ -8,54 +8,54 @@
 Headscale doesn't provide a built-in web interface but users may pick one from the available options.
 
 - [headscale-ui](https://github.com/gurucomputing/headscale-ui)
-  ![GitHub stars](https://img.shields.io/github/stars/gurucomputing/headscale-ui)
+  ![GitHub stars](https://img.shields.io/github/stars/gurucomputing/headscale-ui?style=flat)
   ![GitHub last commit](https://img.shields.io/github/last-commit/gurucomputing/headscale-ui)
   - A web frontend for the headscale Tailscale-compatible coordination server
 - [HeadscaleUi](https://github.com/simcu/headscale-ui)
-  ![GitHub stars](https://img.shields.io/github/stars/simcu/headscale-ui)
+  ![GitHub stars](https://img.shields.io/github/stars/simcu/headscale-ui?style=flat)
   ![GitHub last commit](https://img.shields.io/github/last-commit/simcu/headscale-ui)
   - A static headscale admin ui, no backend environment required
 - [Headplane](https://github.com/tale/headplane)
-  ![GitHub stars](https://img.shields.io/github/stars/tale/headplane)
+  ![GitHub stars](https://img.shields.io/github/stars/tale/headplane?style=flat)
   ![GitHub last commit](https://img.shields.io/github/last-commit/tale/headplane)
   - An advanced Tailscale inspired frontend for headscale
 - [headscale-admin](https://github.com/GoodiesHQ/headscale-admin)
-  ![GitHub stars](https://img.shields.io/github/stars/GoodiesHQ/headscale-admin)
+  ![GitHub stars](https://img.shields.io/github/stars/GoodiesHQ/headscale-admin?style=flat)
   ![GitHub last commit](https://img.shields.io/github/last-commit/GoodiesHQ/headscale-admin)
   - Headscale-Admin is meant to be a simple, modern web interface for headscale
 - [ouroboros](https://github.com/yellowsink/ouroboros)
-  ![GitHub stars](https://img.shields.io/github/stars/yellowsink/ouroboros)
+  ![GitHub stars](https://img.shields.io/github/stars/yellowsink/ouroboros?style=flat)
   ![GitHub last commit](https://img.shields.io/github/last-commit/yellowsink/ouroboros)
   - Ouroboros is designed for users to manage their own devices, rather than for
   admins
 - [unraid-headscale-admin](https://github.com/ich777/unraid-headscale-admin)
-  ![GitHub stars](https://img.shields.io/github/stars/ich777/unraid-headscale-admin)
+  ![GitHub stars](https://img.shields.io/github/stars/ich777/unraid-headscale-admin?style=flat)
   ![GitHub last commit](https://img.shields.io/github/last-commit/ich777/unraid-headscale-admin)
   - A simple headscale admin UI for Unraid, it offers Local (`docker exec`) and
   API Mode
 - [headscale-console](https://github.com/rickli-cloud/headscale-console)
-  ![GitHub stars](https://img.shields.io/github/stars/rickli-cloud/headscale-console)
+  ![GitHub stars](https://img.shields.io/github/stars/rickli-cloud/headscale-console?style=flat)
   ![GitHub last commit](https://img.shields.io/github/last-commit/rickli-cloud/headscale-console)
   - WebAssembly-based client supporting SSH, VNC and RDP with optional
   self-service capabilities
 - [headscale-piying](https://github.com/wszgrcy/headscale-piying)
-  ![GitHub stars](https://img.shields.io/github/stars/wszgrcy/headscale-piying)
+  ![GitHub stars](https://img.shields.io/github/stars/wszgrcy/headscale-piying?style=flat)
   ![GitHub last commit](https://img.shields.io/github/last-commit/wszgrcy/headscale-piying)
   - headscale web ui, support visual ACL configuration
 - [HeadControl](https://github.com/ahmadzip/HeadControl)
-  ![GitHub stars](https://img.shields.io/github/stars/ahmadzip/HeadControl)
+  ![GitHub stars](https://img.shields.io/github/stars/ahmadzip/HeadControl?style=flat)
   ![GitHub last commit](https://img.shields.io/github/last-commit/ahmadzip/HeadControl)
   - Minimal Headscale admin dashboard, built with Go and HTMX
 - [Headscale Manager](https://github.com/hkdone/headscalemanager)
-  ![GitHub stars](https://img.shields.io/github/stars/hkdone/headscalemanager)
+  ![GitHub stars](https://img.shields.io/github/stars/hkdone/headscalemanager?style=flat)
   ![GitHub last commit](https://img.shields.io/github/last-commit/hkdone/headscalemanager)
   - Headscale UI for Android
 - [Headscale UI](https://github.com/MunMunMiao/headscale-ui)
-  ![GitHub stars](https://img.shields.io/github/stars/MunMunMiao/headscale-ui)
+  ![GitHub stars](https://img.shields.io/github/stars/MunMunMiao/headscale-ui?style=flat)
   ![GitHub last commit](https://img.shields.io/github/last-commit/MunMunMiao/headscale-ui)
   - Headscale UI online and Self-hosting
 - [Headscale Panel](https://github.com/headscale-panel/panel)
-  ![GitHub stars](https://img.shields.io/github/stars/headscale-panel/panel)
+  ![GitHub stars](https://img.shields.io/github/stars/headscale-panel/panel?style=flat)
   ![GitHub last commit](https://img.shields.io/github/last-commit/headscale-panel/panel)
   - A modern Headscale management panel with a clean, network-operations-focused
   UI


### PR DESCRIPTION
<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

This is a _very_ minor contribution.

The community web UI list is hard to compare at a glance: a one-line description kinda helps sub-selecting solutions, but it's hard to find a maintained one.

This change adds Shields.io badges next to each listed project:

- GitHub star count
- GitHub last commit

Documentation only. No code, tests, or changelog updates. Raising a GitHub issue not really worth as well.

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
