### PR TITLE
hscontrol: fix authentication and update edge cases

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -466,7 +466,7 @@ auto_update:
 #
 # tuning:
 #   # Maximum number of pending registration entries in the auth cache.
-#   # Oldest entries are evicted when the cap is reached.
+#   # New registrations are rejected while the cap is reached.
 #   #
 #   # register_cache_max_entries: 1024
 #

--- a/hscontrol/api/v1/errors.go
+++ b/hscontrol/api/v1/errors.go
@@ -40,8 +40,12 @@ func mapError(msg string, err error) error {
 		return huma.Error400BadRequest(msg, err)
 
 	case errors.Is(err, state.ErrNodeKeyInUse),
-		errors.Is(err, state.ErrAmbiguousNodeOwnership):
+		errors.Is(err, state.ErrAmbiguousNodeOwnership),
+		errors.Is(err, state.ErrAuthRequestIDInUse):
 		return huma.Error409Conflict(msg, err)
+
+	case errors.Is(err, state.ErrPendingAuthCapacity):
+		return huma.Error503ServiceUnavailable(msg, err)
 
 	default:
 		return huma.Error500InternalServerError(msg, err)

--- a/hscontrol/api/v1/nodes.go
+++ b/hscontrol/api/v1/nodes.go
@@ -24,6 +24,10 @@ func init() {
 // errBackfillNotConfirmed guards BackfillNodeIPs behind explicit confirmed=true.
 var errBackfillNotConfirmed = errors.New("not confirmed, aborting")
 
+const debugNodeNameMaxBytes = 255
+
+var errDebugNodeNameTooLong = errors.New("node name exceeds 255 bytes")
+
 // registerMethodToV1Enum maps the stored register method onto the
 // SCREAMING_SNAKE enum string the v1 contract emits.
 var registerMethodToV1Enum = map[string]string{
@@ -537,6 +541,10 @@ func registerNodeAdminOps(api huma.API, b Backend) {
 		Tags:        []string{"Nodes"},
 		Security:    bearerAuth,
 	}, func(ctx context.Context, in *debugCreateNodeInput) (*nodeOutput, error) {
+		if len(in.Body.Name) > debugNodeNameMaxBytes {
+			return nil, huma.Error400BadRequest("debug creating node", errDebugNodeNameTooLong)
+		}
+
 		user, err := b.State.GetUserByName(in.Body.User)
 		if err != nil {
 			return nil, mapError("looking up user", err)

--- a/hscontrol/api/v1/nodes.go
+++ b/hscontrol/api/v1/nodes.go
@@ -568,7 +568,11 @@ func registerNodeAdminOps(api huma.API, b Backend) {
 		}
 
 		authRegReq := types.NewRegisterAuthRequest(regData)
-		b.State.SetAuthCacheEntry(registrationID, authRegReq)
+
+		err = b.State.SetAuthCacheEntry(registrationID, authRegReq)
+		if err != nil {
+			return nil, mapError("debug creating node", err)
+		}
 
 		// Synthetic echo; the real node is created later via the auth path
 		// from the cached registration data.

--- a/hscontrol/apiv1_auth_test.go
+++ b/hscontrol/apiv1_auth_test.go
@@ -37,7 +37,10 @@ func seedAuthRequest(
 			Hostinfo:   &tailcfg.Hostinfo{Hostname: hostname},
 		}
 
-		app.state.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(regData))
+		require.NoError(t, app.state.SetAuthCacheEntry(
+			authID,
+			types.NewRegisterAuthRequest(regData),
+		))
 	}
 }
 
@@ -124,7 +127,7 @@ func TestAPIV1AuthApprove(t *testing.T) {
 
 		authID := types.MustAuthID()
 		authReq := types.NewAuthRequest()
-		h.app.state.SetAuthCacheEntry(authID, authReq)
+		require.NoError(t, h.app.state.SetAuthCacheEntry(authID, authReq))
 
 		body := fmt.Appendf(nil, `{"authId":%q}`, authID.String())
 		res := h.callHuma(http.MethodPost, "/api/v1/auth/approve", body)
@@ -161,7 +164,7 @@ func TestAPIV1AuthReject(t *testing.T) {
 
 		authID := types.MustAuthID()
 		authReq := types.NewAuthRequest()
-		h.app.state.SetAuthCacheEntry(authID, authReq)
+		require.NoError(t, h.app.state.SetAuthCacheEntry(authID, authReq))
 
 		body := fmt.Appendf(nil, `{"authId":%q}`, authID.String())
 		res := h.callHuma(http.MethodPost, "/api/v1/auth/reject", body)

--- a/hscontrol/apiv1_auth_test.go
+++ b/hscontrol/apiv1_auth_test.go
@@ -132,7 +132,9 @@ func TestAPIV1AuthApprove(t *testing.T) {
 		require.Equal(t, http.StatusOK, res.status)
 		assert.JSONEq(t, `{}`, string(res.body))
 
-		verdict := <-authReq.WaitForAuth()
+		<-authReq.WaitForAuth()
+		verdict, ok := authReq.AuthResult()
+		require.True(t, ok)
 		assert.True(t, verdict.Accept(), "approve must finish the session with a passing verdict")
 	})
 
@@ -167,7 +169,9 @@ func TestAPIV1AuthReject(t *testing.T) {
 		require.Equal(t, http.StatusOK, res.status)
 		assert.JSONEq(t, `{}`, string(res.body))
 
-		verdict := <-authReq.WaitForAuth()
+		<-authReq.WaitForAuth()
+		verdict, ok := authReq.AuthResult()
+		require.True(t, ok)
 		assert.False(t, verdict.Accept(), "reject must finish the session with a failing verdict")
 	})
 

--- a/hscontrol/apiv1_nodes_test.go
+++ b/hscontrol/apiv1_nodes_test.go
@@ -326,7 +326,10 @@ func TestAPIV1NodeRegister(t *testing.T) {
 				MachineKey: mk.Public(),
 				Hostname:   "registered-node",
 			}
-			app.state.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(regData))
+			require.NoError(t, app.state.SetAuthCacheEntry(
+				authID,
+				types.NewRegisterAuthRequest(regData),
+			))
 		}
 
 		assertParityIsolated(t, seed, http.MethodPost,
@@ -371,6 +374,43 @@ func TestAPIV1NodeBackfillIPs(t *testing.T) {
 }
 
 func TestAPIV1NodeDebugCreate(t *testing.T) {
+	t.Run("duplicate registration ID", func(t *testing.T) {
+		h := newAPIV1Harness(t)
+		h.app.state.CreateUserForTest("alice")
+
+		existingID := types.MustAuthID()
+		existing := types.NewRegisterAuthRequest(&types.RegistrationData{})
+		require.NoError(t, h.app.state.SetAuthCacheEntry(existingID, existing))
+
+		body := []byte(`{"user":"alice","key":"` + existingID.String() +
+			`","name":"dbgnode","routes":[]}`)
+		res := h.callHuma(http.MethodPost, "/api/v1/debug/node", body)
+		assertStatus(t, res, http.StatusConflict)
+
+		got, ok := h.app.state.GetAuthCacheEntry(existingID)
+		require.True(t, ok)
+		require.Same(t, existing, got)
+	})
+
+	t.Run("full registration cache", func(t *testing.T) {
+		app := createTestAppWithRegisterCacheMax(t, 1)
+		app.state.CreateUserForTest("alice")
+		h := &apiV1Harness{app: app, huma: newHumaTestHandler(app)}
+
+		existingID := types.MustAuthID()
+		existing := types.NewRegisterAuthRequest(&types.RegistrationData{})
+		require.NoError(t, app.state.SetAuthCacheEntry(existingID, existing))
+
+		body := []byte(`{"user":"alice","key":"` + types.MustAuthID().String() +
+			`","name":"dbgnode","routes":[]}`)
+		res := h.callHuma(http.MethodPost, "/api/v1/debug/node", body)
+		assertStatus(t, res, http.StatusServiceUnavailable)
+
+		got, ok := app.state.GetAuthCacheEntry(existingID)
+		require.True(t, ok)
+		require.Same(t, existing, got)
+	})
+
 	t.Run("oversized name", func(t *testing.T) {
 		h := newAPIV1Harness(t)
 

--- a/hscontrol/apiv1_nodes_test.go
+++ b/hscontrol/apiv1_nodes_test.go
@@ -3,6 +3,7 @@ package hscontrol
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/juanfont/headscale/hscontrol/types"
@@ -370,6 +371,15 @@ func TestAPIV1NodeBackfillIPs(t *testing.T) {
 }
 
 func TestAPIV1NodeDebugCreate(t *testing.T) {
+	t.Run("oversized name", func(t *testing.T) {
+		h := newAPIV1Harness(t)
+
+		body := []byte(`{"user":"alice","key":"` + types.MustAuthID().String() +
+			`","name":"` + strings.Repeat("n", 256) + `","routes":[]}`)
+		res := h.callHuma(http.MethodPost, "/api/v1/debug/node", body)
+		assertStatus(t, res, http.StatusBadRequest)
+	})
+
 	t.Run("unknown user parity", func(t *testing.T) {
 		h := newAPIV1Harness(t)
 		body := []byte(`{"user":"nope","key":"` + types.MustAuthID().String() +

--- a/hscontrol/auth.go
+++ b/hscontrol/auth.go
@@ -317,19 +317,43 @@ func (h *Headscale) waitForFollowup(
 	}
 
 	if reg, ok := h.state.GetAuthCacheEntry(followupReg); ok {
-		var verdict types.AuthVerdict
+		if !reg.IsRegistration() {
+			return nil, NewHTTPError(
+				http.StatusUnauthorized,
+				"auth session is not for registration",
+				nil,
+			)
+		}
+
+		if reg.RegistrationData().MachineKey != machineKey {
+			return nil, NewHTTPError(
+				http.StatusUnauthorized,
+				"registration belongs to a different machine key",
+				nil,
+			)
+		}
+
 		select {
 		// Prefer a completed registration even if the context has also
 		// expired. When both are ready, a plain select picks at random and
 		// would discard a successful registration as a spurious timeout
 		// (issue #3385).
-		case verdict = <-reg.WaitForAuth():
+		case <-reg.WaitForAuth():
 		default:
 			select {
 			case <-ctx.Done():
 				return nil, NewHTTPError(http.StatusUnauthorized, "registration timed out", ctx.Err())
-			case verdict = <-reg.WaitForAuth():
+			case <-reg.WaitForAuth():
 			}
+		}
+
+		verdict, ok := reg.AuthResult()
+		if !ok {
+			return nil, NewHTTPError(
+				http.StatusUnauthorized,
+				"registration completed without a verdict",
+				nil,
+			)
 		}
 
 		if verdict.Accept() {

--- a/hscontrol/auth.go
+++ b/hscontrol/auth.go
@@ -401,8 +401,16 @@ func (h *Headscale) reqToNewRegisterResponse(
 
 	authRegReq := types.NewRegisterAuthRequest(regData)
 
+	err = h.state.SetAuthCacheEntry(newAuthID, authRegReq)
+	if err != nil {
+		return nil, NewHTTPError(
+			http.StatusServiceUnavailable,
+			"too many pending registrations; try again later",
+			err,
+		)
+	}
+
 	log.Info().Msgf("new followup node registration using auth id: %s", newAuthID)
-	h.state.SetAuthCacheEntry(newAuthID, authRegReq)
 
 	return &tailcfg.RegisterResponse{
 		AuthURL: h.authProvider.RegisterURL(newAuthID),
@@ -618,7 +626,14 @@ func (h *Headscale) handleRegisterInteractive(
 
 	authRegReq := types.NewRegisterAuthRequest(regData)
 
-	h.state.SetAuthCacheEntry(authID, authRegReq)
+	err = h.state.SetAuthCacheEntry(authID, authRegReq)
+	if err != nil {
+		return nil, NewHTTPError(
+			http.StatusServiceUnavailable,
+			"too many pending registrations; try again later",
+			err,
+		)
+	}
 
 	log.Info().Msgf("starting node registration using auth id: %s", authID)
 

--- a/hscontrol/auth.go
+++ b/hscontrol/auth.go
@@ -394,9 +394,12 @@ func (h *Headscale) reqToNewRegisterResponse(
 		return nil, NewHTTPError(http.StatusInternalServerError, "failed to generate registration ID", err)
 	}
 
-	authRegReq := types.NewRegisterAuthRequest(
-		registrationDataFromRequest(req, machineKey),
-	)
+	regData, err := registrationDataFromRequest(req, machineKey)
+	if err != nil {
+		return nil, NewHTTPError(http.StatusBadRequest, "registration metadata exceeds limits", err)
+	}
+
+	authRegReq := types.NewRegisterAuthRequest(regData)
 
 	log.Info().Msgf("new followup node registration using auth id: %s", newAuthID)
 	h.state.SetAuthCacheEntry(newAuthID, authRegReq)
@@ -406,25 +409,57 @@ func (h *Headscale) reqToNewRegisterResponse(
 	}, nil
 }
 
-// registrationDataFromRequest builds the [types.RegistrationData] payload stored
-// in the auth cache for a pending registration. The original [tailcfg.Hostinfo] is
-// retained so that consumers (auth callback, observability) see the
-// fields the client originally announced; the bounded-LRU cap on the
-// cache is what bounds the unauthenticated cache-fill DoS surface.
+const (
+	registrationHostnameMaxBytes  = 255
+	registrationOSMaxBytes        = 32
+	registrationVersionMaxBytes   = 256
+	registrationDeviceMaxBytes    = 256
+	registrationTagMaxCount       = 32
+	registrationTagMaxBytes       = 256
+	registrationTagsTotalMaxBytes = 4 << 10
+)
+
+var errRegistrationMetadataTooLarge = errors.New("registration metadata too large")
+
+// registrationDataFromRequest builds the bounded payload stored in the auth
+// cache for a pending registration. Network state is restored by the first
+// MapRequest, so only fields needed by authentication and its confirmation UI
+// are retained here.
 func registrationDataFromRequest(
 	req tailcfg.RegisterRequest,
 	machineKey key.MachinePublic,
-) *types.RegistrationData {
-	var hostname string
+) (*types.RegistrationData, error) {
+	var (
+		hostname string
+		hostinfo *tailcfg.Hostinfo
+	)
+
 	if req.Hostinfo != nil {
-		hostname = req.Hostinfo.Hostname
+		err := validateRegistrationHostinfo(req.Hostinfo)
+		if err != nil {
+			return nil, err
+		}
+
+		hostname = strings.Clone(req.Hostinfo.Hostname)
+
+		hostinfo = &tailcfg.Hostinfo{
+			Hostname:    hostname,
+			OS:          strings.Clone(req.Hostinfo.OS),
+			IPNVersion:  strings.Clone(req.Hostinfo.IPNVersion),
+			OSVersion:   strings.Clone(req.Hostinfo.OSVersion),
+			DeviceModel: strings.Clone(req.Hostinfo.DeviceModel),
+			RequestTags: make([]string, len(req.Hostinfo.RequestTags)),
+		}
+		for idx, tag := range req.Hostinfo.RequestTags {
+			hostinfo.RequestTags[idx] = strings.Clone(tag)
+		}
 	}
 
 	regData := &types.RegistrationData{
 		MachineKey: machineKey,
 		NodeKey:    req.NodeKey,
 		Hostname:   hostname,
-		Hostinfo:   req.Hostinfo,
+		Hostinfo:   hostinfo,
 	}
 
 	if !req.Expiry.IsZero() {
@@ -432,7 +467,63 @@ func registrationDataFromRequest(
 		regData.Expiry = &expiry
 	}
 
-	return regData
+	return regData, nil
+}
+
+func validateRegistrationHostinfo(hostinfo *tailcfg.Hostinfo) error {
+	fields := []struct {
+		name  string
+		value string
+		limit int
+	}{
+		{name: "hostname", value: hostinfo.Hostname, limit: registrationHostnameMaxBytes},
+		{name: "os", value: hostinfo.OS, limit: registrationOSMaxBytes},
+		{name: "client version", value: hostinfo.IPNVersion, limit: registrationVersionMaxBytes},
+		{name: "os version", value: hostinfo.OSVersion, limit: registrationVersionMaxBytes},
+		{name: "device model", value: hostinfo.DeviceModel, limit: registrationDeviceMaxBytes},
+	}
+	for _, field := range fields {
+		if len(field.value) > field.limit {
+			return fmt.Errorf(
+				"%w: %s exceeds %d bytes",
+				errRegistrationMetadataTooLarge,
+				field.name,
+				field.limit,
+			)
+		}
+	}
+
+	if len(hostinfo.RequestTags) > registrationTagMaxCount {
+		return fmt.Errorf(
+			"%w: requested tags exceed %d entries",
+			errRegistrationMetadataTooLarge,
+			registrationTagMaxCount,
+		)
+	}
+
+	total := 0
+
+	for _, tag := range hostinfo.RequestTags {
+		if len(tag) > registrationTagMaxBytes {
+			return fmt.Errorf(
+				"%w: requested tag exceeds %d bytes",
+				errRegistrationMetadataTooLarge,
+				registrationTagMaxBytes,
+			)
+		}
+
+		total += len(tag)
+	}
+
+	if total > registrationTagsTotalMaxBytes {
+		return fmt.Errorf(
+			"%w: requested tags exceed %d bytes",
+			errRegistrationMetadataTooLarge,
+			registrationTagsTotalMaxBytes,
+		)
+	}
+
+	return nil
 }
 
 func (h *Headscale) handleRegisterWithAuthKey(
@@ -520,9 +611,12 @@ func (h *Headscale) handleRegisterInteractive(
 			Msg("Received registration request with empty hostname, generated default")
 	}
 
-	authRegReq := types.NewRegisterAuthRequest(
-		registrationDataFromRequest(req, machineKey),
-	)
+	regData, err := registrationDataFromRequest(req, machineKey)
+	if err != nil {
+		return nil, NewHTTPError(http.StatusBadRequest, "registration metadata exceeds limits", err)
+	}
+
+	authRegReq := types.NewRegisterAuthRequest(regData)
 
 	h.state.SetAuthCacheEntry(authID, authRegReq)
 

--- a/hscontrol/auth_tags_test.go
+++ b/hscontrol/auth_tags_test.go
@@ -847,7 +847,7 @@ func TestExpiryDuringPersonalToTaggedConversion(t *testing.T) {
 		},
 		Expiry: &clientExpiry,
 	})
-	app.state.SetAuthCacheEntry(registrationID1, regEntry1)
+	require.NoError(t, app.state.SetAuthCacheEntry(registrationID1, regEntry1))
 
 	node, _, err := app.state.HandleNodeFromAuthPath(
 		registrationID1, types.UserID(user.ID), nil, "webauth",
@@ -869,7 +869,7 @@ func TestExpiryDuringPersonalToTaggedConversion(t *testing.T) {
 		},
 		Expiry: &clientExpiry, // Client still sends expiry
 	})
-	app.state.SetAuthCacheEntry(registrationID2, regEntry2)
+	require.NoError(t, app.state.SetAuthCacheEntry(registrationID2, regEntry2))
 
 	nodeAfter, _, err := app.state.HandleNodeFromAuthPath(
 		registrationID2, types.UserID(user.ID), nil, "webauth",
@@ -918,7 +918,7 @@ func TestExpiryDuringTaggedToPersonalConversion(t *testing.T) {
 			RequestTags: []string{"tag:server"}, // Tagged node
 		},
 	})
-	app.state.SetAuthCacheEntry(registrationID1, regEntry1)
+	require.NoError(t, app.state.SetAuthCacheEntry(registrationID1, regEntry1))
 
 	node, _, err := app.state.HandleNodeFromAuthPath(
 		registrationID1, types.UserID(user.ID), nil, "webauth",
@@ -941,7 +941,7 @@ func TestExpiryDuringTaggedToPersonalConversion(t *testing.T) {
 		},
 		Expiry: &clientExpiry, // Client requests expiry
 	})
-	app.state.SetAuthCacheEntry(registrationID2, regEntry2)
+	require.NoError(t, app.state.SetAuthCacheEntry(registrationID2, regEntry2))
 
 	nodeAfter, _, err := app.state.HandleNodeFromAuthPath(
 		registrationID2, types.UserID(user.ID), nil, "webauth",

--- a/hscontrol/auth_test.go
+++ b/hscontrol/auth_test.go
@@ -1442,8 +1442,10 @@ func TestAuthenticationFlows(t *testing.T) {
 					Hostinfo: &tailcfg.Hostinfo{
 						Hostname:    "custom-interactive-node",
 						OS:          "linux",
+						IPNVersion:  "1.100.0",
 						OSVersion:   "20.04",
 						DeviceModel: "server",
+						Services:    []tailcfg.Service{{Proto: "tcp", Port: 443}},
 					},
 					Expiry: time.Now().Add(24 * time.Hour),
 				}
@@ -1464,8 +1466,11 @@ func TestAuthenticationFlows(t *testing.T) {
 				if found {
 					assert.Equal(t, "custom-interactive-node", node.Hostname())
 					assert.Equal(t, "linux", node.Hostinfo().OS())
+					assert.Equal(t, "1.100.0", node.Hostinfo().IPNVersion())
 					assert.Equal(t, "20.04", node.Hostinfo().OSVersion())
 					assert.Equal(t, "server", node.Hostinfo().DeviceModel())
+					assert.Empty(t, node.Hostinfo().Services(),
+						"live services are restored by the first MapRequest")
 				}
 			},
 		},
@@ -2564,6 +2569,118 @@ func TestAuthenticationFlows(t *testing.T) {
 			if tt.validate != nil {
 				tt.validate(t, resp, app)
 			}
+		})
+	}
+}
+
+func TestRegistrationDataFromRequestBoundsRetainedHostinfo(t *testing.T) {
+	t.Parallel()
+
+	machineKey := key.NewMachine().Public()
+	nodeKey := key.NewNode().Public()
+	largeService := strings.Repeat("x", int(noiseBodyLimit/2))
+	req := tailcfg.RegisterRequest{
+		NodeKey: nodeKey,
+		Hostinfo: &tailcfg.Hostinfo{
+			Hostname:    "bounded-node",
+			OS:          "linux",
+			IPNVersion:  "1.100.0",
+			OSVersion:   "6.12",
+			DeviceModel: "server",
+			RequestTags: []string{"tag:one", "tag:two"},
+			Services: []tailcfg.Service{{
+				Description: largeService,
+			}},
+		},
+	}
+
+	data, err := registrationDataFromRequest(req, machineKey)
+	require.NoError(t, err)
+	require.NotNil(t, data.Hostinfo)
+	require.Equal(t, machineKey, data.MachineKey)
+	require.Equal(t, nodeKey, data.NodeKey)
+	require.Equal(t, req.Hostinfo.Hostname, data.Hostinfo.Hostname)
+	require.Equal(t, req.Hostinfo.OS, data.Hostinfo.OS)
+	require.Equal(t, req.Hostinfo.IPNVersion, data.Hostinfo.IPNVersion)
+	require.Equal(t, req.Hostinfo.OSVersion, data.Hostinfo.OSVersion)
+	require.Equal(t, req.Hostinfo.DeviceModel, data.Hostinfo.DeviceModel)
+	require.Equal(t, req.Hostinfo.RequestTags, data.Hostinfo.RequestTags)
+	require.Empty(t, data.Hostinfo.Services)
+
+	req.Hostinfo.RequestTags[0] = "tag:changed"
+	require.Equal(t, "tag:one", data.Hostinfo.RequestTags[0],
+		"cached tags must not alias the decoded request")
+}
+
+func TestRegistrationDataFromRequestRejectsOversizedMetadata(t *testing.T) {
+	t.Parallel()
+
+	tagsOverTotal := make([]string, 17)
+	for idx := range tagsOverTotal {
+		tagsOverTotal[idx] = strings.Repeat("t", registrationTagMaxBytes)
+	}
+
+	tests := []struct {
+		name     string
+		hostinfo *tailcfg.Hostinfo
+	}{
+		{
+			name:     "hostname",
+			hostinfo: &tailcfg.Hostinfo{Hostname: strings.Repeat("h", registrationHostnameMaxBytes+1)},
+		},
+		{
+			name:     "os",
+			hostinfo: &tailcfg.Hostinfo{OS: strings.Repeat("o", registrationOSMaxBytes+1)},
+		},
+		{
+			name: "client version",
+			hostinfo: &tailcfg.Hostinfo{
+				IPNVersion: strings.Repeat("v", registrationVersionMaxBytes+1),
+			},
+		},
+		{
+			name: "os version",
+			hostinfo: &tailcfg.Hostinfo{
+				OSVersion: strings.Repeat("v", registrationVersionMaxBytes+1),
+			},
+		},
+		{
+			name: "device model",
+			hostinfo: &tailcfg.Hostinfo{
+				DeviceModel: strings.Repeat("d", registrationDeviceMaxBytes+1),
+			},
+		},
+		{
+			name: "tag count",
+			hostinfo: &tailcfg.Hostinfo{
+				RequestTags: make([]string, registrationTagMaxCount+1),
+			},
+		},
+		{
+			name: "tag length",
+			hostinfo: &tailcfg.Hostinfo{
+				RequestTags: []string{strings.Repeat("t", registrationTagMaxBytes+1)},
+			},
+		},
+		{
+			name: "tag total",
+			hostinfo: &tailcfg.Hostinfo{
+				RequestTags: tagsOverTotal,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := registrationDataFromRequest(tailcfg.RegisterRequest{
+				NodeKey:  key.NewNode().Public(),
+				Hostinfo: test.hostinfo,
+			}, key.NewMachine().Public())
+
+			require.ErrorIs(t, err, errRegistrationMetadataTooLarge)
+			require.Nil(t, data)
 		})
 	}
 }

--- a/hscontrol/auth_test.go
+++ b/hscontrol/auth_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/juanfont/headscale/hscontrol/mapper"
+	"github.com/juanfont/headscale/hscontrol/state"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -686,7 +687,11 @@ func TestAuthenticationFlows(t *testing.T) {
 					MachineKey: machineKey1.Public(),
 					Hostname:   "followup-success-node",
 				})
-				app.state.SetAuthCacheEntry(regID, nodeToRegister)
+
+				err = app.state.SetAuthCacheEntry(regID, nodeToRegister)
+				if err != nil {
+					return "", err
+				}
 
 				// Simulate successful registration
 				// [Headscale.handleRegister] will receive the value when it starts waiting
@@ -733,7 +738,11 @@ func TestAuthenticationFlows(t *testing.T) {
 				nodeToRegister := types.NewRegisterAuthRequest(&types.RegistrationData{
 					Hostname: "followup-timeout-node",
 				})
-				app.state.SetAuthCacheEntry(regID, nodeToRegister)
+
+				err = app.state.SetAuthCacheEntry(regID, nodeToRegister)
+				if err != nil {
+					return "", err
+				}
 				// Don't call FinishRegistration - will timeout
 
 				return fmt.Sprintf("http://localhost:8080/register/%s", regID), nil
@@ -1354,7 +1363,11 @@ func TestAuthenticationFlows(t *testing.T) {
 					MachineKey: machineKey1.Public(),
 					Hostname:   "nil-response-node",
 				})
-				app.state.SetAuthCacheEntry(regID, nodeToRegister)
+
+				err = app.state.SetAuthCacheEntry(regID, nodeToRegister)
+				if err != nil {
+					return "", err
+				}
 
 				// Simulate registration that returns empty NodeView (cache expired during auth)
 				go func() {
@@ -3242,6 +3255,12 @@ func TestWebFlowReauthDifferentUser(t *testing.T) {
 func createTestApp(t *testing.T) *Headscale {
 	t.Helper()
 
+	return createTestAppWithRegisterCacheMax(t, 0)
+}
+
+func createTestAppWithRegisterCacheMax(t *testing.T, maxEntries int) *Headscale {
+	t.Helper()
+
 	tmpDir := t.TempDir()
 
 	cfg := types.Config{
@@ -3258,8 +3277,9 @@ func createTestApp(t *testing.T) *Headscale {
 			Mode: types.PolicyModeDB,
 		},
 		Tuning: types.Tuning{
-			BatchChangeDelay: 100 * time.Millisecond,
-			BatcherWorkers:   1,
+			BatchChangeDelay:        100 * time.Millisecond,
+			BatcherWorkers:          1,
+			RegisterCacheMaxEntries: maxEntries,
 		},
 	}
 
@@ -3278,6 +3298,36 @@ func createTestApp(t *testing.T) *Headscale {
 	})
 
 	return app
+}
+
+func TestInteractiveRegistrationPreservesExistingSessionAtCapacity(t *testing.T) {
+	app := createTestAppWithRegisterCacheMax(t, 1)
+	existingID := types.MustAuthID()
+	existing := types.NewRegisterAuthRequest(&types.RegistrationData{
+		MachineKey: key.NewMachine().Public(),
+		NodeKey:    key.NewNode().Public(),
+		Hostname:   "existing",
+	})
+	require.NoError(t, app.state.SetAuthCacheEntry(existingID, existing))
+
+	response, err := app.handleRegisterInteractive(tailcfg.RegisterRequest{
+		NodeKey: key.NewNode().Public(),
+		Hostinfo: &tailcfg.Hostinfo{
+			Hostname: "new-registration",
+		},
+	}, key.NewMachine().Public())
+
+	require.Error(t, err)
+	require.Nil(t, response)
+	require.ErrorIs(t, err, state.ErrPendingAuthCapacity)
+
+	var httpErr HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	require.Equal(t, http.StatusServiceUnavailable, httpErr.Code)
+
+	got, ok := app.state.GetAuthCacheEntry(existingID)
+	require.True(t, ok)
+	require.Same(t, existing, got)
 }
 
 // TestGitHubIssue2830_NodeRestartWithUsedPreAuthKey tests the scenario reported in
@@ -3702,7 +3752,7 @@ func TestWebAuthRejectsUnauthorizedRequestTags(t *testing.T) {
 			RequestTags: []string{"tag:unauthorized"}, // This tag is not in policy
 		},
 	})
-	app.state.SetAuthCacheEntry(registrationID, regEntry)
+	require.NoError(t, app.state.SetAuthCacheEntry(registrationID, regEntry))
 
 	// Complete the web auth - should fail because tag is unauthorized
 	_, _, err := app.state.HandleNodeFromAuthPath(
@@ -3765,7 +3815,7 @@ func TestWebAuthReauthWithEmptyTagsRemovesAllTags(t *testing.T) {
 			RequestTags: []string{"tag:valid-owned", "tag:second"},
 		},
 	})
-	app.state.SetAuthCacheEntry(registrationID1, regEntry1)
+	require.NoError(t, app.state.SetAuthCacheEntry(registrationID1, regEntry1))
 
 	// Complete initial registration with tags
 	node, _, err := app.state.HandleNodeFromAuthPath(
@@ -3792,7 +3842,7 @@ func TestWebAuthReauthWithEmptyTagsRemovesAllTags(t *testing.T) {
 			RequestTags: []string{}, // EMPTY - should untag
 		},
 	})
-	app.state.SetAuthCacheEntry(registrationID2, regEntry2)
+	require.NoError(t, app.state.SetAuthCacheEntry(registrationID2, regEntry2))
 
 	// Complete reauth with empty tags
 	nodeAfterReauth, _, err := app.state.HandleNodeFromAuthPath(
@@ -3878,7 +3928,7 @@ func TestAuthKeyTaggedToUserOwnedViaReauth(t *testing.T) {
 			RequestTags: []string{}, // EMPTY - should untag
 		},
 	})
-	app.state.SetAuthCacheEntry(registrationID, regEntry)
+	require.NoError(t, app.state.SetAuthCacheEntry(registrationID, regEntry))
 
 	// Complete reauth with empty tags
 	nodeAfterReauth, _, err := app.state.HandleNodeFromAuthPath(
@@ -4077,7 +4127,7 @@ func TestTaggedNodeWithoutUserToDifferentUser(t *testing.T) {
 			RequestTags: []string{}, // Empty - transition to user-owned
 		},
 	})
