### PR TITLE
ci: scope pull request and release jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,18 @@ defaults:
   run:
     shell: nix develop --fallback --command bash -e {0}
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   build-nix:
     runs-on: ubuntu-latest
-    permissions: write-all
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 2
+          persist-credentials: false
       - name: Get changed files
         id: changed-files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -39,27 +43,8 @@ jobs:
         if: steps.changed-files.outputs.files == 'true'
 
       - name: Check vendor hash
-        id: vendorhash
         if: steps.changed-files.outputs.files == 'true'
-        run: |
-          go run ./cmd/vendorhash check | tee check-result
-          {
-            grep '^expected_sri=' check-result || true
-            grep '^actual_sri='   check-result || true
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Vendor hash diverging
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        if: failure() && steps.vendorhash.outcome == 'failure'
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.rest.pulls.createReviewComment({
-              pull_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Vendor hash in `flakehashes.json` is stale (was `${{ steps.vendorhash.outputs.expected_sri }}`, should be `${{ steps.vendorhash.outputs.actual_sri }}`). Run `go run ./cmd/vendorhash update` and commit the result.'
-            })
+        run: go run ./cmd/vendorhash check
 
       - name: Run nix build
         if: steps.changed-files.outputs.files == 'true'
@@ -81,6 +66,8 @@ jobs:
           - "GOARCH=amd64 GOOS=darwin"
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
       - uses: Mic92/hestia@fb239a2f72d4b6e26eec5425f289dea23b27a527 # v2.0.0
 

--- a/.github/workflows/container-main.yml
+++ b/.github/workflows/container-main.yml
@@ -10,8 +10,6 @@ on:
       - "go.*"
       - "**/*.go"
       - ".github/workflows/container-main.yml"
-  workflow_dispatch:
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/integration-test-template.yml
+++ b/.github/workflows/integration-test-template.yml
@@ -14,33 +14,17 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-24.04-arm
-    env:
-      # Github does not allow us to access secrets in pull requests,
-      # so this env var is used to check if we have the secret or not.
-      # If we have the secrets, meaning we are running on push in a fork,
-      # there might be secrets available for more debugging.
-      # If TS_OAUTH_CLIENT_ID and TS_OAUTH_SECRET is set, then the job
-      # will join a debug tailscale network, set up SSH and a tmux session.
-      # The SSH will be configured to use the SSH key of the Github user
-      # that triggered the build.
-      HAS_TAILSCALE_SECRET: ${{ secrets.TS_OAUTH_CLIENT_ID }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 2
-      - name: Tailscale
-        if: ${{ env.HAS_TAILSCALE_SECRET }}
-        uses: tailscale/github-action@a392da0a182bba0e9613b6243ebd69529b1878aa # v4.1.0
-        with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:gh
-      - name: Setup SSH server for Actor
-        if: ${{ env.HAS_TAILSCALE_SECRET }}
-        uses: alexellis/setup-sshd-actor@master
+          persist-credentials: false
       - name: Download headscale image
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
@@ -85,15 +69,6 @@ jobs:
         # in-cluster DNS (kube-dns) is unreachable. The module cannot be loaded
         # from inside the unprivileged-module rancher/k3s image, so load it here.
         run: sudo modprobe br_netfilter
-      - name: Login to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_CI_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_CI_TOKEN }}
-        if: env.DOCKERHUB_USERNAME != ''
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: Load Docker images, Go cache, and prepare binary
         run: |
           gunzip -c /tmp/artifacts/headscale-image.tar.gz | docker load
@@ -115,12 +90,6 @@ jobs:
           HEADSCALE_INTEGRATION_POSTGRES_IMAGE: ${{ inputs.postgres_flag == '--postgres=1' && format('postgres:{0}', github.sha) || '' }}
           HEADSCALE_INTEGRATION_GO_CACHE: /tmp/go-cache/go
           HEADSCALE_INTEGRATION_GO_BUILD_CACHE: /tmp/go-cache/.cache/go-build
-          # Mirror the docker/login-action secrets into env so the
-          # dockertestutil.Credentials resolver picks them up directly
-          # (otherwise it falls back to parsing ~/.docker/config.json,
-          # which works but is one step further from the source).
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_CI_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_CI_TOKEN }}
         run: /tmp/artifacts/hi run --stats --ts-memory-limit=300 --hs-memory-limit=1500 "^${{ inputs.test }}$" \
           --timeout=120m \
           ${{ inputs.postgres_flag }}
@@ -128,7 +97,7 @@ jobs:
       - name: Sanitize test name for artifacts
         if: always()
         id: sanitize
