### PR TITLE
Use tmpfs for /tmp

### DIFF
--- a/docs/setup/install/container.md
+++ b/docs/setup/install/container.md
@@ -34,6 +34,7 @@ Registry](https://github.com/juanfont/headscale/pkgs/container/headscale). The c
       --name headscale \
       --detach \
       --read-only \
+      --tmpfs /tmp \
       --tmpfs /var/run/headscale \
       --volume "$(pwd)/config:/etc/headscale:ro" \
       --volume "$(pwd)/lib:/var/lib/headscale" \

--- a/docs/setup/install/main.md
+++ b/docs/setup/install/main.md
@@ -29,6 +29,7 @@ docker run \
   --name headscale \
   --detach \
   --read-only \
+  --tmpfs /tmp \
   --tmpfs /var/run/headscale \
   --volume "$(pwd)/config:/etc/headscale:ro" \
   --volume "$(pwd)/lib:/var/lib/headscale" \


### PR DESCRIPTION
This is relevant when docker is used as container runtime as it does not set /tmp as tmpfs. With podman /tmp is mounted as tmpfs due to `--read-only-tmpfs` (enabled by default).

Fixes: #3463

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [ ] raised a GitHub issue or discussed it on the projects chat beforehand
- [ ] added unit tests
- [ ] added integration tests
- [x] updated documentation if needed
- [ ] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
