### PR TITLE
state: exclude self from peers on the named peer-ID path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ keys remain all-access.
 
 ### Changes
 
+- Fix a node being listed among its own peers in an incremental map update, which crashes the Tailscale Android app on the device list [#3459](https://github.com/juanfont/headscale/pull/3459)
 - Fix HTTP metrics only counting `OPTIONS` requests, so `http_requests_total` and `http_request_duration_seconds` now cover regular traffic [#3414](https://github.com/juanfont/headscale/pull/3414)
 - Fix extra-records filewatcher hanging on shutdown after the watched file is deleted, and leaking the watcher when setup fails [#3437](https://github.com/juanfont/headscale/pull/3437)
 - Fix `headscale users rename` sending the raw `--identifier` flag value instead of the matched user's identifier, so renaming by name works again [#3442](https://github.com/juanfont/headscale/pull/3442)

--- a/hscontrol/mapper/mapper_test.go
+++ b/hscontrol/mapper/mapper_test.go
@@ -5,6 +5,7 @@ import (
 	"net/netip"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -647,4 +648,168 @@ func TestGenerateDNSConfigNilHostinfoNoPanic(t *testing.T) {
 	require.NotPanics(t, func() {
 		generateDNSConfig(cfg, node, nil)
 	}, "generateDNSConfig must not panic when a node has nil Hostinfo")
+}
+
+// policyShapes covers the paths that decide how the mapper filters peers: a
+// global filter with matchers, a per-node (autogroup:self) filter, a policy
+// that leaves every node with zero matchers, and no rules at all. The
+// zero-matcher shape is the interesting one, because
+// [MapResponseBuilder.buildTailPeers] skips [policy.ReduceNodes] there and
+// emits its input as given.
+var policyShapes = []struct {
+	name   string
+	policy string
+}{
+	{
+		name:   "allow all",
+		policy: `{"acls":[{"action":"accept","src":["*"],"dst":["*:*"]}]}`,
+	},
+	{
+		name:   "autogroup self",
+		policy: `{"acls":[{"action":"accept","src":["autogroup:member"],"dst":["autogroup:self:*"]}]}`,
+	},
+	{
+		name:   "no rules",
+		policy: `{"acls":[]}`,
+	},
+	{
+		name:   "empty policy",
+		policy: `{}`,
+	},
+}
+
+// assertSelfNotAPeer fails when a [tailcfg.MapResponse] addressed to nodeID
+// mentions nodeID in any peer-carrying field.
+//
+// The Tailscale client merges [tailcfg.MapResponse.PeersChanged] straight into
+// its peer map (controlclient updatePeersStateFromResponse) and keeps the self
+// node in a separate field, so a node present in its own peer list is rendered
+// twice by clients that concatenate peers with self.
+func assertSelfNotAPeer(t *testing.T, nodeID types.NodeID, resp *tailcfg.MapResponse, what string) {
+	t.Helper()
+
+	if resp == nil {
+		return
+	}
+
+	self := nodeID.NodeID()
+
+	for _, p := range resp.Peers {
+		assert.NotEqualf(t, self, p.ID, "%s: node %d listed in its own Peers", what, nodeID)
+	}
+
+	for _, p := range resp.PeersChanged {
+		assert.NotEqualf(t, self, p.ID, "%s: node %d listed in its own PeersChanged", what, nodeID)
+	}
+
+	for _, p := range resp.PeersChangedPatch {
+		assert.NotEqualf(t, self, p.NodeID, "%s: node %d patched in its own PeersChangedPatch", what, nodeID)
+	}
+
+	for _, id := range resp.PeersRemoved {
+		assert.NotEqualf(t, self, id, "%s: node %d listed in its own PeersRemoved", what, nodeID)
+	}
+}
+
+// TestMapResponseNeverContainsSelfAsPeer drives the [change.Change] shapes the
+// server emits through the response builder for every node, under each policy
+// shape, and asserts the recipient is never present in its own peer fields.
+func TestMapResponseNeverContainsSelfAsPeer(t *testing.T) {
+	for _, tt := range policyShapes {
+		t.Run(tt.name, func(t *testing.T) {
+			testData, cleanup := setupBatcherWithTestData(t, NewBatcherAndMapper, 2, 3, largeBufferSize)
+			defer cleanup()
+
+			_, err := testData.State.SetPolicy([]byte(tt.policy))
+			require.NoError(t, err)
+
+			batcher := unwrapBatcher(testData.Batcher)
+
+			allIDs := make([]types.NodeID, 0, len(testData.Nodes))
+
+			for i := range testData.Nodes {
+				tn := &testData.Nodes[i]
+				require.NoError(t, testData.Batcher.AddNode(tn.n.ID, tn.ch, 100, nil))
+				allIDs = append(allIDs, tn.n.ID)
+			}
+
+			for _, recipient := range allIDs {
+				changes := map[string]change.Change{
+					"full self":     change.FullSelf(recipient),
+					"full update":   change.FullUpdate(),
+					"policy change": change.PolicyChange(),
+					"self added":    change.NodeAdded(recipient),
+					"self online":   change.NodeOnline(recipient),
+					"self offline":  change.NodeOffline(recipient),
+					// A batch naming every node, the recipient included.
+					// change.PeersChanged carries no OriginNode, so the
+					// self-update short circuit in buildFromChange never fires
+					// and the peer lookup is the only thing left to drop self.
+					"all peers changed": change.PeersChanged("all peers", allIDs...),
+				}
+
+				for name, ch := range changes {
+					resp, err := batcher.MapResponseFromChange(recipient, ch)
+					require.NoError(t, err, "%s for node %d", name, recipient)
+					assertSelfNotAPeer(t, recipient, resp, name)
+				}
+			}
+		})
+	}
+}
+
+// TestNoSelfAsPeerDuringRealNodeChurn exercises the change flow poll.go drives
+// (connect, disconnect, reconnect, policy reload, key expiry) and scans every
+// delivered [tailcfg.MapResponse] for the recipient's own node.
+func TestNoSelfAsPeerDuringRealNodeChurn(t *testing.T) {
+	// How long a node's stream must stay silent before the churn counts as
+	// settled and the scan moves on to the next node.
+	const quietPeriod = 500 * time.Millisecond
+
+	for _, tt := range policyShapes {
+		t.Run(tt.name, func(t *testing.T) {
+			testData, cleanup := setupBatcherWithTestData(t, NewBatcherAndMapper, 2, 3, largeBufferSize)
+			defer cleanup()
+
+			_, err := testData.State.SetPolicy([]byte(tt.policy))
+			require.NoError(t, err)
+
+			batcher := testData.Batcher
+
+			for i := range testData.Nodes {
+				tn := &testData.Nodes[i]
+				require.NoError(t, batcher.AddNode(tn.n.ID, tn.ch, 100, nil))
+			}
+
+			// Drop and re-add every node but the first, then reload the
+			// policy and expire the one node that never reconnected.
+			for i := 1; i < len(testData.Nodes); i++ {
+				tn := &testData.Nodes[i]
+				batcher.RemoveNode(tn.n.ID, tn.ch)
+				require.NoError(t, batcher.AddNode(tn.n.ID, tn.ch, 100, nil))
+			}
+
+			_, err = testData.State.SetPolicy([]byte(tt.policy))
+			require.NoError(t, err)
+
+			expiry := time.Now().Add(time.Hour)
+
+			_, c, err := testData.State.SetNodeExpiry(testData.Nodes[0].n.ID, &expiry)
+			require.NoError(t, err)
+			batcher.AddWork(c)
+
+			for i := range testData.Nodes {
+				tn := &testData.Nodes[i]
+
+				for quiet := false; !quiet; {
+					select {
+					case resp := <-tn.ch:
+						assertSelfNotAPeer(t, tn.n.ID, resp, "churn")
+					case <-time.After(quietPeriod):
+						quiet = true
+					}
+				}
+			}
+		})
+	}
 }

--- a/hscontrol/state/node_store_test.go
+++ b/hscontrol/state/node_store_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/juanfont/headscale/hscontrol/db"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1360,4 +1361,53 @@ func TestGetNodesByMachineKeyAllUsers(t *testing.T) {
 		require.True(t, all[types.UserID(0)].IsTagged())
 		require.Equal(t, types.NodeID(3), all[types.UserID(0)].ID())
 	})
+}
+
+// TestListPeersExcludesSelf proves a node is never returned among its own
+// peers, on both the snapshot path and the explicit peer-ID path.
+//
+// The explicit path is reached for incremental updates, where the caller
+// passes the IDs named by a change batch — a batch that may include the
+// recipient. Without the exclusion the recipient reaches the mapper as one of
+// its own peers, is emitted in [tailcfg.MapResponse.PeersChanged], and the
+// Tailscale client merges it into its peer map next to the self node.
+func TestListPeersExcludesSelf(t *testing.T) {
+	dbPath := t.TempDir() + "/headscale.db"
+	cfg := persistTestConfig(dbPath)
+
+	database, err := db.NewHeadscaleDatabase(cfg)
+	require.NoError(t, err)
+
+	user := database.CreateUserForTest("peer-user")
+	nodes := database.CreateRegisteredNodesForTest(user, 3, "peer-node")
+	require.NoError(t, database.Close())
+
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	allIDs := make([]types.NodeID, 0, len(nodes))
+	for _, n := range nodes {
+		allIDs = append(allIDs, n.ID)
+	}
+
+	for _, self := range allIDs {
+		t.Run(self.String(), func(t *testing.T) {
+			snapshot := s.ListPeers(self)
+			for _, peer := range snapshot.All() {
+				require.NotEqual(t, self, peer.ID(), "node listed in its own snapshot peers")
+			}
+
+			// Every node named, the recipient included.
+			named := s.ListPeers(self, allIDs...)
+			require.Equal(t, len(allIDs)-1, named.Len(), "self must be dropped, every other named node kept")
+
+			for _, peer := range named.All() {
+				require.NotEqual(t, self, peer.ID(), "node listed in its own named peers")
+			}
+
+			// Naming only the recipient yields nothing.
+			require.Zero(t, s.ListPeers(self, self).Len(), "naming only self must yield no peers")
+		})
+	}
 }

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -872,6 +872,17 @@ func (s *State) ListPeers(nodeID types.NodeID, peerIDs ...types.NodeID) views.Sl
 	var filteredNodes []types.NodeView
 
 	for _, node := range allNodes.All() {
+		// A node is never its own peer. [db.ListPeers] enforces this with
+		// `id <> nodeID`; the caller may name the recipient in peerIDs
+		// (a change batch that includes it), and the mapper's only other
+		// self filter is [policy.ReduceNodes], which is skipped when the
+		// node has no matchers. Self would then reach the client in
+		// [tailcfg.MapResponse.PeersChanged], where it is merged into the
+		// peer map and listed alongside the self node.
+		if node.ID() == nodeID {
+			continue
+		}
+
 		if _, exists := nodeIDSet[node.ID()]; exists {
 			filteredNodes = append(filteredNodes, node)
 		}


### PR DESCRIPTION
`State.ListPeers(nodeID, peerIDs...)` filtered every node, not every peer, so a change batch naming the recipient returned it as its own peer; `db.ListPeers` keeps this out with `id <> nodeID` and the NodeStore rewrite dropped it.

Self then reaches the client in `MapResponse.PeersChanged`, and the Tailscale Android app concatenates `peers + selfNode` without deduplicating, so the repeated `StableID` kills its device list — https://github.com/tailscale/tailscale/issues/21128.

> Generated with the help of an AI assistant
