### PR TITLE
cli: fix users rename when resolved by name

### DIFF
--- a/cmd/headscale/cli/users.go
+++ b/cmd/headscale/cli/users.go
@@ -231,7 +231,7 @@ var renameUserCmd = &cobra.Command{
 		newName, _ := cmd.Flags().GetString("new-name")
 
 		renameReq := &v1.RenameUserRequest{
-			OldId:   id,
+			OldId:   users.GetUsers()[0].GetId(),
 			NewName: newName,
 		}
 

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -237,13 +237,52 @@ func TestUserCommand(t *testing.T) {
 		}
 	}, integrationutil.ScaledTimeout(20*time.Second), 1*time.Second)
 
+	_, err = headscale.Execute(
+		[]string{
+			"headscale",
+			"users",
+			"rename",
+			"--output=json",
+			"--name=newname",
+			"--new-name=renamedbyname",
+		},
+	)
+	require.NoError(t, err)
+
+	var listAfterRenameByName []*v1.User
+
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		err := executeAndUnmarshal(headscale,
+			[]string{
+				"headscale",
+				"users",
+				"list",
+				"--output",
+				"json",
+			},
+			&listAfterRenameByName,
+		)
+		assert.NoError(ct, err)
+
+		if !assert.Len(ct, listAfterRenameByName, 1) {
+			return
+		}
+
+		assert.Equal(
+			ct,
+			"renamedbyname",
+			listAfterRenameByName[0].GetName(),
+			"Should have renamedbyname after rename resolved by name",
+		)
+	}, integrationutil.ScaledTimeout(20*time.Second), 1*time.Second)
+
 	deleteResult, err = headscale.Execute(
 		[]string{
 			"headscale",
 			"users",
 			"destroy",
 			"--force",
-			"--name=newname",
+			"--name=renamedbyname",
 		},
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
`headscale users rename --name foo --new-name bar` failed with "user not found".
The command resolved the user with `ListUsers`, then built `RenameUserRequest`
with `OldId: id` — the raw `--identifier` flag, which is 0 when the user was
resolved by name. Send the matched user's ID instead.

Backport of #3442, which fixed the same bug in the HTTP client path on `main`.
The 0.29 CLI still talks gRPC, so the upstream patch does not apply.

`TestUserCommand` only ever renamed by `--identifier`, so it never saw this.
It now renames by `--name` before destroying by `--name`.

Fixes #3441

> Generated with the help of an AI assistant
