### PR TITLE
oidc: add option to retry if unavailable on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ keys remain all-access.
 - Expiring or deleting a non-existent pre-auth key now returns an error instead of silently succeeding [#3324](https://github.com/juanfont/headscale/pull/3324)
 - Improve systemd service file hardening [#3341](https://github.com/juanfont/headscale/pull/3341)
 - The peer map is keyed by node ID and reused for writes that cannot change peer visibility, so a routine map request no longer rebuilds it. Adds `headscale_nodestore_snapshot_builds_total` [#3417](https://github.com/juanfont/headscale/issues/3417) [#3450](https://github.com/juanfont/headscale/pull/3450)
+- Add `oidc.retry_interval` option to periodically retry OIDC provider discovery if unavailable on startup
 - Headscale now requires Go 1.27 to build
 
 ## 0.29.4 (unreleased)

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -367,6 +367,9 @@ unix_socket_permission: "0770"
 #   # Block startup until the identity provider is available and healthy.
 #   only_start_if_oidc_is_available: true
 #
+#   # Interval to retry OIDC provider discovery if unavailable on startup
+#   # retry_interval: 30s
+#
 #   # OpenID Connect Issuer URL from the identity provider
 #   issuer: "https://your-oidc.issuer.com/path"
 #

--- a/docs/ref/oidc.md
+++ b/docs/ref/oidc.md
@@ -175,6 +175,18 @@ reauthenticate. The default node expiration can be configured via the top-level 
     headscale node expire -i <NODE_ID>
     ```
 
+### Retry OIDC provider discovery on startup
+
+If Headscale starts before the identity provider is reachable (for example when both run on the same host or during simultaneous system startup), you can configure `retry_interval`. When set, Headscale temporarily falls back to CLI-based authentication and periodically retries OIDC discovery until the provider becomes available, then automatically switches over to OIDC.
+
+```yaml hl_lines="5"
+oidc:
+  issuer: "https://sso.example.com"
+  client_id: "headscale"
+  client_secret: "generated-secret"
+  retry_interval: 30s
+```
+
 ### Reference a user in the policy
 
 You may refer to users in the Headscale policy via:

--- a/hscontrol/app.go
+++ b/hscontrol/app.go
@@ -91,9 +91,12 @@ type Headscale struct {
 	realIPMiddleware func(http.Handler) http.Handler
 
 	// Things that generate changes
-	extraRecordMan *dns.ExtraRecordsMan
-	authProvider   AuthProvider
-	mapBatcher     *mapper.Batcher
+	extraRecordMan  *dns.ExtraRecordsMan
+	authProviderMu  sync.RWMutex
+	authProvider    AuthProvider
+	oidcRetryCancel context.CancelFunc
+
+	mapBatcher *mapper.Batcher
 
 	clientStreamsOpen sync.WaitGroup
 }
@@ -180,6 +183,10 @@ func NewHeadscale(cfg *types.Config) (*Headscale, error) {
 				return nil, err
 			} else {
 				log.Warn().Err(err).Msg("failed to set up OIDC provider, falling back to CLI based authentication")
+
+				if cfg.OIDC.RetryInterval > 0 {
+					app.startOIDCRetry(cfg.ServerURL, &cfg.OIDC)
+				}
 			}
 		} else {
 			authProvider = oidcProvider
@@ -261,6 +268,52 @@ func NewHeadscale(cfg *types.Config) (*Headscale, error) {
 	}
 
 	return &app, nil
+}
+
+func (h *Headscale) getAuthProvider() AuthProvider {
+	h.authProviderMu.RLock()
+	defer h.authProviderMu.RUnlock()
+
+	return h.authProvider
+}
+
+func (h *Headscale) setAuthProvider(p AuthProvider) {
+	h.authProviderMu.Lock()
+	defer h.authProviderMu.Unlock()
+
+	h.authProvider = p
+}
+
+func (h *Headscale) startOIDCRetry(serverURL string, cfg *types.OIDCConfig) {
+	ctx, cancel := context.WithCancel(context.Background())
+	h.oidcRetryCancel = cancel
+
+	go func() {
+		ticker := time.NewTicker(cfg.RetryInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				discoverCtx, discoverCancel := context.WithTimeout(ctx, 30*time.Second)
+				oidcProvider, err := NewAuthProviderOIDC(discoverCtx, h, serverURL, cfg)
+				discoverCancel()
+
+				if err != nil {
+					log.Debug().Err(err).Msg("retrying OIDC provider discovery: still unavailable")
+
+					continue
+				}
+
+				log.Info().Msg("OIDC provider became available, switching from CLI based authentication")
+				h.setAuthProvider(oidcProvider)
+
+				return
+			}
+		}
+	}()
 }
 
 // Redirect to our TLS url.
@@ -443,6 +496,25 @@ func serveHumaMux(mux http.Handler) http.HandlerFunc {
 	}
 }
 
+func (h *Headscale) authHandlerDispatch(get func(AuthProvider) http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		get(h.getAuthProvider())(w, r)
+	}
+}
+
+func (h *Headscale) oidcHandlerDispatch(get func(*AuthProviderOIDC) http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		provider, ok := h.getAuthProvider().(*AuthProviderOIDC)
+		if !ok {
+			http.NotFound(w, r)
+
+			return
+		}
+
+		get(provider)(w, r)
+	}
+}
+
 func (h *Headscale) createRouter(apiV1Mux, apiV2Mux http.Handler) *chi.Mux {
 	r := chi.NewRouter()
 	r.Use(metrics.Collector(metrics.CollectorOpts{
@@ -473,14 +545,12 @@ func (h *Headscale) createRouter(apiV1Mux, apiV2Mux http.Handler) *chi.Mux {
 	r.Get("/health", h.HealthHandler)
 	r.Get("/version", h.VersionHandler)
 	r.Get("/key", h.KeyHandler)
-	r.Get("/register/{auth_id}", h.authProvider.RegisterHandler)
-	r.Get("/auth/{auth_id}", h.authProvider.AuthHandler)
+	r.Get("/register/{auth_id}", h.authHandlerDispatch(func(p AuthProvider) http.HandlerFunc { return p.RegisterHandler }))
+	r.Get("/auth/{auth_id}", h.authHandlerDispatch(func(p AuthProvider) http.HandlerFunc { return p.AuthHandler }))
 
-	if provider, ok := h.authProvider.(*AuthProviderOIDC); ok {
-		r.Get("/oidc/callback", provider.OIDCCallbackHandler)
-		r.Get("/register/confirm/{auth_id}", provider.RegisterConfirmGetHandler)
-		r.Post("/register/confirm/{auth_id}", provider.RegisterConfirmHandler)
-	}
+	r.Get("/oidc/callback", h.oidcHandlerDispatch(func(p *AuthProviderOIDC) http.HandlerFunc { return p.OIDCCallbackHandler }))
+	r.Get("/register/confirm/{auth_id}", h.oidcHandlerDispatch(func(p *AuthProviderOIDC) http.HandlerFunc { return p.RegisterConfirmGetHandler }))
+	r.Post("/register/confirm/{auth_id}", h.oidcHandlerDispatch(func(p *AuthProviderOIDC) http.HandlerFunc { return p.RegisterConfirmHandler }))
 
 	r.Get("/apple", h.AppleConfigMessage)
 	r.Get("/apple/{platform}", h.ApplePlatformConfig)
@@ -804,6 +874,10 @@ func (h *Headscale) Serve() error {
 
 				scheduleCancel()
 				h.ephemeralGC.Close()
+
+				if h.oidcRetryCancel != nil {
+					h.oidcRetryCancel()
+				}
 
 				// Gracefully shut down servers
 				shutdownCtx, cancel := context.WithTimeout(

--- a/hscontrol/auth.go
+++ b/hscontrol/auth.go
@@ -378,7 +378,7 @@ func (h *Headscale) reqToNewRegisterResponse(
 	h.state.SetAuthCacheEntry(newAuthID, authRegReq)
 
 	return &tailcfg.RegisterResponse{
-		AuthURL: h.authProvider.RegisterURL(newAuthID),
+		AuthURL: h.getAuthProvider().RegisterURL(newAuthID),
 	}, nil
 }
 
@@ -505,6 +505,6 @@ func (h *Headscale) handleRegisterInteractive(
 	log.Info().Msgf("starting node registration using auth id: %s", authID)
 
 	return &tailcfg.RegisterResponse{
-		AuthURL: h.authProvider.RegisterURL(authID),
+		AuthURL: h.getAuthProvider().RegisterURL(authID),
 	}, nil
 }

--- a/hscontrol/noise.go
+++ b/hscontrol/noise.go
@@ -546,7 +546,7 @@ func (ns *noiseServer) sshActionHoldAndDelegate(
 		types.NewSSHCheckAuthRequest(srcNodeID, dstNodeID),
 	)
 
-	authURL := ns.headscale.authProvider.AuthURL(authID)
+	authURL := ns.headscale.getAuthProvider().AuthURL(authID)
 
 	q := holdURL.Query()
 	q.Set("auth_id", authID.String())

--- a/hscontrol/oidc_retry_test.go
+++ b/hscontrol/oidc_retry_test.go
@@ -1,0 +1,139 @@
+package hscontrol
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/oauth2-proxy/mockoidc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOIDCRetryFallsBackThenSwitchesOver(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	idp, err := mockoidc.NewServer(nil)
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+
+	cfg := types.Config{
+		ServerURL:           "http://localhost:8080",
+		NoisePrivateKeyPath: tmpDir + "/noise_private.key",
+		Database: types.DatabaseConfig{
+			Type: "sqlite3",
+			Sqlite: types.SqliteConfig{
+				Path: tmpDir + "/headscale_test.db",
+			},
+		},
+		OIDC: types.OIDCConfig{
+			OnlyStartIfOIDCIsAvailable: false,
+			RetryInterval:              50 * time.Millisecond,
+			Issuer:                     "http://" + addr + "/oidc",
+			ClientID:                   idp.ClientID,
+			ClientSecret:               idp.ClientSecret,
+			Scope:                      []string{"openid", "profile", "email"},
+		},
+		Policy: types.PolicyConfig{
+			Mode: types.PolicyModeDB,
+		},
+		Tuning: types.Tuning{
+			BatchChangeDelay: 100 * time.Millisecond,
+			BatcherWorkers:   1,
+		},
+	}
+
+	app, err := NewHeadscale(&cfg)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if app.oidcRetryCancel != nil {
+			app.oidcRetryCancel()
+		}
+	})
+
+	_, isWeb := app.getAuthProvider().(*AuthProviderWeb)
+	assert.True(t, isWeb)
+
+	router := app.createRouter(nil, nil)
+
+	// In fallback mode, /oidc/callback returns 404
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/oidc/callback", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	newLn, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+
+	err = idp.Start(newLn, nil)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = idp.Shutdown()
+	})
+
+	assert.Eventually(t, func() bool {
+		_, isOIDC := app.getAuthProvider().(*AuthProviderOIDC)
+
+		return isOIDC
+	}, 5*time.Second, 20*time.Millisecond)
+
+	// After switchover, /oidc/callback is handled (not 404)
+	w = httptest.NewRecorder()
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/oidc/callback", nil)
+	router.ServeHTTP(w, req)
+	assert.NotEqual(t, http.StatusNotFound, w.Code)
+}
+
+func TestOIDCRetryDisabledByDefault(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	idp, err := mockoidc.NewServer(nil)
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+
+	cfg := types.Config{
+		ServerURL:           "http://localhost:8080",
+		NoisePrivateKeyPath: tmpDir + "/noise_private.key",
+		Database: types.DatabaseConfig{
+			Type: "sqlite3",
+			Sqlite: types.SqliteConfig{
+				Path: tmpDir + "/headscale_test.db",
+			},
+		},
+		OIDC: types.OIDCConfig{
+			OnlyStartIfOIDCIsAvailable: false,
+			RetryInterval:              0, // Retry disabled
+			Issuer:                     "http://" + addr + "/oidc",
+			ClientID:                   idp.ClientID,
+			ClientSecret:               idp.ClientSecret,
+			Scope:                      []string{"openid", "profile", "email"},
+		},
+		Policy: types.PolicyConfig{
+			Mode: types.PolicyModeDB,
+		},
+		Tuning: types.Tuning{
+			BatchChangeDelay: 100 * time.Millisecond,
+			BatcherWorkers:   1,
+		},
+	}
+
+	app, err := NewHeadscale(&cfg)
+	require.NoError(t, err)
+
+	_, isWeb := app.getAuthProvider().(*AuthProviderWeb)
+	assert.True(t, isWeb)
+	assert.Nil(t, app.oidcRetryCancel)
+}

--- a/hscontrol/oidc_test.go
+++ b/hscontrol/oidc_test.go
@@ -337,7 +337,7 @@ func newOIDCBrowserWithPrefix(t *testing.T, prefix string) *oidcBrowser {
 	)
 	require.NoError(t, err)
 
-	app.authProvider = provider
+	app.setAuthProvider(provider)
 	router = app.createRouter(nil, nil)
 
 	jar, err := cookiejar.New(nil)

--- a/hscontrol/types/config.go
+++ b/hscontrol/types/config.go
@@ -239,6 +239,7 @@ type OIDCConfig struct {
 	EmailVerifiedRequired      bool
 	UseExpiryFromToken         bool
 	PKCE                       PKCEConfig
+	RetryInterval              time.Duration
 }
 
 type DERPConfig struct {
@@ -470,6 +471,7 @@ func LoadConfig(path string, isFile bool) error {
 
 	viper.SetDefault("oidc.scope", []string{oidc.ScopeOpenID, "profile", "email"})
 	viper.SetDefault("oidc.only_start_if_oidc_is_available", true)
+	viper.SetDefault("oidc.retry_interval", "0s")
 	viper.SetDefault("oidc.use_expiry_from_token", false)
 	viper.SetDefault("oidc.pkce.enabled", false)
 	viper.SetDefault("oidc.pkce.method", "S256")
@@ -1276,6 +1278,7 @@ func LoadServerConfig() (*Config, error) {
 			AllowedGroups:         viper.GetStringSlice("oidc.allowed_groups"),
 			EmailVerifiedRequired: viper.GetBool("oidc.email_verified_required"),
 			UseExpiryFromToken:    viper.GetBool("oidc.use_expiry_from_token"),
+			RetryInterval:         viper.GetDuration("oidc.retry_interval"),
 			PKCE: PKCEConfig{
 				Enabled: viper.GetBool("oidc.pkce.enabled"),
 				Method:  viper.GetString("oidc.pkce.method"),

--- a/integration/auth_oidc_test.go
+++ b/integration/auth_oidc_test.go
@@ -1935,3 +1935,68 @@ func TestOIDCReloginSameUserRoutesPreserved(t *testing.T) {
 
 	t.Logf("Test completed - verifying issue #2896 fix for OIDC")
 }
+
+func TestOIDCRetryStartup(t *testing.T) {
+	IntegrationSkip(t)
+
+	scenario, err := NewScenario(ScenarioSpec{
+		OIDCUsers: []mockoidc.MockUser{
+			oidcMockUser("user1", true),
+		},
+	})
+	require.NoError(t, err)
+
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	// Stop mock OIDC container to simulate it being unavailable at Headscale startup
+	err = scenario.pool.Client.StopContainer(scenario.mockOIDC.r.Container.ID, 0)
+	require.NoError(t, err)
+
+	oidcMap := map[string]string{
+		"HEADSCALE_OIDC_ISSUER":             scenario.mockOIDC.Issuer(),
+		"HEADSCALE_OIDC_CLIENT_ID":          scenario.mockOIDC.ClientID(),
+		"CREDENTIALS_DIRECTORY_TEST":        "/tmp",
+		"HEADSCALE_OIDC_CLIENT_SECRET_PATH": "${CREDENTIALS_DIRECTORY_TEST}/hs_client_oidc_secret",
+		"HEADSCALE_OIDC_RETRY_INTERVAL":     "1s",
+	}
+
+	err = scenario.CreateHeadscaleEnvWithLoginURL(
+		nil,
+		hsic.WithTestName("oidcretry"),
+		hsic.WithConfigEnv(oidcMap),
+		hsic.WithFileInContainer("/tmp/hs_client_oidc_secret", []byte(scenario.mockOIDC.ClientSecret())),
+	)
+	requireNoErrHeadscaleEnv(t, err)
+
+	headscale, err := scenario.Headscale()
+	require.NoError(t, err)
+
+	// Start mock OIDC container back up
+	err = scenario.pool.Client.StartContainer(scenario.mockOIDC.r.Container.ID, nil)
+	require.NoError(t, err)
+
+	ts, err := scenario.CreateTailscaleNode(
+		"unstable",
+		tsic.WithNetwork(scenario.networks[scenario.testDefaultNetwork]),
+	)
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		u, err := ts.LoginWithURL(headscale.GetEndpoint())
+		if !assert.NoError(ct, err) {
+			return
+		}
+
+		_, err = doLoginURL(ts.Hostname(), u)
+		assert.NoError(ct, err)
+	}, integrationutil.StatusReadyTimeout, 1*time.Second)
+
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		nodes, err := headscale.ListNodes()
+		if !assert.NoError(ct, err) {
+			return
+		}
+
+		assert.Len(ct, nodes, 1)
+	}, integrationutil.StatusReadyTimeout, integrationutil.SlowPoll)
+}


### PR DESCRIPTION
This is disabled by default to avoid changing the behavior of already-deployed instances, but can prove very useful for cases where the authentication server and headscale live on the same node that gets rebooted, and headscale starts before the authentication server (as it is the case for me).

Fixes #3462 

<!--
Headscale is "Open Source, acknowledged contribution", this means that any
contribution will have to be discussed with the Maintainers before being submitted.

This model has been chosen to reduce the risk of burnout by limiting the
maintenance overhead of reviewing and validating third-party code.

Headscale is open to code contributions for bug fixes without discussion.

If you find mistakes in the documentation, please submit a fix to the documentation.
-->

<!-- Please tick if the following things apply. You… -->

- [x] have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file
- [x] raised a GitHub issue or discussed it on the projects chat beforehand 
- [x] added unit tests
- [x] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