-        run: echo "name=${TEST_NAME//[\":<>|*?\\\/]/-}" >> $GITHUB_OUTPUT
+        run: echo "name=${TEST_NAME//[\":<>|*?\\\/]/-}" >> "$GITHUB_OUTPUT"
         env:
           TEST_NAME: ${{ inputs.test }}
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -141,6 +110,3 @@ jobs:
         with:
           name: ${{ inputs.database_name }}-${{ steps.sanitize.outputs.name }}-artifacts
           path: control_logs/
-      - name: Setup a blocking tmux session
-        if: ${{ env.HAS_TAILSCALE_SECRET }}
-        uses: alexellis/block-with-tmux-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,24 +2,96 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "*" # triggers only if push new tag version
-  workflow_dispatch:
+  repository_dispatch:
+    types: [release]
+
+permissions:
+  contents: read
 
 defaults:
   run:
     shell: nix develop --fallback --command bash -e {0}
 
 jobs:
-  goreleaser:
+  validate:
     if: github.repository == 'juanfont/headscale'
     runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.ref.outputs.sha }}
+      tag: ${{ steps.ref.outputs.tag }}
+    steps:
+      - name: Checkout trusted workflow revision
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate release ref
+        id: ref
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.client_payload.tag }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${RELEASE_TAG}" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "release tag does not match vMAJOR.MINOR.PATCH[-PRERELEASE]" >&2
+            exit 1
+          fi
+          release_line="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+
+          git fetch --force origin \
+            "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}" \
+            "+refs/heads/main:refs/remotes/origin/main"
+
+          target_sha=$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")
+          main_sha=$(git rev-parse refs/remotes/origin/main)
+          release_sha=""
+
+          case "${release_line}" in
+            0.29)
+              git fetch --force origin \
+                "+refs/heads/release-branch/0.29:refs/remotes/origin/release-branch/0.29"
+              release_sha=$(git rev-parse refs/remotes/origin/release-branch/0.29)
+              ;;
+          esac
+
+          if [[ "${target_sha}" != "${main_sha}" && "${target_sha}" != "${release_sha}" ]]; then
+            echo "release tag must point to an approved branch tip" >&2
+            exit 1
+          fi
+
+          echo "sha=${target_sha}" >> "$GITHUB_OUTPUT"
+          echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+
+  goreleaser:
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
+          ref: ${{ needs.validate.outputs.sha }}
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Confirm release tag target
+        shell: bash
+        env:
+          RELEASE_SHA: ${{ needs.validate.outputs.sha }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          tag_sha=$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")
+          if [[ "${tag_sha}" != "${RELEASE_SHA}" ]]; then
+            echo "release tag moved after validation" >&2
+            exit 1
+          fi
 
       - name: Login to DockerHub
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -9,12 +9,14 @@ concurrency:
 defaults:
   run:
     shell: nix develop --fallback --command bash -e {0}
+permissions:
+  contents: read
+  pull-requests: read
 jobs:
   # build: Builds binaries and Docker images once, uploads as artifacts for reuse.
   # build-postgres: Pulls postgres image separately to avoid Docker Hub rate limits.
   # build-tailscale-released: Pre-pulls released Tailscale images from ghcr.io
-  # so fork PRs (no DOCKERHUB_USERNAME secret) don't hit Docker Hub rate
-  # limits at test time.
+  # so pull request jobs don't hit Docker Hub rate limits at test time.
   # sqlite: Runs all integration tests with SQLite backend.
   # postgres: Runs a subset of tests with PostgreSQL to verify database compatibility.
   build:
@@ -25,6 +27,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 2
+          persist-credentials: false
       - name: Get changed files
         id: changed-files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -81,15 +84,6 @@ jobs:
           echo '{"storage-driver":"overlay2"}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker version
-      - name: Login to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_CI_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_CI_TOKEN }}
-        if: env.DOCKERHUB_USERNAME != ''
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: Build headscale image
         if: steps.changed-files.outputs.files == 'true'
         run: |
@@ -132,15 +126,6 @@ jobs:
           echo '{"storage-driver":"overlay2"}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker version
-      - name: Login to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_CI_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_CI_TOKEN }}
-        if: env.DOCKERHUB_USERNAME != ''
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: Pull and save postgres image
         shell: bash
         run: |
@@ -159,6 +144,8 @@ jobs:
     if: needs.build.outputs.files-changed == 'true'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
       - uses: NixOS/nix-installer-action@6b8548fe06acfb0155a50ab5d561accb215764cc # main
       - uses: Mic92/hestia@fb239a2f72d4b6e26eec5425f289dea23b27a527 # v2.0.0
       - name: Force overlay2 storage driver