-	app.state.SetAuthCacheEntry(registrationID, regEntry)
+	require.NoError(t, app.state.SetAuthCacheEntry(registrationID, regEntry))
 
 	// This should NOT panic - before the fix, this would panic with:
 	// panic: runtime error: invalid memory address or nil pointer dereference
@@ -4209,7 +4259,7 @@ func TestHandleNodeFromAuthPath_OldUserNil_NoPanic(t *testing.T) {
 			Hostname: "authpath-orphan-newuser",
 		},
 	})
-	app.state.SetAuthCacheEntry(authID, regEntry)
+	require.NoError(t, app.state.SetAuthCacheEntry(authID, regEntry))
 
 	node, _, err := app.state.HandleNodeFromAuthPath(
 		authID,
@@ -4252,7 +4302,7 @@ func TestWaitForFollowupMachineKeyMismatch(t *testing.T) {
 			NodeKey:    key.NewNode().Public(),
 			Hostname:   hostname,
 		})
-		app.state.SetAuthCacheEntry(authID, regEntry)
+		require.NoError(t, app.state.SetAuthCacheEntry(authID, regEntry))
 
 		user := app.state.CreateUserForTest(hostname + "-user")
 		node := app.state.CreateNodeForTest(user, hostname)
@@ -4288,11 +4338,11 @@ func TestWaitForFollowupMachineKeyMismatch(t *testing.T) {
 
 	t.Run("pending registration rejects mismatched machine key before waiting", func(t *testing.T) {
 		authID := types.MustAuthID()
-		app.state.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(&types.RegistrationData{
+		require.NoError(t, app.state.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(&types.RegistrationData{
 			MachineKey: victimMachineKey.Public(),
 			NodeKey:    key.NewNode().Public(),
 			Hostname:   "pending-mismatch",
-		}))
+		})))
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
@@ -4308,10 +4358,10 @@ func TestWaitForFollowupMachineKeyMismatch(t *testing.T) {
 
 	t.Run("SSH auth session is rejected before waiting", func(t *testing.T) {
 		authID := types.MustAuthID()
-		app.state.SetAuthCacheEntry(
+		require.NoError(t, app.state.SetAuthCacheEntry(
 			authID,
 			types.NewSSHCheckAuthRequest(7, 11),
-		)
+		))
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
@@ -4375,7 +4425,7 @@ func TestFollowupWaitPrefersCompletedAuthOverExpiredContext(t *testing.T) {
 			MachineKey: machineKey,
 			Hostname:   "followup-race-node",
 		})
-		app.state.SetAuthCacheEntry(regID, authReq)
+		require.NoError(t, app.state.SetAuthCacheEntry(regID, authReq))
 
 		// Registration completes BEFORE we wait: verdict is buffered.
 		user := app.state.CreateUserForTest(fmt.Sprintf("followup-race-user-%d", i))

--- a/hscontrol/auth_test.go
+++ b/hscontrol/auth_test.go
@@ -683,7 +683,8 @@ func TestAuthenticationFlows(t *testing.T) {
 				}
 
 				nodeToRegister := types.NewRegisterAuthRequest(&types.RegistrationData{
-					Hostname: "followup-success-node",
+					MachineKey: machineKey1.Public(),
+					Hostname:   "followup-success-node",
 				})
 				app.state.SetAuthCacheEntry(regID, nodeToRegister)
 
@@ -1350,7 +1351,8 @@ func TestAuthenticationFlows(t *testing.T) {
 				}
 
 				nodeToRegister := types.NewRegisterAuthRequest(&types.RegistrationData{
-					Hostname: "nil-response-node",
+					MachineKey: machineKey1.Public(),
+					Hostname:   "nil-response-node",
 				})
 				app.state.SetAuthCacheEntry(regID, nodeToRegister)
 
@@ -4167,6 +4169,45 @@ func TestWaitForFollowupMachineKeyMismatch(t *testing.T) {
 		assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 	})
 
+	t.Run("pending registration rejects mismatched machine key before waiting", func(t *testing.T) {
+		authID := types.MustAuthID()
+		app.state.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(&types.RegistrationData{
+			MachineKey: victimMachineKey.Public(),
+			NodeKey:    key.NewNode().Public(),
+			Hostname:   "pending-mismatch",
+		}))
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		resp, err := app.waitForFollowup(ctx, tailcfg.RegisterRequest{
+			Followup: fmt.Sprintf("http://localhost:8080/register/%s", authID),
+		}, attackerMachineKey.Public())
+
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("SSH auth session is rejected before waiting", func(t *testing.T) {
+		authID := types.MustAuthID()
+		app.state.SetAuthCacheEntry(
+			authID,
+			types.NewSSHCheckAuthRequest(7, 11),
+		)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		resp, err := app.waitForFollowup(ctx, tailcfg.RegisterRequest{
+			Followup: fmt.Sprintf("http://localhost:8080/register/%s", authID),
+		}, victimMachineKey.Public())
+
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		assert.NotErrorIs(t, err, context.DeadlineExceeded)
+	})
+
 	// Positive control. Without it a regression that stops the poll from
 	// finding the cache entry at all would still pass the case above, because
 	// waitForFollowup falls back to handing out a fresh AuthURL.
@@ -4214,7 +4255,8 @@ func TestFollowupWaitPrefersCompletedAuthOverExpiredContext(t *testing.T) {
 		require.NoError(t, err)
 
 		authReq := types.NewRegisterAuthRequest(&types.RegistrationData{
-			Hostname: "followup-race-node",
+			MachineKey: machineKey,
+			Hostname:   "followup-race-node",
 		})
 		app.state.SetAuthCacheEntry(regID, authReq)
 

--- a/hscontrol/mapper/batcher.go
+++ b/hscontrol/mapper/batcher.go
@@ -313,7 +313,10 @@ func (b *Batcher) AddNode(
 				b.totalNodes.Add(1)
 			}
 
-			existing.addConnection(newEntry)
+			existing.addConnectionWithLimit(
+				newEntry,
+				maxConcurrentMapSessionsPerNode,
+			)
 			nodeConn = existing
 
 			return existing, xsync.UpdateOp

--- a/hscontrol/mapper/batcher_test.go
+++ b/hscontrol/mapper/batcher_test.go
@@ -1913,10 +1913,17 @@ func TestBatcherMultiConnection(t *testing.T) {
 
 			thirdChannel := make(chan *tailcfg.MapResponse, 10)
 
-			err = batcher.AddNode(node1.n.ID, thirdChannel, tailcfg.CapabilityVersion(100), nil)
-			if err != nil {
-				t.Fatalf("Failed to add third connection for node1: %v", err)
-			}
+			err = batcher.Batcher.AddNode(node1.n.ID, thirdChannel, tailcfg.CapabilityVersion(100), nil)
+			require.NoError(t, err)
+
+			fourthChannel := make(chan *tailcfg.MapResponse, 10)
+			err = batcher.Batcher.AddNode(node1.n.ID, fourthChannel, tailcfg.CapabilityVersion(100), nil)
+			require.NoError(t, err)
+
+			// The fifth connection replaces the oldest while preserving the cap.
+			fifthChannel := make(chan *tailcfg.MapResponse, 10)
+			err = batcher.Batcher.AddNode(node1.n.ID, fifthChannel, tailcfg.CapabilityVersion(100), nil)
+			require.NoError(t, err)
 
 			// Yield to allow connection to be processed
 			runtime.Gosched()
@@ -1929,14 +1936,14 @@ func TestBatcherMultiConnection(t *testing.T) {
 			if info, exists := debugInfo[node1.n.ID]; exists {
 				t.Logf("Node1 debug info: %+v", info)
 
-				if info.ActiveConnections != 3 {
-					t.Errorf("Node1 should have 3 active connections, got %d", info.ActiveConnections)
+				if info.ActiveConnections != maxConcurrentMapSessionsPerNode {
+					t.Errorf("Node1 should have %d active connections, got %d", maxConcurrentMapSessionsPerNode, info.ActiveConnections)
 				} else {
-					t.Logf("SUCCESS: Node1 correctly shows 3 active connections")
+					t.Logf("SUCCESS: Node1 correctly bounds overlapping connections")
 				}
 
 				if !info.Connected {
-					t.Errorf("Node1 should show as connected with 3 active connections")
+					t.Errorf("Node1 should show as connected with overlapping connections")
 				}
 			}
 
@@ -1964,6 +1971,8 @@ func TestBatcherMultiConnection(t *testing.T) {
 			clearChannel(node1.ch)
 			clearChannel(secondChannel)
 			clearChannel(thirdChannel)
+			clearChannel(fourthChannel)
+			clearChannel(fifthChannel)
 			clearChannel(node2.ch)
 
 			// Send a change notification from node2 (so node1 should receive it on all connections)
@@ -1976,17 +1985,17 @@ func TestBatcherMultiConnection(t *testing.T) {
 				assert.Positive(c, len(node1.ch)+len(secondChannel)+len(thirdChannel), "should have received updates")
 			}, 5*time.Second, 50*time.Millisecond, "waiting for updates to propagate")
 
-			// Verify all three connections for node1 receive the update
+			// Verify the two newest connections receive the update.
 			connection1Received := false
 			connection2Received := false
 			connection3Received := false
+			connection4Received := false
+			connection5Received := false
 
 			select {
-			case mapResp := <-node1.ch:
-				connection1Received = (mapResp != nil)
-				t.Logf("Node1 connection 1 received update: %t", connection1Received)
-			case <-time.After(500 * time.Millisecond):
-				t.Errorf("Node1 connection 1 did not receive update")
+			case <-node1.ch:
+				t.Errorf("Replaced connection received an update")
+			case <-time.After(100 * time.Millisecond):
 			}
 
 			select {
@@ -2005,11 +2014,29 @@ func TestBatcherMultiConnection(t *testing.T) {
 				t.Errorf("Node1 connection 3 did not receive update")
 			}
 
-			if connection1Received && connection2Received && connection3Received {
-				t.Logf("SUCCESS: All three connections for node1 received the update")
+			select {
+			case mapResp := <-fourthChannel:
+				connection4Received = (mapResp != nil)
+				t.Logf("Node1 connection 4 received update: %t", connection4Received)
+			case <-time.After(500 * time.Millisecond):
+				t.Errorf("Node1 connection 4 did not receive update")
+			}
+
+			select {
+			case mapResp := <-fifthChannel:
+				connection5Received = (mapResp != nil)
+				t.Logf("Node1 connection 5 received update: %t", connection5Received)
+			case <-time.After(500 * time.Millisecond):
+				t.Errorf("Node1 connection 5 did not receive update")
+			}
+
+			if !connection1Received && connection2Received && connection3Received &&
+				connection4Received && connection5Received {
+				t.Logf("SUCCESS: Only the four newest connections received the update")
 			} else {
-				t.Errorf("FAILURE: Multi-connection broadcast failed - conn1: %t, conn2: %t, conn3: %t",
-					connection1Received, connection2Received, connection3Received)
+				t.Errorf("FAILURE: Bounded multi-connection broadcast failed - conn1: %t, conn2: %t, conn3: %t, conn4: %t, conn5: %t",
+					connection1Received, connection2Received, connection3Received,
+					connection4Received, connection5Received)
 			}
 
 			// Test connection removal and verify remaining connections still work.
@@ -2024,52 +2051,44 @@ func TestBatcherMultiConnection(t *testing.T) {
 			// Yield to allow removal to be processed
 			runtime.Gosched()
 
-			// Verify debug status shows 2 connections now
+			// Verify the other three admitted connections remain.
 			debugInfo2 := batcher.Debug()
 			if info, exists := debugInfo2[node1.n.ID]; exists {
-				if info.ActiveConnections != 2 {
-					t.Errorf("Node1 should have 2 active connections after removal, got %d", info.ActiveConnections)
+				if info.ActiveConnections != maxConcurrentMapSessionsPerNode-1 {
+					t.Errorf("Node1 should have %d active connections after removal, got %d",
+						maxConcurrentMapSessionsPerNode-1, info.ActiveConnections)
 				} else {
-					t.Logf("SUCCESS: Node1 correctly shows 2 active connections after removal")
+					t.Logf("SUCCESS: Node1 correctly shows %d active connections after removal",
+						maxConcurrentMapSessionsPerNode-1)
 				}
 			}
 
 			// Send another update and verify remaining connections still work
-			clearChannel(node1.ch)
 			clearChannel(thirdChannel)
 
 			testChangeSet2 := change.NodeAdded(node2.n.ID)
 
 			batcher.AddWork(testChangeSet2)
 
-			// Wait for updates to propagate to remaining channels
+			// Wait for updates to propagate to the remaining channel.
 			assert.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Positive(c, len(node1.ch)+len(thirdChannel), "should have received updates")
+				assert.NotEmpty(c, thirdChannel, "should have received updates")
 			}, 5*time.Second, 50*time.Millisecond, "waiting for updates to propagate")
 
-			// Verify remaining connections still receive updates
+			// Verify only the remaining connection receives updates.
 			remaining1Received := false
-			remaining3Received := false
-
-			select {
-			case mapResp := <-node1.ch:
-				remaining1Received = (mapResp != nil)
-			case <-time.After(500 * time.Millisecond):
-				t.Errorf("Node1 connection 1 did not receive update after removal")
-			}
 
 			select {
 			case mapResp := <-thirdChannel:
-				remaining3Received = (mapResp != nil)
+				remaining1Received = (mapResp != nil)
 			case <-time.After(500 * time.Millisecond):
 				t.Errorf("Node1 connection 3 did not receive update after removal")
 			}
 
-			if remaining1Received && remaining3Received {
-				t.Logf("SUCCESS: Remaining connections still receive updates after removal")
+			if remaining1Received {
+				t.Logf("SUCCESS: Remaining connection still receives updates after removal")
 			} else {
-				t.Errorf("FAILURE: Remaining connections failed to receive updates - conn1: %t, conn3: %t",
-					remaining1Received, remaining3Received)
+				t.Errorf("FAILURE: Remaining connection did not receive updates")
 			}
 
 			// Drain secondChannel of any messages received before removal
@@ -2085,6 +2104,25 @@ func TestBatcherMultiConnection(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMapSessionOverlapLimitConcurrent(t *testing.T) {
+	t.Parallel()
+
+	mc := newMultiChannelNodeConn(1, nil)
+
+	const attempts = 64
+
+	panics := runConcurrentlyWithTimeout(t, attempts, 5*time.Second, func(i int) {
+		entry := makeConnectionEntry(
+			fmt.Sprintf("connection-%d", i),
+			make(chan *tailcfg.MapResponse, 1),
+		)
+		mc.addConnectionWithLimit(entry, maxConcurrentMapSessionsPerNode)
+	})
+
+	require.Zero(t, panics)
+	assert.Equal(t, maxConcurrentMapSessionsPerNode, mc.getActiveConnectionCount())
 }
 
 // TestNodeDeletedWhileChangesPending reproduces issue #2924 where deleting a node

--- a/hscontrol/mapper/node_conn.go
+++ b/hscontrol/mapper/node_conn.go
@@ -18,6 +18,8 @@ import (
 	"tailscale.com/tailcfg"
 )
 
+const maxConcurrentMapSessionsPerNode = 4
+
 // errNoActiveConnections is returned by [multiChannelNodeConn.send] when a node
 // has no active connections (disconnected but kept in the batcher for rapid
 // reconnection). Callers must not update peer tracking state (lastSentPeers)
@@ -154,8 +156,25 @@ func (mc *multiChannelNodeConn) removeConnectionAtIndexLocked(i int, stopConnect
 
 // addConnection adds a new connection.
 func (mc *multiChannelNodeConn) addConnection(entry *connectionEntry) {
+	mc.addConnectionWithLimit(entry, 0)
+}
+
+// addConnectionWithLimit atomically adds a connection while keeping at most
+// limit overlapping sessions. The oldest session is stopped and replaced when
+// the limit is full, allowing normal client poll churn to make progress. A zero
+// limit keeps the unbounded behavior used by low-level tests and benchmarks.
+func (mc *multiChannelNodeConn) addConnectionWithLimit(
+	entry *connectionEntry,
+	limit int,
+) {
 	mc.mutex.Lock()
 	defer mc.mutex.Unlock()
+
+	for limit > 0 && len(mc.connections) >= limit {
+		replaced := mc.removeConnectionAtIndexLocked(0, true)
+		mc.log.Debug().Str(zf.ConnID, replaced.id).
+			Msg("oldest overlapping connection replaced")
+	}
 
 	mc.connections = append(mc.connections, entry)
 	mc.log.Debug().Str(zf.ConnID, entry.id).

--- a/hscontrol/noise.go
+++ b/hscontrol/noise.go
@@ -541,10 +541,17 @@ func (ns *noiseServer) sshActionHoldAndDelegate(
 		)
 	}
 
-	ns.headscale.state.SetAuthCacheEntry(
+	err = ns.headscale.state.SetAuthCacheEntry(
 		authID,
 		types.NewSSHCheckAuthRequest(srcNodeID, dstNodeID),
 	)
+	if err != nil {
+		return nil, NewHTTPError(
+			http.StatusServiceUnavailable,
+			"too many pending SSH checks; try again later",
+			err,
+		)
+	}
 
 	authURL := ns.headscale.authProvider.AuthURL(authID)
 

--- a/hscontrol/noise.go
+++ b/hscontrol/noise.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/metrics"
 	"github.com/juanfont/headscale/hscontrol/capver"
+	"github.com/juanfont/headscale/hscontrol/state"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -55,6 +56,10 @@ var ErrSSHAuthSessionNotBound = errors.New(
 var ErrSSHBindingMismatch = errors.New(
 	"ssh action: cached binding does not match request src/dst",
 )
+
+// ErrSSHAccessActionInvalid is returned when state produces an unknown SSH
+// access action.
+var ErrSSHAccessActionInvalid = errors.New("invalid SSH access action")
 
 const (
 	// ts2021UpgradePath is the path that the server listens on for the WebSockets upgrade.
@@ -418,10 +423,11 @@ func (ns *noiseServer) SSHActionHandler(
 		return
 	}
 
+	localUser := req.URL.Query().Get("local_user")
 	reqLog := log.With().
 		Uint64("src_node_id", srcNodeID.Uint64()).
 		Uint64("dst_node_id", dstNodeID.Uint64()).
-		Str("local_user", req.URL.Query().Get("local_user")).
+		Str("local_user", localUser).
 		Logger()
 
 	reqLog.Trace().Caller().Msg("SSH action request")
@@ -431,6 +437,7 @@ func (ns *noiseServer) SSHActionHandler(
 		reqLog,
 		srcNodeID, dstNodeID,
 		req.URL.Query().Get("auth_id"),
+		localUser,
 	)
 	if err != nil {
 		httpError(writer, err)
@@ -469,6 +476,7 @@ func (ns *noiseServer) sshAction(
 	reqLog zerolog.Logger,
 	srcNodeID, dstNodeID types.NodeID,
 	authIDStr string,
+	localUser string,
 ) (*tailcfg.SSHAction, error) {
 	action := tailcfg.SSHAction{
 		AllowAgentForwarding:      true,
@@ -476,39 +484,38 @@ func (ns *noiseServer) sshAction(
 		AllowRemotePortForwarding: true,
 	}
 
-	// Look up check params from the server's own policy rather than
-	// trusting URL parameters, which the client could tamper with.
-	checkPeriod, checkFound := ns.headscale.state.SSHCheckParams(
-		srcNodeID, dstNodeID,
-	)
-
 	// Follow-up request with auth_id — wait for the auth verdict.
 	if authIDStr != "" {
 		return ns.sshActionFollowUp(
 			ctx, reqLog, &action, authIDStr,
-			srcNodeID, dstNodeID,
-			checkFound,
+			srcNodeID, dstNodeID, localUser,
 		)
 	}
 
-	// Initial request — check if auto-approval applies.
-	if checkFound && checkPeriod > 0 {
-		if lastAuth, ok := ns.headscale.state.GetLastSSHAuth(
-			srcNodeID, dstNodeID,
-		); ok && time.Since(lastAuth) < checkPeriod {
-			reqLog.Trace().Caller().
-				Dur("check_period", checkPeriod).
-				Time("last_auth", lastAuth).
-				Msg("auto-approved within check period")
+	evaluation := ns.headscale.state.EvaluateSSHAccess(
+		srcNodeID, dstNodeID, localUser,
+	)
+	switch evaluation.Action {
+	case state.SSHAccessAccept:
+		action.Accept = true
 
-			action.Accept = true
+		return &action, nil
+	case state.SSHAccessReject:
+		action.Reject = true
 
-			return &action, nil
-		}
+		return &action, nil
+	case state.SSHAccessCheck:
+		return ns.sshActionHoldAndDelegate(
+			reqLog, &action, srcNodeID, dstNodeID,
+			localUser, evaluation.PolicyGeneration,
+		)
+	default:
+		return nil, NewHTTPError(
+			http.StatusInternalServerError,
+			"Internal error",
+			fmt.Errorf("%w: %d", ErrSSHAccessActionInvalid, evaluation.Action),
+		)
 	}
-
-	// No auto-approval — create an auth session and hold.
-	return ns.sshActionHoldAndDelegate(reqLog, &action, srcNodeID, dstNodeID)
 }
 
 // sshActionHoldAndDelegate creates a new auth session bound to the
@@ -518,11 +525,12 @@ func (ns *noiseServer) sshActionHoldAndDelegate(
 	reqLog zerolog.Logger,
 	action *tailcfg.SSHAction,
 	srcNodeID, dstNodeID types.NodeID,
+	localUser string,
+	policyGeneration uint64,
 ) (*tailcfg.SSHAction, error) {
 	holdURL, err := url.Parse(
 		ns.headscale.cfg.ServerURL +
-			"/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID" +
-			"?local_user=$LOCAL_USER",
+			"/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID",
 	)
 	if err != nil {
 		return nil, NewHTTPError(
@@ -543,7 +551,9 @@ func (ns *noiseServer) sshActionHoldAndDelegate(
 
 	err = ns.headscale.state.SetAuthCacheEntry(
 		authID,
-		types.NewSSHCheckAuthRequest(srcNodeID, dstNodeID),
+		types.NewSSHCheckAuthRequestForPolicy(
+			srcNodeID, dstNodeID, localUser, policyGeneration,
+		),
 	)
 	if err != nil {
 		return nil, NewHTTPError(
@@ -557,6 +567,7 @@ func (ns *noiseServer) sshActionHoldAndDelegate(
 
 	q := holdURL.Query()
 	q.Set("auth_id", authID.String())
+	q.Set("local_user", localUser)
 	holdURL.RawQuery = q.Encode()
 
 	action.HoldAndDelegate = holdURL.String()
@@ -586,7 +597,7 @@ func (ns *noiseServer) sshActionFollowUp(
 	action *tailcfg.SSHAction,
 	authIDStr string,
 	srcNodeID, dstNodeID types.NodeID,
-	checkFound bool,
+	localUser string,
 ) (*tailcfg.SSHAction, error) {
 	authID, err := types.AuthIDFromString(authIDStr)
 	if err != nil {
@@ -605,13 +616,25 @@ func (ns *noiseServer) sshActionFollowUp(
 		// restart). A bare error dead-ends the client: it keeps polling this
 		// now-defunct auth_id until the SSH connection times out. Re-delegate
 		// so a still-required check can complete instead.
-		if checkFound {
+		evaluation := ns.headscale.state.EvaluateSSHAccess(
+			srcNodeID, dstNodeID, localUser,
+		)
+		switch evaluation.Action {
+		case state.SSHAccessCheck:
 			reqLog.Info().Caller().
 				Msg("SSH check auth session missing; re-delegating")
 
 			return ns.sshActionHoldAndDelegate(
 				reqLog, action, srcNodeID, dstNodeID,
+				localUser, evaluation.PolicyGeneration,
 			)
+		case state.SSHAccessAccept:
+			action.Accept = true
+
+			return action, nil
+		case state.SSHAccessReject:
+			// Preserve the invalid-session response when no current rule
+			// authorizes the tuple.
 		}
 
 		return nil, NewHTTPError(
@@ -634,15 +657,16 @@ func (ns *noiseServer) sshActionFollowUp(
 	}
 
 	binding := auth.SSHCheckBinding()
-	if binding.SrcNodeID != srcNodeID || binding.DstNodeID != dstNodeID {
+	if binding.SrcNodeID != srcNodeID || binding.DstNodeID != dstNodeID ||
+		binding.LocalUser != localUser {
 		return nil, NewHTTPError(
 			http.StatusUnauthorized,
 			"src/dst pair does not match auth session",
 			fmt.Errorf(
-				"%w: cached %d->%d, request %d->%d",
+				"%w: cached %d->%d user %q, request %d->%d user %q",
 				ErrSSHBindingMismatch,
-				binding.SrcNodeID, binding.DstNodeID,
-				srcNodeID, dstNodeID,
+				binding.SrcNodeID, binding.DstNodeID, binding.LocalUser,
+				srcNodeID, dstNodeID, localUser,
 			),
 		)
 	}
@@ -682,15 +706,24 @@ func (ns *noiseServer) sshActionFollowUp(
 		return action, nil
 	}
 
-	action.Accept = true
-
-	// Record the successful auth for future auto-approval.
-	if checkFound {
-		ns.headscale.state.SetLastSSHAuth(srcNodeID, dstNodeID)
+	if ns.headscale.state.CompleteSSHCheck(
+		srcNodeID,
+		dstNodeID,
+		binding.LocalUser,
+		binding.PolicyGeneration,
+	) != state.SSHAccessAccept {
+		action.Reject = true
 
 		reqLog.Trace().Caller().
-			Msg("auth recorded for auto-approval")
+			Msg("authentication rejected after SSH policy changed")
+
+		return action, nil
 	}
+
+	action.Accept = true
+
+	reqLog.Trace().Caller().
+		Msg("authentication accepted by current SSH policy")
 
 	return action, nil
 }

--- a/hscontrol/noise.go
+++ b/hscontrol/noise.go
@@ -642,7 +642,6 @@ func (ns *noiseServer) sshActionFollowUp(
 
 	reqLog.Trace().Caller().Msg("SSH action follow-up")
 
-	var verdict types.AuthVerdict
 	select {
 	case <-ctx.Done():
 		// The client disconnected (or its request timed out) before the
@@ -655,7 +654,16 @@ func (ns *noiseServer) sshActionFollowUp(
 			"ssh action follow-up cancelled",
 			ctx.Err(),
 		)
-	case verdict = <-auth.WaitForAuth():
+	case <-auth.WaitForAuth():
+	}
+
+	verdict, ok := auth.AuthResult()
+	if !ok {
+		action.Reject = true
+
+		reqLog.Error().Caller().Msg("authentication completed without a verdict")
+
+		return action, nil
 	}
 
 	if !verdict.Accept() {

--- a/hscontrol/noise_test.go
+++ b/hscontrol/noise_test.go
@@ -354,6 +354,8 @@ func TestSSHActionAdmissionPreservesExistingSessionAtCapacity(t *testing.T) {
 		&tailcfg.SSHAction{},
 		1,
 		2,
+		"root",
+		1,
 	)
 	require.Error(t, err)
 	require.Nil(t, action)
@@ -440,7 +442,7 @@ func TestSSHActionFollowUp_RejectionIsStableAcrossRetries(t *testing.T) {
 			authID.String(),
 			src.ID,
 			dst.ID,
-			true,
+			"",
 		)
 		require.NoError(t, err)
 		require.NotNil(t, action)
@@ -450,6 +452,41 @@ func TestSSHActionFollowUp_RejectionIsStableAcrossRetries(t *testing.T) {
 
 	_, ok := app.state.GetLastSSHAuth(src.ID, dst.ID)
 	assert.False(t, ok, "rejected retries must not record reusable SSH authorization")
+}
+
+func TestSSHActionFollowUp_RejectsWhenCheckNoLongerApplies(t *testing.T) {
+	t.Parallel()
+
+	app := createTestApp(t)
+	user := app.state.CreateUserForTest("ssh-policy-change-user")
+	src := putTestNodeInStore(t, app, user, "src-policy-change")
+	dst := putTestNodeInStore(t, app, user, "dst-policy-change")
+
+	authID := types.MustAuthID()
+	auth := types.NewSSHCheckAuthRequestForPolicy(src.ID, dst.ID, "root", 0)
+	require.NoError(t, app.state.SetAuthCacheEntry(authID, auth))
+	auth.FinishAuth(types.AuthVerdict{})
+
+	_, checkFound := app.state.SSHCheckParams(src.ID, dst.ID)
+	require.False(t, checkFound, "test setup: the SSH check must no longer apply")
+
+	ns := &noiseServer{headscale: app, machineKey: dst.MachineKey}
+	action, err := ns.sshActionFollowUp(
+		t.Context(),
+		zerolog.Nop(),
+		&tailcfg.SSHAction{},
+		authID.String(),
+		src.ID,
+		dst.ID,
+		"root",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, action)
+	assert.True(t, action.Reject)
+	assert.False(t, action.Accept)
+
+	_, ok := app.state.GetLastSSHAuth(src.ID, dst.ID)
+	assert.False(t, ok, "stale approval must not be recorded for reuse")
 }
 
 // TestOverrideRemoteAddr asserts the middleware used inside the Noise
@@ -493,12 +530,15 @@ func TestSSHActionHoldAndDelegate_PersistsAuthSession(t *testing.T) {
 
 	ns := &noiseServer{headscale: app, machineKey: dst.MachineKey}
 
-	rec := httptest.NewRecorder()
-	ns.SSHActionHandler(rec, newSSHActionRequest(t, src.ID, dst.ID))
-	require.Equal(t, http.StatusOK, rec.Code, "initial poll body=%s", rec.Body.String())
-
-	var action tailcfg.SSHAction
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &action))
+	action, err := ns.sshActionHoldAndDelegate(
+		zerolog.Nop(),
+		&tailcfg.SSHAction{},
+		src.ID,
+		dst.ID,
+		"root",
+		1,
+	)
+	require.NoError(t, err)
 	require.NotEmpty(t, action.HoldAndDelegate, "expected HoldAndDelegate, got %+v", action)
 
 	u, err := url.Parse(action.HoldAndDelegate)
@@ -506,6 +546,7 @@ func TestSSHActionHoldAndDelegate_PersistsAuthSession(t *testing.T) {
 
 	authIDStr := u.Query().Get("auth_id")
 	require.NotEmpty(t, authIDStr, "HoldAndDelegate URL missing auth_id: %s", action.HoldAndDelegate)
+	require.Equal(t, "root", u.Query().Get("local_user"))
 
 	authID, err := types.AuthIDFromString(authIDStr)
 	require.NoError(t, err)

--- a/hscontrol/noise_test.go
+++ b/hscontrol/noise_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,12 +18,15 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/util"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 	"tailscale.com/util/zstdframe"
 )
+
+var errSSHAuthenticationRejected = errors.New("authentication rejected")
 
 // newNoiseRouterWithBodyLimit builds a chi router with the same body-limit
 // middleware used in the real Noise router but wired to a test handler that
@@ -372,6 +376,40 @@ func TestSSHActionFollowUp_RejectsBindingMismatch(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, rec.Code,
 		"binding mismatch must be rejected with 401")
+}
+
+func TestSSHActionFollowUp_RejectionIsStableAcrossRetries(t *testing.T) {
+	t.Parallel()
+
+	app := createTestApp(t)
+	user := app.state.CreateUserForTest("ssh-retry-rejection-user")
+	src := putTestNodeInStore(t, app, user, "src-retry")
+	dst := putTestNodeInStore(t, app, user, "dst-retry")
+
+	authID := types.MustAuthID()
+	auth := types.NewSSHCheckAuthRequest(src.ID, dst.ID)
+	auth.FinishAuth(types.AuthVerdict{Err: errSSHAuthenticationRejected})
+	app.state.SetAuthCacheEntry(authID, auth)
+
+	ns := &noiseServer{headscale: app, machineKey: dst.MachineKey}
+	for range 2 {
+		action, err := ns.sshActionFollowUp(
+			t.Context(),
+			zerolog.Nop(),
+			&tailcfg.SSHAction{},
+			authID.String(),
+			src.ID,
+			dst.ID,
+			true,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, action)
+		assert.True(t, action.Reject)
+		assert.False(t, action.Accept)
+	}
+
+	_, ok := app.state.GetLastSSHAuth(src.ID, dst.ID)
+	assert.False(t, ok, "rejected retries must not record reusable SSH authorization")
 }
 
 // TestOverrideRemoteAddr asserts the middleware used inside the Noise

--- a/hscontrol/noise_test.go
+++ b/hscontrol/noise_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/juanfont/headscale/hscontrol/state"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/util"
 	"github.com/rs/zerolog"
@@ -328,6 +329,45 @@ func TestSSHActionHandler_RejectsUnknownDst(t *testing.T) {
 		"unknown dst node id must be rejected with 404")
 }
 
+func TestSSHActionAdmissionPreservesExistingSessionAtCapacity(t *testing.T) {
+	app := createTestApp(t)
+	firstID := types.MustAuthID()
+	first := types.NewSSHCheckAuthRequest(1, 2)
+	require.NoError(t, app.state.SetAuthCacheEntry(firstID, first))
+
+	for idx := 1; ; idx++ {
+		err := app.state.SetAuthCacheEntry(
+			types.MustAuthID(),
+			types.NewSSHCheckAuthRequest(1, 2),
+		)
+		if errors.Is(err, state.ErrPendingAuthCapacity) {
+			break
+		}
+
+		require.NoError(t, err)
+		require.Less(t, idx, 2048, "SSH admission must have a finite default capacity")
+	}
+
+	ns := &noiseServer{headscale: app}
+	action, err := ns.sshActionHoldAndDelegate(
+		zerolog.Nop(),
+		&tailcfg.SSHAction{},
+		1,
+		2,
+	)
+	require.Error(t, err)
+	require.Nil(t, action)
+	require.ErrorIs(t, err, state.ErrPendingAuthCapacity)
+
+	var httpErr HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	require.Equal(t, http.StatusServiceUnavailable, httpErr.Code)
+
+	got, ok := app.state.GetAuthCacheEntry(firstID)
+	require.True(t, ok)
+	require.Same(t, first, got)
+}
+
 // TestSSHActionFollowUp_RejectsBindingMismatch verifies that the
 // follow-up handler refuses to honour an auth_id whose cached binding
 // does not match the (src, dst) pair on the request URL. Without this
@@ -346,10 +386,10 @@ func TestSSHActionFollowUp_RejectsBindingMismatch(t *testing.T) {
 
 	// Mint an SSH-check auth request bound to (srcCached, dstCached).
 	authID := types.MustAuthID()
-	app.state.SetAuthCacheEntry(
+	require.NoError(t, app.state.SetAuthCacheEntry(
 		authID,
 		types.NewSSHCheckAuthRequest(srcCached.ID, dstCached.ID),
-	)
+	))
 
 	// Build a follow-up that claims to be for (srcOther, dstOther) but
 	// reuses the bound auth_id. The Noise machineKey matches dstOther so
@@ -389,7 +429,7 @@ func TestSSHActionFollowUp_RejectionIsStableAcrossRetries(t *testing.T) {
 	authID := types.MustAuthID()
 	auth := types.NewSSHCheckAuthRequest(src.ID, dst.ID)
 	auth.FinishAuth(types.AuthVerdict{Err: errSSHAuthenticationRejected})
-	app.state.SetAuthCacheEntry(authID, auth)
+	require.NoError(t, app.state.SetAuthCacheEntry(authID, auth))
 
 	ns := &noiseServer{headscale: app, machineKey: dst.MachineKey}
 	for range 2 {

--- a/hscontrol/oidc.go
+++ b/hscontrol/oidc.go
@@ -574,7 +574,7 @@ func (a *AuthProviderOIDC) OIDCCallbackHandler(
 		return
 	}
 
-	user, _, err := a.createOrUpdateUserFromClaim(&claims)
+	user, userChange, err := a.createOrUpdateUserFromClaim(&claims)
 	if err != nil {
 		httpUserError(writer, NewHTTPError(
 			http.StatusInternalServerError,
@@ -584,6 +584,11 @@ func (a *AuthProviderOIDC) OIDCCallbackHandler(
 
 		return
 	}
+
+	// The user write has already refreshed policy state. Notify connected
+	// nodes here, before either completion branch, so an abandoned registration
+	// confirmation or a later SSH rejection cannot leave them on the old view.
+	a.h.Change(userChange)
 
 	// If this is a registration flow, render the confirmation
 	// interstitial instead of finalising the registration immediately.

--- a/hscontrol/oidc.go
+++ b/hscontrol/oidc.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -29,9 +30,8 @@ const (
 	defaultOAuthOptionsCount = 3
 	authCacheExpiration      = time.Minute * 15
 
-	// authCacheMaxEntries bounds the OIDC state→[AuthInfo] cache to prevent
-	// unauthenticated cache-fill DoS via repeated /register/{auth_id} or
-	// /auth/{auth_id} GETs that mint OIDC state cookies.
+	// authCacheMaxEntries bounds each OIDC state pool so active callback state
+	// has a predictable footprint.
 	authCacheMaxEntries = 1024
 
 	// cookieNamePrefixLen is the number of leading characters from a
@@ -45,9 +45,14 @@ const (
 var errOIDCStateTooShort = errors.New("oidc state parameter is too short")
 
 var (
+	errOIDCStateCapacity    = errors.New("pending OIDC authentication capacity reached")
+	errOIDCStateExists      = errors.New("OIDC authentication already started")
+	errOIDCAuthTypeMismatch = errors.New("OIDC authentication request type does not match route")
+)
+
+var (
 	errEmptyOIDCCallbackParams = errors.New("empty OIDC callback params")
 	errNoOIDCIDToken           = errors.New("extracting ID token")
-	errNoOIDCRegistrationInfo  = errors.New("registration info not in cache")
 	errOIDCAllowedDomains      = errors.New(
 		"authenticated principal does not match any allowed domain",
 	)
@@ -66,15 +71,23 @@ type AuthInfo struct {
 	Registration bool
 }
 
+type oidcAuthState struct {
+	state        string
+	registration bool
+}
+
 type AuthProviderOIDC struct {
 	h         *Headscale
 	serverURL string
 	cfg       *types.OIDCConfig
 
-	// authCache holds auth information between the auth and the callback
-	// steps. It is a bounded [expirable.LRU] keyed by OIDC state, evicting oldest
-	// entries to keep the cache footprint constant under attack.
-	authCache *expirable.LRU[string, AuthInfo]
+	// Registration and SSH state have independent capacity so one request class
+	// cannot displace active sessions from the other.
+	authCache            *expirable.LRU[string, AuthInfo]
+	sshAuthCache         *expirable.LRU[string, AuthInfo]
+	authCacheMaxEntries  int
+	authCacheMu          sync.Mutex
+	authStateByRequestID map[types.AuthID]oidcAuthState
 
 	oidcProvider *oidc.Provider
 	oauth2Config *oauth2.Config
@@ -102,16 +115,24 @@ func NewAuthProviderOIDC(
 	}
 
 	authCache := expirable.NewLRU[string, AuthInfo](
-		authCacheMaxEntries,
+		0,
+		nil,
+		authCacheExpiration,
+	)
+	sshAuthCache := expirable.NewLRU[string, AuthInfo](
+		0,
 		nil,
 		authCacheExpiration,
 	)
 
 	return &AuthProviderOIDC{
-		h:         h,
-		serverURL: serverURL,
-		cfg:       cfg,
-		authCache: authCache,
+		h:                    h,
+		serverURL:            serverURL,
+		cfg:                  cfg,
+		authCache:            authCache,
+		sshAuthCache:         sshAuthCache,
+		authCacheMaxEntries:  authCacheMaxEntries,
+		authStateByRequestID: make(map[types.AuthID]oidcAuthState),
 
 		oidcProvider: oidcProvider,
 		oauth2Config: oauth2Config,
@@ -177,11 +198,15 @@ func (a *AuthProviderOIDC) authHandler(
 		return
 	}
 
-	// Set the state and nonce cookies to protect against CSRF attacks
-	state := a.setCSRFCookie(writer, req, "state")
+	err = a.validateOIDCAuthRequest(authID, registration)
+	if err != nil {
+		httpUserError(writer, err)
 
-	// Set the state and nonce cookies to protect against CSRF attacks
-	nonce := a.setCSRFCookie(writer, req, "nonce")
+		return
+	}
+
+	state := rands.HexString(64)
+	nonce := rands.HexString(64)
 
 	registrationInfo := AuthInfo{
 		AuthID:       authID,
@@ -218,8 +243,17 @@ func (a *AuthProviderOIDC) authHandler(
 
 	extras = append(extras, oidc.Nonce(nonce))
 
-	// Cache the registration info
-	a.authCache.Add(state, registrationInfo)
+	// Cache the registration info before redirecting. Admission refusal leaves
+	// every active callback state available.
+	err = a.addOIDCAuthState(state, registrationInfo)
+	if err != nil {
+		httpUserError(writer, err)
+
+		return
+	}
+
+	a.setCSRFCookieValue(writer, req, "state", state)
+	a.setCSRFCookieValue(writer, req, "nonce", nonce)
 
 	authURL := a.oauth2Config.AuthCodeURL(state, extras...)
 	log.Debug().Caller().Msgf("redirecting to %s for authentication", authURL)
@@ -227,11 +261,189 @@ func (a *AuthProviderOIDC) authHandler(
 	http.Redirect(writer, req, authURL, http.StatusFound)
 }
 
+func (a *AuthProviderOIDC) validateOIDCAuthRequest(
+	authID types.AuthID,
+	registration bool,
+) error {
+	authRequest, ok := a.h.state.GetAuthCacheEntry(authID)
+	if !ok {
+		return NewHTTPError(http.StatusNotFound, "authentication request not found", ErrNoAuthSession)
+	}
+
+	if _, complete := authRequest.AuthResult(); complete {
+		return NewHTTPError(http.StatusGone, "authentication request already completed", nil)
+	}
+
+	if authRequest.PendingConfirmation() != nil {
+		return NewHTTPError(http.StatusConflict, "authentication confirmation already pending", errOIDCStateExists)
+	}
+
+	typeMatches := registration && authRequest.IsRegistration() ||
+		!registration && authRequest.IsSSHCheck()
+	if !typeMatches {
+		return NewHTTPError(http.StatusBadRequest, "authentication request type does not match route", errOIDCAuthTypeMismatch)
+	}
+
+	return nil
+}
+
+func (a *AuthProviderOIDC) claimOIDCAuthRequest(
+	authInfo AuthInfo,
+) (*types.AuthRequest, error) {
+	authRequest, ok := a.h.state.GetAuthCacheEntry(authInfo.AuthID)
+	if !ok {
+		return nil, NewHTTPError(http.StatusGone, "authentication request expired", ErrNoAuthSession)
+	}
+
+	typeMatches := authInfo.Registration && authRequest.IsRegistration() ||
+		!authInfo.Registration && authRequest.IsSSHCheck()
+	if !typeMatches {
+		return nil, NewHTTPError(http.StatusBadRequest, "authentication request type changed", errOIDCAuthTypeMismatch)
+	}
+
+	if !authRequest.TryBeginAuth() {
+		return nil, NewHTTPError(http.StatusGone, "authentication request already completed", nil)
+	}
+
+	return authRequest, nil
+}
+
+func (a *AuthProviderOIDC) addOIDCAuthState(state string, info AuthInfo) error {
+	a.authCacheMu.Lock()
+	defer a.authCacheMu.Unlock()
+
+	a.pruneExpiredOIDCAuthStatesLocked()
+
+	if _, exists := a.authStateByRequestID[info.AuthID]; exists {
+		return NewHTTPError(http.StatusConflict, "authentication already started", errOIDCStateExists)
+	}
+
+	if _, exists := a.peekOIDCAuthStateLocked(state); exists {
+		return NewHTTPError(http.StatusConflict, "authentication state already exists", errOIDCStateExists)
+	}
+
+	cache := a.oidcAuthStateCache(info.Registration)
+	if cache.Len() >= a.authCacheMaxEntries {
+		return NewHTTPError(
+			http.StatusServiceUnavailable,
+			"too many pending authentication requests; try again later",
+			errOIDCStateCapacity,
+		)
+	}
+
+	cache.Add(state, info)
+	a.authStateByRequestID[info.AuthID] = oidcAuthState{
+		state:        state,
+		registration: info.Registration,
+	}
+
+	return nil
+}
+
+func (a *AuthProviderOIDC) peekOIDCAuthState(state string) (AuthInfo, bool) {
+	a.authCacheMu.Lock()
+	defer a.authCacheMu.Unlock()
+
+	return a.peekOIDCAuthStateLocked(state)
+}
+
+func (a *AuthProviderOIDC) peekOIDCAuthStateLocked(state string) (AuthInfo, bool) {
+	if info, ok := a.authCache.Peek(state); ok {
+		return info, true
+	}
+
+	if a.sshAuthCache != nil {
+		return a.sshAuthCache.Peek(state)
+	}
+
+	return AuthInfo{}, false
+}
+
+func (a *AuthProviderOIDC) takeOIDCAuthState(state string) (AuthInfo, bool) {
+	a.authCacheMu.Lock()
+	defer a.authCacheMu.Unlock()
+
+	info, ok := a.authCache.Peek(state)
+
+	cache := a.authCache
+	if !ok && a.sshAuthCache != nil {
+		info, ok = a.sshAuthCache.Peek(state)
+		cache = a.sshAuthCache
+	}
+
+	if !ok || !cache.Remove(state) {
+		return AuthInfo{}, false
+	}
+
+	if ref, exists := a.authStateByRequestID[info.AuthID]; exists && ref.state == state {
+		ref.state = ""
+		a.authStateByRequestID[info.AuthID] = ref
+	}
+
+	return info, true
+}
+
+func (a *AuthProviderOIDC) pruneExpiredOIDCAuthStatesLocked() {
+	for authID, ref := range a.authStateByRequestID {
+		if a.h != nil {
+			authRequest, ok := a.h.state.GetAuthCacheEntry(authID)
+			typeMatches := ok && (ref.registration && authRequest.IsRegistration() ||
+				!ref.registration && authRequest.IsSSHCheck())
+
+			complete := false
+			if ok {
+				_, complete = authRequest.AuthResult()
+			}
+
+			if !typeMatches || complete {
+				if ref.state != "" {
+					a.oidcAuthStateCache(ref.registration).Remove(ref.state)
+				}
+
+				delete(a.authStateByRequestID, authID)
+
+				continue
+			}
+		}
+
+		if ref.state == "" {
+			continue
+		}
+
+		cache := a.oidcAuthStateCache(ref.registration)
+		if _, ok := cache.Peek(ref.state); ok {
+			continue
+		}
+
+		cache.Remove(ref.state)
+		delete(a.authStateByRequestID, authID)
+	}
+}
+
+func (a *AuthProviderOIDC) releaseOIDCAuthReservation(authID types.AuthID) {
+	a.authCacheMu.Lock()
+	defer a.authCacheMu.Unlock()
+
+	delete(a.authStateByRequestID, authID)
+}
+
+func (a *AuthProviderOIDC) oidcAuthStateCache(
+	registration bool,
+) *expirable.LRU[string, AuthInfo] {
+	if registration {
+		return a.authCache
+	}
+
+	return a.sshAuthCache
+}
+
 // OIDCCallbackHandler handles the callback from the OIDC endpoint
 // Retrieves the nkey from the state cache and adds the node to the users email user
 // TODO: A confirmation page for new nodes should be added to avoid phishing vulnerabilities
 // TODO: Add groups information from OIDC tokens into node HostInfo
 // Listens in /oidc/callback.
+//
+//nolint:gocyclo // callback validation stages share reservation cleanup state
 func (a *AuthProviderOIDC) OIDCCallbackHandler(
 	writer http.ResponseWriter,
 	req *http.Request,
@@ -255,7 +467,36 @@ func (a *AuthProviderOIDC) OIDCCallbackHandler(
 		return
 	}
 
-	oauth2Token, err := a.getOauth2Token(req.Context(), code, state)
+	authInfo := a.getAuthInfoFromState(state)
+	if authInfo == nil {
+		log.Debug().Caller().Str("state", state).Msg("state not found in cache, login session may have expired")
+		httpUserError(writer, NewHTTPError(http.StatusGone, "login session expired, try again", nil))
+
+		return
+	}
+
+	releaseReservation := true
+	defer func() {
+		if releaseReservation {
+			a.releaseOIDCAuthReservation(authInfo.AuthID)
+		}
+	}()
+
+	authReq, err := a.claimOIDCAuthRequest(*authInfo)
+	if err != nil {
+		httpUserError(writer, err)
+
+		return
+	}
+
+	authClaimed := true
+	defer func() {
+		if authClaimed {
+			authReq.AbortAuth()
+		}
+	}()
+
+	oauth2Token, err := a.getOauth2Token(req.Context(), code, *authInfo)
 	if err != nil {
 		httpUserError(writer, err)
 		return
@@ -344,25 +585,30 @@ func (a *AuthProviderOIDC) OIDCCallbackHandler(
 		return
 	}
 
-	// TODO(kradalby): Is this comment right?
-	// If the node exists, then the node should be reauthenticated,
-	// if the node does not exist, and the machine key exists, then
-	// this is a new node that should be registered.
-	authInfo := a.getAuthInfoFromState(state)
-	if authInfo == nil {
-		log.Debug().Caller().Str("state", state).Msg("state not found in cache, login session may have expired")
-		httpUserError(writer, NewHTTPError(http.StatusGone, "login session expired, try again", nil))
-
-		return
-	}
-
 	// If this is a registration flow, render the confirmation
 	// interstitial instead of finalising the registration immediately.
 	// Without an explicit user click, a single GET to
 	// /register/{auth_id} could silently complete a registration when
 	// the IdP allows silent SSO.
 	if authInfo.Registration {
-		a.beginRegistrationConfirmation(writer, req, authInfo.AuthID, user, nodeExpiry)
+		err = a.beginRegistrationConfirmation(
+			writer,
+			req,
+			authInfo.AuthID,
+			authReq,
+			user,
+			nodeExpiry,
+		)
+		if err != nil {
+			httpUserError(writer, err)
+
+			return
+		}
+
+		authReq.AbortAuth()
+
+		authClaimed = false
+		releaseReservation = false
 
 		return
 	}
@@ -373,23 +619,6 @@ func (a *AuthProviderOIDC) OIDCCallbackHandler(
 	// check any tailnet user could approve a check-mode prompt for any
 	// other user's node, defeating the stolen-key protection that
 	// check-mode is meant to provide.
-
-	authReq, ok := a.h.state.GetAuthCacheEntry(authInfo.AuthID)
-	if !ok {
-		log.Debug().Caller().Str("auth_id", authInfo.AuthID.String()).Msg("auth session expired before authorization completed")
-		httpUserError(writer, NewHTTPError(http.StatusGone, "login session expired, try again", nil))
-
-		return
-	}
-
-	if !authReq.IsSSHCheck() {
-		log.Warn().Caller().
-			Str("auth_id", authInfo.AuthID.String()).
-			Msg("OIDC callback hit non-registration path with auth request that is not an SSH check binding")
-		httpUserError(writer, NewHTTPError(http.StatusBadRequest, "auth session is not for SSH check", nil))
-
-		return
-	}
 
 	binding := authReq.SSHCheckBinding()
 
@@ -432,8 +661,14 @@ func (a *AuthProviderOIDC) OIDCCallbackHandler(
 		return
 	}
 
-	// Identity verified — record the verdict for the waiting follow-up.
-	authReq.FinishAuth(types.AuthVerdict{})
+	currentAuthReq, ok := a.h.state.GetAuthCacheEntry(authInfo.AuthID)
+	if !ok || currentAuthReq != authReq || !authReq.FinishClaimedAuth(types.AuthVerdict{}) {
+		httpUserError(writer, NewHTTPError(http.StatusGone, "login session expired, try again", nil))
+
+		return
+	}
+
+	authClaimed = false
 
 	content := renderAuthSuccessTemplate(user)
 
@@ -478,19 +713,12 @@ func extractCodeAndStateParamFromRequest(
 func (a *AuthProviderOIDC) getOauth2Token(
 	ctx context.Context,
 	code string,
-	state string,
+	authInfo AuthInfo,
 ) (*oauth2.Token, error) {
 	var exchangeOpts []oauth2.AuthCodeOption
 
-	if a.cfg.PKCE.Enabled {
-		regInfo, ok := a.authCache.Get(state)
-		if !ok {
-			return nil, NewHTTPError(http.StatusNotFound, "registration not found", errNoOIDCRegistrationInfo)
-		}
-
-		if regInfo.Verifier != nil {
-			exchangeOpts = []oauth2.AuthCodeOption{oauth2.VerifierOption(*regInfo.Verifier)}
-		}
+	if a.cfg.PKCE.Enabled && authInfo.Verifier != nil {
+		exchangeOpts = []oauth2.AuthCodeOption{oauth2.VerifierOption(*authInfo.Verifier)}
 	}
 
 	oauth2Token, err := a.oauth2Config.Exchange(ctx, code, exchangeOpts...)
@@ -620,12 +848,10 @@ func doOIDCAuthorization(
 // entry is removed on read so a state is single-use: a replayed callback cannot
 // resolve the same auth session twice, even within the cache TTL.
 func (a *AuthProviderOIDC) getAuthInfoFromState(state string) *AuthInfo {
-	authInfo, ok := a.authCache.Get(state)
+	authInfo, ok := a.takeOIDCAuthState(state)
 	if !ok {
 		return nil
 	}
-
-	a.authCache.Remove(state)
 
 	return &authInfo
 }
@@ -755,33 +981,34 @@ func (a *AuthProviderOIDC) beginRegistrationConfirmation(
 	writer http.ResponseWriter,
 	req *http.Request,
 	authID types.AuthID,
+	authReq *types.AuthRequest,
 	user *types.User,
 	nodeExpiry *time.Time,
-) {
-	authReq, ok := a.h.state.GetAuthCacheEntry(authID)
-	if !ok {
+) error {
+	currentAuthReq, ok := a.h.state.GetAuthCacheEntry(authID)
+	if !ok || currentAuthReq != authReq {
 		log.Debug().Caller().Str("auth_id", authID.String()).Msg("registration session expired before authorization completed")
-		httpUserError(writer, NewHTTPError(http.StatusGone, "login session expired, try again", nil))
 
-		return
+		return NewHTTPError(http.StatusGone, "login session expired, try again", nil)
 	}
 
 	if !authReq.IsRegistration() {
 		log.Warn().Caller().
 			Str("auth_id", authID.String()).
 			Msg("OIDC callback hit registration path with auth request that is not a node registration")
-		httpUserError(writer, NewHTTPError(http.StatusBadRequest, "auth session is not for node registration", nil))
 
-		return
+		return NewHTTPError(http.StatusBadRequest, "auth session is not for node registration", nil)
 	}
 
 	csrf := rands.HexString(32)
 
-	authReq.SetPendingConfirmation(&types.PendingRegistrationConfirmation{
+	if !authReq.SetPendingConfirmation(&types.PendingRegistrationConfirmation{
 		UserID:     user.ID,
 		NodeExpiry: nodeExpiry,
 		CSRF:       csrf,
-	})
+	}) {
+		return NewHTTPError(http.StatusConflict, "registration confirmation already pending", errOIDCStateExists)
+	}
 
 	a.setRegisterConfirmCookie(writer, req, authID, csrf, int(authCacheExpiration.Seconds()))
 
@@ -789,6 +1016,8 @@ func (a *AuthProviderOIDC) beginRegistrationConfirmation(
 	// confirmation page and leaves the code-bearing URL behind as a
 	// transient hop rather than a history entry it can return to.
 	http.Redirect(writer, req, a.registerConfirmURL(authID), http.StatusSeeOther)
+
+	return nil
 }
 
 // RegisterConfirmGetHandler renders the OIDC registration confirmation
@@ -812,6 +1041,14 @@ func (a *AuthProviderOIDC) RegisterConfirmGetHandler(
 
 	authReq, ok := a.h.state.GetAuthCacheEntry(authID)
 	if !ok {
+		a.releaseOIDCAuthReservation(authID)
+		httpUserError(writer, errRegistrationLinkSpent)
+
+		return
+	}
+
+	if _, complete := authReq.AuthResult(); complete {
+		a.releaseOIDCAuthReservation(authID)
 		httpUserError(writer, errRegistrationLinkSpent)
 
 		return
@@ -922,6 +1159,14 @@ func (a *AuthProviderOIDC) RegisterConfirmHandler(
 
 	authReq, ok := a.h.state.GetAuthCacheEntry(authID)
 	if !ok {
+		a.releaseOIDCAuthReservation(authID)
+		httpUserError(writer, errRegistrationLinkSpent)
+
+		return
+	}
+
+	if _, complete := authReq.AuthResult(); complete {
+		a.releaseOIDCAuthReservation(authID)
 		httpUserError(writer, errRegistrationLinkSpent)
 
 		return
@@ -950,6 +1195,7 @@ func (a *AuthProviderOIDC) RegisterConfirmHandler(
 	newNode, err := a.handleRegistration(user, authID, pending.NodeExpiry)
 	if err != nil {
 		if errors.Is(err, db.ErrNodeNotFoundRegistrationCache) {
+			a.releaseOIDCAuthReservation(authID)
 			httpUserError(writer, newHTTPUserError(
 				http.StatusGone,
 				registrationLinkSpentMsg,
@@ -964,6 +1210,8 @@ func (a *AuthProviderOIDC) RegisterConfirmHandler(
 
 		return
 	}
+
+	a.releaseOIDCAuthReservation(authID)
 
 	// Clear the CSRF cookie now that the registration is final.
 	a.setRegisterConfirmCookie(writer, req, authID, "", -1)
@@ -1078,9 +1326,17 @@ func (a *AuthProviderOIDC) setCSRFCookie(
 	w http.ResponseWriter,
 	r *http.Request,
 	name string,
-) string {
+) {
 	val := rands.HexString(64)
+	a.setCSRFCookieValue(w, r, name, val)
+}
 
+func (a *AuthProviderOIDC) setCSRFCookieValue(
+	w http.ResponseWriter,
+	r *http.Request,
+	name string,
+	val string,
+) {
 	//nolint:gosec // G124: Secure from server_url scheme or req.TLS; HttpOnly + SameSite set below
 	c := &http.Cookie{
 		Path:     a.oidcCallbackPath(),
@@ -1097,6 +1353,4 @@ func (a *AuthProviderOIDC) setCSRFCookie(
 		SameSite: http.SameSiteLaxMode,
 	}
 	http.SetCookie(w, c)
-
-	return val
 }

--- a/hscontrol/oidc_admission_test.go
+++ b/hscontrol/oidc_admission_test.go
@@ -1,0 +1,365 @@
+package hscontrol
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/juanfont/headscale/hscontrol/db"
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/juanfont/headscale/hscontrol/util"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/key"
+)
+
+var errOIDCTestCancelled = errors.New("cancelled")
+
+func newTestOIDCStateProvider(maxEntries int, expiration time.Duration) *AuthProviderOIDC {
+	return &AuthProviderOIDC{
+		serverURL:            "https://headscale.example.com",
+		cfg:                  &types.OIDCConfig{},
+		authCache:            expirable.NewLRU[string, AuthInfo](0, nil, expiration),
+		sshAuthCache:         expirable.NewLRU[string, AuthInfo](0, nil, expiration),
+		authCacheMaxEntries:  maxEntries,
+		authStateByRequestID: make(map[types.AuthID]oidcAuthState),
+		oauth2Config: &oauth2.Config{
+			ClientID:    "client-id",
+			RedirectURL: "https://headscale.example.com/oidc/callback",
+			Endpoint: oauth2.Endpoint{
+				AuthURL: "https://issuer.example.com/authorize",
+			},
+		},
+	}
+}
+
+func TestOIDCAuthStateCapacityPreservesActiveEntries(t *testing.T) {
+	provider := newTestOIDCStateProvider(2, time.Hour)
+	states := []string{"state-registration-one", "state-registration-two"}
+
+	for _, state := range states {
+		err := provider.addOIDCAuthState(state, AuthInfo{
+			AuthID:       types.MustAuthID(),
+			Registration: true,
+		})
+		require.NoError(t, err)
+	}
+
+	err := provider.addOIDCAuthState("state-registration-three", AuthInfo{
+		AuthID:       types.MustAuthID(),
+		Registration: true,
+	})
+	require.ErrorIs(t, err, errOIDCStateCapacity)
+
+	for _, state := range states {
+		_, ok := provider.peekOIDCAuthState(state)
+		require.True(t, ok)
+	}
+
+	err = provider.addOIDCAuthState("state-ssh", AuthInfo{
+		AuthID: types.MustAuthID(),
+	})
+	require.NoError(t, err, "registration capacity must not block SSH state")
+}
+
+func TestOIDCAuthStateDeduplicatesPendingRequest(t *testing.T) {
+	provider := newTestOIDCStateProvider(2, time.Hour)
+	authID := types.MustAuthID()
+	require.NoError(t, provider.addOIDCAuthState("state-one", AuthInfo{
+		AuthID:       authID,
+		Registration: true,
+	}))
+
+	err := provider.addOIDCAuthState("state-two", AuthInfo{
+		AuthID:       authID,
+		Registration: true,
+	})
+	require.ErrorIs(t, err, errOIDCStateExists)
+	require.Equal(t, 1, provider.authCache.Len())
+}
+
+func TestOIDCAuthStateConcurrentAdmissionStopsAtCapacity(t *testing.T) {
+	const (
+		maxEntries = 8
+		attempts   = 64
+	)
+
+	provider := newTestOIDCStateProvider(maxEntries, time.Hour)
+
+	var accepted atomic.Int32
+
+	var wg sync.WaitGroup
+	for idx := range attempts {
+		wg.Go(func() {
+			err := provider.addOIDCAuthState("state-"+strconv.Itoa(idx), AuthInfo{
+				AuthID:       types.MustAuthID(),
+				Registration: true,
+			})
+			if err == nil {
+				accepted.Add(1)
+			}
+		})
+	}
+
+	wg.Wait()
+
+	require.Equal(t, int32(maxEntries), accepted.Load())
+	require.Equal(t, maxEntries, provider.authCache.Len())
+}
+
+func TestOIDCAuthStateExpirationFreesCapacity(t *testing.T) {
+	provider := newTestOIDCStateProvider(1, 20*time.Millisecond)
+	require.NoError(t, provider.addOIDCAuthState("state-expiring", AuthInfo{
+		AuthID:       types.MustAuthID(),
+		Registration: true,
+	}))
+
+	require.Eventually(t, func() bool {
+		provider.authCacheMu.Lock()
+		defer provider.authCacheMu.Unlock()
+
+		provider.pruneExpiredOIDCAuthStatesLocked()
+
+		return provider.authCache.Len() == 0
+	}, time.Second, time.Millisecond)
+
+	require.NoError(t, provider.addOIDCAuthState("state-new", AuthInfo{
+		AuthID:       types.MustAuthID(),
+		Registration: true,
+	}))
+}
+
+func TestOIDCAuthStateTakeIsSingleUse(t *testing.T) {
+	provider := newTestOIDCStateProvider(1, time.Hour)
+	verifier := "pkce-verifier"
+	authID := types.MustAuthID()
+	require.NoError(t, provider.addOIDCAuthState("state-single-use", AuthInfo{
+		AuthID:       authID,
+		Verifier:     &verifier,
+		Registration: true,
+	}))
+
+	peeked, ok := provider.peekOIDCAuthState("state-single-use")
+	require.True(t, ok)
+	require.Equal(t, verifier, *peeked.Verifier)
+
+	var successes atomic.Int32
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			if _, ok := provider.takeOIDCAuthState("state-single-use"); ok {
+				successes.Add(1)
+			}
+		})
+	}
+
+	wg.Wait()
+
+	require.Equal(t, int32(1), successes.Load())
+
+	err := provider.addOIDCAuthState("state-repeated", AuthInfo{
+		AuthID:       authID,
+		Registration: true,
+	})
+	require.ErrorIs(t, err, errOIDCStateExists)
+
+	provider.releaseOIDCAuthReservation(authID)
+	require.NoError(t, provider.addOIDCAuthState("state-repeated", AuthInfo{
+		AuthID:       authID,
+		Registration: true,
+	}))
+}
+
+func TestOIDCStartValidatesPendingRequestBeforeAllocation(t *testing.T) {
+	provider := newTestOIDCStateProvider(2, time.Hour)
+	provider.h = createTestApp(t)
+
+	missingID := types.MustAuthID()
+	response := serveOIDCStart(t, provider, true, missingID)
+	require.Equal(t, http.StatusNotFound, response.Code)
+	require.Empty(t, response.Header().Get("Location"))
+	require.Empty(t, response.Result().Cookies())
+	require.Zero(t, provider.authCache.Len())
+
+	registrationID := types.MustAuthID()
+	require.NoError(t, provider.h.state.SetAuthCacheEntry(
+		registrationID,
+		types.NewRegisterAuthRequest(&types.RegistrationData{}),
+	))
+	response = serveOIDCStart(t, provider, false, registrationID)
+	require.Equal(t, http.StatusBadRequest, response.Code)
+	require.Empty(t, response.Header().Get("Location"))
+	require.Empty(t, response.Result().Cookies())
+
+	sshID := types.MustAuthID()
+	require.NoError(t, provider.h.state.SetAuthCacheEntry(
+		sshID,
+		types.NewSSHCheckAuthRequest(1, 2),
+	))
+	response = serveOIDCStart(t, provider, true, sshID)
+	require.Equal(t, http.StatusBadRequest, response.Code)
+	require.Empty(t, response.Header().Get("Location"))
+	require.Empty(t, response.Result().Cookies())
+
+	completedID := types.MustAuthID()
+	completed := types.NewRegisterAuthRequest(&types.RegistrationData{})
+	require.NoError(t, provider.h.state.SetAuthCacheEntry(completedID, completed))
+	require.True(t, completed.FinishAuth(types.AuthVerdict{Err: errOIDCTestCancelled}))
+	response = serveOIDCStart(t, provider, true, completedID)
+	require.Equal(t, http.StatusGone, response.Code)
+	require.Empty(t, response.Result().Cookies())
+
+	pendingID := types.MustAuthID()
+	pending := types.NewRegisterAuthRequest(&types.RegistrationData{})
+	require.True(t, pending.SetPendingConfirmation(&types.PendingRegistrationConfirmation{
+		CSRF: "pending",
+	}))
+	require.NoError(t, provider.h.state.SetAuthCacheEntry(pendingID, pending))
+	response = serveOIDCStart(t, provider, true, pendingID)
+	require.Equal(t, http.StatusConflict, response.Code)
+	require.Empty(t, response.Result().Cookies())
+}
+
+func TestOIDCStartAdmissionPreservesExistingFlow(t *testing.T) {
+	provider := newTestOIDCStateProvider(1, time.Hour)
+	provider.h = createTestApp(t)
+
+	registrationID := types.MustAuthID()
+	secondRegistrationID := types.MustAuthID()
+	sshID := types.MustAuthID()
+
+	for _, authID := range []types.AuthID{registrationID, secondRegistrationID} {
+		require.NoError(t, provider.h.state.SetAuthCacheEntry(
+			authID,
+			types.NewRegisterAuthRequest(&types.RegistrationData{}),
+		))
+	}
+
+	require.NoError(t, provider.h.state.SetAuthCacheEntry(
+		sshID,
+		types.NewSSHCheckAuthRequest(1, 2),
+	))
+
+	response := serveOIDCStart(t, provider, true, registrationID)
+	require.Equal(t, http.StatusFound, response.Code)
+	require.NotEmpty(t, response.Header().Get("Location"))
+	require.Len(t, response.Result().Cookies(), 2)
+
+	states := provider.authCache.Keys()
+	require.Len(t, states, 1)
+	existingState := states[0]
+
+	response = serveOIDCStart(t, provider, true, registrationID)
+	require.Equal(t, http.StatusConflict, response.Code)
+	require.Empty(t, response.Header().Get("Location"))
+	require.Empty(t, response.Result().Cookies())
+
+	response = serveOIDCStart(t, provider, true, secondRegistrationID)
+	require.Equal(t, http.StatusServiceUnavailable, response.Code)
+	require.Empty(t, response.Header().Get("Location"))
+	require.Empty(t, response.Result().Cookies())
+
+	info, ok := provider.peekOIDCAuthState(existingState)
+	require.True(t, ok)
+	require.Equal(t, registrationID, info.AuthID)
+
+	response = serveOIDCStart(t, provider, false, sshID)
+	require.Equal(t, http.StatusFound, response.Code)
+	require.NotEmpty(t, response.Header().Get("Location"))
+	require.Equal(t, 1, provider.sshAuthCache.Len())
+}
+
+func TestOIDCStartPrunesCompletedRequest(t *testing.T) {
+	provider := newTestOIDCStateProvider(1, time.Hour)
+	provider.h = createTestApp(t)
+
+	completedID := types.MustAuthID()
+
+	nextID := types.MustAuthID()
+	for _, authID := range []types.AuthID{completedID, nextID} {
+		require.NoError(t, provider.h.state.SetAuthCacheEntry(
+			authID,
+			types.NewRegisterAuthRequest(&types.RegistrationData{}),
+		))
+	}
+
+	response := serveOIDCStart(t, provider, true, completedID)
+	require.Equal(t, http.StatusFound, response.Code)
+
+	completed, ok := provider.h.state.GetAuthCacheEntry(completedID)
+	require.True(t, ok)
+	require.True(t, completed.FinishAuth(types.AuthVerdict{Err: errOIDCTestCancelled}))
+
+	response = serveOIDCStart(t, provider, true, nextID)
+	require.Equal(t, http.StatusFound, response.Code)
+	require.Equal(t, 1, provider.authCache.Len())
+}
+
+func TestHandleNodeFromAuthPathRejectsCompletedRequest(t *testing.T) {
+	app := createTestApp(t)
+	user := app.state.CreateUserForTest("completed-registration")
+	machineKey := key.NewMachine()
+	authID := types.MustAuthID()
+	authReq := types.NewRegisterAuthRequest(&types.RegistrationData{
+		MachineKey: machineKey.Public(),
+		NodeKey:    key.NewNode().Public(),
+		DiscoKey:   key.NewDisco().Public(),
+		Hostname:   "completed-registration",
+		Hostinfo:   &tailcfg.Hostinfo{Hostname: "completed-registration"},
+	})
+	require.NoError(t, app.state.SetAuthCacheEntry(authID, authReq))
+	require.True(t, authReq.FinishAuth(types.AuthVerdict{Err: errOIDCTestCancelled}))
+
+	_, _, err := app.state.HandleNodeFromAuthPath(
+		authID,
+		types.UserID(user.ID),
+		nil,
+		util.RegisterMethodOIDC,
+	)
+	require.ErrorIs(t, err, db.ErrNodeNotFoundRegistrationCache)
+	require.Empty(t, app.state.GetNodesByMachineKeyAllUsers(machineKey.Public()))
+}
+
+func serveOIDCStart(
+	t *testing.T,
+	provider *AuthProviderOIDC,
+	registration bool,
+	authID types.AuthID,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	path := "/auth/" + authID.String()
+	if registration {
+		path = "/register/" + authID.String()
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, nil)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("auth_id", authID.String())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeContext))
+
+	response := httptest.NewRecorder()
+	provider.authHandler(response, req, registration)
+
+	return response
+}
+
+func TestOIDCAuthStateCapacityErrorUnwraps(t *testing.T) {
+	provider := newTestOIDCStateProvider(0, time.Hour)
+	err := provider.addOIDCAuthState("state", AuthInfo{
+		AuthID:       types.MustAuthID(),
+		Registration: true,
+	})
+
+	require.ErrorIs(t, err, errOIDCStateCapacity)
+}

--- a/hscontrol/oidc_confirm_test.go
+++ b/hscontrol/oidc_confirm_test.go
@@ -57,7 +57,7 @@ func TestRegisterConfirmHandler_RejectsCSRFMismatch(t *testing.T) {
 		UserID: 1,
 		CSRF:   "expected-csrf",
 	})
-	app.state.SetAuthCacheEntry(authID, regReq)
+	require.NoError(t, app.state.SetAuthCacheEntry(authID, regReq))
 
 	rec := httptest.NewRecorder()
 	provider.RegisterConfirmHandler(rec,
@@ -89,9 +89,9 @@ func TestRegisterConfirmHandler_RejectsWithoutPending(t *testing.T) {
 	authID := types.MustAuthID()
 	// Cached registration with NO pending confirmation set — i.e. the
 	// OIDC callback has not run yet.
-	app.state.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(
+	require.NoError(t, app.state.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(
 		&types.RegistrationData{Hostname: "no-oidc-yet"},
-	))
+	)))
 
 	rec := httptest.NewRecorder()
 	provider.RegisterConfirmHandler(rec,

--- a/hscontrol/oidc_test.go
+++ b/hscontrol/oidc_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oauth2-proxy/mockoidc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"tailscale.com/tailcfg"
 	"tailscale.com/types/key"
 )
 
@@ -478,6 +479,48 @@ func TestOIDCLoginCompletesAfterReload(t *testing.T) {
 	assert.True(t, b.app.state.ListNodes().ContainsFunc(func(node types.NodeView) bool {
 		return node.Hostname() == "reload-victim"
 	}), "the pending node must be persisted after confirmation")
+}
+
+func TestOIDCUserChangeNotifiesConnectedNodes(t *testing.T) {
+	b := newOIDCBrowser(t)
+
+	recipient := b.app.state.CreateUserForTest("recipient")
+	node := putTestNodeInStore(t, b.app, recipient, "connected-node")
+	updates := make(chan *tailcfg.MapResponse, 4)
+	require.NoError(t, b.app.mapBatcher.AddNode(
+		node.ID,
+		updates,
+		tailcfg.CapabilityVersion(100),
+		nil,
+	))
+	t.Cleanup(func() {
+		b.app.mapBatcher.RemoveNode(node.ID, updates)
+	})
+
+	select {
+	case initial := <-updates:
+		require.NotNil(t, initial)
+	case <-time.After(time.Second):
+		t.Fatal("initial map was not delivered")
+	}
+
+	_, registerURL := b.pendingNode(t)
+	status, _, body := b.get(t, registerURL)
+	require.Equal(t, http.StatusOK, status)
+	require.Contains(t, body, "Confirm node registration")
+
+	select {
+	case update := <-updates:
+		require.NotNil(t, update)
+	case <-time.After(2 * time.Second):
+		t.Fatal("connected node was not notified after the OIDC user changed")
+	}
+
+	select {
+	case <-updates:
+		t.Fatal("OIDC user change emitted more than one map update")
+	case <-time.After(250 * time.Millisecond):
+	}
 }
 
 // TestRegisterConfirmGETIsNotADeadEnd covers the second, independent way

--- a/hscontrol/oidc_test.go
+++ b/hscontrol/oidc_test.go
@@ -374,11 +374,11 @@ func (b *oidcBrowser) pendingNode(t *testing.T) (types.AuthID, string) {
 	t.Helper()
 
 	authID := types.MustAuthID()
-	b.app.state.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(&types.RegistrationData{
+	require.NoError(t, b.app.state.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(&types.RegistrationData{
 		MachineKey: key.NewMachine().Public(),
 		NodeKey:    key.NewNode().Public(),
 		Hostname:   "reload-victim",
-	}))
+	})))
 
 	return authID, b.publicURL + "/register/" + authID.String()
 }

--- a/hscontrol/policy/pm.go
+++ b/hscontrol/policy/pm.go
@@ -24,6 +24,10 @@ type PolicyManager interface {
 	// SSHCheckParams resolves the SSH check period for a (src, dst) pair
 	// from the current policy, avoiding trust of client-provided URL params.
 	SSHCheckParams(srcNodeID, dstNodeID types.NodeID) (time.Duration, bool)
+	// SSHAccessParams resolves the current action for a complete SSH
+	// connection tuple. check and accept are mutually exclusive; check takes
+	// precedence when multiple rules match, mirroring compiled policy order.
+	SSHAccessParams(srcNodeID, dstNodeID types.NodeID, localUser string) (period time.Duration, check, accept bool)
 	SetPolicy(pol []byte) (bool, error)
 	// SetUsers replaces the user list. policyChanged reports whether clients
 	// need a policy refresh; peerMapChanged reports whether user-derived peer

--- a/hscontrol/policy/v2/filter_test.go
+++ b/hscontrol/policy/v2/filter_test.go
@@ -2934,6 +2934,64 @@ func TestSSHCheckParams(t *testing.T) {
 	}
 }
 
+func TestSSHAccessParamsIncludesLocalUser(t *testing.T) {
+	users := types.Users{
+		{Name: "user1", ID: 1},
+		{Name: "user2", ID: 2},
+	}
+	nodes := types.Nodes{
+		{
+			ID:       1,
+			Hostname: "source",
+			IPv4:     createAddr("100.64.0.1"),
+			UserID:   new(users[0].ID),
+			User:     new(users[0]),
+		},
+		{
+			ID:       2,
+			Hostname: "destination",
+			IPv4:     createAddr("100.64.0.2"),
+			UserID:   new(users[0].ID),
+			User:     new(users[0]),
+		},
+	}
+
+	pol := []byte(`{
+		"ssh": [
+			{
+				"action": "accept",
+				"src": ["user1@"],
+				"dst": ["autogroup:self"],
+				"users": ["ubuntu"]
+			},
+			{
+				"action": "check",
+				"checkPeriod": "2h",
+				"src": ["user1@"],
+				"dst": ["autogroup:self"],
+				"users": ["root"]
+			}
+		]
+	}`)
+	pm, err := NewPolicyManager(pol, users, nodes.ViewSlice())
+	require.NoError(t, err)
+
+	period, check, accept := pm.SSHAccessParams(1, 2, "root")
+	assert.Equal(t, 2*time.Hour, period)
+	assert.True(t, check)
+	assert.False(t, accept)
+
+	period, check, accept = pm.SSHAccessParams(1, 2, "ubuntu")
+	assert.Zero(t, period)
+	assert.False(t, check)
+	assert.True(t, accept)
+
+	period, check, accept = pm.SSHAccessParams(1, 2, "daemon")
+	assert.Zero(t, period)
+	assert.False(t, check)
+	assert.False(t, accept)
+}
+
 func TestResolveLocalparts(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -531,6 +531,117 @@ func (pm *PolicyManager) SSHCheckParams(
 	return 0, false
 }
 
+// SSHAccessParams resolves the current policy action for a complete SSH
+// connection tuple. Check rules are evaluated before accept rules to match
+// the ordering used by compileSSHPolicy.
+func (pm *PolicyManager) SSHAccessParams(
+	srcNodeID, dstNodeID types.NodeID,
+	localUser string,
+) (time.Duration, bool, bool) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	if pm.pol == nil || localUser == "" {
+		return 0, false, false
+	}
+
+	var srcNode, dstNode types.NodeView
+
+	for _, node := range pm.nodes.All() {
+		if node.ID() == srcNodeID {
+			srcNode = node
+		}
+
+		if node.ID() == dstNodeID {
+			dstNode = node
+		}
+
+		if srcNode.Valid() && dstNode.Valid() {
+			break
+		}
+	}
+
+	if !srcNode.Valid() || !dstNode.Valid() {
+		return 0, false, false
+	}
+
+	for _, action := range []SSHAction{SSHActionCheck, SSHActionAccept} {
+		for _, rule := range pm.pol.SSHs {
+			if rule.Action != action ||
+				!sshRuleMatchesNodes(pm.pol, pm.users, pm.nodes, rule, srcNode, dstNode) ||
+				!sshRuleAllowsLocalUser(rule, srcNode, pm.users, localUser) {
+				continue
+			}
+
+			if action == SSHActionCheck {
+				return checkPeriodFromRule(rule), true, false
+			}
+
+			return 0, false, true
+		}
+	}
+
+	return 0, false, false
+}
+
+func sshRuleMatchesNodes(
+	pol *Policy,
+	users types.Users,
+	nodes views.Slice[types.NodeView],
+	rule SSH,
+	srcNode, dstNode types.NodeView,
+) bool {
+	srcIPs, err := rule.Sources.Resolve(pol, users, nodes)
+	if err != nil || srcIPs == nil ||
+		!slices.ContainsFunc(srcNode.IPs(), srcIPs.Contains) {
+		return false
+	}
+
+	for _, dst := range rule.Destinations {
+		if ag, isAG := dst.(*AutoGroup); isAG && ag.Is(AutoGroupSelf) {
+			if !srcNode.IsTagged() && !dstNode.IsTagged() &&
+				srcNode.User().Valid() && dstNode.User().Valid() &&
+				srcNode.User().ID() == dstNode.User().ID() {
+				return true
+			}
+
+			continue
+		}
+
+		dstIPs, err := dst.Resolve(pol, users, nodes)
+		if err == nil && dstIPs != nil &&
+			slices.ContainsFunc(dstNode.IPs(), dstIPs.Contains) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func sshRuleAllowsLocalUser(
+	rule SSH,
+	srcNode types.NodeView,
+	users types.Users,
+	localUser string,
+) bool {
+	switch {
+	case localUser == "root":
+		return rule.Users.ContainsRoot()
+	case rule.Users.ContainsNonRoot():
+		return true
+	case slices.ContainsFunc(rule.Users.NormalUsers(), func(user SSHUser) bool {
+		return user.String() == localUser
+	}):
+		return true
+	case srcNode.IsTagged() || !srcNode.User().Valid():
+		return false
+	}
+
+	localparts := resolveLocalparts(rule.Users.LocalpartEntries(), users)
+
+	return localparts[srcNode.User().ID()] == localUser
+}
+
 func (pm *PolicyManager) SetPolicy(polB []byte) (bool, error) {
 	if len(polB) == 0 {
 		return false, nil

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -818,8 +818,47 @@ func (pm *PolicyManager) SetUsers(users []types.User) (bool, bool, error) {
 		return false, false, nil
 	}
 
-	prev := pm.users
+	prev := struct {
+		users              []types.User
+		filterHash         deephash.Sum
+		filter             []tailcfg.FilterRule
+		matchers           []matcher.Match
+		tagOwnerMapHash    deephash.Sum
+		tagOwnerMap        map[Tag]*netipx.IPSet
+		exitSetHash        deephash.Sum
+		exitSet            *netipx.IPSet
+		autoApproveMapHash deephash.Sum
+		autoApproveMap     map[netip.Prefix]*netipx.IPSet
+		relayTargetIPs     *netipx.IPSet
+		viaTargetTags      map[Tag]struct{}
+		compiledGrants     []compiledGrant
+		userNodeIdx        userNodeIndex
+		needsPerNodeFilter bool
+		nodeAttrsMap       map[types.NodeID]tailcfg.NodeCapMap
+		nodeAttrsHashes    map[types.NodeID]deephash.Sum
+		nodeAttrsChanged   []types.NodeID
+	}{
+		users:              pm.users,
+		filterHash:         pm.filterHash,
+		filter:             pm.filter,
+		matchers:           pm.matchers,
+		tagOwnerMapHash:    pm.tagOwnerMapHash,
+		tagOwnerMap:        pm.tagOwnerMap,
+		exitSetHash:        pm.exitSetHash,
+		exitSet:            pm.exitSet,
+		autoApproveMapHash: pm.autoApproveMapHash,
+		autoApproveMap:     pm.autoApproveMap,
+		relayTargetIPs:     pm.relayTargetIPs,
+		viaTargetTags:      pm.viaTargetTags,
+		compiledGrants:     pm.compiledGrants,
+		userNodeIdx:        pm.userNodeIdx,
+		needsPerNodeFilter: pm.needsPerNodeFilter,
+		nodeAttrsMap:       pm.nodeAttrsMap,
+		nodeAttrsHashes:    pm.nodeAttrsHashes,
+		nodeAttrsChanged:   pm.nodeAttrsChanged,
+	}
 	pm.users = users
+	hadPerNodeFilters := pm.needsPerNodeFilter
 
 	// SSH policies resolve users by name, so they are recomputed on any
 	// user change.
@@ -827,9 +866,27 @@ func (pm *PolicyManager) SetUsers(users []types.User) (bool, bool, error) {
 
 	policyChanged, err := pm.updateLocked()
 	if err != nil {
-		// Keep the old list so a retry with the same input recompiles
-		// instead of being treated as unchanged.
-		pm.users = prev
+		// Keep the complete previous policy snapshot. updateLocked compiles
+		// derived state incrementally, and a late error must not expose a
+		// partially refreshed filter or peer view.
+		pm.users = prev.users
+		pm.filterHash = prev.filterHash
+		pm.filter = prev.filter
+		pm.matchers = prev.matchers
+		pm.tagOwnerMapHash = prev.tagOwnerMapHash
+		pm.tagOwnerMap = prev.tagOwnerMap
+		pm.exitSetHash = prev.exitSetHash
+		pm.exitSet = prev.exitSet
+		pm.autoApproveMapHash = prev.autoApproveMapHash
+		pm.autoApproveMap = prev.autoApproveMap
+		pm.relayTargetIPs = prev.relayTargetIPs
+		pm.viaTargetTags = prev.viaTargetTags
+		pm.compiledGrants = prev.compiledGrants
+		pm.userNodeIdx = prev.userNodeIdx
+		pm.needsPerNodeFilter = prev.needsPerNodeFilter
+		pm.nodeAttrsMap = prev.nodeAttrsMap
+		pm.nodeAttrsHashes = prev.nodeAttrsHashes
+		pm.nodeAttrsChanged = prev.nodeAttrsChanged
 
 		return false, false, err
 	}
@@ -837,6 +894,17 @@ func (pm *PolicyManager) SetUsers(users []types.User) (bool, bool, error) {
 	// SSH rules embed user identity, so a user change needs a client refresh
 	// even when the filter hash did not move.
 	if pm.pol != nil && len(pm.pol.SSHs) > 0 {
+		policyChanged = true
+	}
+
+	// Per-node grants can change even when the global filter and policy text
+	// hashes do not. User identity is an input to those grants, so discard the
+	// derived caches and notify clients whenever either side of the update uses
+	// per-node filters.
+	if hadPerNodeFilters || pm.needsPerNodeFilter {
+		pm.filterRulesMap.Clear()
+		pm.matchersForNodeMap.Clear()
+
 		policyChanged = true
 	}
 

--- a/hscontrol/policy/v2/policy_test.go
+++ b/hscontrol/policy/v2/policy_test.go
@@ -433,6 +433,115 @@ func TestSetUsers(t *testing.T) {
 	}
 }
 
+func TestSetUsersRefreshesPerNodeFilters(t *testing.T) {
+	oldUser := types.User{ID: 1, Name: "alice", Email: "old@example.com"}
+	users := types.Users{oldUser}
+
+	node1 := node("node1", "100.64.0.1", "fd7a:115c:a1e0::1", oldUser)
+	node1.ID = 1
+	node2 := node("node2", "100.64.0.2", "fd7a:115c:a1e0::2", oldUser)
+	node2.ID = 2
+	nodes := types.Nodes{node1, node2}
+
+	policy := `{
+		"acls": [
+			{
+				"action": "accept",
+				"src": ["old@example.com"],
+				"dst": ["autogroup:self:*"]
+			}
+		]
+	}`
+
+	pm, err := NewPolicyManager([]byte(policy), users, nodes.ViewSlice())
+	require.NoError(t, err)
+	require.True(t, pm.needsPerNodeFilter)
+
+	rules, err := pm.FilterForNode(node1.View())
+	require.NoError(t, err)
+	require.NotEmpty(t, rules)
+
+	matchers, err := pm.MatchersForNode(node1.View())
+	require.NoError(t, err)
+	require.NotEmpty(t, matchers)
+
+	updated := slices.Clone(users)
+	updated[0].Email = "new@example.com"
+
+	policyChanged, peerMapChanged, err := pm.SetUsers(updated)
+	require.NoError(t, err)
+	require.True(t, policyChanged)
+	require.True(t, peerMapChanged)
+
+	rules, err = pm.FilterForNode(node1.View())
+	require.NoError(t, err)
+	require.Empty(t, rules)
+
+	matchers, err = pm.MatchersForNode(node1.View())
+	require.NoError(t, err)
+	require.Empty(t, matchers)
+}
+
+func TestSetUsersFailureRetainsCompiledState(t *testing.T) {
+	oldUser := types.User{ID: 1, Name: "alice", Email: "old@example.com"}
+	users := types.Users{oldUser}
+
+	node1 := node("node1", "100.64.0.1", "fd7a:115c:a1e0::1", oldUser)
+	node1.ID = 1
+	node2 := node("node2", "100.64.0.2", "fd7a:115c:a1e0::2", oldUser)
+	node2.ID = 2
+	nodes := types.Nodes{node1, node2}
+
+	policy := `{
+		"acls": [
+			{
+				"action": "accept",
+				"src": ["new@example.com"],
+				"dst": ["autogroup:self:*"]
+			}
+		],
+		"nodeAttrs": [
+			{
+				"target": ["old@example.com"],
+				"attr": ["randomize-client-port"]
+			}
+		]
+	}`
+
+	pm, err := NewPolicyManager([]byte(policy), users, nodes.ViewSlice())
+	require.NoError(t, err)
+
+	beforeRules, err := pm.FilterForNode(node1.View())
+	require.NoError(t, err)
+	beforeMatchers, err := pm.MatchersForNode(node1.View())
+	require.NoError(t, err)
+
+	beforePeers := pm.BuildPeerMap(nodes.ViewSlice())
+	beforePerNode := pm.needsPerNodeFilter
+
+	updated := slices.Clone(users)
+	updated[0].Email = "new@example.com"
+
+	_, _, err = pm.SetUsers(updated)
+	require.Error(t, err)
+
+	afterRules, err := pm.FilterForNode(node1.View())
+	require.NoError(t, err)
+	afterMatchers, err := pm.MatchersForNode(node1.View())
+	require.NoError(t, err)
+	uncachedRules, err := pm.FilterForNode(node2.View())
+	require.NoError(t, err)
+
+	afterPeers := pm.BuildPeerMap(nodes.ViewSlice())
+
+	require.Equal(t, "old@example.com", pm.users[0].Email)
+	require.Equal(t, beforePerNode, pm.needsPerNodeFilter)
+	require.Equal(t, beforeRules, afterRules)
+	require.Equal(t, beforeMatchers, afterMatchers)
+	require.Empty(t, uncachedRules)
+	require.Equal(t, beforePeers, afterPeers)
+}
+
 // TestInvalidateGlobalPolicyCache tests the cache invalidation logic for global policies.
 func TestInvalidateGlobalPolicyCache(t *testing.T) {
 	mustIPPtr := func(s string) *netip.Addr {

--- a/hscontrol/servertest/sshcheck_test.go
+++ b/hscontrol/servertest/sshcheck_test.go
@@ -84,9 +84,13 @@ func pollSSHAction(
 	t.Helper()
 
 	actionURL := fmt.Sprintf("%s/machine/ssh/action/%d/to/%d", serverURL, srcID, dstID)
+
+	q := url.Values{"local_user": {"ubuntu"}}
 	if authID != "" {
-		actionURL += "?auth_id=" + authID
+		q.Set("auth_id", authID)
 	}
+
+	actionURL += "?" + q.Encode()
 
 	// Noise requests are addressed with the https scheme; the control client
 	// routes them over the established Noise connection (mirroring how

--- a/hscontrol/state/auth_cache_test.go
+++ b/hscontrol/state/auth_cache_test.go
@@ -1,66 +1,182 @@
 package state
 
 import (
+	"sync"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestAuthCacheBoundedLRU verifies that the registration auth cache is
-// bounded by a maximum entry count, that exceeding the maxEntries evicts the
-// oldest entry, and that the eviction callback resolves the parked
-// AuthRequest with ErrRegistrationExpired so any waiting goroutine wakes.
-func TestAuthCacheBoundedLRU(t *testing.T) {
+func TestPendingAuthCacheRejectsAtCapacity(t *testing.T) {
 	const maxEntries = 4
 
-	cache := expirable.NewLRU[types.AuthID, *types.AuthRequest](
-		maxEntries,
-		func(_ types.AuthID, rn *types.AuthRequest) {
-			rn.FinishAuth(types.AuthVerdict{Err: ErrRegistrationExpired})
-		},
-		time.Hour, // long TTL — we test eviction by size, not by time
+	cache := newPendingAuthCache(maxEntries, time.Hour)
+	ids := make([]types.AuthID, 0, maxEntries)
+
+	for range maxEntries {
+		id := types.MustAuthID()
+		require.True(t, cache.add(id, types.NewRegisterAuthRequest(&types.RegistrationData{})))
+		ids = append(ids, id)
+	}
+
+	require.False(t, cache.add(
+		types.MustAuthID(),
+		types.NewRegisterAuthRequest(&types.RegistrationData{}),
+	))
+	require.Equal(t, maxEntries, cache.entries.Len())
+
+	for _, id := range ids {
+		_, ok := cache.entries.Get(id)
+		assert.True(t, ok, "existing request must remain available when admission is refused")
+	}
+}
+
+func TestPendingAuthCacheRetiresCompletedEntryAtCapacity(t *testing.T) {
+	cache := newPendingAuthCache(1, time.Hour)
+	firstID := types.MustAuthID()
+	first := types.NewSSHCheckAuthRequest(1, 2)
+	require.True(t, cache.add(firstID, first))
+	first.FinishAuth(types.AuthVerdict{})
+
+	secondID := types.MustAuthID()
+	require.True(t, cache.add(secondID, types.NewSSHCheckAuthRequest(1, 2)))
+
+	_, ok := cache.entries.Get(firstID)
+	require.False(t, ok)
+	_, ok = cache.entries.Get(secondID)
+	require.True(t, ok)
+}
+
+func TestPendingAuthPoolsHaveIndependentCapacity(t *testing.T) {
+	const maxEntries = 2
+
+	s := &State{
+		registrationAuthCache: newPendingAuthCache(maxEntries, time.Hour),
+		sshCheckAuthCache:     newPendingAuthCache(maxEntries, time.Hour),
+	}
+
+	registrationIDs := make([]types.AuthID, 0, maxEntries)
+	for range maxEntries {
+		id := types.MustAuthID()
+		err := s.SetAuthCacheEntry(id, types.NewRegisterAuthRequest(&types.RegistrationData{}))
+		require.NoError(t, err)
+
+		registrationIDs = append(registrationIDs, id)
+	}
+
+	err := s.SetAuthCacheEntry(
+		types.MustAuthID(),
+		types.NewRegisterAuthRequest(&types.RegistrationData{}),
+	)
+	require.ErrorIs(t, err, ErrPendingAuthCapacity)
+
+	sshIDs := make([]types.AuthID, 0, maxEntries)
+	for range maxEntries {
+		id := types.MustAuthID()
+		err := s.SetAuthCacheEntry(id, types.NewSSHCheckAuthRequest(1, 2))
+		require.NoError(t, err)
+
+		sshIDs = append(sshIDs, id)
+	}
+
+	err = s.SetAuthCacheEntry(types.MustAuthID(), types.NewSSHCheckAuthRequest(1, 2))
+	require.ErrorIs(t, err, ErrPendingAuthCapacity)
+
+	for _, id := range append(registrationIDs, sshIDs...) {
+		_, ok := s.GetAuthCacheEntry(id)
+		assert.True(t, ok, "one full pool must not displace requests from either pool")
+	}
+}
+
+func TestPendingAuthPoolsRejectDuplicateID(t *testing.T) {
+	s := &State{
+		registrationAuthCache: newPendingAuthCache(1, time.Hour),
+		sshCheckAuthCache:     newPendingAuthCache(1, time.Hour),
+	}
+
+	id := types.MustAuthID()
+	registration := types.NewRegisterAuthRequest(&types.RegistrationData{})
+	require.NoError(t, s.SetAuthCacheEntry(id, registration))
+
+	err := s.SetAuthCacheEntry(id, types.NewSSHCheckAuthRequest(1, 2))
+	require.ErrorIs(t, err, ErrAuthRequestIDInUse)
+	require.Zero(t, s.sshCheckAuthCache.entries.Len())
+
+	got, ok := s.GetAuthCacheEntry(id)
+	require.True(t, ok)
+	require.Same(t, registration, got)
+}
+
+func TestPendingAuthPoolsAcceptGenericApprovalSession(t *testing.T) {
+	s := &State{
+		registrationAuthCache: newPendingAuthCache(1, time.Hour),
+		sshCheckAuthCache:     newPendingAuthCache(1, time.Hour),
+	}
+
+	id := types.MustAuthID()
+	request := types.NewAuthRequest()
+	require.NoError(t, s.SetAuthCacheEntry(id, request))
+
+	got, ok := s.GetAuthCacheEntry(id)
+	require.True(t, ok)
+	require.Same(t, request, got)
+}
+
+func TestPendingAuthCacheConcurrentAdmissionStopsAtCapacity(t *testing.T) {
+	const (
+		maxEntries = 8
+		attempts   = 64
 	)
 
-	entries := make([]*types.AuthRequest, 0, maxEntries+1)
-	ids := make([]types.AuthID, 0, maxEntries+1)
+	cache := newPendingAuthCache(maxEntries, time.Hour)
+	accepted := make(chan types.AuthID, attempts)
 
-	for range maxEntries + 1 {
-		id := types.MustAuthID()
-		entry := types.NewAuthRequest()
-		cache.Add(id, entry)
-		ids = append(ids, id)
-		entries = append(entries, entry)
+	var wg sync.WaitGroup
+	for range attempts {
+		wg.Go(func() {
+			id := types.MustAuthID()
+			if cache.add(id, types.NewRegisterAuthRequest(&types.RegistrationData{})) {
+				accepted <- id
+			}
+		})
 	}
 
-	// Cap should be respected.
-	assert.Equal(t, maxEntries, cache.Len(), "cache must not exceed the configured maxEntries")
+	wg.Wait()
+	close(accepted)
 
-	// The oldest entry must have been evicted.
-	_, ok := cache.Get(ids[0])
-	assert.False(t, ok, "oldest entry must be evicted when maxEntries is exceeded")
+	require.Len(t, accepted, maxEntries)
+	require.Equal(t, maxEntries, cache.entries.Len())
 
-	// The eviction callback must have woken the parked AuthRequest.
+	for id := range accepted {
+		_, ok := cache.entries.Get(id)
+		assert.True(t, ok)
+	}
+}
+
+func TestPendingAuthCacheExpirationFreesCapacity(t *testing.T) {
+	const expiration = 20 * time.Millisecond
+
+	cache := newPendingAuthCache(1, expiration)
+	request := types.NewRegisterAuthRequest(&types.RegistrationData{})
+	require.True(t, cache.add(types.MustAuthID(), request))
+
 	select {
-	case <-entries[0].WaitForAuth():
-		verdict, ok := entries[0].AuthResult()
-		require.True(t, ok, "evicted entry must retain its terminal verdict")
-		require.False(t, verdict.Accept(), "evicted entry must not signal Accept")
-		require.ErrorIs(t,
-			verdict.Err, ErrRegistrationExpired,
-			"evicted entry must surface ErrRegistrationExpired, got: %v",
-			verdict.Err,
-		)
+	case <-request.WaitForAuth():
+		verdict, ok := request.AuthResult()
+		require.True(t, ok)
+		require.ErrorIs(t, verdict.Err, ErrRegistrationExpired)
 	case <-time.After(time.Second):
-		t.Fatal("eviction callback did not wake the parked AuthRequest")
+		t.Fatal("expired request was not completed")
 	}
 
-	// All non-evicted entries must still be retrievable.
-	for i := 1; i <= maxEntries; i++ {
-		_, ok := cache.Get(ids[i])
-		assert.True(t, ok, "non-evicted entry %d should still be in the cache", i)
-	}
+	require.Eventually(t, func() bool {
+		return cache.entries.Len() == 0
+	}, time.Second, time.Millisecond)
+	require.True(t, cache.add(
+		types.MustAuthID(),
+		types.NewRegisterAuthRequest(&types.RegistrationData{}),
+	))
 }

--- a/hscontrol/state/auth_cache_test.go
+++ b/hscontrol/state/auth_cache_test.go
@@ -45,7 +45,9 @@ func TestAuthCacheBoundedLRU(t *testing.T) {
 
 	// The eviction callback must have woken the parked AuthRequest.
 	select {
-	case verdict := <-entries[0].WaitForAuth():
+	case <-entries[0].WaitForAuth():
+		verdict, ok := entries[0].AuthResult()
+		require.True(t, ok, "evicted entry must retain its terminal verdict")
 		require.False(t, verdict.Accept(), "evicted entry must not signal Accept")
 		require.ErrorIs(t,
 			verdict.Err, ErrRegistrationExpired,

--- a/hscontrol/state/auth_cache_test.go
+++ b/hscontrol/state/auth_cache_test.go
@@ -180,3 +180,22 @@ func TestPendingAuthCacheExpirationFreesCapacity(t *testing.T) {
 		types.NewRegisterAuthRequest(&types.RegistrationData{}),
 	))
 }
+
+func TestPendingAuthCacheExpirationFinishesClaimedRequest(t *testing.T) {
+	const expiration = 20 * time.Millisecond
+
+	cache := newPendingAuthCache(1, expiration)
+	request := types.NewRegisterAuthRequest(&types.RegistrationData{})
+	require.True(t, cache.add(types.MustAuthID(), request))
+	require.True(t, request.TryBeginAuth())
+
+	select {
+	case <-request.WaitForAuth():
+		verdict, ok := request.AuthResult()
+		require.True(t, ok)
+		require.ErrorIs(t, verdict.Err, ErrRegistrationExpired)
+		require.False(t, request.FinishClaimedAuth(types.AuthVerdict{}))
+	case <-time.After(time.Second):
+		t.Fatal("expired claimed request was not completed")
+	}
+}

--- a/hscontrol/state/auth_tagged_expiry_test.go
+++ b/hscontrol/state/auth_tagged_expiry_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -845,6 +846,35 @@ func TestTaggedReauthPreservesOnlineAndLastSeen(t *testing.T) {
 	require.True(t, finalNode.IsOnline().Get(),
 		"re-auth must not reset online status (owned by the poll lifecycle)")
 	require.NotNil(t, finalNode.LastSeen().Get(), "LastSeen must be set on reauth")
+}
+
+func TestTaggedReauthPreservesLiveHostinfo(t *testing.T) {
+	n := seedTagOwnedNode(t, []string{"tag:foo"}, "")
+
+	owner := n.s.CreateUserForTest("owner")
+	_, err := n.s.SetPolicy(fmt.Appendf(nil, `{"tagOwners":{"tag:foo":["%s@"]}}`, owner.Name))
+	require.NoError(t, err)
+
+	route := netip.MustParsePrefix("10.23.0.0/16")
+	services := []tailcfg.Service{{Proto: tailcfg.TCP, Port: 443}}
+	_, ok := n.s.nodeStore.UpdateNode(n.id, func(node *types.Node) {
+		if node.Hostinfo == nil {
+			node.Hostinfo = &tailcfg.Hostinfo{}
+		}
+
+		node.Hostinfo.RoutableIPs = []netip.Prefix{route}
+		node.Hostinfo.Services = services
+	})
+	require.True(t, ok)
+
+	finalNode, err := n.reauth(t, owner, []string{"tag:foo"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, []netip.Prefix{route}, finalNode.Hostinfo().RoutableIPs().AsSlice())
+	require.Equal(t, services, finalNode.Hostinfo().Services().AsSlice())
+
+	reloaded := n.reopen(t)
+	require.Equal(t, []netip.Prefix{route}, reloaded.Hostinfo().RoutableIPs().AsSlice())
+	require.Equal(t, services, reloaded.Hostinfo().Services().AsSlice())
 }
 
 // TestIssue3371_TaggedNodeInteractiveReloginAfterLogout reproduces the

--- a/hscontrol/state/auth_tagged_expiry_test.go
+++ b/hscontrol/state/auth_tagged_expiry_test.go
@@ -992,49 +992,144 @@ func TestIssue3371_TaggedNodePastExpirySelfHealsOnReregister(t *testing.T) {
 	require.Equal(t, nodeID, healed.ID(), "must be the same node")
 }
 
-// TestIssue3371_ExpiredTaggedNodeSameSpentKeyNotRevalidated is the gating test
-// for the isExpired-gate exclusion (state.go: `&& !existingNodeSameUser.IsTagged()`).
-// A tagged node carrying a stale PAST expiry, re-registering with the SAME
-// single-use key and the SAME node key (no rotation), must take the
-// skip-validation fast path — otherwise the spent key is re-validated and
-// rejected with "authkey already used", the exact lockout #3371 fixes. Without
-// the tagged exclusion this fails; with it the node self-heals. The neighbours
-// all rotate the node key or use a reusable key, so validation runs regardless
-// and none probes this fast-path exclusion.
-func TestIssue3371_ExpiredTaggedNodeSameSpentKeyNotRevalidated(t *testing.T) {
+func TestExpiredTaggedNodeRejectsInvalidPriorKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		reusable   bool
+		invalidate func(*testing.T, *State, uint64)
+		wantError  string
+	}{
+		{
+			name:      "spent",
+			wantError: "authkey already used",
+		},
+		{
+			name:     "expired",
+			reusable: true,
+			invalidate: func(t *testing.T, s *State, pakID uint64) {
+				t.Helper()
+
+				past := time.Now().Add(-time.Hour)
+				require.NoError(t, s.db.DB.Model(&types.PreAuthKey{}).
+					Where("id = ?", pakID).
+					Update("expiration", past).Error)
+			},
+			wantError: "authkey expired",
+		},
+		{
+			name:     "revoked",
+			reusable: true,
+			invalidate: func(t *testing.T, s *State, pakID uint64) {
+				t.Helper()
+				require.NoError(t, s.RevokePreAuthKey(pakID))
+			},
+			wantError: "authkey revoked",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := newRetagTestState(t)
+
+			pak, err := s.CreatePreAuthKey(
+				nil,
+				test.reusable,
+				false,
+				nil,
+				[]string{"tag:foo"},
+			)
+			require.NoError(t, err)
+
+			machineKey := key.NewMachine()
+			regReq := tailcfg.RegisterRequest{
+				Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
+				NodeKey:  key.NewNode().Public(),
+				Hostinfo: &tailcfg.Hostinfo{Hostname: "expired-tagged"},
+			}
+			node, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+			require.NoError(t, err)
+
+			past := time.Now().Add(-time.Hour)
+			_, _, err = s.SetNodeExpiry(node.ID(), &past)
+			require.NoError(t, err)
+
+			if test.invalidate != nil {
+				test.invalidate(t, s, pak.ID)
+			}
+
+			_, _, err = s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+			require.ErrorContains(t, err, test.wantError)
+
+			unchanged, ok := s.GetNodeByID(node.ID())
+			require.True(t, ok)
+			require.True(t, unchanged.IsExpired())
+			require.Equal(t, past.Unix(), unchanged.Expiry().Get().Unix())
+		})
+	}
+}
+
+func TestExpiredTaggedNodeAcceptsFreshKey(t *testing.T) {
 	s := newRetagTestState(t)
 
-	// Single-use tagged key.
-	pak, err := s.CreatePreAuthKey(nil, false, false, nil, []string{"tag:foo"})
+	priorKey, err := s.CreatePreAuthKey(nil, false, false, nil, []string{"tag:foo"})
 	require.NoError(t, err)
 
 	machineKey := key.NewMachine()
-	nodeKey := key.NewNode()
 	regReq := tailcfg.RegisterRequest{
-		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: pak.Key},
-		NodeKey:  nodeKey.Public(),
-		Hostinfo: &tailcfg.Hostinfo{Hostname: "spent-tagged"},
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: priorKey.Key},
+		NodeKey:  key.NewNode().Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "fresh-key-tagged"},
 	}
 	node, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
 	require.NoError(t, err)
-	require.True(t, node.IsTagged())
 
-	// Stale past (logout) expiry, and the single-use key is now spent.
-	past := time.Now().Add(-1 * time.Hour)
-	_, ok := s.nodeStore.UpdateNode(node.ID(), func(n *types.Node) {
-		n.Expiry = &past
-	})
+	past := time.Now().Add(-time.Hour)
+	_, _, err = s.SetNodeExpiry(node.ID(), &past)
+	require.NoError(t, err)
+
+	freshKey, err := s.CreatePreAuthKey(nil, false, false, nil, []string{"tag:foo"})
+	require.NoError(t, err)
+
+	regReq.Auth.AuthKey = freshKey.Key
+
+	reauthenticated, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err)
+	require.Equal(t, node.ID(), reauthenticated.ID())
+	require.False(t, reauthenticated.IsExpired())
+	require.False(t, reauthenticated.Expiry().Valid())
+}
+
+func TestExpiredTaggedNodeRejectsUntaggedKey(t *testing.T) {
+	s := newRetagTestState(t)
+
+	taggedKey, err := s.CreatePreAuthKey(nil, false, false, nil, []string{"tag:foo"})
+	require.NoError(t, err)
+
+	machineKey := key.NewMachine()
+	regReq := tailcfg.RegisterRequest{
+		Auth:     &tailcfg.RegisterResponseAuth{AuthKey: taggedKey.Key},
+		NodeKey:  key.NewNode().Public(),
+		Hostinfo: &tailcfg.Hostinfo{Hostname: "untagged-key-rejected"},
+	}
+	node, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.NoError(t, err)
+
+	past := time.Now().Add(-time.Hour)
+	_, _, err = s.SetNodeExpiry(node.ID(), &past)
+	require.NoError(t, err)
+
+	user := s.CreateUserForTest("other-user")
+	untaggedKey, err := s.CreatePreAuthKey(user.TypedID(), true, false, nil, nil)
+	require.NoError(t, err)
+
+	regReq.Auth.AuthKey = untaggedKey.Key
+	_, _, err = s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
+	require.ErrorContains(t, err, "tagged node reauthentication requires tagged authkey")
+
+	unchanged, ok := s.GetNodeByID(node.ID())
 	require.True(t, ok)
-
-	// Re-register with the SAME key and the SAME node key (no rotation). The
-	// tagged exclusion from the isExpired gate must let this skip validation, so
-	// the spent single-use key is not rejected.
-	healed, _, err := s.HandleNodeFromPreAuthKey(regReq, machineKey.Public())
-	require.NoError(t, err,
-		"a tagged node with a stale past expiry must skip re-validation of its spent key")
-	require.False(t, healed.IsExpired(), "stale expiry cleared")
-	require.Nil(t, healed.AsStruct().Expiry, "tagged node key-expiry disabled")
-	require.Equal(t, node.ID(), healed.ID())
+	require.True(t, unchanged.IsExpired())
+	require.Equal(t, []string{"tag:foo"}, unchanged.Tags().AsSlice())
 }
 
 // TestTaggedPAKReauthRetagsExistingTaggedNode reproduces issue #3370: an

--- a/hscontrol/state/auth_tagged_expiry_test.go
+++ b/hscontrol/state/auth_tagged_expiry_test.go
@@ -77,7 +77,7 @@ func TestTaggedReauthKeepsNilExpiry(t *testing.T) {
 	}
 
 	authID := types.MustAuthID()
-	s.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(regData))
+	require.NoError(t, s.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(regData)))
 
 	finalNode, _, err := s.HandleNodeFromAuthPath(
 		authID,
@@ -403,7 +403,7 @@ func TestAuthPathRejectsTaggedAndUserCoexistence(t *testing.T) {
 		Hostinfo:   &tailcfg.Hostinfo{Hostname: "multi"},
 	}
 	authID := types.MustAuthID()
-	s.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(regData))
+	require.NoError(t, s.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(regData)))
 
 	_, _, err = s.HandleNodeFromAuthPath(authID, types.UserID(u3.ID), nil, util.RegisterMethodOIDC)
 	require.ErrorIs(t, err, ErrAmbiguousNodeOwnership)
@@ -514,7 +514,7 @@ func (n seededTaggedNode) reauth(t *testing.T, authUser *types.User, requestTags
 	rd.Expiry = clientExpiry
 
 	authID := types.MustAuthID()
-	n.s.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(&rd))
+	require.NoError(t, n.s.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(&rd)))
 
 	node, _, err := n.s.HandleNodeFromAuthPath(
 		authID,
@@ -944,7 +944,7 @@ func TestIssue3371_TaggedNodeInteractiveReloginAfterLogout(t *testing.T) {
 		},
 	}
 	authID := types.MustAuthID()
-	s.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(regData))
+	require.NoError(t, s.SetAuthCacheEntry(authID, types.NewRegisterAuthRequest(regData)))
 
 	relogged, _, err := s.HandleNodeFromAuthPath(
 		authID, types.UserID(user.ID), nil, util.RegisterMethodOIDC,

--- a/hscontrol/state/debug.go
+++ b/hscontrol/state/debug.go
@@ -179,11 +179,13 @@ func (s *State) DebugSSHPolicies() map[string]*tailcfg.SSHPolicy {
 // DebugRegistrationCache returns debug information about the registration cache.
 func (s *State) DebugRegistrationCache() map[string]any {
 	return map[string]any{
-		"type":        "expirable-lru",
-		"expiration":  registerCacheExpiration.String(),
-		"max_entries": defaultRegisterCacheMaxEntries,
-		"current_len": s.authCache.Len(),
-		"status":      "active",
+		"type":                     "expirable-lru",
+		"expiration":               s.registrationAuthCache.expiration.String(),
+		"registration_max_entries": s.registrationAuthCache.maxEntries,
+		"registration_current_len": s.registrationAuthCache.entries.Len(),
+		"ssh_check_max_entries":    s.sshCheckAuthCache.maxEntries,
+		"ssh_check_current_len":    s.sshCheckAuthCache.entries.Len(),
+		"status":                   "active",
 	}
 }
 

--- a/hscontrol/state/persist_test.go
+++ b/hscontrol/state/persist_test.go
@@ -646,6 +646,27 @@ func TestConcurrentPreAuthKeyRegistrationSameMachineKey(t *testing.T) {
 
 	require.Equal(t, 1, s.ListNodes().Len(),
 		"concurrent registrations of one machine key must yield a single node")
+	require.Zero(t, s.registerLocks.Size(),
+		"registration lock entry must be released after the final caller")
+}
+
+func TestInvalidPreAuthKeyRegistrationsReleaseMachineLocks(t *testing.T) {
+	dbPath := t.TempDir() + "/headscale.db"
+	cfg := persistTestConfig(dbPath)
+
+	s, err := NewState(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	for range 128 {
+		_, _, err := s.HandleNodeFromPreAuthKey(tailcfg.RegisterRequest{
+			Auth: &tailcfg.RegisterResponseAuth{AuthKey: "invalid-auth-key"},
+		}, key.NewMachine().Public())
+		require.Error(t, err)
+	}
+
+	require.Zero(t, s.registerLocks.Size(),
+		"failed registrations must not retain per-machine lock entries")
 }
 
 // TestUpdatePolicyManagerUsersUnchangedKeepsSnapshot ensures re-sending the

--- a/hscontrol/state/ssh_check_test.go
+++ b/hscontrol/state/ssh_check_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/juanfont/headscale/hscontrol/db"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,6 +15,25 @@ func newTestStateForSSHCheck() *State {
 	return &State{
 		sshCheckAuth: make(map[sshCheckPair]time.Time),
 	}
+}
+
+func newSSHPolicyTestState(t *testing.T) (*State, types.NodeID, types.NodeID) {
+	t.Helper()
+
+	dbPath := t.TempDir() + "/headscale.db"
+	database, err := db.NewHeadscaleDatabase(persistTestConfig(dbPath))
+	require.NoError(t, err)
+
+	user := database.CreateUserForTest("ssh-source")
+	src := database.CreateRegisteredNodeForTest(user, "ssh-source-node")
+	dst := database.CreateRegisteredNodeForTest(user, "ssh-destination-node")
+	require.NoError(t, database.Close())
+
+	s, err := NewState(persistTestConfig(dbPath))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+
+	return s, src.ID, dst.ID
 }
 
 func TestSSHCheckAuth(t *testing.T) {
@@ -94,4 +114,77 @@ func TestSSHCheckAuthConcurrent(t *testing.T) {
 	})
 
 	wg.Wait()
+}
+
+func TestCompleteSSHCheckUsesCurrentPolicy(t *testing.T) {
+	s, src, dst := newSSHPolicyTestState(t)
+
+	checkRoot := []byte(`{
+		"ssh": [{
+			"action": "check",
+			"checkPeriod": "2h",
+			"src": ["ssh-source@"],
+			"dst": ["autogroup:self"],
+			"users": ["root"]
+		}]
+	}`)
+	acceptRoot := []byte(`{
+		"ssh": [{
+			"action": "accept",
+			"src": ["ssh-source@"],
+			"dst": ["autogroup:self"],
+			"users": ["root"]
+		}]
+	}`)
+	checkUbuntu := []byte(`{
+		"ssh": [{
+			"action": "check",
+			"src": ["ssh-source@"],
+			"dst": ["autogroup:self"],
+			"users": ["ubuntu"]
+		}]
+	}`)
+
+	_, err := s.SetPolicy(checkRoot)
+	require.NoError(t, err)
+
+	evaluation := s.EvaluateSSHAccess(src, dst, "root")
+	require.Equal(t, SSHAccessCheck, evaluation.Action)
+	assert.Equal(t, SSHAccessAccept, s.CompleteSSHCheck(
+		src, dst, "root", evaluation.PolicyGeneration,
+	))
+	_, ok := s.GetLastSSHAuth(src, dst)
+	assert.True(t, ok, "unchanged check policy must record reusable approval")
+
+	evaluation = s.EvaluateSSHAccess(src, dst, "root")
+	require.Equal(t, SSHAccessAccept, evaluation.Action,
+		"recorded approval should satisfy the current check period")
+
+	_, err = s.SetPolicy(checkRoot)
+	require.NoError(t, err)
+
+	evaluation = s.EvaluateSSHAccess(src, dst, "root")
+	require.Equal(t, SSHAccessCheck, evaluation.Action)
+
+	_, err = s.SetPolicy(acceptRoot)
+	require.NoError(t, err)
+	assert.Equal(t, SSHAccessAccept, s.CompleteSSHCheck(
+		src, dst, "root", evaluation.PolicyGeneration,
+	), "a current direct-accept rule must not be rejected")
+	_, ok = s.GetLastSSHAuth(src, dst)
+	assert.False(t, ok, "direct accept must not create a reusable check approval")
+
+	_, err = s.SetPolicy(checkRoot)
+	require.NoError(t, err)
+
+	evaluation = s.EvaluateSSHAccess(src, dst, "root")
+	require.Equal(t, SSHAccessCheck, evaluation.Action)
+
+	_, err = s.SetPolicy(checkUbuntu)
+	require.NoError(t, err)
+	assert.Equal(t, SSHAccessReject, s.CompleteSSHCheck(
+		src, dst, "root", evaluation.PolicyGeneration,
+	), "approval for a removed local-user rule must be rejected")
+	_, ok = s.GetLastSSHAuth(src, dst)
+	assert.False(t, ok, "stale approval must not be recorded")
 }

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -1726,6 +1726,7 @@ type authNodeUpdateParams struct {
 // applyAuthNodeUpdate applies common update logic for re-authenticating or converting
 // an existing node. It updates the node in [NodeStore], processes RequestTags, and
 // persists changes to the database.
+//nolint:gocyclo // validation and mutation stages must remain in a fixed order
 func (s *State) applyAuthNodeUpdate(params authNodeUpdateParams) (types.NodeView, error) {
 	regData := params.RegData
 	// Log the operation type
@@ -1791,8 +1792,20 @@ func (s *State) applyAuthNodeUpdate(params authNodeUpdateParams) (types.NodeView
 		node.DiscoKey = regData.DiscoKey
 		node.Hostname = params.Hostname
 
-		// Preserve NetInfo from existing node when re-registering
-		node.Hostinfo = params.ValidHostinfo
+		// Registration retains only the identity fields needed during auth.
+		// Overlay those fields on the live Hostinfo so re-authentication does
+		// not temporarily withdraw routes, services, or other map state.
+		node.Hostinfo = params.ExistingNode.Hostinfo().AsStruct()
+		if node.Hostinfo == nil {
+			node.Hostinfo = &tailcfg.Hostinfo{}
+		}
+
+		node.Hostinfo.Hostname = params.ValidHostinfo.Hostname
+		node.Hostinfo.OS = params.ValidHostinfo.OS
+		node.Hostinfo.IPNVersion = params.ValidHostinfo.IPNVersion
+		node.Hostinfo.OSVersion = params.ValidHostinfo.OSVersion
+		node.Hostinfo.DeviceModel = params.ValidHostinfo.DeviceModel
+		node.Hostinfo.RequestTags = slices.Clone(params.ValidHostinfo.RequestTags)
 		node.Hostinfo.NetInfo = preserveNetInfo(
 			params.ExistingNode,
 			params.ExistingNode.ID(),

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -50,11 +50,15 @@ const (
 	registerCacheExpiration = time.Minute * 15
 
 	// defaultRegisterCacheMaxEntries is the default upper bound on the number
-	// of pending registration entries the auth cache will hold. With a 15-minute
+	// of pending registration entries the registration cache will hold. With a 15-minute
 	// TTL and a stripped-down RegistrationData payload (~200 bytes per entry),
 	// 1024 entries cap the worst-case cache footprint at well under 1 MiB even
 	// under sustained unauthenticated cache-fill attempts.
 	defaultRegisterCacheMaxEntries = 1024
+
+	// defaultSSHCheckCacheMaxEntries bounds pending SSH check sessions
+	// independently from node registrations.
+	defaultSSHCheckCacheMaxEntries = 1024
 
 	// defaultNodeStoreBatchSize is the default number of write operations to batch
 	// before rebuilding the in-memory node snapshot.
@@ -116,7 +120,15 @@ var nodeUpdateColumns = []string{
 // ErrRegistrationExpired is returned when a registration has expired.
 var ErrRegistrationExpired = errors.New("registration expired")
 
+// ErrPendingAuthCapacity is returned when a pending authentication pool is full.
+var ErrPendingAuthCapacity = errors.New("pending authentication capacity reached")
+
 var errAuthRequestNotRegistration = errors.New("auth request is not a registration")
+
+var errAuthRequestTypeInvalid = errors.New("auth request has no supported payload")
+
+// ErrAuthRequestIDInUse is returned when an authentication request ID is active.
+var ErrAuthRequestIDInUse = errors.New("authentication request ID already in use")
 
 // ErrNodeKeyInUse is returned when a registration or re-auth claims a NodeKey
 // already bound to a different machine, enforcing the 1:1 NodeKey<->MachineKey
@@ -135,6 +147,68 @@ var ErrAmbiguousNodeOwnership = errors.New("machine key maps to ambiguous node o
 type sshCheckPair struct {
 	Src types.NodeID
 	Dst types.NodeID
+}
+
+// pendingAuthCache retains live requests until completion or expiration. The
+// underlying TTL cache is intentionally unlimited: admission rejects new keys
+// at the configured limit so live sessions are never displaced by size.
+type pendingAuthCache struct {
+	entries    *expirable.LRU[types.AuthID, *types.AuthRequest]
+	maxEntries int
+	expiration time.Duration
+	admitMu    sync.Mutex
+}
+
+func newPendingAuthCache(maxEntries int, expiration time.Duration) *pendingAuthCache {
+	return &pendingAuthCache{
+		entries: expirable.NewLRU[types.AuthID, *types.AuthRequest](
+			0,
+			func(_ types.AuthID, request *types.AuthRequest) {
+				request.FinishAuth(types.AuthVerdict{Err: ErrRegistrationExpired})
+			},
+			expiration,
+		),
+		maxEntries: maxEntries,
+		expiration: expiration,
+	}
+}
+
+func (c *pendingAuthCache) add(id types.AuthID, request *types.AuthRequest) bool {
+	c.admitMu.Lock()
+	defer c.admitMu.Unlock()
+
+	if _, ok := c.entries.Peek(id); ok {
+		return false
+	}
+
+	if c.entries.Len() >= c.maxEntries {
+		if !c.removeOldestCompleted() {
+			return false
+		}
+	}
+
+	c.entries.Add(id, request)
+
+	return true
+}
+
+func (c *pendingAuthCache) removeOldestCompleted() bool {
+	for _, id := range c.entries.Keys() {
+		request, ok := c.entries.Peek(id)
+		if !ok {
+			c.entries.Remove(id)
+
+			return c.entries.Len() < c.maxEntries
+		}
+
+		if _, complete := request.AuthResult(); complete {
+			c.entries.Remove(id)
+
+			return c.entries.Len() < c.maxEntries
+		}
+	}
+
+	return false
 }
 
 // State manages Headscale's core state, coordinating between database, policy management,
@@ -159,12 +233,11 @@ type State struct {
 	// polMan handles policy evaluation and management
 	polMan policy.PolicyManager
 
-	// authCache holds any pending authentication requests from either auth
-	// type (Web and OIDC). It is a bounded LRU keyed by AuthID; oldest
-	// entries are evicted once the size cap is reached, and entries that
-	// time out have their auth verdict resolved with ErrRegistrationExpired
-	// via the eviction callback so any waiting goroutines wake.
-	authCache *expirable.LRU[types.AuthID, *types.AuthRequest]
+	// Pending node registrations and SSH checks have independent admission
+	// pools so one request class cannot consume the other's capacity.
+	registrationAuthCache *pendingAuthCache
+	sshCheckAuthCache     *pendingAuthCache
+	authAdmissionMu       sync.Mutex
 
 	// pings tracks pending ping requests and their response channels.
 	pings *pingTracker
@@ -220,13 +293,8 @@ func NewState(cfg *types.Config) (*State, error) {
 		cacheMaxEntries = cfg.Tuning.RegisterCacheMaxEntries
 	}
 
-	authCache := expirable.NewLRU[types.AuthID, *types.AuthRequest](
-		cacheMaxEntries,
-		func(id types.AuthID, rn *types.AuthRequest) {
-			rn.FinishAuth(types.AuthVerdict{Err: ErrRegistrationExpired})
-		},
-		cacheExpiration,
-	)
+	registrationAuthCache := newPendingAuthCache(cacheMaxEntries, cacheExpiration)
+	sshCheckAuthCache := newPendingAuthCache(defaultSSHCheckCacheMaxEntries, cacheExpiration)
 
 	db, err := hsdb.NewHeadscaleDatabase(cfg)
 	if err != nil {
@@ -285,12 +353,13 @@ func NewState(cfg *types.Config) (*State, error) {
 	s := &State{
 		cfg: cfg,
 
-		db:        db,
-		ipAlloc:   ipAlloc,
-		polMan:    polMan,
-		authCache: authCache,
-		nodeStore: nodeStore,
-		pings:     newPingTracker(),
+		db:                    db,
+		ipAlloc:               ipAlloc,
+		polMan:                polMan,
+		registrationAuthCache: registrationAuthCache,
+		sshCheckAuthCache:     sshCheckAuthCache,
+		nodeStore:             nodeStore,
+		pings:                 newPingTracker(),
 
 		sshCheckAuth:  make(map[sshCheckPair]time.Time),
 		registerLocks: xsync.NewMap[key.MachinePublic, *sync.Mutex](),
@@ -1628,20 +1697,52 @@ func (s *State) DeleteExpiredAccessTokens(cutoff time.Time) (int64, error) {
 
 // GetAuthCacheEntry retrieves a pending auth request from the cache.
 func (s *State) GetAuthCacheEntry(id types.AuthID) (*types.AuthRequest, bool) {
-	return s.authCache.Get(id)
+	if request, ok := s.registrationAuthCache.entries.Get(id); ok {
+		return request, true
+	}
+
+	return s.sshCheckAuthCache.entries.Get(id)
 }
 
-// SetAuthCacheEntry stores a pending auth request in the cache.
-func (s *State) SetAuthCacheEntry(id types.AuthID, entry *types.AuthRequest) {
-	s.authCache.Add(id, entry)
+// SetAuthCacheEntry stores a pending auth request when its request-class pool
+// has capacity. Existing entries are preserved when the pool is full.
+func (s *State) SetAuthCacheEntry(id types.AuthID, entry *types.AuthRequest) error {
+	s.authAdmissionMu.Lock()
+	defer s.authAdmissionMu.Unlock()
+
+	if _, ok := s.registrationAuthCache.entries.Peek(id); ok {
+		return ErrAuthRequestIDInUse
+	}
+
+	if _, ok := s.sshCheckAuthCache.entries.Peek(id); ok {
+		return ErrAuthRequestIDInUse
+	}
+
+	var cache *pendingAuthCache
+
+	switch {
+	case entry != nil && entry.IsRegistration():
+		cache = s.registrationAuthCache
+	case entry != nil:
+		cache = s.sshCheckAuthCache
+	default:
+		return errAuthRequestTypeInvalid
+	}
+
+	if !cache.add(id, entry) {
+		return ErrPendingAuthCapacity
+	}
+
+	return nil
 }
 
 // DeleteAuthCacheEntryForTest drops a pending auth request from the cache,
 // exposed for testing so a test can reproduce a session that was lost
-// (expired, evicted, or dropped on a control-plane restart) without faking an
+// (expired or dropped on a control-plane restart) without faking an
 // auth_id.
 func (s *State) DeleteAuthCacheEntryForTest(id types.AuthID) {
-	s.authCache.Remove(id)
+	s.registrationAuthCache.entries.Remove(id)
+	s.sshCheckAuthCache.entries.Remove(id)
 }
 
 // SetLastSSHAuth records a successful SSH check authentication
@@ -1726,6 +1827,7 @@ type authNodeUpdateParams struct {
 // applyAuthNodeUpdate applies common update logic for re-authenticating or converting
 // an existing node. It updates the node in [NodeStore], processes RequestTags, and
 // persists changes to the database.
+//
 //nolint:gocyclo // validation and mutation stages must remain in a fixed order
 func (s *State) applyAuthNodeUpdate(params authNodeUpdateParams) (types.NodeView, error) {
 	regData := params.RegData
@@ -2396,7 +2498,7 @@ func (s *State) HandleNodeFromAuthPath(
 	regEntry.FinishAuth(types.AuthVerdict{Node: finalNode})
 
 	// Remove from registration cache
-	s.authCache.Remove(authID)
+	s.registrationAuthCache.entries.Remove(authID)
 
 	// Update policy managers
 	usersChange, err := s.updatePolicyManagerUsers()

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -2549,14 +2549,17 @@ func (s *State) HandleNodeFromPreAuthKey(
 	// after expiry would skip validation and be re-authorised with a spent or
 	// expired key; the boundary must not depend on the client rotating its key.
 	//
-	// Tagged nodes are excluded: they never expire (KB 1068), so an
-	// IsExpired() tagged node only reflects a stale logout stamp left by an
-	// older headscale (#3371). Forcing it down the re-validation path burns its
-	// fresh key and blocks re-auth forever; treat it as a plain re-registration
-	// and clear the stale expiry in the update below.
+	// This includes tagged nodes. Legacy logout stamps were cleared by a
+	// migration and current versions do not create them, while administrators
+	// can deliberately expire a tagged node. Reactivating one must therefore
+	// require a currently valid credential.
 	isExpired := existsSameUser && existingNodeSameUser.Valid() &&
-		!existingNodeSameUser.IsTagged() &&
 		existingNodeSameUser.IsExpired()
+	if isExpired && existingNodeSameUser.IsTagged() && !pak.IsTagged() {
+		return types.NodeView{}, change.Change{}, types.PAKError(
+			"tagged node reauthentication requires tagged authkey",
+		)
+	}
 
 	// A tagged key presented for a currently user-owned node converts that node
 	// to tagged. That is an ownership change, not a plain refresh, so it must
@@ -2689,12 +2692,10 @@ func (s *State) HandleNodeFromPreAuthKey(
 				node.User = nil
 
 				// Converting a user-owned node to tagged drops the user's key
-				// expiry (tagged nodes never expire). But retagging an
-				// already-tagged node must preserve a deliberate FUTURE expiry
-				// set via `headscale nodes expire` - that is a node property, not
-				// tied to the auth key - and only clear a stale PAST expiry. This
-				// keeps the retag path symmetric with the same-key relogin path
-				// (#3371) rather than silently overriding an admin decision.
+				// expiry (tagged nodes never expire). Retagging an
+				// already-tagged node preserves a FUTURE expiry set via
+				// `headscale nodes expire`; a valid reauthentication clears an
+				// expiry that has already taken effect.
 				if wasUserOwned || node.IsExpired() {
 					node.Expiry = nil
 				}
@@ -2724,11 +2725,9 @@ func (s *State) HandleNodeFromPreAuthKey(
 					node.Expiry = nil
 				}
 			} else if node.IsExpired() {
-				// #3371: a tagged node must never carry key expiry. Clear a
-				// stale PAST expiry left by a logout (older headscale) so
-				// re-auth is not permanently blocked. A deliberate future
-				// expiry (headscale nodes expire) has IsExpired() == false and
-				// is left untouched.
+				// Validation above established a currently valid credential.
+				// Successful reauthentication disables expiry for the tagged
+				// node; a future administrative expiry remains untouched.
 				node.Expiry = nil
 			}
 		})

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -149,6 +149,22 @@ type sshCheckPair struct {
 	Dst types.NodeID
 }
 
+// SSHAccessAction is the current server-side decision for an SSH connection.
+type SSHAccessAction uint8
+
+const (
+	SSHAccessReject SSHAccessAction = iota
+	SSHAccessAccept
+	SSHAccessCheck
+)
+
+// SSHAccessEvaluation captures the action and policy generation observed
+// together. Generation is meaningful only for SSHAccessCheck.
+type SSHAccessEvaluation struct {
+	Action           SSHAccessAction
+	PolicyGeneration uint64
+}
+
 // pendingAuthCache retains live requests until completion or expiration. The
 // underlying TTL cache is intentionally unlimited: admission rejects new keys
 // at the configured limit so live sessions are never displaced by size.
@@ -260,6 +276,10 @@ type State struct {
 	// Ref: https://github.com/tailscale/tailscale/issues/7125
 	sshCheckAuth map[sshCheckPair]time.Time
 	sshCheckMu   sync.RWMutex
+	// sshPolicyGeneration advances whenever policy inputs affecting SSH
+	// authorization change. Policy mutation and check completion both hold
+	// sshCheckMu so an approval cannot cross the mutation boundary.
+	sshPolicyGeneration uint64
 
 	// persistMu serialises node-row persistence and deletion so the database
 	// always converges on [NodeStore] rather than being clobbered by a stale
@@ -440,14 +460,19 @@ func (s *State) ReloadPolicy() ([]change.Change, error) {
 		return nil, fmt.Errorf("loading policy: %w", err)
 	}
 
+	s.sshCheckMu.Lock()
+
 	policyChanged, err := s.polMan.SetPolicy(pol)
 	if err != nil {
+		s.sshCheckMu.Unlock()
+
 		return nil, fmt.Errorf("setting policy: %w", err)
 	}
 
 	// Clear SSH check auth times when policy changes to ensure stale
 	// approvals don't persist if checkPeriod rules are modified or removed.
-	s.ClearSSHCheckAuth()
+	s.advanceSSHPolicyGenerationLocked()
+	s.sshCheckMu.Unlock()
 
 	// Rebuild peer maps after policy changes because the peersFunc in [NodeStore]
 	// uses the [policy.PolicyManager]'s filters. Without this, nodes won't see
@@ -1289,13 +1314,16 @@ func (s *State) NodeCanHaveTag(node types.NodeView, tag string) bool {
 
 // SetPolicy updates the policy configuration.
 func (s *State) SetPolicy(pol []byte) (bool, error) {
+	s.sshCheckMu.Lock()
+	defer s.sshCheckMu.Unlock()
+
 	changed, err := s.polMan.SetPolicy(pol)
 	if err != nil {
 		return changed, err
 	}
 
 	// Clear SSH check auth times when policy changes.
-	s.ClearSSHCheckAuth()
+	s.advanceSSHPolicyGenerationLocked()
 
 	// Payload-only writes reuse the cached adjacency, so a policy swap
 	// must rebuild it here rather than wait for the next relation write.
@@ -1807,7 +1835,70 @@ func (s *State) ClearSSHCheckAuth() {
 	s.sshCheckMu.Lock()
 	defer s.sshCheckMu.Unlock()
 
+	s.clearSSHCheckAuthLocked()
+}
+
+func (s *State) clearSSHCheckAuthLocked() {
 	s.sshCheckAuth = make(map[sshCheckPair]time.Time)
+}
+
+func (s *State) advanceSSHPolicyGenerationLocked() {
+	s.sshPolicyGeneration++
+	s.clearSSHCheckAuthLocked()
+}
+
+// EvaluateSSHAccess resolves the current SSH action and applies any reusable
+// check approval while holding the same lock used by policy mutation.
+func (s *State) EvaluateSSHAccess(
+	src, dst types.NodeID,
+	localUser string,
+) SSHAccessEvaluation {
+	s.sshCheckMu.RLock()
+	defer s.sshCheckMu.RUnlock()
+
+	period, check, accept := s.polMan.SSHAccessParams(src, dst, localUser)
+	if check {
+		if period > 0 {
+			if last, ok := s.sshCheckAuth[sshCheckPair{Src: src, Dst: dst}]; ok && time.Since(last) < period {
+				return SSHAccessEvaluation{Action: SSHAccessAccept}
+			}
+		}
+
+		return SSHAccessEvaluation{
+			Action:           SSHAccessCheck,
+			PolicyGeneration: s.sshPolicyGeneration,
+		}
+	}
+
+	if accept {
+		return SSHAccessEvaluation{Action: SSHAccessAccept}
+	}
+
+	return SSHAccessEvaluation{Action: SSHAccessReject}
+}
+
+// CompleteSSHCheck revalidates a successful interactive verdict against the
+// current policy. An unchanged check records a reusable approval; a direct
+// accept needs no record; any other result is rejected.
+func (s *State) CompleteSSHCheck(
+	src, dst types.NodeID,
+	localUser string,
+	policyGeneration uint64,
+) SSHAccessAction {
+	s.sshCheckMu.Lock()
+	defer s.sshCheckMu.Unlock()
+
+	_, check, accept := s.polMan.SSHAccessParams(src, dst, localUser)
+	switch {
+	case accept:
+		return SSHAccessAccept
+	case !check || policyGeneration != s.sshPolicyGeneration:
+		return SSHAccessReject
+	default:
+		s.sshCheckAuth[sshCheckPair{Src: src, Dst: dst}] = time.Now()
+
+		return SSHAccessAccept
+	}
 }
 
 // preserveNetInfo preserves NetInfo from an existing node for faster DERP connectivity.
@@ -3077,10 +3168,19 @@ func (s *State) updatePolicyManagerUsers() (change.Change, error) {
 
 	log.Debug().Caller().Int("user.count", len(users)).Msg("policy manager user update initiated because user list modification detected")
 
+	s.sshCheckMu.Lock()
+
 	changed, peerMapChanged, err := s.polMan.SetUsers(users)
 	if err != nil {
+		s.sshCheckMu.Unlock()
+
 		return change.Change{}, fmt.Errorf("updating policy manager users: %w", err)
 	}
+
+	if changed {
+		s.advanceSSHPolicyGenerationLocked()
+	}
+	s.sshCheckMu.Unlock()
 
 	log.Debug().Caller().Bool("policy.changed", changed).Msg("policy manager user update completed because SetUsers operation finished")
 
@@ -3115,10 +3215,19 @@ func (s *State) UpdatePolicyManagerUsersForTest() error {
 func (s *State) updatePolicyManagerNodes() (change.Change, error) {
 	nodes := s.ListNodes()
 
+	s.sshCheckMu.Lock()
+
 	changed, err := s.polMan.SetNodes(nodes)
 	if err != nil {
+		s.sshCheckMu.Unlock()
+
 		return change.Change{}, fmt.Errorf("updating policy manager nodes: %w", err)
 	}
+
+	if changed {
+		s.advanceSSHPolicyGenerationLocked()
+	}
+	s.sshCheckMu.Unlock()
 
 	if changed {
 		// Rebuild peer maps because policy-affecting node changes (tags, user, IPs)

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -116,6 +116,8 @@ var nodeUpdateColumns = []string{
 // ErrRegistrationExpired is returned when a registration has expired.
 var ErrRegistrationExpired = errors.New("registration expired")
 
+var errAuthRequestNotRegistration = errors.New("auth request is not a registration")
+
 // ErrNodeKeyInUse is returned when a registration or re-auth claims a NodeKey
 // already bound to a different machine, enforcing the 1:1 NodeKey<->MachineKey
 // binding.
@@ -2251,6 +2253,10 @@ func (s *State) HandleNodeFromAuthPath(
 	regEntry, ok := s.GetAuthCacheEntry(authID)
 	if !ok {
 		return types.NodeView{}, change.Change{}, hsdb.ErrNodeNotFoundRegistrationCache
+	}
+
+	if !regEntry.IsRegistration() {
+		return types.NodeView{}, change.Change{}, errAuthRequestNotRegistration
 	}
 
 	// Get the user

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -269,18 +269,54 @@ type State struct {
 	// registerLocks serialises registration per machine key so concurrent
 	// registrations of the same machine resolve to a single node instead of
 	// racing the find-then-create section and each creating their own.
-	// ponytail: entries are never pruned; bounded by distinct machine keys
-	// seen, add cleanup on node delete only if it ever matters.
-	registerLocks *xsync.Map[key.MachinePublic, *sync.Mutex]
+	registerLocks *xsync.Map[key.MachinePublic, *registrationLock]
+}
+
+type registrationLock struct {
+	mu sync.Mutex
+
+	// references counts callers holding or waiting for mu. It is updated only
+	// from registerLocks.Compute callbacks.
+	references int
 }
 
 // lockRegistration serialises registration for a single machine key and
-// returns the unlock function.
+// returns a release function. Per-machine entries exist only while callers are
+// holding or waiting for the lock.
 func (s *State) lockRegistration(machineKey key.MachinePublic) func() {
-	mu, _ := s.registerLocks.LoadOrStore(machineKey, &sync.Mutex{})
-	mu.Lock()
+	entry, _ := s.registerLocks.Compute(
+		machineKey,
+		func(current *registrationLock, loaded bool) (*registrationLock, xsync.ComputeOp) {
+			if !loaded {
+				current = &registrationLock{}
+			}
 
-	return mu.Unlock
+			current.references++
+
+			return current, xsync.UpdateOp
+		},
+	)
+	entry.mu.Lock()
+
+	return func() {
+		entry.mu.Unlock()
+
+		s.registerLocks.Compute(
+			machineKey,
+			func(current *registrationLock, loaded bool) (*registrationLock, xsync.ComputeOp) {
+				if !loaded {
+					return current, xsync.CancelOp
+				}
+
+				current.references--
+				if current.references == 0 {
+					return nil, xsync.DeleteOp
+				}
+
+				return current, xsync.UpdateOp
+			},
+		)
+	}
 }
 
 // NewState creates and initializes a new [State] instance, setting up the database,
@@ -362,7 +398,7 @@ func NewState(cfg *types.Config) (*State, error) {
 		pings:                 newPingTracker(),
 
 		sshCheckAuth:  make(map[sshCheckPair]time.Time),
-		registerLocks: xsync.NewMap[key.MachinePublic, *sync.Mutex](),
+		registerLocks: xsync.NewMap[key.MachinePublic, *registrationLock](),
 	}
 
 	// Surface nodes whose stored data would break map generation (e.g. an

--- a/hscontrol/state/state.go
+++ b/hscontrol/state/state.go
@@ -2410,6 +2410,17 @@ func (s *State) HandleNodeFromAuthPath(
 		return types.NodeView{}, change.Change{}, errAuthRequestNotRegistration
 	}
 
+	if !regEntry.TryBeginAuth() {
+		return types.NodeView{}, change.Change{}, hsdb.ErrNodeNotFoundRegistrationCache
+	}
+
+	authFinished := false
+	defer func() {
+		if !authFinished {
+			regEntry.AbortAuth()
+		}
+	}()
+
 	// Get the user
 	user, err := s.db.GetUserByID(userID)
 	if err != nil {
@@ -2531,7 +2542,11 @@ func (s *State) HandleNodeFromAuthPath(
 	}
 
 	// Signal to waiting clients
-	regEntry.FinishAuth(types.AuthVerdict{Node: finalNode})
+	if !regEntry.FinishClaimedAuth(types.AuthVerdict{Node: finalNode}) {
+		return types.NodeView{}, change.Change{}, hsdb.ErrNodeNotFoundRegistrationCache
+	}
+
+	authFinished = true
 
 	// Remove from registration cache
 	s.registrationAuthCache.entries.Remove(authID)

--- a/hscontrol/types/common.go
+++ b/hscontrol/types/common.go
@@ -110,11 +110,11 @@ type PendingRegistrationConfirmation struct {
 // AuthRequest represents a pending authentication request from a user or a
 // node. It carries the minimum data needed to either complete a node
 // registration (regData populated) or an SSH check-mode auth (sshBinding
-// populated), and signals the verdict via the finished channel. The closed
-// flag guards [AuthRequest.FinishAuth] against double-close.
+// populated), and signals completion by closing done. The terminal verdict is
+// stored separately so every waiter observes the same result.
 //
-// [AuthRequest] is always handled by pointer so the channel and atomic flag
-// have a single canonical instance even when stored in caches that
+// [AuthRequest] is always handled by pointer so the completion signal and
+// terminal verdict have a single canonical instance even when stored in caches that
 // internally copy values.
 type AuthRequest struct {
 	// regData is populated for node-registration flows (interactive web
@@ -141,16 +141,15 @@ type AuthRequest struct {
 	// finalise the registration without re-running the OIDC flow.
 	pendingConfirmation *PendingRegistrationConfirmation
 
-	finished chan AuthVerdict
-	closed   *atomic.Bool
+	done    chan struct{}
+	verdict atomic.Pointer[AuthVerdict]
 }
 
 // NewAuthRequest creates a pending auth request with no payload, suitable
 // for non-registration flows that only need a verdict channel.
 func NewAuthRequest() *AuthRequest {
 	return &AuthRequest{
-		finished: make(chan AuthVerdict, 1),
-		closed:   &atomic.Bool{},
+		done: make(chan struct{}),
 	}
 }
 
@@ -159,9 +158,8 @@ func NewAuthRequest() *AuthRequest {
 // stored by pointer; callers must not mutate it after handing it off.
 func NewRegisterAuthRequest(data *RegistrationData) *AuthRequest {
 	return &AuthRequest{
-		regData:  data,
-		finished: make(chan AuthVerdict, 1),
-		closed:   &atomic.Bool{},
+		regData: data,
+		done:    make(chan struct{}),
 	}
 }
 
@@ -175,8 +173,7 @@ func NewSSHCheckAuthRequest(src, dst NodeID) *AuthRequest {
 			SrcNodeID: src,
 			DstNodeID: dst,
 		},
-		finished: make(chan AuthVerdict, 1),
-		closed:   &atomic.Bool{},
+		done: make(chan struct{}),
 	}
 }
 
@@ -232,17 +229,27 @@ func (rn *AuthRequest) PendingConfirmation() *PendingRegistrationConfirmation {
 }
 
 func (rn *AuthRequest) FinishAuth(verdict AuthVerdict) {
-	if rn.closed.Swap(true) {
+	if !rn.verdict.CompareAndSwap(nil, &verdict) {
 		return
 	}
 
-	rn.finished <- verdict
-
-	close(rn.finished)
+	close(rn.done)
 }
 
-func (rn *AuthRequest) WaitForAuth() <-chan AuthVerdict {
-	return rn.finished
+func (rn *AuthRequest) WaitForAuth() <-chan struct{} {
+	return rn.done
+}
+
+// AuthResult returns the immutable terminal verdict after WaitForAuth is
+// closed. The boolean is false before completion, allowing callers to fail
+// closed if they ever observe completion without a stored result.
+func (rn *AuthRequest) AuthResult() (AuthVerdict, bool) {
+	verdict := rn.verdict.Load()
+	if verdict == nil {
+		return AuthVerdict{}, false
+	}
+
+	return *verdict, true
 }
 
 type AuthVerdict struct {

--- a/hscontrol/types/common.go
+++ b/hscontrol/types/common.go
@@ -87,8 +87,10 @@ func (r AuthID) Validate() error {
 // time so the follow-up request and OIDC callback can verify that no
 // other (src, dst) pair has been substituted via tampered URL parameters.
 type SSHCheckBinding struct {
-	SrcNodeID NodeID
-	DstNodeID NodeID
+	SrcNodeID        NodeID
+	DstNodeID        NodeID
+	LocalUser        string
+	PolicyGeneration uint64
 }
 
 // PendingRegistrationConfirmation captures the server-side state needed
@@ -169,10 +171,22 @@ func NewRegisterAuthRequest(data *RegistrationData) *AuthRequest {
 // OIDC callback must verify their incoming request matches this binding
 // before recording any verdict.
 func NewSSHCheckAuthRequest(src, dst NodeID) *AuthRequest {
+	return NewSSHCheckAuthRequestForPolicy(src, dst, "", 0)
+}
+
+// NewSSHCheckAuthRequestForPolicy creates an SSH check request bound to the
+// complete connection identity and the policy generation that required it.
+func NewSSHCheckAuthRequestForPolicy(
+	src, dst NodeID,
+	localUser string,
+	policyGeneration uint64,
+) *AuthRequest {
 	return &AuthRequest{
 		sshBinding: &SSHCheckBinding{
-			SrcNodeID: src,
-			DstNodeID: dst,
+			SrcNodeID:        src,
+			DstNodeID:        dst,
+			LocalUser:        localUser,
+			PolicyGeneration: policyGeneration,
 		},
 		done: make(chan struct{}),
 	}

--- a/hscontrol/types/common.go
+++ b/hscontrol/types/common.go
@@ -139,10 +139,11 @@ type AuthRequest struct {
 	// but before the user has explicitly confirmed the registration on
 	// the interstitial. The /register/confirm POST handler reads it to
 	// finalise the registration without re-running the OIDC flow.
-	pendingConfirmation *PendingRegistrationConfirmation
+	pendingConfirmation atomic.Pointer[PendingRegistrationConfirmation]
 
-	done    chan struct{}
-	verdict atomic.Pointer[AuthVerdict]
+	done       chan struct{}
+	verdict    atomic.Pointer[AuthVerdict]
+	processing atomic.Bool
 }
 
 // NewAuthRequest creates a pending auth request with no payload, suitable
@@ -212,28 +213,71 @@ func (rn *AuthRequest) IsSSHCheck() bool {
 	return rn.sshBinding != nil
 }
 
-// SetPendingConfirmation marks this [AuthRequest] as having an
-// OIDC-resolved user that is waiting to confirm the registration on
-// the interstitial. The OIDC callback should call this and then render
-// the confirmation page; the /register/confirm POST handler reads the
-// stored UserID/NodeExpiry to finish the registration.
-func (rn *AuthRequest) SetPendingConfirmation(p *PendingRegistrationConfirmation) {
-	rn.pendingConfirmation = p
+// SetPendingConfirmation records the first OIDC-resolved user waiting to
+// confirm the registration. It returns false if confirmation is already
+// pending, leaving the original value unchanged.
+func (rn *AuthRequest) SetPendingConfirmation(p *PendingRegistrationConfirmation) bool {
+	return rn.pendingConfirmation.CompareAndSwap(nil, p)
 }
 
 // PendingConfirmation returns the pending OIDC-resolved registration
 // state captured by [AuthRequest.SetPendingConfirmation], or nil if no OIDC callback
 // has yet resolved an identity for this [AuthRequest].
 func (rn *AuthRequest) PendingConfirmation() *PendingRegistrationConfirmation {
-	return rn.pendingConfirmation
+	return rn.pendingConfirmation.Load()
 }
 
-func (rn *AuthRequest) FinishAuth(verdict AuthVerdict) {
-	if !rn.verdict.CompareAndSwap(nil, &verdict) {
-		return
+// TryBeginAuth reserves a pending request for one completion path. The caller
+// must finish it with [AuthRequest.FinishClaimedAuth] or release it with
+// [AuthRequest.AbortAuth].
+func (rn *AuthRequest) TryBeginAuth() bool {
+	if rn.verdict.Load() != nil || !rn.processing.CompareAndSwap(false, true) {
+		return false
+	}
+
+	// A terminal verdict can race the reservation after the first check.
+	// Give it precedence and release the claim so no completion path starts
+	// after the request has finished.
+	if rn.verdict.Load() != nil {
+		rn.processing.Store(false)
+
+		return false
+	}
+
+	return true
+}
+
+// AbortAuth releases an unfinished completion reservation.
+func (rn *AuthRequest) AbortAuth() {
+	if rn.verdict.Load() == nil {
+		rn.processing.Store(false)
+	}
+}
+
+// FinishClaimedAuth publishes the terminal verdict for a request reserved by
+// [AuthRequest.TryBeginAuth].
+func (rn *AuthRequest) FinishClaimedAuth(verdict AuthVerdict) bool {
+	if !rn.processing.Load() || !rn.verdict.CompareAndSwap(nil, &verdict) {
+		return false
 	}
 
 	close(rn.done)
+
+	return true
+}
+
+func (rn *AuthRequest) FinishAuth(verdict AuthVerdict) bool {
+	// Administrative decisions and expiry remain authoritative while a
+	// completion path is doing external work. Whichever terminal verdict is
+	// published first wins; a claimed completion that loses this race fails
+	// closed in FinishClaimedAuth.
+	if !rn.verdict.CompareAndSwap(nil, &verdict) {
+		return false
+	}
+
+	close(rn.done)
+
+	return true
 }
 
 func (rn *AuthRequest) WaitForAuth() <-chan struct{} {

--- a/hscontrol/types/common_test.go
+++ b/hscontrol/types/common_test.go
@@ -67,9 +67,13 @@ func TestAuthRequestHasNoResultBeforeCompletion(t *testing.T) {
 // captures the (src, dst) node pair at construction time and rejects
 // callers that try to read [AuthRequest.RegistrationData] from it.
 func TestNewSSHCheckAuthRequestBinding(t *testing.T) {
-	const src, dst NodeID = 7, 11
+	const (
+		src, dst         NodeID = 7, 11
+		localUser               = "root"
+		policyGeneration        = 42
+	)
 
-	req := NewSSHCheckAuthRequest(src, dst)
+	req := NewSSHCheckAuthRequestForPolicy(src, dst, localUser, policyGeneration)
 
 	require.True(t, req.IsSSHCheck(), "SSH-check request must report IsSSHCheck=true")
 	require.False(t, req.IsRegistration(), "SSH-check request must not report IsRegistration")
@@ -77,6 +81,9 @@ func TestNewSSHCheckAuthRequestBinding(t *testing.T) {
 	binding := req.SSHCheckBinding()
 	assert.Equal(t, src, binding.SrcNodeID, "SrcNodeID must match")
 	assert.Equal(t, dst, binding.DstNodeID, "DstNodeID must match")
+	assert.Equal(t, localUser, binding.LocalUser, "LocalUser must match")
+	assert.Equal(t, uint64(policyGeneration), binding.PolicyGeneration,
+		"PolicyGeneration must match")
 
 	assert.Panics(t, func() {
 		_ = req.RegistrationData()

--- a/hscontrol/types/common_test.go
+++ b/hscontrol/types/common_test.go
@@ -126,12 +126,32 @@ func TestPendingRegistrationConfirmation(t *testing.T) {
 		UserID: 42,
 		CSRF:   "csrf-marker",
 	}
-	req.SetPendingConfirmation(pending)
+	require.True(t, req.SetPendingConfirmation(pending))
+	require.False(t, req.SetPendingConfirmation(&PendingRegistrationConfirmation{
+		UserID: 7,
+		CSRF:   "replacement",
+	}))
 
 	got := req.PendingConfirmation()
 	require.NotNil(t, got, "PendingConfirmation must return the stored value")
 	assert.Equal(t, uint(42), got.UserID)
 	assert.Equal(t, "csrf-marker", got.CSRF)
+}
+
+func TestAuthRequestCompletionClaim(t *testing.T) {
+	t.Parallel()
+
+	req := NewAuthRequest()
+	require.True(t, req.TryBeginAuth())
+	require.False(t, req.TryBeginAuth())
+	require.True(t, req.FinishAuth(AuthVerdict{Err: errAuthRequestRejected}))
+	require.False(t, req.FinishClaimedAuth(AuthVerdict{}))
+	require.False(t, req.TryBeginAuth())
+
+	req.AbortAuth()
+	verdict, ok := req.AuthResult()
+	require.True(t, ok)
+	require.ErrorIs(t, verdict.Err, errAuthRequestRejected)
 }
 
 func TestDefaultBatcherWorkersFor(t *testing.T) {

--- a/hscontrol/types/common_test.go
+++ b/hscontrol/types/common_test.go
@@ -1,11 +1,67 @@
 package types
 
 import (
+	"errors"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var errAuthRequestRejected = errors.New("rejected")
+
+func TestAuthRequestBroadcastsTerminalVerdict(t *testing.T) {
+	t.Parallel()
+
+	const waiters = 32
+
+	req := NewSSHCheckAuthRequest(7, 11)
+
+	type result struct {
+		verdict AuthVerdict
+		ok      bool
+	}
+
+	results := make(chan result, waiters)
+
+	var ready sync.WaitGroup
+	ready.Add(waiters)
+
+	for range waiters {
+		go func() {
+			ready.Done()
+			<-req.WaitForAuth()
+
+			verdict, ok := req.AuthResult()
+			results <- result{verdict: verdict, ok: ok}
+		}()
+	}
+
+	ready.Wait()
+	req.FinishAuth(AuthVerdict{Err: errAuthRequestRejected})
+
+	for range waiters {
+		result := <-results
+		require.True(t, result.ok)
+		require.ErrorIs(t, result.verdict.Err, errAuthRequestRejected)
+		assert.False(t, result.verdict.Accept())
+	}
+
+	// Completion is immutable and remains readable by retries.
+	req.FinishAuth(AuthVerdict{})
+	verdict, ok := req.AuthResult()
+	require.True(t, ok)
+	require.ErrorIs(t, verdict.Err, errAuthRequestRejected)
+}
+
+func TestAuthRequestHasNoResultBeforeCompletion(t *testing.T) {
+	t.Parallel()
+
+	req := NewAuthRequest()
+	_, ok := req.AuthResult()
+	assert.False(t, ok)
+}
 
 // TestNewSSHCheckAuthRequestBinding verifies that an SSH-check [AuthRequest]
 // captures the (src, dst) node pair at construction time and rejects

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -319,13 +319,13 @@ type Tuning struct {
 	// updates for connected clients.
 	BatcherWorkers int
 
-	// RegisterCacheExpiration is how long registration cache entries remain
-	// valid before being eligible for eviction.
+	// RegisterCacheExpiration is how long pending registration and SSH check
+	// entries remain valid before expiring.
 	RegisterCacheExpiration time.Duration
 
 	// RegisterCacheMaxEntries bounds the number of pending registration
-	// entries the auth cache will hold. Older entries are evicted (LRU)
-	// when the cap is reached, preventing unauthenticated cache-fill DoS.
+	// entries the auth cache will hold. New registrations are rejected while
+	// the cap is reached so existing authentication sessions remain available.
 	// A value of 0 falls back to defaultRegisterCacheMaxEntries (1024).
 	RegisterCacheMaxEntries int
 

--- a/hscontrol/types/registration.go
+++ b/hscontrol/types/registration.go
@@ -13,11 +13,9 @@ import (
 // only the fields the registration callback path actually consumes when
 // promoting a pending registration to a real node.
 //
-// Combined with the bounded-LRU cache that holds these entries, this caps
-// the worst-case memory footprint of unauthenticated cache-fill attempts
-// at (max_entries × per_entry_size). The cache is sized so that the
-// product is bounded to a few MiB even with attacker-supplied 1 MiB
-// Hostinfos (the Noise body limit).
+// Hostinfo is a bounded projection created at admission time rather than the
+// full client request, keeping the count-bounded cache within a predictable
+// memory budget.
 type RegistrationData struct {
 	// MachineKey is the cryptographic identity of the machine being
 	// registered. Required.
@@ -34,11 +32,8 @@ type RegistrationData struct {
 	// Already validated/normalised by EnsureHostname at producer time.
 	Hostname string
 
-	// Hostinfo is the original [tailcfg.Hostinfo] from the [tailcfg.RegisterRequest],
-	// stored so that the auth callback can populate the new node's
-	// initial [tailcfg.Hostinfo] (and so that observability/CLI consumers see
-	// fields like OS, OSVersion, and IPNVersion before the first
-	// [tailcfg.MapRequest] restores the live set).
+	// Hostinfo contains only bounded identity/display fields and RequestTags.
+	// The first [tailcfg.MapRequest] restores live network and service state.
 	//
 	// May be nil if the client did not send [tailcfg.Hostinfo] in the original
 	// [tailcfg.RegisterRequest].


### PR DESCRIPTION
Prevent concurrent authentication and map activity from losing results, retaining excessive state, or applying stale policy decisions.

Keep registration, OIDC, and SSH behavior consistent under retries and policy updates.

> Generated with the help of an AI assistant