@@ -167,15 +154,6 @@ jobs:
           echo '{"storage-driver":"overlay2"}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           docker version
-      - name: Login to Docker Hub
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_CI_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_CI_TOKEN }}
-        if: env.DOCKERHUB_USERNAME != ''
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: List Tailscale versions to pre-pull
         id: versions
         run: |
@@ -391,7 +369,6 @@ jobs:
           - TestTS2021WASMClientUnderNode
           - TestTailscaleRustAxum
     uses: ./.github/workflows/integration-test-template.yml
-    secrets: inherit
     with:
       test: ${{ matrix.test }}
       postgres_flag: "--postgres=0"
@@ -409,7 +386,6 @@ jobs:
           - TestPingAllByIPManyUpDown
           - TestSubnetRouterMultiNetwork
     uses: ./.github/workflows/integration-test-template.yml
-    secrets: inherit
     with:
       test: ${{ matrix.test }}
       postgres_flag: "--postgres=1"

--- a/integration/k3sic/k3sic.go
+++ b/integration/k3sic/k3sic.go
@@ -24,8 +24,10 @@ package k3sic
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -60,11 +62,12 @@ const (
 
 	dockerExecuteTimeout = 300 * time.Second
 
-	// helmVersionFallback is used when the latest helm release cannot be
-	// resolved at runtime (see resolveHelmVersion). The image ships no helm and
-	// cannot fetch it itself, so we inject a binary that matches the container
-	// arch.
-	helmVersionFallback = "v3.19.1"
+	// The image ships no helm and cannot fetch it itself, so the test harness
+	// injects this pinned release for the container architecture.
+	helmVersion = "v3.19.1"
+
+	maxHelmArchiveSize = 64 << 20
+	maxHelmBinarySize  = 128 << 20
 
 	// kubeconfigPath is where k3s writes the kubeconfig (see RunOptions.Env);
 	// helm needs it pointed explicitly, kubectl finds it by default.
@@ -84,8 +87,12 @@ const (
 )
 
 var (
-	errHelmDownload     = errors.New("helm download failed")
-	errHelmNotInTarball = errors.New("helm binary not found in release tarball")
+	errHelmDownload        = errors.New("helm download failed")
+	errHelmNotInTarball    = errors.New("helm binary not found in release tarball")
+	errHelmUnsupportedArch = errors.New("unsupported architecture for Helm")
+	errHelmArchiveTooLarge = errors.New("helm archive exceeds size limit")
+	errHelmBinaryTooLarge  = errors.New("helm binary exceeds size limit")
+	errHelmChecksum        = errors.New("helm archive checksum mismatch")
 
 	errNoKubeDNSEndpoints = errors.New("kube-dns Service has no ready endpoints yet")
 )
@@ -352,7 +359,7 @@ func (k *K3sInContainer) WaitForRunning() error {
 // has network egress) and inject the binary. helm's own HTTPS client then
 // fetches the operator chart from inside the container.
 func (k *K3sInContainer) InstallHelm() error {
-	bin, err := fetchHelmBinary(resolveHelmVersion(), runtime.GOARCH)
+	bin, err := fetchHelmBinary(helmVersion, runtime.GOARCH)
 	if err != nil {
 		return fmt.Errorf("fetching helm: %w", err)
 	}
@@ -494,43 +501,14 @@ func (k *K3sInContainer) DumpDiagnostics() {
 	}
 }
 
-// resolveHelmVersion returns the latest published helm release tag (e.g.
-// "v3.19.1"), falling back to [helmVersionFallback] if it cannot be resolved.
-// get.helm.sh is not Docker Hub and has no anonymous rate limit, so a "rolling"
-// latest is cheap; the fallback keeps a broken release from breaking CI.
-func resolveHelmVersion() string {
-	req, err := http.NewRequestWithContext(
-		context.Background(), http.MethodGet, "https://get.helm.sh/helm-latest-version", nil)
-	if err != nil {
-		return helmVersionFallback
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return helmVersionFallback
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return helmVersionFallback
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 32))
-	if err != nil {
-		return helmVersionFallback
-	}
-
-	version := strings.TrimSpace(string(body))
-	if !strings.HasPrefix(version, "v") {
-		return helmVersionFallback
-	}
-
-	return version
-}
-
 // fetchHelmBinary downloads the helm release tarball for version and goarch and
-// returns the helm binary bytes.
+// returns the verified helm binary bytes.
 func fetchHelmBinary(version, goarch string) ([]byte, error) {
+	wantHash, err := helmArchiveSHA256(goarch)
+	if err != nil {
+		return nil, err
+	}
+
 	url := fmt.Sprintf("https://get.helm.sh/helm-%s-linux-%s.tar.gz", version, goarch)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
@@ -548,7 +526,36 @@ func fetchHelmBinary(version, goarch string) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %s returned status %d", errHelmDownload, url, resp.StatusCode)
 	}
 
-	gz, err := gzip.NewReader(resp.Body)
+	archive, err := io.ReadAll(io.LimitReader(resp.Body, maxHelmArchiveSize+1))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(archive) > maxHelmArchiveSize {
+		return nil, fmt.Errorf("%w: %s", errHelmArchiveTooLarge, url)
+	}
+
+	return extractHelmBinary(archive, goarch, wantHash)
+}
+
+func helmArchiveSHA256(goarch string) (string, error) {
+	switch goarch {
+	case "amd64":
+		return "966bed9b1e0dda11268f59bd7268c3cd3e308b37b070546e1d78a02526ff63f2", nil
+	case "arm64":
+		return "ceed150305a1d1ef4a37923a7f66931a6807c34a38ea487fa8340e102dd2c7f7", nil
+	default:
+		return "", fmt.Errorf("%w: %s", errHelmUnsupportedArch, goarch)
+	}
+}
+
+func extractHelmBinary(archive []byte, goarch, wantHash string) ([]byte, error) {
+	gotHash := fmt.Sprintf("%x", sha256.Sum256(archive))
+	if gotHash != wantHash {
+		return nil, fmt.Errorf("%w: got %s", errHelmChecksum, gotHash)
+	}
+
+	gz, err := gzip.NewReader(bytes.NewReader(archive))
 	if err != nil {
 		return nil, err
 	}
@@ -568,7 +575,20 @@ func fetchHelmBinary(version, goarch string) ([]byte, error) {
 		}
 
 		if hdr.Name == want {
-			return io.ReadAll(tr)
+			if hdr.Size < 0 || hdr.Size > maxHelmBinarySize {
+				return nil, fmt.Errorf("%w: %d bytes", errHelmBinaryTooLarge, hdr.Size)
+			}
+
+			bin, err := io.ReadAll(io.LimitReader(tr, maxHelmBinarySize+1))
+			if err != nil {
+				return nil, err
+			}
+
+			if len(bin) > maxHelmBinarySize {
+				return nil, fmt.Errorf("%w: more than %d bytes", errHelmBinaryTooLarge, maxHelmBinarySize)
+			}
+
+			return bin, nil
 		}
 	}
 

--- a/integration/k3sic/k3sic_test.go
+++ b/integration/k3sic/k3sic_test.go
@@ -1,0 +1,70 @@
+package k3sic
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func helmTestArchive(t *testing.T, goarch string, body []byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "linux-" + goarch + "/helm",
+		Mode: 0o755,
+		Size: int64(len(body)),
+	}))
+	_, err := tw.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+
+	return buf.Bytes()
+}
+
+func TestExtractHelmBinaryVerifiesArchive(t *testing.T) {
+	archive := helmTestArchive(t, "amd64", []byte("helm-binary"))
+	wantHash := fmt.Sprintf("%x", sha256.Sum256(archive))
+
+	got, err := extractHelmBinary(archive, "amd64", wantHash)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("helm-binary"), got)
+
+	archive[len(archive)-1] ^= 1
+	_, err = extractHelmBinary(archive, "amd64", wantHash)
+	require.ErrorIs(t, err, errHelmChecksum)
+}
+
+func TestExtractHelmBinaryRejectsOversizedMember(t *testing.T) {
+	var buf bytes.Buffer
+
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "linux-amd64/helm",
+		Mode: 0o755,
+		Size: maxHelmBinarySize + 1,
+	}))
+	require.Error(t, tw.Close())
+	require.NoError(t, gz.Close())
+
+	archive := buf.Bytes()
+	wantHash := fmt.Sprintf("%x", sha256.Sum256(archive))
+	_, err := extractHelmBinary(archive, "amd64", wantHash)
+	require.ErrorIs(t, err, errHelmBinaryTooLarge)
+}
+
+func TestHelmArchiveSHA256RejectsUnsupportedArchitecture(t *testing.T) {
+	_, err := helmArchiveSHA256("riscv64")
+	require.ErrorIs(t, err, errHelmUnsupportedArch)
+}


### PR DESCRIPTION
Keep pull-request and publishing jobs tied to their intended refs and credentials.

Pin downloaded integration tooling so test runs use the expected binaries.

> Generated with the help of an AI assistant